### PR TITLE
feat(ui): ZUS calculator + mobile optimization

### DIFF
--- a/backend/app/api/zus.py
+++ b/backend/app/api/zus.py
@@ -1,0 +1,25 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.schemas.zus import ZusCalculatorInputs, ZusCalculatorResponse, ZusPrefillResponse
+from app.services import zus_calculator
+
+router = APIRouter(prefix="/api/zus", tags=["zus"])
+
+
+@router.post("/calculate", response_model=ZusCalculatorResponse)
+def calculate_zus_pension(inputs: ZusCalculatorInputs) -> ZusCalculatorResponse:
+    """Calculate projected ZUS retirement pension."""
+    return zus_calculator.calculate_zus_pension(inputs)
+
+
+@router.get("/prefill", response_model=ZusPrefillResponse)
+def get_zus_prefill(
+    db: Annotated[Session, Depends(get_db)],
+    owner: str | None = Query(None),
+) -> ZusPrefillResponse:
+    """Prefill ZUS calculator form from salary records and config."""
+    return zus_calculator.get_zus_prefill(db, owner)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from app.api import (
     simulations,
     snapshots,
     transactions,
+    zus,
 )
 from app.core.config import settings
 from app.core.init_db import init_db
@@ -55,6 +56,7 @@ app.include_router(salary_records.router)
 app.include_router(simulations.router)
 app.include_router(snapshots.router)
 app.include_router(transactions.router)
+app.include_router(zus.router)
 
 
 @app.get("/health")

