### PR TITLE
refactor(backend): Phase 6 - Configuration Cleanup

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -5,15 +5,8 @@ class Settings(BaseSettings):
     database_url: str
     app_password: str
     cors_origins: str
-    owner_names: str = "Marcin,Ewa,Shared"
-    default_owner: str = "Marcin"
 
     model_config = SettingsConfigDict(env_file=".env")
-
-    @property
-    def owner_names_list(self) -> list[str]:
-        """Parse comma-separated owner names into a list"""
-        return [name.strip() for name in self.owner_names.split(",")]
 
 
 settings = Settings()

--- a/backend/app/schemas/debt_payments.py
+++ b/backend/app/schemas/debt_payments.py
@@ -2,14 +2,14 @@ from datetime import date, datetime
 
 from pydantic import BaseModel, field_validator
 
-from app.core.config import settings
+from app.core.enums import Owner
 from app.utils.validators import validate_not_future_date, validate_positive_amount
 
 
 class DebtPaymentCreate(BaseModel):
     amount: float
     date: date
-    owner: str
+    owner: Owner
 
     @field_validator("amount")
     @classmethod
@@ -21,14 +21,6 @@ class DebtPaymentCreate(BaseModel):
     def validate_date(cls, v: date) -> date:
         return validate_not_future_date(v)
 
-    @field_validator("owner")
-    @classmethod
-    def validate_owner(cls, v: str) -> str:
-        allowed_owners = settings.owner_names_list
-        if v not in allowed_owners:
-            raise ValueError(f"Owner must be one of: {', '.join(allowed_owners)}")
-        return v
-
 
 class DebtPaymentResponse(BaseModel):
     id: int
@@ -36,7 +28,7 @@ class DebtPaymentResponse(BaseModel):
     account_name: str
     amount: float
     date: date
-    owner: str
+    owner: Owner
     created_at: datetime
 
 


### PR DESCRIPTION
## Motivation

Eliminate hardcoded owner values and use Owner enum consistently across all schemas. Closes #79.

## Implementation information

- **debt_payments.py**: Changed `owner: str` to `owner: Owner` enum, removed custom string validator
- **config.py**: Removed unused `owner_names`, `default_owner`, and `owner_names_list` - no longer needed after enum consolidation

Single source of truth for owner names is now `Owner` enum in `app.core.enums`.

## Supporting documentation

Closes #79