### PR TITLE
chore(deps): wire dependency alerts

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,38 @@
+name: Dependency Audit
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          experimental: true
+        env:
+          MISE_PYTHON_COMPILE: '0'
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Report outdated npm packages
+        run: |
+          echo '## Outdated npm packages' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          npm outdated >> "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report outdated Python packages
+        working-directory: backend
+        run: |
+          echo '## Outdated Python packages' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          uv tree --outdated --depth 1 >> "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,29 @@
   "extends": [
     "config:recommended"
   ],
-  "reviewers": ["Automaat"]
+  "reviewers": ["Automaat"],
+  "packageRules": [
+    {
+      "description": "Group the Svelte / Vite / Vitest toolchain",
+      "groupName": "svelte toolchain",
+      "matchPackageNames": [
+        "/^svelte/",
+        "/^@sveltejs\\//",
+        "/^vite/",
+        "/^@vitest\\//"
+      ]
+    },
+    {
+      "description": "Group the FastAPI / Pydantic / SQLAlchemy backend stack",
+      "groupName": "fastapi stack",
+      "matchPackageNames": [
+        "fastapi",
+        "starlette",
+        "uvicorn",
+        "alembic",
+        "/^pydantic/",
+        "/^sqlalchemy/"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Motivation

Closes #331. Dependabot alerts were disabled and dependency upgrades arrived ungrouped, so vulnerable or stale dependencies could linger unnoticed across frontend and backend.

> Changelog: skip

## Implementation information

- Enabled repo-level vulnerability alerts and automated security fixes via the GitHub API (`gh api --method PUT .../vulnerability-alerts` and `.../automated-security-fixes`). `gh api repos/Automaat/finance-buddy/dependabot/alerts` now returns `[]` instead of a disabled error.
- `renovate.json`: grouped the Svelte/Vite/Vitest toolchain and the FastAPI/Pydantic/SQLAlchemy backend stack so related upgrades land in single PRs.
- Added a weekly `Dependency Audit` workflow (`workflow_dispatch` + Monday cron) that reports `npm outdated` and `uv tree --outdated` to the job summary.

Renovate already raises the follow-up upgrade PRs for FastAPI, SQLAlchemy, SvelteKit, Vite, Vitest, and pandas once this grouping config merges.

## Supporting documentation

Issue #331 (parent #327).