--- a/backend/app/schemas/zus.py
+++ b/backend/app/schemas/zus.py
@@ -1,0 +1,129 @@
+from datetime import UTC, date, datetime
+
+from pydantic import BaseModel, field_validator, model_validator
+
+
+class SalaryHistoryEntry(BaseModel):
+    year: int
+    annual_gross: float
+
+
+class ZusCalculatorInputs(BaseModel):
+    owner: str
+    birth_date: date
+    gender: str  # "M" or "F"
+    retirement_age: int = 65
+    current_gross_monthly_salary: float
+    salary_growth_rate: float = 3.0
+    inflation_rate: float = 3.0
+    valorization_rate_konto: float = 5.0
+    valorization_rate_subkonto: float = 4.0
+    has_ofe: bool = False
+    kapital_poczatkowy: float = 0.0
+    work_start_year: int
+    salary_history: list[SalaryHistoryEntry] = []
+
+    @field_validator("gender")
+    @classmethod
+    def validate_gender(cls, v: str) -> str:
+        if v not in ("M", "F"):
+            raise ValueError("Gender must be 'M' or 'F'")
+        return v
+
+    @field_validator("retirement_age")
+    @classmethod
+    def validate_retirement_age(cls, v: int) -> int:
+        if not (55 <= v <= 70):
+            raise ValueError("Retirement age must be between 55 and 70")
+        return v
+
+    @field_validator("current_gross_monthly_salary")
+    @classmethod
+    def validate_salary(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError("Salary cannot be negative")
+        return v
+
+    @field_validator(
+        "salary_growth_rate",
+        "inflation_rate",
+        "valorization_rate_konto",
+        "valorization_rate_subkonto",
+    )
+    @classmethod
+    def validate_rate(cls, v: float) -> float:
+        if not (0 <= v <= 20):
+            raise ValueError("Rate must be between 0% and 20%")
+        return v
+
+    @field_validator("kapital_poczatkowy")
+    @classmethod
+    def validate_kapital(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError("Kapitał początkowy cannot be negative")
+        return v
+
+    @field_validator("work_start_year")
+    @classmethod
+    def validate_work_start(cls, v: int) -> int:
+        if not (1970 <= v <= 2030):
+            raise ValueError("Work start year must be between 1970 and 2030")
+        return v
+
+    @model_validator(mode="after")
+    def validate_retirement_after_current_age(self) -> ZusCalculatorInputs:
+        today = datetime.now(UTC).date()
+        current_age = today.year - self.birth_date.year
+        if today.month < self.birth_date.month or (
+            today.month == self.birth_date.month and today.day < self.birth_date.day
+        ):
+            current_age -= 1
+        if self.retirement_age <= current_age:
+            raise ValueError("Retirement age must be greater than current age")
+        return self
+
+
+class ZusYearlyProjection(BaseModel):
+    year: int
+    age: int
+    annual_gross_salary: float
+    salary_capped: bool
+    contribution_konto: float
+    contribution_subkonto: float
+    konto_balance: float
+    subkonto_balance: float
+    total_balance: float
+
+
+class ZusSensitivityScenario(BaseModel):
+    label: str
+    valorization_konto: float
+    valorization_subkonto: float
+    monthly_pension_gross: float
+    monthly_pension_net: float
+    replacement_rate: float
+
+
+class ZusCalculatorResponse(BaseModel):
+    inputs: ZusCalculatorInputs
+    yearly_projections: list[ZusYearlyProjection]
+    life_expectancy_months: float
+    konto_at_retirement: float
+    subkonto_at_retirement: float
+    kapital_poczatkowy_valorized: float
+    total_capital: float
+    monthly_pension_gross: float
+    monthly_pension_net: float
+    replacement_rate: float
+    last_gross_salary: float
+    sensitivity: list[ZusSensitivityScenario]
+
+
+class ZusPrefillResponse(BaseModel):
+    birth_date: date | None = None
+    retirement_age: int = 65
+    gender: str = "M"
+    current_gross_monthly_salary: float | None = None
+    owner: str | None = None
+    salary_history: list[SalaryHistoryEntry] = []
+    work_start_year: int | None = None

--- a/backend/app/services/zus_calculator.py
+++ b/backend/app/services/zus_calculator.py
@@ -1,0 +1,363 @@
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.app_config import AppConfig
+from app.models.persona import Persona
+from app.models.salary_record import SalaryRecord
+from app.schemas.zus import (
+    SalaryHistoryEntry,
+    ZusCalculatorInputs,
+    ZusCalculatorResponse,
+    ZusPrefillResponse,
+    ZusSensitivityScenario,
+    ZusYearlyProjection,
+)
+
+# ZUS contribution rates (% of gross salary)
+CONTRIBUTION_RATE_KONTO = 0.1222  # 12.22% goes to individual account (konto)
+CONTRIBUTION_RATE_SUBKONTO_NO_OFE = 0.0730  # 7.30% to subkonto when no OFE
+CONTRIBUTION_RATE_SUBKONTO_OFE = 0.0438  # 4.38% to subkonto with OFE (rest goes to OFE)
+TOTAL_CONTRIBUTION_RATE = 0.1952  # 19.52% total pension contribution
+
+# 30x average salary cap — annual limit on contribution base (2026 estimate)
+CAP_30X_2026 = 282_600.0
+CAP_GROWTH_RATE = 0.05  # ~5% annual growth of cap
+
+# GUS 2025 life expectancy in months (dalsze trwanie życia) by retirement age
+LIFE_EXPECTANCY_MONTHS: dict[int, float] = {
+    55: 318.0,
+    56: 312.0,
+    57: 306.0,
+    58: 300.0,
+    59: 294.0,
+    60: 266.4,
+    61: 260.4,
+    62: 254.4,
+    63: 248.4,
+    64: 234.6,
+    65: 220.8,
+    66: 214.8,
+    67: 208.8,
+    68: 202.8,
+    69: 196.8,
+    70: 190.8,
+}
+
+# Pension tax parameters (2026)
+PIT_RATE = 0.12  # 12% PIT
+HEALTH_RATE = 0.09  # 9% health insurance
+ANNUAL_FREE_THRESHOLD = 30_000.0  # Tax-free amount
+
+
+def apply_pension_tax(monthly_gross: float) -> float:
+    """Calculate net pension from gross pension.
+
+    Pension taxation: 12% PIT (with 30k/year free threshold) + 9% health insurance.
+    Health insurance is deducted from gross before PIT calculation.
+    """
+    annual_gross = monthly_gross * 12
+
+    # Health insurance (9% of gross, not tax-deductible for pensioners)
+    annual_health = annual_gross * HEALTH_RATE
+
+    # PIT: 12% on (gross - free threshold), but not below 0
+    taxable_income = max(0.0, annual_gross - ANNUAL_FREE_THRESHOLD)
+    annual_pit = taxable_income * PIT_RATE
+
+    annual_net = annual_gross - annual_health - annual_pit
+    return max(0, annual_net / 12)
+
+
+def get_life_expectancy(retirement_age: int) -> float:
+    """Look up life expectancy months from GUS table, interpolate if needed."""
+    if retirement_age in LIFE_EXPECTANCY_MONTHS:
+        return LIFE_EXPECTANCY_MONTHS[retirement_age]
+    # Clamp to table bounds
+    if retirement_age < 55:
+        return LIFE_EXPECTANCY_MONTHS[55]
+    if retirement_age > 70:
+        return LIFE_EXPECTANCY_MONTHS[70]
+    # Linear interpolation between two nearest ages
+    lower = max(k for k in LIFE_EXPECTANCY_MONTHS if k <= retirement_age)
+    upper = min(k for k in LIFE_EXPECTANCY_MONTHS if k >= retirement_age)
+    if lower == upper:
+        return LIFE_EXPECTANCY_MONTHS[lower]
+    frac = (retirement_age - lower) / (upper - lower)
+    return LIFE_EXPECTANCY_MONTHS[lower] + frac * (
+        LIFE_EXPECTANCY_MONTHS[upper] - LIFE_EXPECTANCY_MONTHS[lower]
+    )
+
+
+def calculate_zus_pension(inputs: ZusCalculatorInputs) -> ZusCalculatorResponse:
+    """Core ZUS pension calculation.
+
+    Formula: Emerytura = (Kapitał Początkowy + Suma Zwaloryzowanych Składek) / Dalsze Trwanie Życia
+
+    Steps per year:
+    1. Determine salary (from history or projected)
+    2. Apply 30x cap
+    3. Compute konto + subkonto contributions
+    4. Valorize existing balances
+    5. Add new contributions
+    6. Apply suwak bezpieczeństwa (10 years before retirement)
+    """
+    today = datetime.now(UTC).date()
+    current_year = today.year
+    birth_year = inputs.birth_date.year
+    retirement_year = birth_year + inputs.retirement_age
+
+    subkonto_rate = (
+        CONTRIBUTION_RATE_SUBKONTO_OFE if inputs.has_ofe else CONTRIBUTION_RATE_SUBKONTO_NO_OFE
+    )
+
+    # Build salary lookup from history
+    salary_by_year: dict[int, float] = {}
+    for entry in inputs.salary_history:
+        salary_by_year[entry.year] = entry.annual_gross
+
+    konto_balance = 0.0
+    subkonto_balance = 0.0
+    projections: list[ZusYearlyProjection] = []
+    last_salary = inputs.current_gross_monthly_salary * 12
+
+    # Valorize kapitał początkowy alongside konto balance
+    kapital_valorized = inputs.kapital_poczatkowy
+
+    for year in range(inputs.work_start_year, retirement_year):
+        age = year - birth_year
+
+        # Determine annual gross salary for this year
+        if year in salary_by_year:
+            annual_salary = salary_by_year[year]
+        elif year <= current_year:
+            # Past year with no record — use current salary as estimate
+            annual_salary = inputs.current_gross_monthly_salary * 12
+        else:
+            # Future year — project from current salary with growth
+            years_ahead = year - current_year
+            annual_salary = (
+                inputs.current_gross_monthly_salary
+                * 12
+                * (1 + inputs.salary_growth_rate / 100) ** years_ahead
+            )
+
+        last_salary = annual_salary
+
+        # 30x cap grows annually from 2026 base
+        years_from_base = year - 2026
+        cap = CAP_30X_2026 * (1 + CAP_GROWTH_RATE) ** max(0, years_from_base)
+        salary_capped = annual_salary > cap
+        capped_salary = min(annual_salary, cap)
+
+        # Contributions
+        contribution_konto = capped_salary * CONTRIBUTION_RATE_KONTO
+        contribution_subkonto = capped_salary * subkonto_rate
+
+        # Suwak bezpieczeństwa: 10 years before retirement, subkonto contributions → konto
+        suwak_active = (retirement_year - year) <= 10
+        if suwak_active:
+            contribution_konto += contribution_subkonto
+            contribution_subkonto = 0.0
+
+        # Valorize existing balances (applied before adding new contributions)
+        konto_balance *= 1 + inputs.valorization_rate_konto / 100
+        subkonto_balance *= 1 + inputs.valorization_rate_subkonto / 100
+        kapital_valorized *= 1 + inputs.valorization_rate_konto / 100
+
+        # Add new contributions after valorization
+        konto_balance += contribution_konto
+        subkonto_balance += contribution_subkonto
+
+        projections.append(
+            ZusYearlyProjection(
+                year=year,
+                age=age,
+                annual_gross_salary=round(annual_salary, 2),
+                salary_capped=salary_capped,
+                contribution_konto=round(contribution_konto, 2),
+                contribution_subkonto=round(contribution_subkonto, 2),
+                konto_balance=round(konto_balance, 2),
+                subkonto_balance=round(subkonto_balance, 2),
+                total_balance=round(konto_balance + subkonto_balance + kapital_valorized, 2),
+            )
+        )
+
+    # At retirement
+    life_expectancy = get_life_expectancy(inputs.retirement_age)
+    total_capital = kapital_valorized + konto_balance + subkonto_balance
+    monthly_pension_gross = total_capital / life_expectancy
+    monthly_pension_net = apply_pension_tax(monthly_pension_gross)
+    replacement_rate = (monthly_pension_gross / (last_salary / 12) * 100) if last_salary > 0 else 0
+
+    # Sensitivity analysis: ±2% valorization
+    sensitivity = _build_sensitivity(inputs, retirement_year, salary_by_year, life_expectancy)
+
+    return ZusCalculatorResponse(
+        inputs=inputs,
+        yearly_projections=projections,
+        life_expectancy_months=life_expectancy,
+        konto_at_retirement=round(konto_balance, 2),
+        subkonto_at_retirement=round(subkonto_balance, 2),
+        kapital_poczatkowy_valorized=round(kapital_valorized, 2),
+        total_capital=round(total_capital, 2),
+        monthly_pension_gross=round(monthly_pension_gross, 2),
+        monthly_pension_net=round(monthly_pension_net, 2),
+        replacement_rate=round(replacement_rate, 2),
+        last_gross_salary=round(last_salary / 12, 2),
+        sensitivity=sensitivity,
+    )
+
+
+def _build_sensitivity(
+    inputs: ZusCalculatorInputs,
+    retirement_year: int,
+    salary_by_year: dict[int, float],
+    life_expectancy: float,
+) -> list[ZusSensitivityScenario]:
+    """Run 3 scenarios: pessimistic (-2%), baseline, optimistic (+2%)."""
+    scenarios = [
+        ("Pesymistyczny", -2.0),
+        ("Bazowy", 0.0),
+        ("Optymistyczny", 2.0),
+    ]
+    results: list[ZusSensitivityScenario] = []
+
+    for label, delta in scenarios:
+        val_konto = inputs.valorization_rate_konto + delta
+        val_subkonto = inputs.valorization_rate_subkonto + delta
+        # Re-run simplified calculation with adjusted rates
+        total = _quick_calculate(inputs, retirement_year, salary_by_year, val_konto, val_subkonto)
+        gross = total / life_expectancy
+        net = apply_pension_tax(gross)
+        last_salary = _get_last_salary(inputs, retirement_year)
+        rr = (gross / last_salary * 100) if last_salary > 0 else 0
+
+        results.append(
+            ZusSensitivityScenario(
+                label=label,
+                valorization_konto=val_konto,
+                valorization_subkonto=val_subkonto,
+                monthly_pension_gross=round(gross, 2),
+                monthly_pension_net=round(net, 2),
+                replacement_rate=round(rr, 2),
+            )
+        )
+
+    return results
+
+
+def _get_last_salary(inputs: ZusCalculatorInputs, retirement_year: int) -> float:
+    """Get projected monthly salary at retirement."""
+    current_year = datetime.now(UTC).date().year
+    years_ahead = retirement_year - 1 - current_year
+    if years_ahead <= 0:
+        return inputs.current_gross_monthly_salary
+    growth = (1 + inputs.salary_growth_rate / 100) ** years_ahead
+    return inputs.current_gross_monthly_salary * growth
+
+
+def _quick_calculate(
+    inputs: ZusCalculatorInputs,
+    retirement_year: int,
+    salary_by_year: dict[int, float],
+    val_konto: float,
+    val_subkonto: float,
+) -> float:
+    """Simplified total capital calculation for sensitivity analysis."""
+    current_year = datetime.now(UTC).date().year
+    subkonto_rate = (
+        CONTRIBUTION_RATE_SUBKONTO_OFE if inputs.has_ofe else CONTRIBUTION_RATE_SUBKONTO_NO_OFE
+    )
+
+    konto = 0.0
+    subkonto = 0.0
+    kapital = inputs.kapital_poczatkowy
+
+    for year in range(inputs.work_start_year, retirement_year):
+        if year in salary_by_year:
+            annual_salary = salary_by_year[year]
+        elif year <= current_year:
+            annual_salary = inputs.current_gross_monthly_salary * 12
+        else:
+            years_ahead = year - current_year
+            annual_salary = (
+                inputs.current_gross_monthly_salary
+                * 12
+                * (1 + inputs.salary_growth_rate / 100) ** years_ahead
+            )
+
+        years_from_base = year - 2026
+        cap = CAP_30X_2026 * (1 + CAP_GROWTH_RATE) ** max(0, years_from_base)
+        capped = min(annual_salary, cap)
+
+        c_konto = capped * CONTRIBUTION_RATE_KONTO
+        c_subkonto = capped * subkonto_rate
+
+        suwak = (retirement_year - year) <= 10
+        if suwak:
+            c_konto += c_subkonto
+            c_subkonto = 0.0
+
+        konto *= 1 + val_konto / 100
+        subkonto *= 1 + val_subkonto / 100
+        kapital *= 1 + val_konto / 100
+
+        konto += c_konto
+        subkonto += c_subkonto
+
+    return kapital + konto + subkonto
+
+
+def get_zus_prefill(db: Session, owner: str | None = None) -> ZusPrefillResponse:
+    """Prefill ZUS calculator form from SalaryRecord + AppConfig."""
+    config = db.execute(select(AppConfig)).scalar_one_or_none()
+
+    # Find first persona if owner not specified
+    if not owner:
+        persona = db.execute(select(Persona).order_by(Persona.name)).scalars().first()
+        owner = persona.name if persona else None
+
+    if not owner:
+        return ZusPrefillResponse()
+
+    # Get latest active salary for the owner
+    salary = (
+        db.execute(
+            select(SalaryRecord)
+            .where(SalaryRecord.owner == owner, SalaryRecord.is_active.is_(True))
+            .order_by(SalaryRecord.date.desc())
+        )
+        .scalars()
+        .first()
+    )
+
+    # Get salary history — all records for the owner grouped by year
+    all_salaries = (
+        db.execute(
+            select(SalaryRecord).where(SalaryRecord.owner == owner).order_by(SalaryRecord.date)
+        )
+        .scalars()
+        .all()
+    )
+
+    # Build yearly salary history (use latest record per year)
+    yearly: dict[int, float] = {}
+    for s in all_salaries:
+        yearly[s.date.year] = float(s.gross_amount) * 12
+
+    salary_history = [SalaryHistoryEntry(year=y, annual_gross=g) for y, g in sorted(yearly.items())]
+
+    # Determine work_start_year from earliest salary record
+    work_start_year = min(yearly.keys()) if yearly else None
+
+    return ZusPrefillResponse(
+        birth_date=config.birth_date if config else None,
+        retirement_age=config.retirement_age if config else 65,
+        gender="M",
+        current_gross_monthly_salary=float(salary.gross_amount) if salary else None,
+        owner=owner,
+        salary_history=salary_history,
+        work_start_year=work_start_year,
+    )

--- a/backend/tests/test_services_zus_calculator.py
+++ b/backend/tests/test_services_zus_calculator.py
@@ -1,0 +1,233 @@
+from datetime import date
+
+from app.schemas.zus import SalaryHistoryEntry, ZusCalculatorInputs
+from app.services.zus_calculator import (
+    apply_pension_tax,
+    calculate_zus_pension,
+    get_life_expectancy,
+)
+
+
+def _make_inputs(**overrides) -> ZusCalculatorInputs:
+    """Helper to create test inputs with sensible defaults."""
+    defaults = {
+        "owner": "Marcin",
+        "birth_date": date(1990, 1, 1),
+        "gender": "M",
+        "retirement_age": 65,
+        "current_gross_monthly_salary": 15000.0,
+        "salary_growth_rate": 3.0,
+        "inflation_rate": 3.0,
+        "valorization_rate_konto": 5.0,
+        "valorization_rate_subkonto": 4.0,
+        "has_ofe": False,
+        "kapital_poczatkowy": 0.0,
+        "work_start_year": 2015,
+        "salary_history": [],
+    }
+    defaults.update(overrides)
+    return ZusCalculatorInputs(**defaults)
+
+
+class TestBasicProjection:
+    def test_returns_projections(self):
+        inputs = _make_inputs()
+        result = calculate_zus_pension(inputs)
+
+        # Should have projections from work_start_year to retirement year
+        retirement_year = 1990 + 65  # 2055
+        expected_years = retirement_year - 2015  # 40 years
+        assert len(result.yearly_projections) == expected_years
+
+    def test_pension_is_positive(self):
+        inputs = _make_inputs()
+        result = calculate_zus_pension(inputs)
+
+        assert result.monthly_pension_gross > 0
+        assert result.monthly_pension_net > 0
+        assert result.total_capital > 0
+
+    def test_pension_reasonable_range(self):
+        """Average salary should yield pension roughly 2000-6000 PLN gross."""
+        inputs = _make_inputs(current_gross_monthly_salary=10000.0, work_start_year=2015)
+        result = calculate_zus_pension(inputs)
+
+        assert result.monthly_pension_gross > 1000
+        assert result.monthly_pension_gross < 20000
+
+    def test_net_less_than_gross(self):
+        inputs = _make_inputs()
+        result = calculate_zus_pension(inputs)
+
+        assert result.monthly_pension_net < result.monthly_pension_gross
+
+    def test_replacement_rate_positive(self):
+        inputs = _make_inputs()
+        result = calculate_zus_pension(inputs)
+
+        assert 0 < result.replacement_rate < 100
+
+    def test_life_expectancy_returned(self):
+        inputs = _make_inputs(retirement_age=65)
+        result = calculate_zus_pension(inputs)
+
+        assert result.life_expectancy_months == 220.8
+
+
+class TestCapApplication:
+    def test_cap_triggers_for_high_salary(self):
+        """Very high salary should hit 30x cap."""
+        inputs = _make_inputs(current_gross_monthly_salary=50000.0)
+        result = calculate_zus_pension(inputs)
+
+        # Some future projections should show salary_capped=True
+        capped_years = [p for p in result.yearly_projections if p.salary_capped]
+        assert len(capped_years) > 0
+
+    def test_cap_does_not_trigger_for_low_salary(self):
+        """Normal salary should not hit 30x cap."""
+        inputs = _make_inputs(current_gross_monthly_salary=8000.0)
+        result = calculate_zus_pension(inputs)
+
+        capped_years = [p for p in result.yearly_projections if p.salary_capped]
+        assert len(capped_years) == 0
+
+
+class TestSuwakBezpieczenstwa:
+    def test_suwak_activates_10_years_before_retirement(self):
+        """In last 10 years, subkonto contributions should be 0."""
+        inputs = _make_inputs()
+        result = calculate_zus_pension(inputs)
+
+        retirement_year = 1990 + 65  # 2055
+        suwak_start = retirement_year - 10  # 2045
+
+        for p in result.yearly_projections:
+            if p.year >= suwak_start:
+                assert p.contribution_subkonto == 0.0, (
+                    f"Year {p.year}: subkonto contribution should be 0 during suwak"
+                )
+
+    def test_suwak_redirects_to_konto(self):
+        """During suwak, konto contributions should be higher than normal."""
+        inputs = _make_inputs(valorization_rate_konto=0.0, valorization_rate_subkonto=0.0)
+        result = calculate_zus_pension(inputs)
+
+        retirement_year = 1990 + 65
+        # Check a year before and during suwak
+        before_suwak = [p for p in result.yearly_projections if p.year == retirement_year - 11]
+        during_suwak = [p for p in result.yearly_projections if p.year == retirement_year - 5]
+
+        if before_suwak and during_suwak:
+            # During suwak, konto contribution should include subkonto portion
+            assert during_suwak[0].contribution_konto > before_suwak[0].contribution_konto
+
+
+class TestOfeFlag:
+    def test_ofe_changes_subkonto_rate(self):
+        """OFE flag should reduce subkonto contribution rate."""
+        inputs_no_ofe = _make_inputs(
+            has_ofe=False, valorization_rate_konto=0, valorization_rate_subkonto=0
+        )
+        inputs_ofe = _make_inputs(
+            has_ofe=True, valorization_rate_konto=0, valorization_rate_subkonto=0
+        )
+
+        result_no_ofe = calculate_zus_pension(inputs_no_ofe)
+        result_ofe = calculate_zus_pension(inputs_ofe)
+
+        # First year (before suwak) — subkonto contribution should differ
+        first_no_ofe = result_no_ofe.yearly_projections[0]
+        first_ofe = result_ofe.yearly_projections[0]
+
+        assert first_no_ofe.contribution_subkonto > first_ofe.contribution_subkonto
+
+
+class TestSensitivity:
+    def test_produces_three_scenarios(self):
+        inputs = _make_inputs()
+        result = calculate_zus_pension(inputs)
+
+        assert len(result.sensitivity) == 3
+
+    def test_scenarios_ordered(self):
+        inputs = _make_inputs()
+        result = calculate_zus_pension(inputs)
+
+        labels = [s.label for s in result.sensitivity]
+        assert labels == ["Pesymistyczny", "Bazowy", "Optymistyczny"]
+
+    def test_optimistic_higher_than_pessimistic(self):
+        inputs = _make_inputs()
+        result = calculate_zus_pension(inputs)
+
+        pessimistic = result.sensitivity[0]
+        optimistic = result.sensitivity[2]
+
+        assert optimistic.monthly_pension_gross > pessimistic.monthly_pension_gross
+
+
+class TestTaxCalculation:
+    def test_low_pension_mostly_health_tax(self):
+        """Pension below 2500/month (30k/year) should only pay health insurance."""
+        net = apply_pension_tax(2000.0)
+        # 2000 * 12 = 24000 < 30000 threshold → no PIT
+        # Health: 24000 * 0.09 = 2160
+        expected = (24000 - 2160) / 12
+        assert abs(net - expected) < 1.0
+
+    def test_higher_pension_pays_pit(self):
+        """Pension above 2500/month should pay PIT on excess."""
+        net = apply_pension_tax(5000.0)
+        # 60000 gross, health: 5400, PIT: (60000-30000)*0.12 = 3600
+        expected = (60000 - 5400 - 3600) / 12
+        assert abs(net - expected) < 1.0
+
+    def test_net_always_positive(self):
+        net = apply_pension_tax(1000.0)
+        assert net > 0
+
+
+class TestSalaryHistory:
+    def test_uses_actual_salary_from_history(self):
+        """Past salary entries should be used instead of projections."""
+        history = [
+            SalaryHistoryEntry(year=2020, annual_gross=120000.0),
+            SalaryHistoryEntry(year=2021, annual_gross=132000.0),
+        ]
+        inputs = _make_inputs(
+            salary_history=history,
+            work_start_year=2020,
+            current_gross_monthly_salary=15000.0,
+        )
+        result = calculate_zus_pension(inputs)
+
+        # First projection year should use history value
+        first = result.yearly_projections[0]
+        assert first.year == 2020
+        assert first.annual_gross_salary == 120000.0
+
+
+class TestLifeExpectancy:
+    def test_known_age(self):
+        assert get_life_expectancy(65) == 220.8
+        assert get_life_expectancy(60) == 266.4
+
+    def test_clamp_below(self):
+        assert get_life_expectancy(50) == 318.0
+
+    def test_clamp_above(self):
+        assert get_life_expectancy(75) == 190.8
+
+
+class TestKapitalPoczatkowy:
+    def test_kapital_poczatkowy_included(self):
+        """Kapitał początkowy should be valorized and added to total."""
+        inputs_no_kp = _make_inputs(kapital_poczatkowy=0.0)
+        inputs_with_kp = _make_inputs(kapital_poczatkowy=100000.0)
+
+        result_no = calculate_zus_pension(inputs_no_kp)
+        result_with = calculate_zus_pension(inputs_with_kp)
+
+        assert result_with.total_capital > result_no.total_capital
+        assert result_with.kapital_poczatkowy_valorized > 100000.0  # Should grow with valorization

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -200,7 +200,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "pyrefly", specifier = "==0.53.0" },
+    { name = "pyrefly", specifier = "==0.55.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.14.13" },
@@ -467,18 +467,18 @@ wheels = [
 
 [[package]]
 name = "pyrefly"
-version = "0.53.0"
+version = "0.55.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/73/262196c4ea5afec6389366a4b3d49f67655c6396efa1a4053cca37be7c8d/pyrefly-0.53.0.tar.gz", hash = "sha256:aef117e8abb9aa4cf17fc64fbf450d825d3c65fc9de3c02ed20129ebdd57aa74", size = 5040338, upload-time = "2026-02-17T21:15:44.877Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/c4/76e0797215e62d007f81f86c9c4fb5d6202685a3f5e70810f3fd94294f92/pyrefly-0.55.0.tar.gz", hash = "sha256:434c3282532dd4525c4840f2040ed0eb79b0ec8224fe18d957956b15471f2441", size = 5135682, upload-time = "2026-03-03T00:46:38.122Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/9b/3af46ac06dcfd7b27f15e991d2d4f0082519e6906b1f304f511e4db3ad5f/pyrefly-0.53.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:79d7fb35dff0988b3943c26f74cc752fad54357a0bc33f7db665f02d1c9a5bcc", size = 12041081, upload-time = "2026-02-17T21:15:24.769Z" },
-    { url = "https://files.pythonhosted.org/packages/79/4f/23422479153f8f88d1699461bf8f22e32320bb0fc1272774ea8a17463302/pyrefly-0.53.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e1d98b1e86f3c38db44860695b7986e731238e1b19c3cad7a3050476a8f6f84d", size = 11604301, upload-time = "2026-02-17T21:15:27.23Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/9a/f4cc6b81a464c31c3112b46abbd44ccd569f01c71a0abf39eeccf6ace914/pyrefly-0.53.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb9f2440f7e0c70aa18400f44aed994c326a1ab00f2b01cf7253a63fc62d7c6b", size = 32674148, upload-time = "2026-02-17T21:15:29.762Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/cc/fa98606a628380b7ae4623dbc30843e8fed6b7a631c89503bdf123e47453/pyrefly-0.53.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e4e826a5ff2aba2c41e02e6094580751c512db7916e60728cd8612dbcf178d7b", size = 35099098, upload-time = "2026-02-17T21:15:32.383Z" },
-    { url = "https://files.pythonhosted.org/packages/71/d2/ab4105ee90495314a8ad6be4d6736c9f20e4b0ceb49cf015ddc84c394c25/pyrefly-0.53.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf4c69410c7a96b417a390a0e3d340f4370fdab02f9d3eaa222c4bd42e3ce24a", size = 37777824, upload-time = "2026-02-17T21:15:35.474Z" },
-    { url = "https://files.pythonhosted.org/packages/38/99/0779b7202d801cdf67f08159cf7dd318d23114661143689a767d9b8a98f1/pyrefly-0.53.0-py3-none-win32.whl", hash = "sha256:00687bb6be6e366b8c0137a89625da40ced3b9212a65e561857ff888fe88e6e8", size = 11111961, upload-time = "2026-02-17T21:15:38.455Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/71/dc7e59f0acb81dcf3f56e7ad30e740a08527403cb1d657caca9d44fef803/pyrefly-0.53.0-py3-none-win_amd64.whl", hash = "sha256:e0512e6f7af44ae01cfddba096ff7740e15cbd1d0497a3d34a7afcb504e2b300", size = 11888648, upload-time = "2026-02-17T21:15:40.471Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/72/2a7c00a439c6593430289a4581426efe0bee73f6e5a443f501969e104300/pyrefly-0.53.0-py3-none-win_arm64.whl", hash = "sha256:5066e2102769683749102421b8b8667cae26abe1827617f04e8df4317e0a94af", size = 11368150, upload-time = "2026-02-17T21:15:42.74Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b0/16e50cf716784513648e23e726a24f71f9544aa4f86103032dcaa5ff71a2/pyrefly-0.55.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:49aafcefe5e2dd4256147db93e5b0ada42bff7d9a60db70e03d1f7055338eec9", size = 12210073, upload-time = "2026-03-03T00:46:15.51Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ad/89500c01bac3083383011600370289fbc67700c5be46e781787392628a3a/pyrefly-0.55.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2827426e6b28397c13badb93c0ede0fb0f48046a7a89e3d774cda04e8e2067cd", size = 11767474, upload-time = "2026-03-03T00:46:18.003Z" },
+    { url = "https://files.pythonhosted.org/packages/78/68/4c66b260f817f304ead11176ff13985625f7c269e653304b4bdb546551af/pyrefly-0.55.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7346b2d64dc575bd61aa3bca854fbf8b5a19a471cbdb45e0ca1e09861b63488c", size = 33260395, upload-time = "2026-03-03T00:46:20.509Z" },
+    { url = "https://files.pythonhosted.org/packages/47/09/10bd48c9f860064f29f412954126a827d60f6451512224912c265e26bbe6/pyrefly-0.55.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:233b861b4cff008b1aff62f4f941577ed752e4d0060834229eb9b6826e6973c9", size = 35848269, upload-time = "2026-03-03T00:46:23.418Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/39/bc65cdd5243eb2dfea25dd1321f9a5a93e8d9c3a308501c4c6c05d011585/pyrefly-0.55.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5aa85657d76da1d25d081a49f0e33c8fc3ec91c1a0f185a8ed393a5a3d9e178", size = 38449820, upload-time = "2026-03-03T00:46:26.309Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/64/58b38963b011af91209e87f868cc85cfc762ec49a4568ce610c45e7a5f40/pyrefly-0.55.0-py3-none-win32.whl", hash = "sha256:23f786a78536a56fed331b245b7d10ec8945bebee7b723491c8d66fdbc155fe6", size = 11259415, upload-time = "2026-03-03T00:46:30.875Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0b/a4aa519ff632a1ea69eec942566951670b870b99b5c08407e1387b85b6a4/pyrefly-0.55.0-py3-none-win_amd64.whl", hash = "sha256:d465b49e999b50eeb069ad23f0f5710651cad2576f9452a82991bef557df91ee", size = 12043581, upload-time = "2026-03-03T00:46:33.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/51/89017636fbe1ffd166ad478990c6052df615b926182fa6d3c0842b407e89/pyrefly-0.55.0-py3-none-win_arm64.whl", hash = "sha256:732ff490e0e863b296e7c0b2471e08f8ba7952f9fa6e9de09d8347fd67dde77f", size = 11548076, upload-time = "2026-03-03T00:46:36.193Z" },
 ]
 
 [[package]]

