### PR TITLE
fix(frontend): configure CSRF trusted origins for local dev

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -7,7 +7,7 @@ const config = {
 	kit: {
 		adapter: adapter(),
 		csrf: {
-			checkOrigin: true
+			trustedOrigins: ['http://localhost:5173']
 		}
 	}
 };


### PR DESCRIPTION
## Motivation

SvelteKit CSRF protection needs explicit trusted origins configured for local development to work properly.

## Implementation information

Replaced `checkOrigin: true` with `trustedOrigins: ['http://localhost:5173']` in svelte.config.js to allow localhost requests during development.

## Supporting documentation

N/A