### PR TITLE
test(frontend): cover page workflows

### DIFF
--- a/src/lib/components/SnapshotForm.test.ts
+++ b/src/lib/components/SnapshotForm.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/svelte';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { goto } from '$app/navigation';
 import SnapshotForm from './SnapshotForm.svelte';
-import type { Account, Asset, SnapshotResponse } from '$lib/types';
+import type { Account, Asset, SnapshotResponse, SnapshotValueResponse } from '$lib/types';
 
 vi.mock('$env/dynamic/public', () => ({
 	env: {
@@ -40,6 +41,18 @@ function makeAsset(overrides: Partial<Asset>): Asset {
 		is_active: true,
 		created_at: '2024-01-01',
 		current_value: 0,
+		...overrides
+	};
+}
+
+function makeSnapshotValue(overrides: Partial<SnapshotValueResponse>): SnapshotValueResponse {
+	return {
+		id: 1,
+		asset_id: null,
+		asset_name: null,
+		account_id: null,
+		account_name: null,
+		value: 0,
 		...overrides
 	};
 }
@@ -122,5 +135,176 @@ describe('SnapshotForm', () => {
 		await fireEvent.click(screen.getByTitle('Usuń pole'));
 
 		expect(screen.queryByLabelText(/Konto Główne/)).toBeNull();
+	});
+});
+
+describe('SnapshotForm submit', () => {
+	const bankAccount = makeAccount({
+		id: 1,
+		name: 'Konto Główne',
+		category: 'bank',
+		current_value: 5000
+	});
+	const mortgage = makeAccount({
+		id: 2,
+		name: 'Kredyt Hipoteczny',
+		type: 'liability',
+		category: 'mortgage',
+		current_value: 200000
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('POSTs a new snapshot and navigates home on success', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ id: 99 })
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(SnapshotForm, {
+			props: { assets: [bankAccount], liabilities: [mortgage], physicalAssets: [] }
+		});
+
+		await fireEvent.submit(
+			screen.getByRole('button', { name: /Zapisz Snapshot/ }).closest('form')!
+		);
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		const [url, options] = fetchMock.mock.calls[0];
+		expect(url).toBe('http://localhost:8000/api/snapshots');
+		expect(options.method).toBe('POST');
+		const body = JSON.parse(options.body as string);
+		expect(body.values).toEqual(
+			expect.arrayContaining([
+				{ account_id: 1, value: 5000 },
+				{ account_id: 2, value: 200000 }
+			])
+		);
+		expect(goto).toHaveBeenCalledWith('/');
+	});
+
+	it('shows the API error detail when create fails', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: false,
+			json: async () => ({ detail: 'Snapshot już istnieje' })
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(SnapshotForm, {
+			props: { assets: [bankAccount], liabilities: [], physicalAssets: [] }
+		});
+
+		await fireEvent.submit(
+			screen.getByRole('button', { name: /Zapisz Snapshot/ }).closest('form')!
+		);
+
+		await waitFor(() => expect(screen.getByText('Snapshot już istnieje')).toBeTruthy());
+		expect(goto).not.toHaveBeenCalled();
+	});
+
+	it('PUTs an updated snapshot to the snapshot id endpoint in edit mode', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ id: 7 })
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		const editingSnapshot: SnapshotResponse = {
+			id: 7,
+			date: '2024-03-31',
+			notes: 'Marcowy snapshot',
+			values: [makeSnapshotValue({ account_id: 1, value: 4200 })]
+		};
+
+		render(SnapshotForm, {
+			props: { editingSnapshot, assets: [bankAccount], liabilities: [], physicalAssets: [] }
+		});
+
+		await fireEvent.submit(
+			screen.getByRole('button', { name: /Zapisz Snapshot/ }).closest('form')!
+		);
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		const [url, options] = fetchMock.mock.calls[0];
+		expect(url).toBe('http://localhost:8000/api/snapshots/7');
+		expect(options.method).toBe('PUT');
+		const body = JSON.parse(options.body as string);
+		expect(body.date).toBe('2024-03-31');
+		expect(body.values).toEqual([{ account_id: 1, value: 4200 }]);
+		expect(goto).toHaveBeenCalledWith('/');
+	});
+
+	it('shows the API error detail when edit fails', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: false,
+			json: async () => ({ detail: 'Nie udało się zaktualizować' })
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		const editingSnapshot: SnapshotResponse = {
+			id: 7,
+			date: '2024-03-31',
+			notes: '',
+			values: [makeSnapshotValue({ account_id: 1, value: 4200 })]
+		};
+
+		render(SnapshotForm, {
+			props: { editingSnapshot, assets: [bankAccount], liabilities: [], physicalAssets: [] }
+		});
+
+		await fireEvent.submit(
+			screen.getByRole('button', { name: /Zapisz Snapshot/ }).closest('form')!
+		);
+
+		await waitFor(() => expect(screen.getByText('Nie udało się zaktualizować')).toBeTruthy());
+		expect(goto).not.toHaveBeenCalled();
+	});
+
+	it('includes physical asset values in the edit payload', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ id: 8 })
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		const apartment = makeAsset({ id: 5, name: 'Mieszkanie', current_value: 500000 });
+		const editingSnapshot: SnapshotResponse = {
+			id: 8,
+			date: '2024-04-30',
+			notes: '',
+			values: [
+				makeSnapshotValue({ id: 1, account_id: 1, value: 4200 }),
+				makeSnapshotValue({ id: 2, asset_id: 5, value: 500000 })
+			]
+		};
+
+		render(SnapshotForm, {
+			props: {
+				editingSnapshot,
+				assets: [bankAccount],
+				liabilities: [],
+				physicalAssets: [apartment]
+			}
+		});
+
+		await fireEvent.submit(
+			screen.getByRole('button', { name: /Zapisz Snapshot/ }).closest('form')!
+		);
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+		expect(body.values).toEqual(
+			expect.arrayContaining([
+				{ account_id: 1, value: 4200 },
+				{ asset_id: 5, value: 500000 }
+			])
+		);
 	});
 });