--- a/src/lib/components/SnapshotForm.svelte
+++ b/src/lib/components/SnapshotForm.svelte
@@ -807,7 +807,7 @@
 
 	.form-input {
 		width: 100%;
-		padding: var(--size-2) var(--size-3);
+		padding: var(--size-3);
 		border: 1px solid var(--color-border);
 		border-radius: var(--radius-2);
 		background: var(--color-bg);
@@ -815,6 +815,7 @@
 		font-size: var(--font-size-2);
 		font-family: inherit;
 		transition: all 0.2s;
+		min-height: var(--tap-target-min);
 	}
 
 	.form-input:focus {
@@ -885,8 +886,8 @@
 
 	.btn-remove {
 		flex-shrink: 0;
-		width: 32px;
-		height: 32px;
+		width: var(--tap-target-min);
+		height: var(--tap-target-min);
 		margin-top: 28px;
 		padding: 0;
 		border: 1px solid var(--color-border);
@@ -897,6 +898,9 @@
 		line-height: 1;
 		cursor: pointer;
 		transition: all 0.2s;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 	}
 
 	.btn-remove:hover {
@@ -1005,8 +1009,8 @@
 	}
 
 	.btn-close {
-		width: 32px;
-		height: 32px;
+		width: var(--tap-target-min);
+		height: var(--tap-target-min);
 		padding: 0;
 		border: none;
 		background: transparent;
@@ -1015,6 +1019,9 @@
 		line-height: 1;
 		cursor: pointer;
 		transition: all 0.2s;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 	}
 
 	.btn-close:hover {
@@ -1034,5 +1041,20 @@
 
 	.modal-footer .btn {
 		flex: 1;
+	}
+
+	@media (max-width: 640px) {
+		.button-group {
+			flex-direction: column-reverse;
+		}
+
+		.button-group .btn {
+			width: 100%;
+			flex: none;
+		}
+
+		.btn-remove {
+			margin-top: 32px;
+		}
 	}
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
 		{ href: '/metryki', label: 'Metryki', icon: '📈' },
 		{ href: '/simulations', label: 'Symulacje', icon: '🔮' },
 		{ href: '/simulations/mortgage', label: 'Hipoteka', icon: '🏦' },
+		{ href: '/simulations/zus', label: 'Emerytura ZUS', icon: '🏛️' },
 		{ href: '/accounts', label: 'Konta', icon: '💰' },
 		{ href: '/transactions', label: 'Transakcje', icon: '💸' },
 		{ href: '/assets', label: 'Majątek', icon: '🏠' },
@@ -56,7 +57,8 @@
 
 	@media (max-width: 767px) {
 		.main {
-			margin-top: 60px;
+			margin-top: var(--size-8);
+			padding-top: var(--size-6);
 		}
 	}
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -41,6 +41,12 @@
 		max-width: 1200px;
 		margin: 0 auto;
 		width: 100%;
+		min-width: 0;
+	}
+
+	:global(html),
+	:global(body) {
+		overflow-x: hidden;
 	}
 
 	@media (min-width: 768px) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -467,6 +467,12 @@
 		height: 300px;
 	}
 
