### PR TITLE
test(components): cover largest components

### DIFF
--- a/src/lib/components/SnapshotForm.test.ts
+++ b/src/lib/components/SnapshotForm.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import SnapshotForm from './SnapshotForm.svelte';
+import type { Account, Asset, SnapshotResponse } from '$lib/types';
+
+vi.mock('$env/dynamic/public', () => ({
+	env: {
+		PUBLIC_API_URL_BROWSER: 'http://localhost:8000',
+		PUBLIC_API_URL: 'http://localhost:8000'
+	}
+}));
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn()
+}));
+
+function makeAccount(overrides: Partial<Account>): Account {
+	return {
+		id: 1,
+		name: 'Account',
+		type: 'asset',
+		category: 'bank',
+		owner: 'Marcin',
+		currency: 'PLN',
+		account_wrapper: null,
+		purpose: 'general',
+		square_meters: null,
+		is_active: true,
+		receives_contributions: false,
+		created_at: '2024-01-01',
+		current_value: 0,
+		...overrides
+	};
+}
+
+function makeAsset(overrides: Partial<Asset>): Asset {
+	return {
+		id: 1,
+		name: 'Asset',
+		is_active: true,
+		created_at: '2024-01-01',
+		current_value: 0,
+		...overrides
+	};
+}
+
+describe('SnapshotForm', () => {
+	const bankAccount = makeAccount({
+		id: 1,
+		name: 'Konto Główne',
+		category: 'bank',
+		current_value: 5000
+	});
+	const mortgage = makeAccount({
+		id: 2,
+		name: 'Kredyt Hipoteczny',
+		type: 'liability',
+		category: 'mortgage',
+		current_value: 200000
+	});
+
+	it('renders the date snapshot section with date and notes inputs', () => {
+		render(SnapshotForm, {
+			props: { assets: [], liabilities: [], physicalAssets: [] }
+		});
+		expect(screen.getByRole('heading', { name: 'Data Snapshot' })).toBeTruthy();
+		expect(screen.getByLabelText('Data')).toBeTruthy();
+		expect(screen.getByLabelText('Notatki (opcjonalne)')).toBeTruthy();
+	});
+
+	it('renders the financial accounts section', () => {
+		render(SnapshotForm, {
+			props: { assets: [bankAccount], liabilities: [], physicalAssets: [] }
+		});
+		expect(screen.getByRole('heading', { name: /Konta finansowe/ })).toBeTruthy();
+	});
+
+	it('shows an input for a financial account with positive value in create mode', () => {
+		render(SnapshotForm, {
+			props: { assets: [bankAccount], liabilities: [], physicalAssets: [] }
+		});
+		expect(screen.getByLabelText(/Konto Główne/)).toBeTruthy();
+	});
+
+	it('renders the liabilities section when liabilities are provided', () => {
+		render(SnapshotForm, {
+			props: { assets: [bankAccount], liabilities: [mortgage], physicalAssets: [] }
+		});
+		expect(screen.getByRole('heading', { name: /Zobowiązania/ })).toBeTruthy();
+		expect(screen.getByLabelText(/Kredyt Hipoteczny/)).toBeTruthy();
+	});
+
+	it('renders the submit button', () => {
+		render(SnapshotForm, {
+			props: { assets: [], liabilities: [], physicalAssets: [] }
+		});
+		expect(screen.getByRole('button', { name: /Zapisz Snapshot/ })).toBeTruthy();
+	});
+
+	it('populates date and notes from editingSnapshot', () => {
+		const editingSnapshot: SnapshotResponse = {
+			id: 7,
+			date: '2024-03-31',
+			notes: 'Marcowy snapshot',
+			values: []
+		};
+		render(SnapshotForm, {
+			props: { editingSnapshot, assets: [], liabilities: [], physicalAssets: [] }
+		});
+		expect((screen.getByLabelText('Data') as HTMLInputElement).value).toBe('2024-03-31');
+		expect((screen.getByLabelText('Notatki (opcjonalne)') as HTMLInputElement).value).toBe(
+			'Marcowy snapshot'
+		);
+	});
+
+	it('removes a financial account field when its remove button is clicked', async () => {
+		render(SnapshotForm, {
+			props: { assets: [bankAccount], liabilities: [], physicalAssets: [] }
+		});
+		expect(screen.getByLabelText(/Konto Główne/)).toBeTruthy();
+
+		await fireEvent.click(screen.getByTitle('Usuń pole'));
+
+		expect(screen.queryByLabelText(/Konto Główne/)).toBeNull();
+	});
+});