--- a/src/routes/metryki/page.test.ts
+++ b/src/routes/metryki/page.test.ts
@@ -84,4 +84,107 @@ describe('Metryki Page', () => {
 		expect(screen.getByText('Ile miesięcy bez pracy')).toBeTruthy();
 		expect(screen.getByText('6,00')).toBeTruthy();
 	});
+
+	it('shows the no-rebalancing message when there are no suggestions', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.getByText(/Portfel jest zgodny z docelową alokacją/)).toBeTruthy();
+	});
+
+	it('hides optional metric cards when their values are null', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.queryByText('Ile oszczędzamy miesięcznie')).toBeNull();
+		expect(screen.queryByText('Stosunek długu do dochodu')).toBeNull();
+		expect(screen.queryByText('Koszt godziny pracy')).toBeNull();
+		expect(screen.queryByText('Koszt godziny życia')).toBeNull();
+	});
+
+	it('omits PPK, stock and bond summary sections when no data', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.queryByRole('heading', { name: 'Podsumowanie PPK' })).toBeNull();
+		expect(screen.queryByRole('heading', { name: 'Podsumowanie Akcji' })).toBeNull();
+		expect(screen.queryByRole('heading', { name: 'Podsumowanie Obligacji' })).toBeNull();
+	});
+});
+
+describe('Metryki Page with populated data', () => {
+	const populatedData = {
+		metricCards: {
+			property_sqm: 42,
+			emergency_fund_months: 8,
+			retirement_income_monthly: 1200,
+			mortgage_remaining: 300000,
+			mortgage_months_left: 240,
+			mortgage_years_left: 20,
+			retirement_total: 90000,
+			investment_contributions: 50000,
+			investment_returns: 12000,
+			savings_rate: 22.5,
+			debt_to_income_ratio: 28,
+			hour_of_work_cost: 75,
+			hour_of_life_cost: 30
+		},
+		allocationAnalysis: {
+			by_category: [{ category: 'stock', current_percentage: 60, target_percentage: 70 }],
+			by_wrapper: [{ wrapper: 'IKE', value: 30000 }],
+			rebalancing: [{ category: 'stock', amount: 5000 }],
+			total_investment_value: 80000
+		},
+		investmentTimeSeries: [{ date: '2024-01', value: 50000, contributions: 45000 }],
+		wrapperTimeSeries: {
+			ike: [{ date: '2024-01', value: 30000, contributions: 28000 }],
+			ikze: [{ date: '2024-01', value: 10000, contributions: 9000 }],
+			ppk: [{ date: '2024-01', value: 20000, contributions: 18000 }]
+		},
+		categoryTimeSeries: {
+			stock: [{ date: '2024-01', value: 40000, contributions: 35000 }],
+			bond: [{ date: '2024-01', value: 10000, contributions: 9500 }]
+		},
+		ppkStats: [
+			{
+				owner: 'Marcin',
+				total_value: 20000,
+				employee_contributed: 8000,
+				employer_contributed: 6000,
+				government_contributed: 1000,
+				total_contributed: 15000,
+				returns: 5000,
+				roi_percentage: 33.33
+			}
+		],
+		stockStats: {
+			total_value: 40000,
+			total_contributed: 35000,
+			returns: 5000,
+			roi_percentage: 14.29
+		},
+		bondStats: {
+			total_value: 10000,
+			total_contributed: 9500,
+			returns: 500,
+			roi_percentage: 5.26
+		}
+	};
+
+	it('renders the rebalancing suggestions when present', () => {
+		render(Page, { props: { data: populatedData } });
+		expect(screen.getByText('KUP')).toBeTruthy();
+		expect(screen.getByText('stock')).toBeTruthy();
+		expect(screen.queryByText(/Portfel jest zgodny z docelową alokacją/)).toBeNull();
+	});
+
+	it('renders the optional metric cards when values are present', () => {
+		render(Page, { props: { data: populatedData } });
+		expect(screen.getByText('Ile oszczędzamy miesięcznie')).toBeTruthy();
+		expect(screen.getByText('Stosunek długu do dochodu')).toBeTruthy();
+		expect(screen.getByText('Koszt godziny pracy')).toBeTruthy();
+		expect(screen.getByText('Koszt godziny życia')).toBeTruthy();
+	});
+
+	it('renders the PPK, stock and bond summary sections', () => {
+		render(Page, { props: { data: populatedData } });
+		expect(screen.getByRole('heading', { name: 'Podsumowanie PPK' })).toBeTruthy();
+		expect(screen.getByRole('heading', { name: 'Marcin', level: 3 })).toBeTruthy();
+		expect(screen.getByRole('heading', { name: 'Podsumowanie Akcji' })).toBeTruthy();
+		expect(screen.getByRole('heading', { name: 'Podsumowanie Obligacji' })).toBeTruthy();
+	});
 });

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, beforeAll } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it, beforeAll, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import { vi } from 'vitest';
+import { invalidateAll } from '$app/navigation';
 import Page from './+page.svelte';
 
 // Mock window.matchMedia for media query tests