+	@media (max-width: 640px) {
+		.chart-container {
+			height: 260px;
+		}
+	}
+
 	@media (min-width: 768px) {
 		.chart-container {
 			height: 400px;
@@ -486,8 +492,13 @@
 		border: none;
 		font-size: var(--font-size-3);
 		cursor: pointer;
-		padding: var(--size-1);
+		padding: var(--size-2);
 		transition: transform 0.2s;
+		min-width: var(--tap-target-min);
+		min-height: var(--tap-target-min);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 	}
 
 	.settings-btn:hover {
@@ -673,5 +684,37 @@
 
 	.btn-secondary:hover {
 		background: var(--color-accent);
+	}
+
+	@media (max-width: 640px) {
+		.kpi-grid {
+			grid-template-columns: 1fr;
+			gap: var(--size-4);
+		}
+
+		.kpi-value {
+			font-size: var(--font-size-5);
+		}
+
+		.page-header h1 {
+			font-size: var(--font-size-5);
+		}
+
+		.retirement-grid {
+			grid-template-columns: 1fr;
+		}
+
+		.limit-inputs-grid {
+			grid-template-columns: 1fr;
+			gap: var(--size-3);
+		}
+
+		.form-actions {
+			flex-direction: column-reverse;
+		}
+
+		.form-actions .btn {
+			width: 100%;
+		}
 	}
 </style>

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -700,6 +700,11 @@
 		font-size: var(--font-size-3);
 		padding: var(--size-2);
 		transition: transform 0.2s;
+		min-width: var(--tap-target-min);
+		min-height: var(--tap-target-min);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 	}
 
 	.btn-icon:hover {
@@ -913,6 +918,12 @@
 			flex-direction: column;
 			align-items: flex-start;
 			gap: var(--size-2);
+		}
+	}
+
+	@media (max-width: 640px) {
+		.page-header .btn {
+			width: 100%;
 		}
 	}
 </style>

--- a/src/routes/assets/+page.svelte
+++ b/src/routes/assets/+page.svelte
@@ -375,4 +375,18 @@
 			gap: var(--size-4);
 		}
 	}
+
+	@media (max-width: 640px) {
+		.page-header .btn {
+			width: 100%;
+		}
+
+		.form-actions {
+			flex-direction: column-reverse;
+		}
+
+		.form-actions .btn {
+			width: 100%;
+		}
+	}
 </style>

