### PR TITLE
fix(a11y): clear Svelte warnings

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -25,12 +25,8 @@
 		children
 	}: Props = $props();
 
-	function handleBackdropClick() {
-		onCancel?.();
-	}
-
-	function handleDialogClick(event: MouseEvent) {
-		event.stopPropagation();
+	function handleBackdropClick(event: MouseEvent) {
+		if (event.target === event.currentTarget) onCancel?.();
 	}
 
 	function handleKeydown(event: KeyboardEvent) {
@@ -56,7 +52,6 @@
 			aria-modal="true"
 			aria-labelledby="modal-title"
 			tabindex="-1"
-			onclick={handleDialogClick}
 		>
 			<header class="flex items-center justify-between px-5 py-4 border-b border-surface-200-800">
 				<h2 id="modal-title" class="h4 font-bold">{title}</h2>

--- a/src/lib/components/Modal.test.ts
+++ b/src/lib/components/Modal.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import Modal from './Modal.svelte';
+
+describe('Modal', () => {
+	it('does not render when closed', () => {
+		render(Modal, { props: { open: false, title: 'Tytuł' } });
+		expect(screen.queryByRole('dialog')).toBeNull();
+	});
+
+	it('renders an accessible dialog with the title when open', () => {
+		render(Modal, { props: { open: true, title: 'Tytuł' } });
+		const dialog = screen.getByRole('dialog');
+		expect(dialog.getAttribute('aria-modal')).toBe('true');
+		expect(dialog.getAttribute('aria-labelledby')).toBe('modal-title');
+		expect(screen.getByText('Tytuł')).toBeTruthy();
+	});
+
+	it('closes via the × button', async () => {
+		const onCancel = vi.fn();
+		render(Modal, { props: { open: true, title: 'Tytuł', onCancel } });
+		await fireEvent.click(screen.getByLabelText('Zamknij'));
+		expect(onCancel).toHaveBeenCalledOnce();
+	});
+
+	it('closes on Escape', async () => {
+		const onCancel = vi.fn();
+		render(Modal, { props: { open: true, title: 'Tytuł', onCancel } });
+		await fireEvent.keyDown(window, { key: 'Escape' });
+		expect(onCancel).toHaveBeenCalledOnce();
+	});
+
+	it('closes on backdrop click', async () => {
+		const onCancel = vi.fn();
+		const { container } = render(Modal, { props: { open: true, title: 'Tytuł', onCancel } });
+		const backdrop = container.querySelector('[role="presentation"]');
+		expect(backdrop).not.toBeNull();
+		await fireEvent.click(backdrop as Element);
+		expect(onCancel).toHaveBeenCalledOnce();
+	});
+
+	it('stays open when the dialog body is clicked', async () => {
+		const onCancel = vi.fn();
+		render(Modal, { props: { open: true, title: 'Tytuł', onCancel } });
+		await fireEvent.click(screen.getByRole('dialog'));
+		expect(onCancel).not.toHaveBeenCalled();
+	});
+
+	it('confirms via the confirm button', async () => {
+		const onConfirm = vi.fn();
+		render(Modal, { props: { open: true, title: 'Tytuł', onConfirm } });
+		await fireEvent.click(screen.getByText('Zapisz'));
+		expect(onConfirm).toHaveBeenCalledOnce();
+	});
+});

--- a/src/lib/components/SnapshotForm.svelte
+++ b/src/lib/components/SnapshotForm.svelte
@@ -366,7 +366,23 @@
 		mortgage: 'Hipoteka',
 		installment: 'Raty'
 	};
+
+	function closeModalsOnEscape(event: KeyboardEvent) {
+		if (event.key !== 'Escape') return;
+		showNewAccountForm = false;
+		showNewAssetForm = false;
+	}
+
+	function closeNewAccountModal(event: MouseEvent) {
+		if (event.target === event.currentTarget) showNewAccountForm = false;
+	}
+
+	function closeNewAssetModal(event: MouseEvent) {
+		if (event.target === event.currentTarget) showNewAssetForm = false;
+	}
 </script>
+
+<svelte:window on:keydown={closeModalsOnEscape} />
 
 <form on:submit|preventDefault={handleSubmit} class="snapshot-form">
 	<!-- Date & Notes -->
@@ -758,10 +774,16 @@
 
 	<!-- New Account Modal -->
 	{#if showNewAccountForm}
-		<div class="modal-overlay" on:click={() => (showNewAccountForm = false)}>
-			<div class="modal" role="dialog" on:click|stopPropagation>
+		<div class="modal-overlay" role="presentation" on:click={closeNewAccountModal}>
+			<div
+				class="modal"
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="new-account-modal-title"
+				tabindex="-1"
+			>
 				<div class="modal-header">
-					<h2>Dodaj nowe konto</h2>
+					<h2 id="new-account-modal-title">Dodaj nowe konto</h2>
 					<button
 						type="button"
 						class="btn-close"
@@ -870,10 +892,16 @@
 
 	<!-- New Asset Modal -->
 	{#if showNewAssetForm}
-		<div class="modal-overlay" on:click={() => (showNewAssetForm = false)}>
-			<div class="modal" role="dialog" on:click|stopPropagation>
+		<div class="modal-overlay" role="presentation" on:click={closeNewAssetModal}>
+			<div
+				class="modal"
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="new-asset-modal-title"
+				tabindex="-1"
+			>
 				<div class="modal-header">
-					<h2>Dodaj nowy majątek</h2>
+					<h2 id="new-asset-modal-title">Dodaj nowy majątek</h2>
 					<button
 						type="button"
 						class="btn-close"

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -1057,11 +1057,6 @@
 		border-color: var(--green-6);
 	}
 
-	.rebalancing-item.sell {
-		background: rgba(191, 97, 106, 0.1);
-		border-color: var(--red-6);
-	}
-
 	.action-label {
 		font-weight: var(--font-weight-7);
 		min-width: 120px;
@@ -1069,10 +1064,6 @@
 
 	.rebalancing-item.buy .action-label {
 		color: var(--green-6);
-	}
-
-	.rebalancing-item.sell .action-label {
-		color: var(--red-6);
 	}
 
 	.category-name {


### PR DESCRIPTION
## Motivation

Closes #336. `npm run check` passed but reported 11 Svelte warnings, including keyboard-inaccessible modal overlays in `SnapshotForm.svelte` and `Modal.svelte`.

> Changelog: fix(a11y): clear Svelte warnings

## Implementation information

- `Modal.svelte`: backdrop closes only when its own element is clicked (`target === currentTarget`) instead of relying on a `stopPropagation` click handler on the dialog - removes the static-element click warning.
- `SnapshotForm.svelte`: the two ad-hoc account/asset modals now use the same backdrop pattern, with `role="presentation"` overlays and `role="dialog"` content carrying `aria-modal`, `aria-labelledby`, and `tabindex="-1"`. Escape now closes them via a `svelte:window` keydown handler.
- `metryki/+page.svelte`: removed unused `.rebalancing-item.sell` CSS (rebalancing suggestions only ever render the `buy` variant).
- Added `Modal.test.ts` covering close button, Escape, backdrop click, and body-click-keeps-open.

`npm run check` now reports 0 warnings.

## Supporting documentation

Issue #336 (parent #327).