### PR TITLE
fix(security): require database password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 # Database
-DATABASE_URL=postgresql://finance:password@localhost:5432/finance
+# Set a strong, unique password - do NOT keep this placeholder in production
+POSTGRES_PASSWORD=replace-with-strong-password
+# Optional: override the full connection string instead of using POSTGRES_PASSWORD
+DATABASE_URL=postgresql://finance:replace-with-strong-password@localhost:5432/finance
 
 # App
 NODE_ENV=development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: ghcr.io/automaat/finance-buddy-backend:latest
     container_name: finance-backend
     environment:
-      - DATABASE_URL=${DATABASE_URL:-postgresql://finance:password@postgres:5432/finance}
+      - DATABASE_URL=${DATABASE_URL:-postgresql://finance:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/finance}
       - APP_PASSWORD=${APP_PASSWORD:?APP_PASSWORD must be set}
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:3000}
     restart: unless-stopped
@@ -29,7 +29,7 @@ services:
     container_name: finance-postgres
     environment:
       - POSTGRES_USER=finance
-      - POSTGRES_PASSWORD=password
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
       - POSTGRES_DB=finance
     volumes:
       - postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
## Motivation

Closes #330. Production `docker-compose.yml` defaulted the PostgreSQL password to `password` and baked it into `DATABASE_URL`, so a self-hosted deployment could silently run with a known database password.

> Changelog: fix(security): require database password

## Implementation information

- `POSTGRES_PASSWORD` is now required via `${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}` in the `postgres` service.
- `DATABASE_URL` default is built from the required `POSTGRES_PASSWORD` instead of a hardcoded password; a full `DATABASE_URL` can still be supplied to override.
- `.env.example` uses non-production placeholder language and documents `POSTGRES_PASSWORD`.
- CI keeps its explicit test-only credentials unchanged.

Verified with `docker compose config`: fails fast without `POSTGRES_PASSWORD`, interpolates correctly when set.

## Supporting documentation

Issue #330 (parent #327).