--- a/src/routes/config/+page.svelte
+++ b/src/routes/config/+page.svelte
@@ -354,7 +354,7 @@
 
 	.input {
 		width: 100%;
-		padding: var(--size-2) var(--size-3);
+		padding: var(--size-3);
 		border: 1px solid var(--color-border);
 		border-radius: var(--radius-2);
 		font-size: var(--font-size-2);
@@ -362,6 +362,7 @@
 		color: var(--color-text);
 		font-family: inherit;
 		transition: all 0.2s;
+		min-height: var(--tap-target-min);
 	}
 
 	.input:focus {
@@ -420,6 +421,7 @@
 		font-weight: var(--font-weight-6);
 		cursor: pointer;
 		transition: all 0.2s;
+		min-height: var(--tap-target-min);
 	}
 
 	.save-button:hover:not(:disabled) {
@@ -477,5 +479,21 @@
 		font-weight: var(--font-weight-6);
 		color: var(--color-text);
 		margin-bottom: var(--size-3);
+	}
+
+	@media (max-width: 640px) {
+		.container {
+			padding: var(--size-3);
+		}
+
+		.save-button {
+			width: 100%;
+		}
+
+		.calculated-info {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: var(--size-2);
+		}
 	}
 </style>

--- a/src/routes/debts/+page.svelte
+++ b/src/routes/debts/+page.svelte
@@ -640,6 +640,11 @@
 		font-size: var(--font-size-3);
 		padding: var(--size-2);
 		transition: transform 0.2s;
+		min-width: var(--tap-target-min);
+		min-height: var(--tap-target-min);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 	}
 
 	.btn-icon:hover {
@@ -802,6 +807,12 @@
 		.page-header {
 			flex-direction: column;
 			gap: var(--size-4);
+		}
+	}
+
+	@media (max-width: 640px) {
+		.page-header .btn {
+			width: 100%;
 		}
 	}
 </style>

--- a/src/routes/kalkulator/+page.svelte
+++ b/src/routes/kalkulator/+page.svelte
@@ -686,9 +686,75 @@
 		color: hsl(0 60% 45%);
 	}
 
-	@media (max-width: 1100px) {
+	@media (max-width: 640px) {
+		table {
+			font-size: var(--font-size-0);
+		}
+
+		th,
+		td {
+			padding: var(--size-1);
+			white-space: normal;
+			word-break: break-word;
+		}
+
+		th:first-child,
+		td:first-child {
+			position: sticky;
+			left: 0;
+			background: var(--surface-2);
+			z-index: 1;
+		}
+
+		th:first-child {
+			background: var(--surface-4);
+		}
+	}
+
+	@media (max-width: 1024px) {
 		.content {
 			grid-template-columns: 1fr;
+		}
+	}
+
+	@media (max-width: 640px) {
+		.calculator-page {
+			padding: var(--size-3);
+		}
+
+		.form-section,
+		.results-section {
+			padding: var(--size-4);
+		}
+
+		.chart-container {
+			height: 260px;
+		}
+
+		.winner-banner {
+			flex-direction: column;
+			align-items: flex-start;
+			font-size: var(--font-size-2);
+			gap: var(--size-2);
+		}
+
+		.form-actions {
+			flex-direction: column;
+		}
+
+		.primary-button,
+		.secondary-button {
+			width: 100%;
+			min-height: var(--tap-target-min);
+		}
+
+		.remove-btn {
+			min-width: var(--tap-target-min);
+			min-height: var(--tap-target-min);
+		}
+
+		h1 {
+			font-size: var(--font-size-4);
 		}
 	}
 </style>

--- a/src/routes/kalkulator/+page.svelte
+++ b/src/routes/kalkulator/+page.svelte
@@ -494,6 +494,8 @@
 		color: var(--color-text-3);
 		cursor: pointer;
 		font-size: var(--font-size-1);
+		min-width: var(--tap-target-min);
+		min-height: var(--tap-target-min);
 	}
 
 	.remove-btn:hover {
@@ -523,6 +525,7 @@
 		background: var(--surface-1);
 		color: var(--color-text-1);
 		font-size: var(--font-size-1);
+		min-height: var(--tap-target-min);
 	}
 
 	.checkbox-label {

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -1119,8 +1119,45 @@
 	}
 
 	@media (max-width: 640px) {
+		.container {
+			padding: var(--size-3);
+		}
+
 		.metrics-grid {
 			grid-template-columns: 1fr;
+		}
+
+		.chart {
+			height: 280px;
+		}
+
+		.chart-wide {
+			height: 320px;
+		}
+
+		.chart-container,
+		.chart-container-wide,
+		.rebalancing-container {
+			padding: var(--size-3);
+		}
+
+		h1 {
+			font-size: var(--font-size-5);
+		}
+
+		h2 {
+			font-size: var(--font-size-3);
+			margin-top: var(--size-6);
+		}
+
+		.rebalancing-item {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: var(--size-2);
+		}
+
+		.action-label {
+			min-width: auto;
 		}
 	}
 </style>

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -555,6 +555,11 @@
 		font-size: var(--font-size-3);
 		padding: var(--size-2);
 		transition: transform 0.2s;
+		min-width: var(--tap-target-min);
+		min-height: var(--tap-target-min);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 	}
 
 	.btn-icon:hover {
@@ -637,6 +642,31 @@
 	@media (max-width: 768px) {
 		.filters-row {
 			grid-template-columns: 1fr;
+		}
+	}
+
+	@media (max-width: 640px) {
+		.page-header {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: var(--size-4);
+		}
+
+		.page-header .btn {
+			width: 100%;
+		}
+
+		.filters-actions {
+			flex-direction: column;
+		}
+
+		.filters-actions .btn {
+			width: 100%;
+		}
+
+		.current-salaries {
+			flex-direction: column;
+			gap: var(--size-3);
 		}
 	}
 </style>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -267,6 +267,11 @@
 		font-size: var(--font-size-3);
 		padding: var(--size-2);
 		transition: transform 0.2s;
+		min-width: var(--tap-target-min);
+		min-height: var(--tap-target-min);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 	}
 
 	.btn-icon:hover {
@@ -322,5 +327,23 @@
 	.form-group input:focus {
 		outline: none;
 		border-color: var(--color-primary);
+	}
+
+	@media (max-width: 640px) {
+		.page-header {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: var(--size-4);
+		}
+
+		.card-header-row {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: var(--size-3);
+		}
+
+		.card-header-row .btn {
+			width: 100%;
+		}
 	}
 </style>

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -829,4 +829,47 @@
 			grid-template-columns: 1fr;
 		}
 	}
+
+	@media (max-width: 640px) {
+		.simulations-page {
+			padding: var(--size-3);
+		}
+
+		.form-section,
+		.results-section {
+			padding: var(--size-4);
+		}
+
+		.chart-container {
+			height: 280px;
+		}
+
+		.summary-cards {
+			grid-template-columns: 1fr 1fr;
+			gap: var(--size-2);
+		}
+
+		.card-value {
+			font-size: var(--font-size-2);
+		}
+
+		.primary-button {
+			min-height: var(--tap-target-min);
+		}
+
+		table {
+			font-size: var(--font-size-0);
+		}
+
+		th,
+		td {
+			padding: var(--size-1);
+			white-space: normal;
+			word-break: break-word;
+		}
+
+		h1 {
+			font-size: var(--font-size-4);
+		}
+	}
 </style>

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -697,6 +697,7 @@
 		background: var(--surface-1);
 		color: var(--color-text-1);
 		font-size: var(--font-size-1);
+		min-height: var(--tap-target-min);
 	}
 
 	input[type='checkbox'] {

--- a/src/routes/simulations/mortgage/+page.svelte
+++ b/src/routes/simulations/mortgage/+page.svelte
@@ -446,6 +446,7 @@
 		background: var(--surface-1);
 		color: var(--color-text-1);
 		font-size: var(--font-size-1);
+		min-height: var(--tap-target-min);
 	}
 
 	small {

--- a/src/routes/simulations/mortgage/+page.svelte
+++ b/src/routes/simulations/mortgage/+page.svelte
@@ -634,9 +634,73 @@
 		color: hsl(0 60% 45%);
 	}
 
