### PR TITLE
refactor(db): make init_db async-first

### DIFF
--- a/backend/app/core/init_db.py
+++ b/backend/app/core/init_db.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from decimal import Decimal
 from pathlib import Path
@@ -88,10 +89,20 @@ def _seed_defaults() -> None:
         db.close()
 
 
-def init_db() -> None:
+def _init_db_sync() -> None:
     _run_migrations()
     _seed_defaults()
 
 
+async def init_db() -> None:
+    """Async-first database initialization for the app lifespan.
+
+    Migrations and seeding run on the synchronous SQLAlchemy/Alembic stack,
+    so the blocking work is offloaded to a worker thread to keep the startup
+    event loop responsive.
+    """
+    await asyncio.to_thread(_init_db_sync)
+
+
 if __name__ == "__main__":
-    init_db()
+    asyncio.run(init_db())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,3 @@
-import asyncio
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -26,8 +25,8 @@ from app.core.init_db import init_db
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
-    # Startup: Initialize database tables
-    await asyncio.to_thread(init_db)
+    # Startup: initialize the database schema (migrations + seeding)
+    await init_db()
     yield
     # Shutdown: cleanup if needed
 

--- a/backend/tests/test_core_init_db.py
+++ b/backend/tests/test_core_init_db.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import MagicMock, patch
 
 from app.core.database import Base
@@ -11,7 +12,7 @@ def test_init_db_runs_migrations_then_seeds():
         patch("app.core.init_db._run_migrations") as mock_migrations,
         patch("app.core.init_db._seed_defaults") as mock_seed,
     ):
-        init_db()
+        asyncio.run(init_db())
 
         mock_migrations.assert_called_once_with()
         mock_seed.assert_called_once_with()


### PR DESCRIPTION
## Motivation

`main.py` wrapped a blocking `init_db` in `asyncio.to_thread(init_db)` at the lifespan call site — a workaround bolted onto the caller rather than a proper async init path.

## Implementation information

- `init_db` is now an `async def` coroutine. It owns its own async/sync boundary: the blocking migration + seeding work (synchronous SQLAlchemy/Alembic) is offloaded via `asyncio.to_thread` inside `init_db`, in the new `_init_db_sync` helper.
- The lifespan handler now `await init_db()` directly; `main.py` no longer imports `asyncio`.
- CLI entry point uses `asyncio.run(init_db())`.
- Updated the unit test to drive the coroutine with `asyncio.run`.

ruff, pyrefly clean; 514 backend tests pass.

## Supporting documentation

Closes #318