### PR TITLE
refactor(db): unify query patterns on select()

### DIFF
--- a/backend/app/api/personas.py
+++ b/backend/app/api/personas.py
@@ -1,6 +1,7 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -18,7 +19,7 @@ router = APIRouter(prefix="/api/personas", tags=["personas"])
 
 @router.get("", response_model=list[PersonaResponse])
 def list_personas(db: Annotated[Session, Depends(get_db)]) -> list[PersonaResponse]:
-    personas = db.query(Persona).order_by(Persona.name).all()
+    personas = db.execute(select(Persona).order_by(Persona.name)).scalars().all()
     return [PersonaResponse.model_validate(p, from_attributes=True) for p in personas]
 
 
@@ -43,7 +44,7 @@ def create_persona(data: PersonaCreate, db: Annotated[Session, Depends(get_db)])
 def update_persona(
     persona_id: int, data: PersonaUpdate, db: Annotated[Session, Depends(get_db)]
 ) -> PersonaResponse:
-    persona = db.query(Persona).filter(Persona.id == persona_id).first()
+    persona = db.execute(select(Persona).where(Persona.id == persona_id)).scalar_one_or_none()
     if not persona:
         raise HTTPException(status_code=404, detail="Persona not found")
 
@@ -58,14 +59,20 @@ def update_persona(
 
     try:
         if data.name is not None and data.name != old_name:
-            db.query(Account).filter(Account.owner == old_name).update({"owner": data.name})
-            db.query(Transaction).filter(Transaction.owner == old_name).update({"owner": data.name})
-            db.query(SalaryRecord).filter(SalaryRecord.owner == old_name).update(
-                {"owner": data.name}
+            db.execute(update(Account).where(Account.owner == old_name).values(owner=data.name))
+            db.execute(
+                update(Transaction).where(Transaction.owner == old_name).values(owner=data.name)
             )
-            db.query(DebtPayment).filter(DebtPayment.owner == old_name).update({"owner": data.name})
-            db.query(RetirementLimit).filter(RetirementLimit.owner == old_name).update(
-                {"owner": data.name}
+            db.execute(
+                update(SalaryRecord).where(SalaryRecord.owner == old_name).values(owner=data.name)
+            )
+            db.execute(
+                update(DebtPayment).where(DebtPayment.owner == old_name).values(owner=data.name)
+            )
+            db.execute(
+                update(RetirementLimit)
+                .where(RetirementLimit.owner == old_name)
+                .values(owner=data.name)
             )
         db.commit()
         db.refresh(persona)
@@ -77,25 +84,37 @@ def update_persona(
 
 @router.delete("/{persona_id}", status_code=204)
 def delete_persona(persona_id: int, db: Annotated[Session, Depends(get_db)]) -> None:
-    persona = db.query(Persona).filter(Persona.id == persona_id).first()
+    persona = db.execute(select(Persona).where(Persona.id == persona_id)).scalar_one_or_none()
     if not persona:
         raise HTTPException(status_code=404, detail="Persona not found")
 
     conflicts: list[str] = []
-    account_count = db.query(Account).filter(Account.owner == persona.name).count()
-    if account_count > 0:
+    account_count = db.scalar(
+        select(func.count()).select_from(Account).where(Account.owner == persona.name)
+    )
+    if account_count:
         conflicts.append(f"{account_count} account(s)")
-    transaction_count = db.query(Transaction).filter(Transaction.owner == persona.name).count()
-    if transaction_count > 0:
+    transaction_count = db.scalar(
+        select(func.count()).select_from(Transaction).where(Transaction.owner == persona.name)
+    )
+    if transaction_count:
         conflicts.append(f"{transaction_count} transaction(s)")
-    salary_count = db.query(SalaryRecord).filter(SalaryRecord.owner == persona.name).count()
-    if salary_count > 0:
+    salary_count = db.scalar(
+        select(func.count()).select_from(SalaryRecord).where(SalaryRecord.owner == persona.name)
+    )
+    if salary_count:
         conflicts.append(f"{salary_count} salary record(s)")
-    payment_count = db.query(DebtPayment).filter(DebtPayment.owner == persona.name).count()
-    if payment_count > 0:
+    payment_count = db.scalar(
+        select(func.count()).select_from(DebtPayment).where(DebtPayment.owner == persona.name)
+    )
+    if payment_count:
         conflicts.append(f"{payment_count} debt payment(s)")
-    limit_count = db.query(RetirementLimit).filter(RetirementLimit.owner == persona.name).count()
-    if limit_count > 0:
+    limit_count = db.scalar(
+        select(func.count())
+        .select_from(RetirementLimit)
+        .where(RetirementLimit.owner == persona.name)
+    )
+    if limit_count:
         conflicts.append(f"{limit_count} retirement limit(s)")
 
     if conflicts:

--- a/backend/app/api/retirement.py
+++ b/backend/app/api/retirement.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
@@ -55,7 +56,7 @@ def get_limits_for_year(
     year: int,
 ) -> list[RetirementLimitResponse]:
     """Get all limits for a specific year"""
-    limits = db.query(RetirementLimit).filter(RetirementLimit.year == year).all()
+    limits = db.execute(select(RetirementLimit).where(RetirementLimit.year == year)).scalars().all()
     return [
         RetirementLimitResponse(
             id=limit.id,

--- a/backend/app/core/init_db.py
+++ b/backend/app/core/init_db.py
@@ -4,6 +4,8 @@ import sys
 from decimal import Decimal
 from pathlib import Path
 
+from sqlalchemy import func, select
+
 from app.core.database import Base, SessionLocal, engine
 from app.core.enums import Wrapper
 
@@ -69,7 +71,7 @@ def init_db() -> None:
     # Seed default personas if none exist
     db = SessionLocal()
     try:
-        if db.query(Persona).count() == 0:
+        if db.scalar(select(func.count()).select_from(Persona)) == 0:
             default_personas = [
                 Persona(
                     name="Marcin",
@@ -86,8 +88,8 @@ def init_db() -> None:
             db.commit()
 
         # Seed default retirement limits if none exist
-        if db.query(RetirementLimit).count() == 0:
-            personas = db.query(Persona).all()
+        if db.scalar(select(func.count()).select_from(RetirementLimit)) == 0:
+            personas = db.execute(select(Persona)).scalars().all()
             defaults = []
             for persona in personas:
                 defaults.append(

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -72,10 +72,13 @@ def _calculate_savings_rate(
 
     # Get last 3 salary records
     salaries = (
-        db.query(SalaryRecord)
-        .filter(SalaryRecord.is_active.is_(True))
-        .order_by(SalaryRecord.date.desc())
-        .limit(3)
+        db.execute(
+            select(SalaryRecord)
+            .where(SalaryRecord.is_active.is_(True))
+            .order_by(SalaryRecord.date.desc())
+            .limit(3)
+        )
+        .scalars()
         .all()
     )
 
@@ -93,9 +96,12 @@ def _calculate_savings_rate(
 def _get_latest_active_salary(db: Session) -> SalaryRecord | None:
     """Get latest active salary record."""
     return (
-        db.query(SalaryRecord)
-        .filter(SalaryRecord.is_active.is_(True))
-        .order_by(SalaryRecord.date.desc())
+        db.execute(
+            select(SalaryRecord)
+            .where(SalaryRecord.is_active.is_(True))
+            .order_by(SalaryRecord.date.desc())
+        )
+        .scalars()
         .first()
     )
 

--- a/backend/app/services/investment.py
+++ b/backend/app/services/investment.py
@@ -1,4 +1,4 @@
-from sqlalchemy import func
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.models import Account, Snapshot, SnapshotValue, Transaction
@@ -9,7 +9,9 @@ def get_category_stats(db: Session, category: str) -> CategoryStatsResponse:
     """Calculate aggregate statistics for a given investment category (stock/bond)"""
     # Get all active accounts for this category
     accounts = (
-        db.query(Account).filter(Account.category == category, Account.is_active.is_(True)).all()
+        db.execute(select(Account).where(Account.category == category, Account.is_active.is_(True)))
+        .scalars()
+        .all()
     )
 
     if not accounts:
@@ -25,37 +27,35 @@ def get_category_stats(db: Session, category: str) -> CategoryStatsResponse:
 
     # Get latest snapshot date (subquery) - needed for both transactions and snapshot value
     max_date_subquery = (
-        db.query(func.max(Snapshot.date))
+        select(func.max(Snapshot.date))
         .join(SnapshotValue, Snapshot.id == SnapshotValue.snapshot_id)
-        .filter(SnapshotValue.account_id.in_(account_ids))
+        .where(SnapshotValue.account_id.in_(account_ids))
         .scalar_subquery()
     )
 
     # Sum active transactions up to latest snapshot date (or all if no snapshots)
-    transaction_query = db.query(func.coalesce(func.sum(Transaction.amount), 0)).filter(
+    transaction_query = select(func.coalesce(func.sum(Transaction.amount), 0)).where(
         Transaction.account_id.in_(account_ids), Transaction.is_active.is_(True)
     )
 
     # Only filter by date if snapshots exist (max_date_subquery returns value, not NULL)
-    has_snapshots = (
-        db.query(Snapshot.id)
+    has_snapshots = db.scalar(
+        select(Snapshot.id)
         .join(SnapshotValue, Snapshot.id == SnapshotValue.snapshot_id)
-        .filter(SnapshotValue.account_id.in_(account_ids))
+        .where(SnapshotValue.account_id.in_(account_ids))
         .limit(1)
-        .scalar()
     )
 
     if has_snapshots:
-        transaction_query = transaction_query.filter(Transaction.date <= max_date_subquery)
+        transaction_query = transaction_query.where(Transaction.date <= max_date_subquery)
 
-    total_contributed = float(transaction_query.scalar() or 0)
+    total_contributed = float(db.scalar(transaction_query) or 0)
 
     # Get sum of values for the latest snapshot
-    latest_snapshot_value = (
-        db.query(func.sum(SnapshotValue.value))
+    latest_snapshot_value = db.scalar(
+        select(func.sum(SnapshotValue.value))
         .join(Snapshot, SnapshotValue.snapshot_id == Snapshot.id)
-        .filter(SnapshotValue.account_id.in_(account_ids), Snapshot.date == max_date_subquery)
-        .scalar()
+        .where(SnapshotValue.account_id.in_(account_ids), Snapshot.date == max_date_subquery)
     )
     total_value = float(latest_snapshot_value if latest_snapshot_value else 0)
 

--- a/backend/app/services/retirement.py
+++ b/backend/app/services/retirement.py
@@ -3,7 +3,7 @@ from datetime import date
 from decimal import Decimal
 
 from fastapi import HTTPException
-from sqlalchemy import case, extract, func, or_
+from sqlalchemy import case, extract, func, or_, select
 from sqlalchemy.orm import Session
 
 from app.models import Account, RetirementLimit, Snapshot, SnapshotValue, Transaction
@@ -21,15 +21,23 @@ def get_yearly_stats(db: Session, year: int, owner: str | None = None) -> list[Y
     """Calculate yearly contribution stats for IKE/IKZE per owner"""
     stats = []
 
-    owners = [owner] if owner else [p.name for p in db.query(Persona).order_by(Persona.name).all()]
+    owners = (
+        [owner]
+        if owner
+        else [p.name for p in db.execute(select(Persona).order_by(Persona.name)).scalars().all()]
+    )
     wrappers = ["IKE", "IKZE"]
 
     for wrapper in wrappers:
         for owner_name in owners:
             # Get all accounts with this wrapper and owner
             accounts = (
-                db.query(Account)
-                .filter(Account.account_wrapper == wrapper, Account.owner == owner_name)
+                db.execute(
+                    select(Account).where(
+                        Account.account_wrapper == wrapper, Account.owner == owner_name
+                    )
+                )
+                .scalars()
                 .all()
             )
             account_ids = [acc.id for acc in accounts]
@@ -38,8 +46,8 @@ def get_yearly_stats(db: Session, year: int, owner: str | None = None) -> list[Y
                 continue
 
             # Aggregate transactions for this year
-            contributions = (
-                db.query(
+            contributions = db.execute(
+                select(
                     func.coalesce(func.sum(Transaction.amount), 0).label("total"),
                     func.coalesce(
                         func.sum(
@@ -59,14 +67,12 @@ def get_yearly_stats(db: Session, year: int, owner: str | None = None) -> list[Y
                         ),
                         0,
                     ).label("employer"),
-                )
-                .filter(
+                ).where(
                     Transaction.account_id.in_(account_ids),
                     extract("year", Transaction.date) == year,
                     Transaction.is_active.is_(True),
                 )
-                .first()
-            )
+            ).first()
 
             total = float(contributions.total if contributions else 0)
             employee = float(contributions.employee if contributions else 0)
@@ -80,12 +86,14 @@ def get_yearly_stats(db: Session, year: int, owner: str | None = None) -> list[Y
 
             # Get limit for this wrapper and owner
             limit = (
-                db.query(RetirementLimit)
-                .filter(
-                    RetirementLimit.year == year,
-                    RetirementLimit.account_wrapper == wrapper,
-                    RetirementLimit.owner == owner_name,
+                db.execute(
+                    select(RetirementLimit).where(
+                        RetirementLimit.year == year,
+                        RetirementLimit.account_wrapper == wrapper,
+                        RetirementLimit.owner == owner_name,
+                    )
                 )
+                .scalars()
                 .first()
             )
 
@@ -118,12 +126,14 @@ def get_or_create_limit(
 ) -> RetirementLimit:
     """Get existing limit or create new one"""
     limit = (
-        db.query(RetirementLimit)
-        .filter(
-            RetirementLimit.year == year,
-            RetirementLimit.account_wrapper == wrapper,
-            RetirementLimit.owner == owner,
+        db.execute(
+            select(RetirementLimit).where(
+                RetirementLimit.year == year,
+                RetirementLimit.account_wrapper == wrapper,
+                RetirementLimit.owner == owner,
+            )
         )
+        .scalars()
         .first()
     )
 
@@ -148,12 +158,14 @@ def update_limit(
 ) -> RetirementLimit:
     """Update existing limit"""
     limit = (
-        db.query(RetirementLimit)
-        .filter(
-            RetirementLimit.year == year,
-            RetirementLimit.account_wrapper == wrapper,
-            RetirementLimit.owner == owner,
+        db.execute(
+            select(RetirementLimit).where(
+                RetirementLimit.year == year,
+                RetirementLimit.account_wrapper == wrapper,
+                RetirementLimit.owner == owner,
+            )
         )
+        .scalars()
         .first()
     )
 
@@ -171,13 +183,19 @@ def update_limit(
 def get_ppk_stats(db: Session, owner: str | None = None) -> list[PPKStatsResponse]:
     """Calculate PPK contribution breakdown and returns per owner"""
     stats = []
-    owners = [owner] if owner else [p.name for p in db.query(Persona).order_by(Persona.name).all()]
+    owners = (
+        [owner]
+        if owner
+        else [p.name for p in db.execute(select(Persona).order_by(Persona.name)).scalars().all()]
+    )
 
     for owner_name in owners:
         # Get all PPK accounts for this owner
         accounts = (
-            db.query(Account)
-            .filter(Account.account_wrapper == "PPK", Account.owner == owner_name)
+            db.execute(
+                select(Account).where(Account.account_wrapper == "PPK", Account.owner == owner_name)
+            )
+            .scalars()
             .all()
         )
 
@@ -187,8 +205,8 @@ def get_ppk_stats(db: Session, owner: str | None = None) -> list[PPKStatsRespons
         account_ids = [acc.id for acc in accounts]
 
         # Aggregate all-time contributions by type
-        contributions = (
-            db.query(
+        contributions = db.execute(
+            select(
                 func.coalesce(
                     func.sum(
                         case(
@@ -233,10 +251,8 @@ def get_ppk_stats(db: Session, owner: str | None = None) -> list[PPKStatsRespons
                     ),
                     0,
                 ).label("government"),
-            )
-            .filter(Transaction.account_id.in_(account_ids), Transaction.is_active.is_(True))
-            .first()
-        )
+            ).where(Transaction.account_id.in_(account_ids), Transaction.is_active.is_(True))
+        ).first()
 
         employee_contrib = float(contributions.employee if contributions else 0)
         employer_contrib = float(contributions.employer if contributions else 0)
@@ -251,18 +267,17 @@ def get_ppk_stats(db: Session, owner: str | None = None) -> list[PPKStatsRespons
 
         # Get latest snapshot date first (subquery for performance)
         max_date_subquery = (
-            db.query(func.max(Snapshot.date))
+            select(func.max(Snapshot.date))
             .join(SnapshotValue, Snapshot.id == SnapshotValue.snapshot_id)
-            .filter(SnapshotValue.account_id.in_(account_ids))
+            .where(SnapshotValue.account_id.in_(account_ids))
             .scalar_subquery()
         )
 
         # Get sum of values for the latest snapshot
-        latest_snapshot_value = (
-            db.query(func.sum(SnapshotValue.value))
+        latest_snapshot_value = db.scalar(
+            select(func.sum(SnapshotValue.value))
             .join(Snapshot, SnapshotValue.snapshot_id == Snapshot.id)
-            .filter(SnapshotValue.account_id.in_(account_ids), Snapshot.date == max_date_subquery)
-            .scalar()
+            .where(SnapshotValue.account_id.in_(account_ids), Snapshot.date == max_date_subquery)
         )
 
         total_value = float(latest_snapshot_value if latest_snapshot_value else 0)
@@ -302,7 +317,7 @@ def generate_ppk_contributions(
         )
 
     # Get PPK rates from Persona table
-    persona = db.query(Persona).filter(Persona.name == data.owner).first()
+    persona = db.execute(select(Persona).where(Persona.name == data.owner)).scalar_one_or_none()
     if not persona:
         raise HTTPException(status_code=404, detail=f"Persona '{data.owner}' not found")
 
@@ -315,13 +330,15 @@ def generate_ppk_contributions(
 
     # Get active PPK account for this owner (receives contributions)
     ppk_account = (
-        db.query(Account)
-        .filter(
-            Account.account_wrapper == "PPK",
-            Account.owner == data.owner,
-            Account.is_active.is_(True),
-            Account.receives_contributions.is_(True),
+        db.execute(
+            select(Account).where(
+                Account.account_wrapper == "PPK",
+                Account.owner == data.owner,
+                Account.is_active.is_(True),
+                Account.receives_contributions.is_(True),
+            )
         )
+        .scalars()
         .first()
     )
 
@@ -335,18 +352,18 @@ def generate_ppk_contributions(
     # Check if contributions already exist for this month
     # DB unique constraint provides ultimate safeguard against race conditions
     last_day = date(data.year, data.month, calendar.monthrange(data.year, data.month)[1])
-    existing_count = (
-        db.query(Transaction)
-        .filter(
+    existing_count = db.scalar(
+        select(func.count())
+        .select_from(Transaction)
+        .where(
             Transaction.account_id == ppk_account.id,
             Transaction.date == last_day,
             Transaction.transaction_type.in_(["employee", "employer"]),
             Transaction.is_active.is_(True),
         )
-        .count()
     )
 
-    if existing_count > 0:
+    if existing_count and existing_count > 0:
         raise HTTPException(
             status_code=409,
             detail=f"Contributions already exist for {data.month}/{data.year}",


### PR DESCRIPTION
## Motivation

38 legacy `.query()` calls coexisted with modern `select()` statements across `backend/app/api/*` and `backend/app/services/*`. SQLAlchemy 2.0 deprecates the `.query()` API; mixed patterns raise cognitive load and block a future async DB migration.

## Implementation information

Converted all remaining `.query()` usage to `select()`:

- ORM fetches → `db.execute(select(...)).scalars().all()/.first()`, single-row PK lookups → `.scalar_one_or_none()`
- Aggregate rows → `db.execute(select(...)).first()`
- Scalar aggregates / subqueries → `db.scalar(...)` / `select(...).scalar_subquery()`
- `.count()` → `db.scalar(select(func.count()).select_from(Model).where(...))`
- Bulk `.update()` → `db.execute(update(Model).where(...).values(...))`
- `.filter()` → `.where()` to match the existing `select()` style

Files: `core/init_db.py`, `api/personas.py`, `api/retirement.py`, `services/investment.py`, `services/retirement.py`, `services/dashboard.py`.

No `.query()` calls remain. ruff, pyrefly clean; 510 tests pass.

## Supporting documentation

Closes #316