-	@media (max-width: 1100px) {
+	@media (max-width: 640px) {
+		table {
+			font-size: var(--font-size-0);
+		}
+
+		th,
+		td {
+			padding: var(--size-1);
+			white-space: normal;
+			word-break: break-word;
+		}
+
+		th:first-child,
+		td:first-child {
+			position: sticky;
+			left: 0;
+			background: var(--surface-2);
+			z-index: 1;
+		}
+
+		th:first-child {
+			background: var(--surface-4);
+		}
+	}
+
+	@media (max-width: 1024px) {
 		.content {
 			grid-template-columns: 1fr;
+		}
+	}
+
+	@media (max-width: 640px) {
+		.mortgage-page {
+			padding: var(--size-3);
+		}
+
+		.form-section,
+		.results-section {
+			padding: var(--size-4);
+		}
+
+		.chart-container {
+			height: 280px;
+		}
+
+		.summary-cards {
+			grid-template-columns: 1fr 1fr;
+			gap: var(--size-2);
+		}
+
+		.card-value {
+			font-size: var(--font-size-2);
+		}
+
+		.winner-banner {
+			flex-direction: column;
+			align-items: flex-start;
+			font-size: var(--font-size-2);
+			gap: var(--size-2);
+		}
+
+		.primary-button {
+			min-height: var(--tap-target-min);
+		}
+
+		h1 {
+			font-size: var(--font-size-4);
 		}
 	}
 </style>

--- a/src/routes/simulations/zus/+page.svelte
+++ b/src/routes/simulations/zus/+page.svelte
@@ -1,0 +1,721 @@
+<script lang="ts">
+	import { onMount, tick } from 'svelte';
+	import { browser } from '$app/environment';
+	import { env } from '$env/dynamic/public';
+	import * as echarts from 'echarts';
+	import type { EChartsOption } from 'echarts';
+
+	export let data: {
+		prefill: {
+			birth_date: string | null;
+			retirement_age: number;
+			gender: string;
+			current_gross_monthly_salary: number | null;
+			owner: string | null;
+			salary_history: { year: number; annual_gross: number }[];
+			work_start_year: number | null;
+		};
+		personas: { name: string }[];
+	};
+
+	interface ZusYearlyProjection {
+		year: number;
+		age: number;
+		annual_gross_salary: number;
+		salary_capped: boolean;
+		contribution_konto: number;
+		contribution_subkonto: number;
+		konto_balance: number;
+		subkonto_balance: number;
+		total_balance: number;
+	}
+
+	interface ZusSensitivityScenario {
+		label: string;
+		valorization_konto: number;
+		valorization_subkonto: number;
+		monthly_pension_gross: number;
+		monthly_pension_net: number;
+		replacement_rate: number;
+	}
+
+	interface ZusCalculatorResponse {
+		yearly_projections: ZusYearlyProjection[];
+		life_expectancy_months: number;
+		konto_at_retirement: number;
+		subkonto_at_retirement: number;
+		kapital_poczatkowy_valorized: number;
+		total_capital: number;
+		monthly_pension_gross: number;
+		monthly_pension_net: number;
+		replacement_rate: number;
+		last_gross_salary: number;
+		sensitivity: ZusSensitivityScenario[];
+	}
+
+	// Form state
+	let owner = data.prefill.owner ?? data.personas[0]?.name ?? '';
+	let birthDate = data.prefill.birth_date ?? '';
+	let gender = data.prefill.gender ?? 'M';
+	let retirementAge = data.prefill.retirement_age ?? 65;
+	let currentGrossMonthly = data.prefill.current_gross_monthly_salary ?? 10000;
+	let salaryGrowthRate = 3.0;
+	let inflationRate = 3.0;
+	let valorizationKonto = 5.0;
+	let valorizationSubkonto = 4.0;
+	let hasOfe = false;
+	let kapitalPoczatkowy = 0;
+	let workStartYear = data.prefill.work_start_year ?? 2015;
+
+	// Results
+	let results: ZusCalculatorResponse | null = null;
+	let loading = false;
+	let error = '';
+
+	// Chart
+	let chartContainer: HTMLDivElement;
+	let chart: echarts.ECharts | null = null;
+
+	async function runCalculation() {
+		loading = true;
+		error = '';
+
+		if (chart) {
+			chart.dispose();
+			chart = null;
+		}
+		results = null;
+
+		try {
+			const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+			if (!apiUrl) throw new Error('API URL not configured');
+
+			const response = await fetch(`${apiUrl}/api/zus/calculate`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					owner,
+					birth_date: birthDate,
+					gender,
+					retirement_age: retirementAge,
+					current_gross_monthly_salary: currentGrossMonthly,
+					salary_growth_rate: salaryGrowthRate,
+					inflation_rate: inflationRate,
+					valorization_rate_konto: valorizationKonto,
+					valorization_rate_subkonto: valorizationSubkonto,
+					has_ofe: hasOfe,
+					kapital_poczatkowy: kapitalPoczatkowy,
+					work_start_year: workStartYear,
+					salary_history: data.prefill.salary_history
+				})
+			});
+
+			if (!response.ok) {
+				const detail = await response.json().catch(() => ({ detail: response.statusText }));
+				throw new Error(detail.detail ?? response.statusText);
+			}
+
+			results = await response.json();
+			await tick();
+			renderChart();
+		} catch (err) {
+			console.error('ZUS calculation failed:', err);
+			if (err instanceof Error) {
+				error = err.message;
+			}
+		} finally {
+			loading = false;
+		}
+	}
+
+	function renderChart() {
+		if (!results || !chartContainer) return;
+
+		if (!chart) {
+			chart = echarts.init(chartContainer);
+		}
+
+		const years = results.yearly_projections.map((r) => r.year.toString());
+		const kontoData = results.yearly_projections.map((r) => r.konto_balance);
+		const subkontoData = results.yearly_projections.map((r) => r.subkonto_balance);
+
+		const option: EChartsOption = {
+			title: { text: 'Wzrost kapitału ZUS' },
+			tooltip: {
+				trigger: 'axis',
+				formatter: (params: any) => {
+					let result = `<strong>Rok ${params[0].name}</strong><br/>`;
+					params.forEach((p: any) => {
+						result += `${p.seriesName}: ${formatCurrency(p.value)} PLN<br/>`;
+					});
+					return result;
+				}
+			},
+			legend: { data: ['Konto', 'Subkonto'], bottom: 0 },
+			grid: { left: '3%', right: '4%', bottom: '15%', containLabel: true },
+			xAxis: {
+				type: 'category',
+				data: years,
+				axisLabel: {
+					interval: Math.max(0, Math.floor(years.length / 10) - 1)
+				}
+			},
+			yAxis: {
+				type: 'value',
+				name: 'Wartość (PLN)',
+				axisLabel: { formatter: (v: number) => `${(v / 1000).toFixed(0)}k` }
+			},
+			series: [
+				{
+					name: 'Konto',
+					type: 'bar',
+					stack: 'total',
+					data: kontoData,
+					itemStyle: { color: '#5E81AC' }
+				},
+				{
+					name: 'Subkonto',
+					type: 'bar',
+					stack: 'total',
+					data: subkontoData,
+					itemStyle: { color: '#A3BE8C' }
+				}
+			]
+		};
+
+		chart.setOption(option);
+	}
+
+	onMount(() => {
+		const handleResize = () => chart?.resize();
+		if (browser) window.addEventListener('resize', handleResize);
+		return () => {
+			if (browser) window.removeEventListener('resize', handleResize);
+			chart?.dispose();
+		};
+	});
+
+	function formatCurrency(value: number): string {
+		return value.toLocaleString('pl-PL', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+	}
+</script>
+
+<div class="zus-page">
+	<h1>Kalkulator emerytury ZUS</h1>
+
+	<div class="content">
+		<div class="form-section">
+			<h2>Parametry</h2>
+
+			<div class="form-group">
+				<label>
+					Osoba
+					<select bind:value={owner}>
+						{#each data.personas as persona}
+							<option value={persona.name}>{persona.name}</option>
+						{/each}
+					</select>
+				</label>
+
+				<label>
+					Data urodzenia
+					<input type="date" bind:value={birthDate} />
+				</label>
+
+				<label>
+					Płeć
+					<select bind:value={gender}>
+						<option value="M">Mężczyzna</option>
+						<option value="F">Kobieta</option>
+					</select>
+				</label>
+
+				<label>
+					Wiek emerytalny
+					<input type="number" bind:value={retirementAge} min="55" max="70" step="1" />
+				</label>
+
+				<label>
+					Aktualne wynagrodzenie brutto (PLN/mies.)
+					<input type="number" bind:value={currentGrossMonthly} min="0" step="500" />
+				</label>
+
+				<label>
+					Rok rozpoczęcia pracy
+					<input type="number" bind:value={workStartYear} min="1970" max="2030" step="1" />
+				</label>
+
+				<label>
+					Kapitał początkowy (PLN)
+					<input type="number" bind:value={kapitalPoczatkowy} min="0" step="1000" />
+					<small>Dla pracy przed 1999 r.</small>
+				</label>
+			</div>
+
+			<h3>Założenia</h3>
+			<div class="form-group">
+				<label>
+					Wzrost wynagrodzeń (% rocznie)
+					<input type="number" bind:value={salaryGrowthRate} min="0" max="20" step="0.5" />
+				</label>
+
+				<label>
+					Waloryzacja konto (%)
+					<input type="number" bind:value={valorizationKonto} min="0" max="20" step="0.5" />
+				</label>
+
+				<label>
+					Waloryzacja subkonto (%)
+					<input type="number" bind:value={valorizationSubkonto} min="0" max="20" step="0.5" />
+				</label>
+
+				<label>
+					Inflacja (% rocznie)
+					<input type="number" bind:value={inflationRate} min="0" max="20" step="0.5" />
+				</label>
+
+				<label class="checkbox-label">
+					<input type="checkbox" bind:checked={hasOfe} />
+					Członek OFE
+					<small>Zmniejsza składkę na subkonto (4.38% zamiast 7.30%)</small>
+				</label>
+			</div>
+
+			{#if data.prefill.salary_history.length > 0}
+				<details class="salary-history">
+					<summary>Historia wynagrodzeń ({data.prefill.salary_history.length} lat)</summary>
+					<div class="history-list">
+						{#each data.prefill.salary_history as entry}
+							<div class="history-entry">
+								<span>{entry.year}</span>
+								<span>{formatCurrency(entry.annual_gross)} PLN/rok</span>
+							</div>
+						{/each}
+					</div>
+				</details>
+			{/if}
+
+			<button class="primary-button" on:click={runCalculation} disabled={loading}>
+				{loading ? 'Obliczanie...' : 'Oblicz emeryturę'}
+			</button>
+
+			{#if error}
+				<div class="error-message">{error}</div>
+			{/if}
+		</div>
+
+		{#if results}
+			<div class="results-section">
+				<h2>Wyniki</h2>
+
+				<div class="summary-cards">
+					<div class="summary-card highlight">
+						<div class="card-label">Emerytura brutto</div>
+						<div class="card-value">
+							{formatCurrency(results.monthly_pension_gross)} PLN
+						</div>
+						<div class="card-note">miesięcznie</div>
+					</div>
+					<div class="summary-card highlight">
+						<div class="card-label">Emerytura netto</div>
+						<div class="card-value">
+							{formatCurrency(results.monthly_pension_net)} PLN
+						</div>
+						<div class="card-note">miesięcznie</div>
+					</div>
+					<div class="summary-card">
+						<div class="card-label">Stopa zastąpienia</div>
+						<div class="card-value">{results.replacement_rate.toFixed(1)}%</div>
+						<div class="card-note">
+							emerytura / ostatnia pensja ({formatCurrency(results.last_gross_salary)} PLN)
+						</div>
+					</div>
+					<div class="summary-card">
+						<div class="card-label">Kapitał łączny</div>
+						<div class="card-value">{formatCurrency(results.total_capital)} PLN</div>
+					</div>
+					<div class="summary-card">
+						<div class="card-label">Konto indywidualne</div>
+						<div class="card-value">
+							{formatCurrency(results.konto_at_retirement)} PLN
+						</div>
+					</div>
+					<div class="summary-card">
+						<div class="card-label">Subkonto</div>
+						<div class="card-value">
+							{formatCurrency(results.subkonto_at_retirement)} PLN
+						</div>
+					</div>
+					<div class="summary-card">
+						<div class="card-label">Kapitał początkowy (zwal.)</div>
+						<div class="card-value">
+							{formatCurrency(results.kapital_poczatkowy_valorized)} PLN
+						</div>
+					</div>
+					<div class="summary-card">
+						<div class="card-label">Dalsze trwanie życia</div>
+						<div class="card-value">{results.life_expectancy_months.toFixed(1)} mies.</div>
+						<div class="card-note">
+							{(results.life_expectancy_months / 12).toFixed(1)} lat
+						</div>
+					</div>
+				</div>
+
+				<div class="chart-container" bind:this={chartContainer}></div>
+
+				<h3>Analiza wrażliwości</h3>
+				<div class="sensitivity-table">
+					<table>
+						<thead>
+							<tr>
+								<th>Scenariusz</th>
+								<th>Wal. konto</th>
+								<th>Wal. subkonto</th>
+								<th>Emerytura brutto</th>
+								<th>Emerytura netto</th>
+								<th>Stopa zastąpienia</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each results.sensitivity as scenario}
+								<tr>
+									<td>{scenario.label}</td>
+									<td>{scenario.valorization_konto.toFixed(1)}%</td>
+									<td>{scenario.valorization_subkonto.toFixed(1)}%</td>
+									<td>{formatCurrency(scenario.monthly_pension_gross)} PLN</td>
+									<td>{formatCurrency(scenario.monthly_pension_net)} PLN</td>
+									<td>{scenario.replacement_rate.toFixed(1)}%</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+
+				<details class="projection-details">
+					<summary>Projekcja roczna</summary>
+					<div class="projection-table">
+						<table>
+							<thead>
+								<tr>
+									<th>Rok</th>
+									<th>Wiek</th>
+									<th>Wynagrodzenie</th>
+									<th>Limit</th>
+									<th>Składka konto</th>
+									<th>Składka subkonto</th>
+									<th>Saldo konto</th>
+									<th>Saldo subkonto</th>
+									<th>Razem</th>
+								</tr>
+							</thead>
+							<tbody>
+								{#each results.yearly_projections as row}
+									<tr class:capped={row.salary_capped}>
+										<td>{row.year}</td>
+										<td>{row.age}</td>
+										<td>{formatCurrency(row.annual_gross_salary)}</td>
+										<td>{row.salary_capped ? '30x' : '—'}</td>
+										<td>{formatCurrency(row.contribution_konto)}</td>
+										<td>{formatCurrency(row.contribution_subkonto)}</td>
+										<td>{formatCurrency(row.konto_balance)}</td>
+										<td>{formatCurrency(row.subkonto_balance)}</td>
+										<td>{formatCurrency(row.total_balance)}</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				</details>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.zus-page {
+		padding: var(--size-4);
+		max-width: 1400px;
+		margin: 0 auto;
+	}
+
+	h1 {
+		margin-bottom: var(--size-6);
+		color: var(--color-text-1);
+	}
+
+	.content {
+		display: grid;
+		grid-template-columns: 400px 1fr;
+		gap: var(--size-6);
+		align-items: start;
+	}
+
+	.form-section,
+	.results-section {
+		background: var(--surface-2);
+		padding: var(--size-5);
+		border-radius: var(--radius-2);
+	}
+
+	h2 {
+		margin-top: 0;
+		margin-bottom: var(--size-4);
+		color: var(--color-text-2);
+	}
+
+	h3 {
+		margin-top: var(--size-4);
+		margin-bottom: var(--size-3);
+		color: var(--color-text-2);
+	}
+
+	.form-group {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-3);
+		margin-bottom: var(--size-4);
+	}
+
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-1);
+		font-size: var(--font-size-1);
+		color: var(--color-text-2);
+	}
+
+	input[type='number'],
+	input[type='date'],
+	select {
+		padding: var(--size-2);
+		border: 1px solid var(--surface-4);
+		border-radius: var(--radius-2);
+		background: var(--surface-1);
+		color: var(--color-text-1);
+		font-size: var(--font-size-1);
+	}
+
+	small {
+		font-size: var(--font-size-0);
+		color: var(--color-text-3);
+	}
+
+	.checkbox-label {
+		flex-direction: row;
+		align-items: center;
+		gap: var(--size-2);
+		font-weight: 600;
+	}
+
+	.checkbox-label input[type='checkbox'] {
+		width: 1rem;
+		height: 1rem;
+		cursor: pointer;
+	}
+
+	.salary-history {
+		margin-bottom: var(--size-4);
+		background: var(--surface-3);
+		padding: var(--size-3);
+		border-radius: var(--radius-2);
+	}
+
+	.salary-history summary {
+		cursor: pointer;
+		font-size: var(--font-size-1);
+		font-weight: 600;
+	}
+
+	.history-list {
+		margin-top: var(--size-2);
+	}
+
+	.history-entry {
+		display: flex;
+		justify-content: space-between;
+		padding: var(--size-1) 0;
+		font-size: var(--font-size-0);
+		border-bottom: 1px solid var(--surface-4);
+	}
+
+	.primary-button {
+		width: 100%;
+		padding: var(--size-3);
+		background: var(--color-primary);
+		color: white;
+		border: none;
+		border-radius: var(--radius-2);
+		font-size: var(--font-size-2);
+		font-weight: 600;
+		cursor: pointer;
+	}
+
+	.primary-button:hover:not(:disabled) {
+		background: var(--color-primary-hover);
+	}
+
+	.primary-button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.error-message {
+		margin-top: var(--size-3);
+		padding: var(--size-3);
+		background: var(--color-error-bg);
+		color: var(--color-error);
+		border-radius: var(--radius-2);
+	}
+
+	.summary-cards {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+		gap: var(--size-3);
+		margin-bottom: var(--size-5);
+	}
+
+	.summary-card {
+		background: var(--surface-3);
+		padding: var(--size-4);
+		border-radius: var(--radius-2);
+	}
+
+	.summary-card.highlight {
+		border-left: 3px solid hsl(140 60% 45%);
+	}
+
+	.card-label {
+		font-size: var(--font-size-0);
+		color: var(--color-text-3);
+		margin-bottom: var(--size-2);
+	}
+
+	.card-value {
+		font-size: var(--font-size-3);
+		font-weight: 700;
+		color: var(--color-text-1);
+	}
+
+	.card-note {
+		font-size: var(--font-size-0);
+		color: var(--color-text-3);
+		margin-top: var(--size-1);
+	}
+
+	.chart-container {
+		width: 100%;
+		height: 380px;
+		margin-bottom: var(--size-5);
+	}
+
+	.sensitivity-table,
+	.projection-table {
+		overflow-x: auto;
+		margin-bottom: var(--size-4);
+	}
+
+	.projection-details {
+		background: var(--surface-3);
+		padding: var(--size-3);
+		border-radius: var(--radius-2);
+	}
+
+	.projection-details summary {
+		cursor: pointer;
+		padding: var(--size-2);
+		font-size: var(--font-size-2);
+		font-weight: 600;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: var(--font-size-0);
+	}
+
+	th,
+	td {
+		padding: var(--size-2);
+		text-align: right;
+		border-bottom: 1px solid var(--surface-4);
+		white-space: nowrap;
+	}
+
+	th {
+		background: var(--surface-4);
+		font-weight: 600;
+		color: var(--color-text-2);
+	}
+
+	th:first-child,
+	td:first-child {
+		text-align: left;
+	}
+
+	tr.capped {
+		background: hsl(40 80% 95%);
+	}
+
+	@media (max-width: 640px) {
+		table {
+			font-size: var(--font-size-0);
+		}
+
+		th,
+		td {
+			padding: var(--size-1);
+			white-space: normal;
+			word-break: break-word;
+		}
+
+		th:first-child,
+		td:first-child {
+			position: sticky;
+			left: 0;
+			background: var(--surface-2);
+			z-index: 1;
+		}
+
+		th:first-child {
+			background: var(--surface-4);
+		}
+	}
+
+	@media (max-width: 1024px) {
+		.content {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	@media (max-width: 640px) {
+		.zus-page {
+			padding: var(--size-3);
+		}
+
+		.form-section,
+		.results-section {
+			padding: var(--size-4);
+		}
+
+		.chart-container {
+			height: 280px;
+		}
+
+		.summary-cards {
+			grid-template-columns: 1fr 1fr;
+			gap: var(--size-2);
+		}
+
+		.card-value {
+			font-size: var(--font-size-2);
+		}
+
+		.primary-button {
+			min-height: var(--tap-target-min);
+		}
+
+		h1 {
+			font-size: var(--font-size-4);
+		}
+	}
+</style>

--- a/src/routes/simulations/zus/+page.svelte
+++ b/src/routes/simulations/zus/+page.svelte
@@ -493,6 +493,7 @@
 		background: var(--surface-1);
 		color: var(--color-text-1);
 		font-size: var(--font-size-1);
+		min-height: var(--tap-target-min);
 	}
 
 	small {

--- a/src/routes/simulations/zus/+page.ts
+++ b/src/routes/simulations/zus/+page.ts
@@ -1,0 +1,24 @@
+import { error } from '@sveltejs/kit';
+import { browser } from '$app/environment';
+import { env } from '$env/dynamic/public';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ fetch }) => {
+	try {
+		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+		if (!apiUrl) throw error(500, 'API URL not configured');
+
+		const [prefillRes, personasRes] = await Promise.all([
+			fetch(`${apiUrl}/api/zus/prefill`),
+			fetch(`${apiUrl}/api/personas`)
+		]);
+		if (!prefillRes.ok) throw error(prefillRes.status, 'Failed to load ZUS prefill data');
+
+		const prefill = await prefillRes.json();
+		const personas = personasRes.ok ? await personasRes.json() : [];
+		return { prefill, personas };
+	} catch (err) {
+		if (err instanceof Error && 'status' in err) throw err;
+		throw error(500, 'Failed to load ZUS calculator data');
+	}
+};

--- a/src/routes/snapshots/+page.svelte
+++ b/src/routes/snapshots/+page.svelte
@@ -188,6 +188,10 @@
 		font-size: var(--font-size-1);
 		cursor: pointer;
 		transition: all 0.2s;
+		min-height: var(--tap-target-min);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 	}
 
 	.btn-edit:hover {
@@ -204,6 +208,12 @@
 
 		.actions-cell {
 			text-align: left;
+		}
+	}
+
+	@media (max-width: 640px) {
+		.page-header .btn {
+			width: 100%;
 		}
 	}
 </style>

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -523,6 +523,11 @@
 		font-size: var(--font-size-3);
 		padding: var(--size-2);
 		transition: transform 0.2s;
+		min-width: var(--tap-target-min);
+		min-height: var(--tap-target-min);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 	}
 
 	.btn-icon:hover {
@@ -618,6 +623,31 @@
 			flex-direction: column;
 			align-items: flex-start;
 			gap: var(--size-2);
+		}
+	}
+
+	@media (max-width: 640px) {
+		.page-header {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: var(--size-4);
+		}
+
+		.header-buttons {
+			flex-direction: column;
+			width: 100%;
+		}
+
+		.header-buttons .btn {
+			width: 100%;
+		}
+
+		.filters-actions {
+			flex-direction: column;
+		}
+
+		.filters-actions .btn {
+			width: 100%;
 		}
 	}
 </style>

