### PR TITLE
feat: add mise dev task to start all services

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -25,7 +25,15 @@ docker-compose up -d postgres
 
 # Wait for PostgreSQL to be ready
 echo "Waiting for PostgreSQL..."
+MAX_RETRIES=30
+RETRY_COUNT=0
 until docker exec finance-postgres pg_isready -U finance > /dev/null 2>&1; do
+  RETRY_COUNT=$((RETRY_COUNT + 1))
+  if [ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
+    echo "Error: PostgreSQL did not become ready within ${MAX_RETRIES} seconds. Exiting."
+    docker-compose logs postgres || true
+    exit 1
+  fi
   sleep 1
 done
 echo "PostgreSQL ready"
@@ -45,14 +53,15 @@ FRONTEND_PID=$!
 # Trap to cleanup on exit
 cleanup() {
   echo "Shutting down..."
-  kill $BACKEND_PID $FRONTEND_PID 2>/dev/null || true
+  kill -- -"$BACKEND_PID" -"$FRONTEND_PID" 2>/dev/null || true
   docker-compose stop postgres
   exit 0
 }
 trap cleanup SIGINT SIGTERM
 
 # Wait for both processes
-wait
+wait "$BACKEND_PID" "$FRONTEND_PID" || true
+cleanup
 """
 
 [tasks.down]


### PR DESCRIPTION
## Motivation

Need simple way to start all services (postgres, backend API, frontend) for local development testing.

## Implementation information

Added mise tasks to `.mise.toml`:
- `mise run dev` - starts postgres via docker-compose, backend API (uvicorn), frontend (vite)
- `mise run down` - stops all services
- `mise run backend` - backend only
- `mise run frontend` - frontend only

Dev task:
- Loads `.env` for docker-compose env vars
- Starts postgres in docker
- Waits for postgres readiness
- Starts backend and frontend in background
- Cleanup handler stops all on SIGINT/SIGTERM

## Supporting documentation

N/A