@@ -49,6 +50,10 @@ vi.mock('echarts', () => ({
 	}
 }));
 
+vi.mock('$app/navigation', () => ({
+	invalidateAll: vi.fn()
+}));
+
 describe('Dashboard Page', () => {
 	const mockData = {
 		net_worth_history: [
@@ -75,5 +80,91 @@ describe('Dashboard Page', () => {
 	it('renders the description', () => {
 		render(Page, { props: { data: mockData } });
 		expect(screen.getByText('Twoja sytuacja finansowa w jednym miejscu')).toBeTruthy();
+	});
+});
+
+describe('Dashboard retirement limits save flow', () => {
+	const dataWithStats = {
+		net_worth_history: [{ date: '2024-01-01', value: 5000 }],
+		current_net_worth: 6000,
+		change_vs_last_month: 1000,
+		total_assets: 10000,
+		total_liabilities: 4000,
+		allocation: [{ category: 'banking', owner: 'Marcin', value: 5000 }],
+		retirementStats: [
+			{
+				account_wrapper: 'IKE',
+				owner: 'Marcin',
+				total_contributed: 5000,
+				limit_amount: 23000,
+				remaining: 18000,
+				percentage_used: 21
+			}
+		],
+		personas: [{ name: 'Marcin' }],
+		currentYear: 2024
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('renders the retirement limits card when stats exist', () => {
+		render(Page, { props: { data: dataWithStats } });
+		expect(screen.getByRole('heading', { name: /Limity Emerytalne 2024/ })).toBeTruthy();
+	});
+
+	it('opens the limits modal and PUTs each persona/wrapper limit on save', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: dataWithStats } });
+
+		await fireEvent.click(screen.getByLabelText('Konfiguruj limity'));
+		expect(screen.getByText('Konfiguracja Limitów Emerytalnych')).toBeTruthy();
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+		const urls = fetchMock.mock.calls.map((c) => c[0] as string);
+		expect(urls).toEqual(
+			expect.arrayContaining([
+				'http://localhost:8000/api/retirement/limits/2024/IKE/Marcin',
+				'http://localhost:8000/api/retirement/limits/2024/IKZE/Marcin'
+			])
+		);
+		for (const call of fetchMock.mock.calls) {
+			expect(call[1].method).toBe('PUT');
+		}
+		await waitFor(() => expect(invalidateAll).toHaveBeenCalled());
+	});
+
+	it('prefills the IKE limit from existing retirement stats', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: dataWithStats } });
+		await fireEvent.click(screen.getByLabelText('Konfiguruj limity'));
+
+		const ikeInput = screen.getByLabelText('IKE Marcin (PLN)') as HTMLInputElement;
+		expect(ikeInput.value).toBe('23000');
+	});
+
+	it('alerts when a limit save request fails', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+		vi.stubGlobal('fetch', fetchMock);
+		const alertMock = vi.fn();
+		vi.stubGlobal('alert', alertMock);
+
+		render(Page, { props: { data: dataWithStats } });
+		await fireEvent.click(screen.getByLabelText('Konfiguruj limity'));
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() => expect(alertMock).toHaveBeenCalled());
+		expect(invalidateAll).not.toHaveBeenCalled();
 	});
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,13 @@ export default defineConfig({
 		coverage: {
 			provider: 'v8',
 			reporter: ['text', 'json', 'html', 'lcov'],
-			exclude: ['node_modules/**', '.svelte-kit/**', 'build/**', '**/*.config.*', '**/.*rc.*']
+			exclude: ['node_modules/**', '.svelte-kit/**', 'build/**', '**/*.config.*', '**/.*rc.*'],
+			thresholds: {
+				statements: 62,
+				branches: 46,
+				functions: 63,
+				lines: 65
+			}
 		}
 	}
 });