--- a/uv.lock
+++ b/uv.lock
@@ -211,7 +211,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "pyrefly", specifier = "==0.53.0" },
+    { name = "pyrefly", specifier = "==0.55.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.14.13" },
@@ -478,18 +478,18 @@ wheels = [
 
 [[package]]
 name = "pyrefly"
-version = "0.53.0"
+version = "0.55.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/73/262196c4ea5afec6389366a4b3d49f67655c6396efa1a4053cca37be7c8d/pyrefly-0.53.0.tar.gz", hash = "sha256:aef117e8abb9aa4cf17fc64fbf450d825d3c65fc9de3c02ed20129ebdd57aa74", size = 5040338, upload-time = "2026-02-17T21:15:44.877Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/c4/76e0797215e62d007f81f86c9c4fb5d6202685a3f5e70810f3fd94294f92/pyrefly-0.55.0.tar.gz", hash = "sha256:434c3282532dd4525c4840f2040ed0eb79b0ec8224fe18d957956b15471f2441", size = 5135682, upload-time = "2026-03-03T00:46:38.122Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/9b/3af46ac06dcfd7b27f15e991d2d4f0082519e6906b1f304f511e4db3ad5f/pyrefly-0.53.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:79d7fb35dff0988b3943c26f74cc752fad54357a0bc33f7db665f02d1c9a5bcc", size = 12041081, upload-time = "2026-02-17T21:15:24.769Z" },
-    { url = "https://files.pythonhosted.org/packages/79/4f/23422479153f8f88d1699461bf8f22e32320bb0fc1272774ea8a17463302/pyrefly-0.53.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e1d98b1e86f3c38db44860695b7986e731238e1b19c3cad7a3050476a8f6f84d", size = 11604301, upload-time = "2026-02-17T21:15:27.23Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/9a/f4cc6b81a464c31c3112b46abbd44ccd569f01c71a0abf39eeccf6ace914/pyrefly-0.53.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb9f2440f7e0c70aa18400f44aed994c326a1ab00f2b01cf7253a63fc62d7c6b", size = 32674148, upload-time = "2026-02-17T21:15:29.762Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/cc/fa98606a628380b7ae4623dbc30843e8fed6b7a631c89503bdf123e47453/pyrefly-0.53.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e4e826a5ff2aba2c41e02e6094580751c512db7916e60728cd8612dbcf178d7b", size = 35099098, upload-time = "2026-02-17T21:15:32.383Z" },
-    { url = "https://files.pythonhosted.org/packages/71/d2/ab4105ee90495314a8ad6be4d6736c9f20e4b0ceb49cf015ddc84c394c25/pyrefly-0.53.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf4c69410c7a96b417a390a0e3d340f4370fdab02f9d3eaa222c4bd42e3ce24a", size = 37777824, upload-time = "2026-02-17T21:15:35.474Z" },
-    { url = "https://files.pythonhosted.org/packages/38/99/0779b7202d801cdf67f08159cf7dd318d23114661143689a767d9b8a98f1/pyrefly-0.53.0-py3-none-win32.whl", hash = "sha256:00687bb6be6e366b8c0137a89625da40ced3b9212a65e561857ff888fe88e6e8", size = 11111961, upload-time = "2026-02-17T21:15:38.455Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/71/dc7e59f0acb81dcf3f56e7ad30e740a08527403cb1d657caca9d44fef803/pyrefly-0.53.0-py3-none-win_amd64.whl", hash = "sha256:e0512e6f7af44ae01cfddba096ff7740e15cbd1d0497a3d34a7afcb504e2b300", size = 11888648, upload-time = "2026-02-17T21:15:40.471Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/72/2a7c00a439c6593430289a4581426efe0bee73f6e5a443f501969e104300/pyrefly-0.53.0-py3-none-win_arm64.whl", hash = "sha256:5066e2102769683749102421b8b8667cae26abe1827617f04e8df4317e0a94af", size = 11368150, upload-time = "2026-02-17T21:15:42.74Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b0/16e50cf716784513648e23e726a24f71f9544aa4f86103032dcaa5ff71a2/pyrefly-0.55.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:49aafcefe5e2dd4256147db93e5b0ada42bff7d9a60db70e03d1f7055338eec9", size = 12210073, upload-time = "2026-03-03T00:46:15.51Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ad/89500c01bac3083383011600370289fbc67700c5be46e781787392628a3a/pyrefly-0.55.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2827426e6b28397c13badb93c0ede0fb0f48046a7a89e3d774cda04e8e2067cd", size = 11767474, upload-time = "2026-03-03T00:46:18.003Z" },
+    { url = "https://files.pythonhosted.org/packages/78/68/4c66b260f817f304ead11176ff13985625f7c269e653304b4bdb546551af/pyrefly-0.55.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7346b2d64dc575bd61aa3bca854fbf8b5a19a471cbdb45e0ca1e09861b63488c", size = 33260395, upload-time = "2026-03-03T00:46:20.509Z" },
+    { url = "https://files.pythonhosted.org/packages/47/09/10bd48c9f860064f29f412954126a827d60f6451512224912c265e26bbe6/pyrefly-0.55.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:233b861b4cff008b1aff62f4f941577ed752e4d0060834229eb9b6826e6973c9", size = 35848269, upload-time = "2026-03-03T00:46:23.418Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/39/bc65cdd5243eb2dfea25dd1321f9a5a93e8d9c3a308501c4c6c05d011585/pyrefly-0.55.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5aa85657d76da1d25d081a49f0e33c8fc3ec91c1a0f185a8ed393a5a3d9e178", size = 38449820, upload-time = "2026-03-03T00:46:26.309Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/64/58b38963b011af91209e87f868cc85cfc762ec49a4568ce610c45e7a5f40/pyrefly-0.55.0-py3-none-win32.whl", hash = "sha256:23f786a78536a56fed331b245b7d10ec8945bebee7b723491c8d66fdbc155fe6", size = 11259415, upload-time = "2026-03-03T00:46:30.875Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0b/a4aa519ff632a1ea69eec942566951670b870b99b5c08407e1387b85b6a4/pyrefly-0.55.0-py3-none-win_amd64.whl", hash = "sha256:d465b49e999b50eeb069ad23f0f5710651cad2576f9452a82991bef557df91ee", size = 12043581, upload-time = "2026-03-03T00:46:33.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/51/89017636fbe1ffd166ad478990c6052df615b926182fa6d3c0842b407e89/pyrefly-0.55.0-py3-none-win_arm64.whl", hash = "sha256:732ff490e0e863b296e7c0b2471e08f8ba7952f9fa6e9de09d8347fd67dde77f", size = 11548076, upload-time = "2026-03-03T00:46:36.193Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Motivation

Two related changes:

1. **ZUS retirement calculator** — new simulator projecting Polish ZUS retirement benefits (konto + subkonto) with sensitivity analysis and yearly projection breakdown. Backend service + schemas + API router + tests; frontend page under \`/simulations/zus\`.

2. **Mobile optimization** — Finance-Buddy is now used primarily on iPhone 17 (~402px) and iPad (768–1024px). The app was built desktop-first and had several blockers on mobile: simulator sidebars didn't collapse until 1100px, raw tables forced horizontal overflow with \`white-space: nowrap\`, icon buttons were ~32×32 (below 44px iOS tap target), page headers with multiple buttons crowded, and the retirement-limits modal grid was hardcoded two-column.

## Implementation information

**ZUS feature** (commit 1):
- \`backend/app/services/zus_calculator.py\` — konto + subkonto projection, valorization, sensitivity scenarios
- \`backend/app/schemas/zus.py\` + \`backend/app/api/zus.py\` — Pydantic schemas + FastAPI router
- \`backend/tests/test_services_zus_calculator.py\` — unit tests
- \`src/routes/simulations/zus/+page.svelte\` + \`+page.ts\` — form, ECharts visualization, projection + sensitivity tables
- Router wired in \`backend/app/main.py\`; pyrefly bumped 0.53 → 0.55

**Mobile optimization** (commit 2) — CSS-only additive changes across 15 files:
- Simulator layouts (ZUS, mortgage, kalkulator) now collapse at 1024px instead of 1100px, with a 640px pass for tight padding
- Simulator projection tables wrap + gain a sticky first column on phones (so horizontal scroll still shows year/label)
- \`.btn-icon\`, \`.btn-edit\`, \`.btn-remove\`, \`.btn-close\`, \`.settings-btn\` all now meet 44×44 tap target via \`min-width/min-height: var(--tap-target-min)\`
- Page headers on accounts / transactions / debts / assets / salaries / snapshots / settings stack at 640px with full-width buttons
- Dashboard KPI grid, retirement-grid, and retirement-limits-modal grid collapse to one column on phones; chart heights reduced to 260–320px
- SnapshotForm inputs get \`min-height: var(--tap-target-min)\`, button group stacks
- Layout top margin + padding fix so the home-ui hamburger doesn't clip page content

> Changelog: feat(ui): ZUS calculator + mobile optimization

## Supporting documentation

- Plan: \`~/.claude/plans/calm-wobbling-shore.md\` (mobile optimization strategy)
- Validation run locally: \`npm run lint\` ✅, \`npm run check\` ✅ (0 errors, 51 pre-existing unused-CSS warnings), \`npm run test\` ✅ (38/38)

## Test plan

- [ ] \`docker-compose -f docker-compose.dev.yml up --build\` starts cleanly
- [ ] \`/simulations/zus\` renders, form submits, projection table populates, ECharts renders
- [ ] ZUS sensitivity scenarios display
- [ ] Backend tests pass: \`cd backend && uv run pytest tests/test_services_zus_calculator.py\`
- [ ] DevTools iPhone 14 Pro (390×844): every route renders without horizontal scroll
- [ ] DevTools iPad Mini (768×1024): simulators show form above results, no horizontal scroll
- [ ] All icon buttons measure ≥44×44 px in DevTools
- [ ] Hamburger menu opens, navigates, closes on mobile viewport
- [ ] Retirement limits modal on dashboard fits 390px width