--- a/src/routes/metryki/page.test.ts
+++ b/src/routes/metryki/page.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, beforeAll, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Page from './+page.svelte';
+
+beforeAll(() => {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn()
+		}))
+	});
+});
+
+vi.mock('$env/dynamic/public', () => ({
+	env: {
+		PUBLIC_API_URL_BROWSER: 'http://localhost:8000',
+		PUBLIC_API_URL: 'http://localhost:8000'
+	}
+}));
+
+vi.mock('$app/environment', () => ({ browser: false }));
+
+vi.mock('echarts', () => ({
+	init: vi.fn(() => ({ setOption: vi.fn(), resize: vi.fn(), dispose: vi.fn() }))
+}));
+
+const metricCards = {
+	property_sqm: 0,
+	emergency_fund_months: 6,
+	retirement_income_monthly: 0,
+	mortgage_remaining: 0,
+	mortgage_months_left: 0,
+	mortgage_years_left: 0,
+	retirement_total: 0,
+	investment_contributions: 0,
+	investment_returns: 0,
+	savings_rate: null,
+	debt_to_income_ratio: null,
+	hour_of_work_cost: null,
+	hour_of_life_cost: null
+};
+
+const mockData = {
+	metricCards,
+	allocationAnalysis: {
+		by_category: [],
+		by_wrapper: [],
+		rebalancing: [],
+		total_investment_value: 0
+	},
+	investmentTimeSeries: [],
+	wrapperTimeSeries: { ike: [], ikze: [], ppk: [] },
+	categoryTimeSeries: { stock: [], bond: [] },
+	ppkStats: [],
+	stockStats: null,
+	bondStats: null
+};
+
+describe('Metryki Page', () => {
+	it('renders the main heading', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.getByRole('heading', { name: 'Metryki', level: 1 })).toBeTruthy();
+	});
+
+	it('renders the financial overview section', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.getByRole('heading', { name: 'Przegląd finansowy' })).toBeTruthy();
+	});
+
+	it('renders the investing guidance section', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.getByRole('heading', { name: 'Jak inwestować nowe pieniądze' })).toBeTruthy();
+	});
+
+	it('renders the emergency fund metric card with its formatted value', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.getByText('Ile miesięcy bez pracy')).toBeTruthy();
+		expect(screen.getByText('6,00')).toBeTruthy();
+	});
+});

--- a/src/routes/simulations/page.test.ts
+++ b/src/routes/simulations/page.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, beforeAll, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Page from './+page.svelte';
+
+beforeAll(() => {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn()
+		}))
+	});
+});
+
+vi.mock('$env/dynamic/public', () => ({
+	env: {
+		PUBLIC_API_URL_BROWSER: 'http://localhost:8000',
+		PUBLIC_API_URL: 'http://localhost:8000'
+	}
+}));
+
+vi.mock('$app/environment', () => ({ browser: false }));
+
+vi.mock('echarts', () => ({
+	init: vi.fn(() => ({ setOption: vi.fn(), resize: vi.fn(), dispose: vi.fn() }))
+}));
+
+const mockData = {
+	current_age: 35,
+	retirement_age: 65,
+	personas: [{ name: 'Marcin' }, { name: 'Ewa' }],
+	balances: {},
+	ppk_balances: {},
+	monthly_salaries: {},
+	ppk_rates: {}
+};
+
+describe('Simulations Page', () => {
+	it('renders the main heading', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.getByRole('heading', { name: 'Symulacje Emerytalne' })).toBeTruthy();
+	});
+
+	it('renders the simulation parameters section', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.getByRole('heading', { name: 'Parametry symulacji' })).toBeTruthy();
+	});
+
+	it('renders the accounts-to-simulate section', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.getByRole('heading', { name: 'Konta do symulacji' })).toBeTruthy();
+	});
+
+	it('does not render results before a simulation is run', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.queryByRole('heading', { name: 'Wyniki symulacji' })).toBeNull();
+	});
+});


### PR DESCRIPTION
## Motivation

Only 4 frontend test files existed. The largest components — `SnapshotForm.svelte` (~1,200 lines), `metryki` page (~1,100 lines), `simulations` page (~870 lines) — had no coverage, making refactors fragile and PR review low-confidence.

## Implementation information

Added Vitest + `@testing-library/svelte` tests for the three largest components:

- **SnapshotForm** — section/heading rendering, account/liability inputs in create mode, submit button, edit-mode date/notes population, and field-removal interaction.
- **metryki page** — main heading, financial-overview and investing-guidance sections, a formatted metric-card value.
- **simulations page** — main heading, parameters and accounts sections, results hidden until a run.

echarts, `$env/dynamic/public`, `$app/environment`, and `$app/navigation` are mocked per the existing test pattern. 53 frontend tests pass; lint, format, and `svelte-check` clean.

## Supporting documentation

Closes #315