### PR DESCRIPTION
## Motivation

Closes #329. Frontend coverage sat at 48-50% statements / 33% branches while CI uploaded coverage without enforcing any floor, so dashboard, snapshot, and metrics regressions could ship unnoticed.

> Changelog: skip

## Implementation information

Added 15 tests (60 -> 75 total) covering the previously weakest page workflows:

- **`SnapshotForm.svelte`** (31.9% -> 40.5%): snapshot create POST success + redirect, create error surfaced, edit PUT path, edit error surfaced, physical-asset values in the edit payload.
- **Dashboard `+page.svelte`** (44.2% -> 93.5%): retirement-limit card render, modal open + per-persona/wrapper PUT + `invalidateAll`, input prefill from stats, alert on failed save.
- **`metryki/+page.svelte`** (51.7% -> 89.8%, branches 7.4% -> 40.7%): empty-data and populated-data render edge cases for rebalancing, optional metric cards, and summary sections.

Added a `thresholds` block to `vite.config.ts` (statements 62 / branches 46 / functions 63 / lines 65 - achieved value floored, minus a 1-point margin) so CI's existing `vitest run --coverage` fails on regression. Ratchet upward in future PRs.

Overall coverage: statements 49.76% -> 63.55%, branches 33.7% -> 47.08%, functions 43.26% -> 64.13%, lines 52.61% -> 66.61%.

## Supporting documentation

Issue #329 (parent #327).