### PR TITLE
refactor(frontend): split oversized views

### DIFF
--- a/src/lib/components/SnapshotForm.svelte
+++ b/src/lib/components/SnapshotForm.svelte
@@ -3,6 +3,9 @@
 	import { env } from '$env/dynamic/public';
 	import { Wallet, Umbrella, TrendingUp, Home, CreditCard } from 'lucide-svelte';
 	import type { Account, Asset, SnapshotResponse } from '$lib/types';
+	import NewAccountModal from './snapshot/NewAccountModal.svelte';
+	import NewAssetModal from './snapshot/NewAssetModal.svelte';
+	import ValueRow from './snapshot/ValueRow.svelte';
 
 	export let editingSnapshot: SnapshotResponse | null = null;
 	export let assets: Account[];
@@ -367,22 +370,22 @@
 		installment: 'Raty'
 	};
 
-	function closeModalsOnEscape(event: KeyboardEvent) {
-		if (event.key !== 'Escape') return;
+	function accountMeta(account: Account): string {
+		return `(${categoryLabels[account.category] || account.category})`;
+	}
+
+	function liabilityMeta(account: Account): string {
+		return `(${categoryLabels[account.category]})`;
+	}
+
+	function closeNewAccountModal() {
 		showNewAccountForm = false;
+	}
+
+	function closeNewAssetModal() {
 		showNewAssetForm = false;
 	}
-
-	function closeNewAccountModal(event: MouseEvent) {
-		if (event.target === event.currentTarget) showNewAccountForm = false;
-	}
-
-	function closeNewAssetModal(event: MouseEvent) {
-		if (event.target === event.currentTarget) showNewAssetForm = false;
-	}
 </script>
-
-<svelte:window on:keydown={closeModalsOnEscape} />
 
 <form on:submit|preventDefault={handleSubmit} class="snapshot-form">
 	<!-- Date & Notes -->
@@ -416,32 +419,13 @@
 		</header>
 		<div class="space-y-4">
 			{#each financialAccounts.filter((a) => visibleAccountIds.has(a.id)) as account}
-				<div class="form-group-with-remove">
-					<div class="form-group">
-						<label for="account-{account.id}" class="form-label">
-							{account.name}
-							<span class="label-meta"
-								>({categoryLabels[account.category] || account.category})</span
-							>
-						</label>
-						<input
-							id="account-{account.id}"
-							type="number"
-							step="0.01"
-							bind:value={accountValues[account.id]}
-							placeholder="0.00"
-							class="form-input"
-						/>
-					</div>
-					<button
-						type="button"
-						class="btn-remove"
-						on:click={() => removeAccount(account.id)}
-						title="Usuń pole"
-					>
-						×
-					</button>
-				</div>
+				<ValueRow
+					inputId="account-{account.id}"
+					label={account.name}
+					meta={accountMeta(account)}
+					bind:value={accountValues[account.id]}
+					onRemove={() => removeAccount(account.id)}
+				/>
 			{/each}
 
 			<div class="add-account">
@@ -485,32 +469,13 @@
 				{#each retirementByWrapper as group}
 					<h3 class="wrapper-subheading">{group.wrapper}</h3>
 					{#each group.accounts.filter((a) => visibleAccountIds.has(a.id)) as account}
-						<div class="form-group-with-remove">
-							<div class="form-group">
-								<label for="account-{account.id}" class="form-label">
-									{account.name}
-									<span class="label-meta"
-										>({categoryLabels[account.category] || account.category})</span
-									>
-								</label>
-								<input
-									id="account-{account.id}"
-									type="number"
-									step="0.01"
-									bind:value={accountValues[account.id]}
-									placeholder="0.00"
-									class="form-input"
-								/>
-							</div>
-							<button
-								type="button"
-								class="btn-remove"
-								on:click={() => removeAccount(account.id)}
-								title="Usuń pole"
-							>
-								×
-							</button>
-						</div>
+						<ValueRow
+							inputId="account-{account.id}"
+							label={account.name}
+							meta={accountMeta(account)}
+							bind:value={accountValues[account.id]}
+							onRemove={() => removeAccount(account.id)}
+						/>
 					{/each}
 				{/each}
 
@@ -551,32 +516,13 @@
 		</header>
 		<div class="space-y-4">
 			{#each investmentAccounts.filter((a) => visibleAccountIds.has(a.id)) as account}
-				<div class="form-group-with-remove">
-					<div class="form-group">
-						<label for="account-{account.id}" class="form-label">
-							{account.name}
-							<span class="label-meta"
-								>({categoryLabels[account.category] || account.category})</span
-							>
-						</label>
-						<input
-							id="account-{account.id}"
-							type="number"
-							step="0.01"
-							bind:value={accountValues[account.id]}
-							placeholder="0.00"
-							class="form-input"
-						/>
-					</div>
-					<button
-						type="button"
-						class="btn-remove"
-						on:click={() => removeAccount(account.id)}
-						title="Usuń pole"
-					>
-						×
-					</button>
-				</div>
+				<ValueRow
+					inputId="account-{account.id}"
+					label={account.name}
+					meta={accountMeta(account)}
+					bind:value={accountValues[account.id]}
+					onRemove={() => removeAccount(account.id)}
+				/>
 			{/each}
 
 			<div class="add-account">
@@ -617,56 +563,22 @@
 		</header>
 		<div class="space-y-4">
 			{#each majatekAccounts.filter((a) => visibleAccountIds.has(a.id)) as account}
-				<div class="form-group-with-remove">
-					<div class="form-group">
-						<label for="account-{account.id}" class="form-label">
-							{account.name}
-							<span class="label-meta"
-								>({categoryLabels[account.category] || account.category})</span
-							>
-						</label>
-						<input
-							id="account-{account.id}"
-							type="number"
-							step="0.01"
-							bind:value={accountValues[account.id]}
-							placeholder="0.00"
-							class="form-input"
-						/>
-					</div>
-					<button
-						type="button"
-						class="btn-remove"
-						on:click={() => removeAccount(account.id)}
-						title="Usuń pole"
-					>
-						×
-					</button>
-				</div>
+				<ValueRow
+					inputId="account-{account.id}"
+					label={account.name}
+					meta={accountMeta(account)}
+					bind:value={accountValues[account.id]}
+					onRemove={() => removeAccount(account.id)}
+				/>
 			{/each}
 
 			{#each physicalAssets.filter((a) => visibleAssetIds.has(a.id)) as asset}
-				<div class="form-group-with-remove">
-					<div class="form-group">
-						<label for="asset-{asset.id}" class="form-label">{asset.name}</label>
-						<input
-							id="asset-{asset.id}"
-							type="number"
-							step="0.01"
-							bind:value={assetValues[asset.id]}
-							placeholder="0.00"
-							class="form-input"
-						/>
-					</div>
-					<button
-						type="button"
-						class="btn-remove"
-						on:click={() => removeAsset(asset.id)}
-						title="Usuń pole"
-					>
-						×
-					</button>
-				</div>
+				<ValueRow
+					inputId="asset-{asset.id}"
+					label={asset.name}
+					bind:value={assetValues[asset.id]}
+					onRemove={() => removeAsset(asset.id)}
+				/>
 			{/each}
 
 			<div class="add-account">
@@ -716,30 +628,13 @@
 			</header>
 			<div class="space-y-4">
 				{#each liabilities.filter((a) => visibleAccountIds.has(a.id)) as account}
-					<div class="form-group-with-remove">
-						<div class="form-group">
-							<label for="account-{account.id}" class="form-label">
-								{account.name}
-								<span class="label-meta">({categoryLabels[account.category]})</span>
-							</label>
-							<input
-								id="account-{account.id}"
-								type="number"
-								step="0.01"
-								bind:value={accountValues[account.id]}
-								placeholder="0.00"
-								class="form-input"
-							/>
-						</div>
-						<button
-							type="button"
-							class="btn-remove"
-							on:click={() => removeAccount(account.id)}
-							title="Usuń pole"
-						>
-							×
-						</button>
-					</div>
+					<ValueRow
+						inputId="account-{account.id}"
+						label={account.name}
+						meta={liabilityMeta(account)}
+						bind:value={accountValues[account.id]}
+						onRemove={() => removeAccount(account.id)}
+					/>
 				{/each}
 
 				<div class="add-account">
@@ -774,187 +669,29 @@
 
 	<!-- New Account Modal -->
 	{#if showNewAccountForm}
-		<div class="modal-overlay" role="presentation" on:click={closeNewAccountModal}>
-			<div
-				class="modal"
-				role="dialog"
-				aria-modal="true"
-				aria-labelledby="new-account-modal-title"
-				tabindex="-1"
-			>
-				<div class="modal-header">
-					<h2 id="new-account-modal-title">Dodaj nowe konto</h2>
-					<button
-						type="button"
-						class="btn-close"
-						on:click={() => (showNewAccountForm = false)}
-						title="Zamknij"
-					>
-						×
-					</button>
-				</div>
-				<div class="modal-content">
-					<div class="form-group">
-						<label for="newAccountName" class="form-label">Nazwa konta *</label>
-						<input
-							id="newAccountName"
-							type="text"
-							bind:value={newAccountName}
-							placeholder="np. Konto oszczędnościowe"
-							class="form-input"
-							required
-						/>
-					</div>
-
-					<div class="form-group">
-						<label for="newAccountCategory" class="form-label">Kategoria *</label>
-						<select id="newAccountCategory" bind:value={newAccountCategory} class="form-input">
-							{#if newAccountSection === 'financial'}
-								<option value="bank">Konto bankowe</option>
-								<option value="saving_account">Konto oszczędnościowe</option>
-							{:else if newAccountSection === 'retirement'}
-								<option value="stock">Akcje</option>
-								<option value="bond">Obligacje</option>
-								<option value="fund">Fundusz</option>
-								<option value="etf">ETF</option>
-								<option value="ppk">PPK</option>
-							{:else if newAccountSection === 'investment'}
-								<option value="stock">Akcje</option>
-								<option value="bond">Obligacje</option>
-								<option value="fund">Fundusz</option>
-								<option value="etf">ETF</option>
-								<option value="gold">Złoto</option>
-								<option value="other">Inne</option>
-							{:else if newAccountSection === 'majatek'}
-								<option value="real_estate">Nieruchomości</option>
-								<option value="vehicle">Pojazd</option>
-								<option value="other">Inne</option>
-							{:else}
-								<option value="mortgage">Hipoteka</option>
-								<option value="installment">Raty</option>
-								<option value="other">Inne</option>
-							{/if}
-						</select>
-					</div>
-
-					{#if newAccountSection === 'retirement'}
-						<div class="form-group">
-							<label for="newAccountWrapper" class="form-label">Wrapper *</label>
-							<select id="newAccountWrapper" bind:value={newAccountWrapper} class="form-input">
-								<option value="IKE">IKE</option>
-								<option value="IKZE">IKZE</option>
-								<option value="PPK">PPK</option>
-							</select>
-						</div>
-					{/if}
-
-					<div class="form-group">
-						<label for="newAccountOwner" class="form-label">Właściciel</label>
-						<select id="newAccountOwner" bind:value={newAccountOwner} class="form-input">
-							{#each personas as persona}
-								<option value={persona.name}>{persona.name}</option>
-							{/each}
-						</select>
-					</div>
-
-					<div class="form-group">
-						<label for="newAccountValue" class="form-label">Wartość początkowa</label>
-						<input
-							id="newAccountValue"
-							type="number"
-							step="0.01"
-							bind:value={newAccountValue}
-							placeholder="0.00"
-							class="form-input"
-						/>
-					</div>
-				</div>
-				<div class="modal-footer">
-					<button
-						type="button"
-						class="btn btn-secondary"
-						on:click={() => (showNewAccountForm = false)}
-					>
-						Anuluj
-					</button>
-					<button
-						type="button"
-						class="btn btn-primary"
-						disabled={creatingAccount}
-						on:click={createNewAccount}
-					>
-						{creatingAccount ? 'Tworzenie...' : 'Utwórz konto'}
-					</button>
-				</div>
-			</div>
-		</div>
+		<NewAccountModal
+			section={newAccountSection}
+			bind:name={newAccountName}
+			bind:category={newAccountCategory}
+			bind:wrapper={newAccountWrapper}
+			bind:owner={newAccountOwner}
+			bind:value={newAccountValue}
+			creating={creatingAccount}
+			{personas}
+			onCreate={createNewAccount}
+			onClose={closeNewAccountModal}
+		/>
 	{/if}
 
 	<!-- New Asset Modal -->
 	{#if showNewAssetForm}
-		<div class="modal-overlay" role="presentation" on:click={closeNewAssetModal}>
-			<div
-				class="modal"
-				role="dialog"
-				aria-modal="true"
-				aria-labelledby="new-asset-modal-title"
-				tabindex="-1"
-			>
-				<div class="modal-header">
-					<h2 id="new-asset-modal-title">Dodaj nowy majątek</h2>
-					<button
-						type="button"
-						class="btn-close"
-						on:click={() => (showNewAssetForm = false)}
-						title="Zamknij"
-					>
-						×
-					</button>
-				</div>
-				<div class="modal-content">
-					<div class="form-group">
-						<label for="newAssetName" class="form-label">Nazwa *</label>
-						<input
-							id="newAssetName"
-							type="text"
-							bind:value={newAssetName}
-							placeholder="np. Mieszkanie Poznań, Rower"
-							class="form-input"
-							required
-						/>
-					</div>
-
-					<div class="form-group">
-						<label for="newAssetValue" class="form-label">Wartość początkowa</label>
-						<input
-							id="newAssetValue"
-							type="number"
-							step="0.01"
-							bind:value={newAssetValue}
-							placeholder="0.00"
-							class="form-input"
-						/>
-					</div>
-				</div>
-				<div class="modal-footer">
-					<button
-						type="button"
-						class="btn btn-secondary"
-						on:click={() => (showNewAssetForm = false)}
-					>
-						Anuluj
-					</button>
-					<button
-						type="button"
-						class="btn btn-primary"
-						disabled={creatingAsset}
-						on:click={createNewAsset}
-					>
-						{creatingAsset ? 'Tworzenie...' : 'Utwórz majątek'}
-					</button>
-				</div>
-			</div>
-		</div>
+		<NewAssetModal
+			bind:name={newAssetName}
+			bind:value={newAssetValue}
+			creating={creatingAsset}
+			onCreate={createNewAsset}
+			onClose={closeNewAssetModal}
+		/>
 	{/if}
 
 	<!-- Error Message -->
@@ -1081,43 +818,6 @@
 		background: var(--color-accent);
 	}
 
-	.form-group-with-remove {
-		display: flex;
-		gap: var(--size-2);
-		align-items: flex-start;
-		margin-bottom: var(--size-4);
-	}
-
-	.form-group-with-remove .form-group {
-		flex: 1;
-		margin-bottom: 0;
-	}
-
-	.btn-remove {
-		flex-shrink: 0;
-		width: var(--tap-target-min);
-		height: var(--tap-target-min);
-		margin-top: 28px;
-		padding: 0;
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-2);
-		background: transparent;
-		color: var(--color-text-secondary);
-		font-size: var(--font-size-4);
-		line-height: 1;
-		cursor: pointer;
-		transition: all 0.2s;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-	}
-
-	.btn-remove:hover {
-		background: var(--nord11);
-		color: var(--nord6);
-		border-color: var(--nord11);
-	}
-
 	.add-account {
 		margin-top: var(--size-4);
 		padding: var(--size-3);
@@ -1180,78 +880,6 @@
 		color: var(--nord6);
 	}
 
-	.modal-overlay {
-		position: fixed;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		background: rgba(0, 0, 0, 0.5);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		z-index: 1000;
-		padding: var(--size-4);
-	}
-
-	.modal {
-		background: var(--color-bg);
-		border-radius: var(--radius-2);
-		max-width: 500px;
-		width: 100%;
-		box-shadow: var(--shadow-6);
-	}
-
-	.modal-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: var(--size-4);
-		border-bottom: 1px solid var(--color-border);
-	}
-
-	.modal-header h2 {
-		margin: 0;
-		font-size: var(--font-size-4);
-		font-weight: var(--font-weight-7);
-		color: var(--color-text);
-	}
-
-	.btn-close {
-		width: var(--tap-target-min);
-		height: var(--tap-target-min);
-		padding: 0;
-		border: none;
-		background: transparent;
-		color: var(--color-text-secondary);
-		font-size: var(--font-size-5);
-		line-height: 1;
-		cursor: pointer;
-		transition: all 0.2s;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-	}
-
-	.btn-close:hover {
-		color: var(--nord11);
-	}
-
-	.modal-content {
-		padding: var(--size-4);
-	}
-
-	.modal-footer {
-		display: flex;
-		gap: var(--size-3);
-		padding: var(--size-4);
-		border-top: 1px solid var(--color-border);
-	}
-
-	.modal-footer .btn {
-		flex: 1;
-	}
-
 	@media (max-width: 640px) {
 		.button-group {
 			flex-direction: column-reverse;
@@ -1260,10 +888,6 @@
 		.button-group .btn {
 			width: 100%;
 			flex: none;
-		}
-
-		.btn-remove {
-			margin-top: 32px;
 		}
 	}
 </style>

--- a/src/lib/components/snapshot/NewAccountModal.svelte
+++ b/src/lib/components/snapshot/NewAccountModal.svelte
@@ -1,0 +1,264 @@
+<script lang="ts">
+	type NewAccountSection = 'financial' | 'retirement' | 'investment' | 'majatek' | 'liabilities';
+
+	export let section: NewAccountSection;
+	export let name = '';
+	export let category = '';
+	export let wrapper: '' | 'PPK' | 'IKE' | 'IKZE' = '';
+	export let owner = '';
+	export let value = 0;
+	export let creating = false;
+	export let personas: Array<{ id: number; name: string }> = [];
+	export let onCreate: () => void;
+	export let onClose: () => void;
+
+	function closeOnBackdrop(event: MouseEvent) {
+		if (event.target === event.currentTarget) onClose();
+	}
+
+	function closeOnEscape(event: KeyboardEvent) {
+		if (event.key === 'Escape') onClose();
+	}
+</script>
+
+<svelte:window on:keydown={closeOnEscape} />
+
+<div class="modal-overlay" role="presentation" on:click={closeOnBackdrop}>
+	<div
+		class="modal"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="new-account-modal-title"
+		tabindex="-1"
+	>
+		<div class="modal-header">
+			<h2 id="new-account-modal-title">Dodaj nowe konto</h2>
+			<button type="button" class="btn-close" on:click={onClose} title="Zamknij"> × </button>
+		</div>
+		<div class="modal-content">
+			<div class="form-group">
+				<label for="newAccountName" class="form-label">Nazwa konta *</label>
+				<input
+					id="newAccountName"
+					type="text"
+					bind:value={name}
+					placeholder="np. Konto oszczędnościowe"
+					class="form-input"
+					required
+				/>
+			</div>
+
+			<div class="form-group">
+				<label for="newAccountCategory" class="form-label">Kategoria *</label>
+				<select id="newAccountCategory" bind:value={category} class="form-input">
+					{#if section === 'financial'}
+						<option value="bank">Konto bankowe</option>
+						<option value="saving_account">Konto oszczędnościowe</option>
+					{:else if section === 'retirement'}
+						<option value="stock">Akcje</option>
+						<option value="bond">Obligacje</option>
+						<option value="fund">Fundusz</option>
+						<option value="etf">ETF</option>
+						<option value="ppk">PPK</option>
+					{:else if section === 'investment'}
+						<option value="stock">Akcje</option>
+						<option value="bond">Obligacje</option>
+						<option value="fund">Fundusz</option>
+						<option value="etf">ETF</option>
+						<option value="gold">Złoto</option>
+						<option value="other">Inne</option>
+					{:else if section === 'majatek'}
+						<option value="real_estate">Nieruchomości</option>
+						<option value="vehicle">Pojazd</option>
+						<option value="other">Inne</option>
+					{:else}
+						<option value="mortgage">Hipoteka</option>
+						<option value="installment">Raty</option>
+						<option value="other">Inne</option>
+					{/if}
+				</select>
+			</div>
+
+			{#if section === 'retirement'}
+				<div class="form-group">
+					<label for="newAccountWrapper" class="form-label">Wrapper *</label>
+					<select id="newAccountWrapper" bind:value={wrapper} class="form-input">
+						<option value="IKE">IKE</option>
+						<option value="IKZE">IKZE</option>
+						<option value="PPK">PPK</option>
+					</select>
+				</div>
+			{/if}
+
+			<div class="form-group">
+				<label for="newAccountOwner" class="form-label">Właściciel</label>
+				<select id="newAccountOwner" bind:value={owner} class="form-input">
+					{#each personas as persona}
+						<option value={persona.name}>{persona.name}</option>
+					{/each}
+				</select>
+			</div>
+
+			<div class="form-group">
+				<label for="newAccountValue" class="form-label">Wartość początkowa</label>
+				<input
+					id="newAccountValue"
+					type="number"
+					step="0.01"
+					bind:value
+					placeholder="0.00"
+					class="form-input"
+				/>
+			</div>
+		</div>
+		<div class="modal-footer">
+			<button type="button" class="btn btn-secondary" on:click={onClose}> Anuluj </button>
+			<button type="button" class="btn btn-primary" disabled={creating} on:click={onCreate}>
+				{creating ? 'Tworzenie...' : 'Utwórz konto'}
+			</button>
+		</div>
+	</div>
+</div>
+
+<style>
+	.form-group {
+		margin-bottom: var(--size-4);
+	}
+
+	.form-group:last-child {
+		margin-bottom: 0;
+	}
+
+	.form-label {
+		display: block;
+		font-weight: var(--font-weight-6);
+		margin-bottom: var(--size-2);
+		color: var(--color-text);
+	}
+
+	.form-input {
+		width: 100%;
+		padding: var(--size-3);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-2);
+		background: var(--color-bg);
+		color: var(--color-text);
+		font-size: var(--font-size-2);
+		font-family: inherit;
+		transition: all 0.2s;
+		min-height: var(--tap-target-min);
+	}
+
+	.form-input:focus {
+		outline: none;
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 2px rgba(94, 129, 172, 0.2);
+	}
+
+	.btn {
+		padding: var(--size-3) var(--size-5);
+		border: none;
+		border-radius: var(--radius-2);
+		font-weight: var(--font-weight-6);
+		font-size: var(--font-size-2);
+		cursor: pointer;
+		transition: all 0.2s;
+	}
+
+	.btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.btn-primary {
+		background: var(--color-primary);
+		color: var(--nord6);
+		flex: 1;
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		background: var(--nord9);
+	}
+
+	.btn-secondary {
+		background: transparent;
+		color: var(--color-text);
+		border: 1px solid var(--color-border);
+	}
+
+	.btn-secondary:hover {
+		background: var(--color-accent);
+	}
+
+	.modal-overlay {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+		padding: var(--size-4);
+	}
+
+	.modal {
+		background: var(--color-bg);
+		border-radius: var(--radius-2);
+		max-width: 500px;
+		width: 100%;
+		box-shadow: var(--shadow-6);
+	}
+
+	.modal-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: var(--size-4);
+		border-bottom: 1px solid var(--color-border);
+	}
+
+	.modal-header h2 {
+		margin: 0;
+		font-size: var(--font-size-4);
+		font-weight: var(--font-weight-7);
+		color: var(--color-text);
+	}
+
+	.btn-close {
+		width: var(--tap-target-min);
+		height: var(--tap-target-min);
+		padding: 0;
+		border: none;
+		background: transparent;
+		color: var(--color-text-secondary);
+		font-size: var(--font-size-5);
+		line-height: 1;
+		cursor: pointer;
+		transition: all 0.2s;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.btn-close:hover {
+		color: var(--nord11);
+	}
+
+	.modal-content {
+		padding: var(--size-4);
+	}
+
+	.modal-footer {
+		display: flex;
+		gap: var(--size-3);
+		padding: var(--size-4);
+		border-top: 1px solid var(--color-border);
+	}
+
+	.modal-footer .btn {
+		flex: 1;
+	}
+</style>

--- a/src/lib/components/snapshot/NewAccountModal.test.ts
+++ b/src/lib/components/snapshot/NewAccountModal.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import NewAccountModal from './NewAccountModal.svelte';
+
+const personas = [
+	{ id: 1, name: 'Marcin' },
+	{ id: 2, name: 'Ewa' }
+];
+
+describe('NewAccountModal', () => {
+	it('renders an accessible dialog with the title', () => {
+		render(NewAccountModal, {
+			props: {
+				section: 'financial',
+				onCreate: vi.fn(),
+				onClose: vi.fn(),
+				personas
+			}
+		});
+		const dialog = screen.getByRole('dialog');
+		expect(dialog.getAttribute('aria-modal')).toBe('true');
+		expect(dialog.getAttribute('aria-labelledby')).toBe('new-account-modal-title');
+		expect(screen.getByText('Dodaj nowe konto')).toBeTruthy();
+	});
+
+	it('shows financial category options for the financial section', () => {
+		render(NewAccountModal, {
+			props: { section: 'financial', onCreate: vi.fn(), onClose: vi.fn(), personas }
+		});
+		expect(screen.getByRole('option', { name: 'Konto bankowe' })).toBeTruthy();
+		expect(screen.queryByRole('option', { name: 'Hipoteka' })).toBeNull();
+	});
+
+	it('shows the wrapper select only for the retirement section', () => {
+		render(NewAccountModal, {
+			props: { section: 'retirement', onCreate: vi.fn(), onClose: vi.fn(), personas }
+		});
+		expect(screen.getByLabelText('Wrapper *')).toBeTruthy();
+	});
+
+	it('hides the wrapper select for non-retirement sections', () => {
+		render(NewAccountModal, {
+			props: { section: 'liabilities', onCreate: vi.fn(), onClose: vi.fn(), personas }
+		});
+		expect(screen.queryByLabelText('Wrapper *')).toBeNull();
+	});
+
+	it('calls onCreate when the confirm button is clicked', async () => {
+		const onCreate = vi.fn();
+		render(NewAccountModal, {
+			props: { section: 'financial', onCreate, onClose: vi.fn(), personas }
+		});
+		await fireEvent.click(screen.getByText('Utwórz konto'));
+		expect(onCreate).toHaveBeenCalledOnce();
+	});
+
+	it('disables the confirm button while creating', () => {
+		render(NewAccountModal, {
+			props: { section: 'financial', creating: true, onCreate: vi.fn(), onClose: vi.fn(), personas }
+		});
+		const button = screen.getByText('Tworzenie...') as HTMLButtonElement;
+		expect(button.disabled).toBe(true);
+	});
+
+	it('closes via the × button', async () => {
+		const onClose = vi.fn();
+		render(NewAccountModal, {
+			props: { section: 'financial', onCreate: vi.fn(), onClose, personas }
+		});
+		await fireEvent.click(screen.getByTitle('Zamknij'));
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('closes on Escape', async () => {
+		const onClose = vi.fn();
+		render(NewAccountModal, {
+			props: { section: 'financial', onCreate: vi.fn(), onClose, personas }
+		});
+		await fireEvent.keyDown(window, { key: 'Escape' });
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('closes on backdrop click', async () => {
+		const onClose = vi.fn();
+		const { container } = render(NewAccountModal, {
+			props: { section: 'financial', onCreate: vi.fn(), onClose, personas }
+		});
+		const backdrop = container.querySelector('[role="presentation"]');
+		expect(backdrop).not.toBeNull();
+		await fireEvent.click(backdrop as Element);
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('stays open when the dialog body is clicked', async () => {
+		const onClose = vi.fn();
+		render(NewAccountModal, {
+			props: { section: 'financial', onCreate: vi.fn(), onClose, personas }
+		});
+		await fireEvent.click(screen.getByRole('dialog'));
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('renders one owner option per persona', () => {
+		render(NewAccountModal, {
+			props: { section: 'financial', onCreate: vi.fn(), onClose: vi.fn(), personas }
+		});
+		expect(screen.getByRole('option', { name: 'Marcin' })).toBeTruthy();
+		expect(screen.getByRole('option', { name: 'Ewa' })).toBeTruthy();
+	});
+});

--- a/src/lib/components/snapshot/NewAssetModal.svelte
+++ b/src/lib/components/snapshot/NewAssetModal.svelte
@@ -1,0 +1,206 @@
+<script lang="ts">
+	export let name = '';
+	export let value = 0;
+	export let creating = false;
+	export let onCreate: () => void;
+	export let onClose: () => void;
+
+	function closeOnBackdrop(event: MouseEvent) {
+		if (event.target === event.currentTarget) onClose();
+	}
+
+	function closeOnEscape(event: KeyboardEvent) {
+		if (event.key === 'Escape') onClose();
+	}
+</script>
+
+<svelte:window on:keydown={closeOnEscape} />
+
+<div class="modal-overlay" role="presentation" on:click={closeOnBackdrop}>
+	<div
+		class="modal"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="new-asset-modal-title"
+		tabindex="-1"
+	>
+		<div class="modal-header">
+			<h2 id="new-asset-modal-title">Dodaj nowy majątek</h2>
+			<button type="button" class="btn-close" on:click={onClose} title="Zamknij"> × </button>
+		</div>
+		<div class="modal-content">
+			<div class="form-group">
+				<label for="newAssetName" class="form-label">Nazwa *</label>
+				<input
+					id="newAssetName"
+					type="text"
+					bind:value={name}
+					placeholder="np. Mieszkanie Poznań, Rower"
+					class="form-input"
+					required
+				/>
+			</div>
+
+			<div class="form-group">
+				<label for="newAssetValue" class="form-label">Wartość początkowa</label>
+				<input
+					id="newAssetValue"
+					type="number"
+					step="0.01"
+					bind:value
+					placeholder="0.00"
+					class="form-input"
+				/>
+			</div>
+		</div>
+		<div class="modal-footer">
+			<button type="button" class="btn btn-secondary" on:click={onClose}> Anuluj </button>
+			<button type="button" class="btn btn-primary" disabled={creating} on:click={onCreate}>
+				{creating ? 'Tworzenie...' : 'Utwórz majątek'}
+			</button>
+		</div>
+	</div>
+</div>
+
+<style>
+	.form-group {
+		margin-bottom: var(--size-4);
+	}
+
+	.form-group:last-child {
+		margin-bottom: 0;
+	}
+
+	.form-label {
+		display: block;
+		font-weight: var(--font-weight-6);
+		margin-bottom: var(--size-2);
+		color: var(--color-text);
+	}
+
+	.form-input {
+		width: 100%;
+		padding: var(--size-3);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-2);
+		background: var(--color-bg);
+		color: var(--color-text);
+		font-size: var(--font-size-2);
+		font-family: inherit;
+		transition: all 0.2s;
+		min-height: var(--tap-target-min);
+	}
+
+	.form-input:focus {
+		outline: none;
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 2px rgba(94, 129, 172, 0.2);
+	}
+
+	.btn {
+		padding: var(--size-3) var(--size-5);
+		border: none;
+		border-radius: var(--radius-2);
+		font-weight: var(--font-weight-6);
+		font-size: var(--font-size-2);
+		cursor: pointer;
+		transition: all 0.2s;
+	}
+
+	.btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.btn-primary {
+		background: var(--color-primary);
+		color: var(--nord6);
+		flex: 1;
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		background: var(--nord9);
+	}
+
+	.btn-secondary {
+		background: transparent;
+		color: var(--color-text);
+		border: 1px solid var(--color-border);
+	}
+
+	.btn-secondary:hover {
+		background: var(--color-accent);
+	}
+
+	.modal-overlay {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+		padding: var(--size-4);
+	}
+
+	.modal {
+		background: var(--color-bg);
+		border-radius: var(--radius-2);
+		max-width: 500px;
+		width: 100%;
+		box-shadow: var(--shadow-6);
+	}
+
+	.modal-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: var(--size-4);
+		border-bottom: 1px solid var(--color-border);
+	}
+
+	.modal-header h2 {
+		margin: 0;
+		font-size: var(--font-size-4);
+		font-weight: var(--font-weight-7);
+		color: var(--color-text);
+	}
+
+	.btn-close {
+		width: var(--tap-target-min);
+		height: var(--tap-target-min);
+		padding: 0;
+		border: none;
+		background: transparent;
+		color: var(--color-text-secondary);
+		font-size: var(--font-size-5);
+		line-height: 1;
+		cursor: pointer;
+		transition: all 0.2s;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.btn-close:hover {
+		color: var(--nord11);
+	}
+
+	.modal-content {
+		padding: var(--size-4);
+	}
+
+	.modal-footer {
+		display: flex;
+		gap: var(--size-3);
+		padding: var(--size-4);
+		border-top: 1px solid var(--color-border);
+	}
+
+	.modal-footer .btn {
+		flex: 1;
+	}
+</style>

--- a/src/lib/components/snapshot/NewAssetModal.test.ts
+++ b/src/lib/components/snapshot/NewAssetModal.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import NewAssetModal from './NewAssetModal.svelte';
+
+describe('NewAssetModal', () => {
+	it('renders an accessible dialog with the title', () => {
+		render(NewAssetModal, { props: { onCreate: vi.fn(), onClose: vi.fn() } });
+		const dialog = screen.getByRole('dialog');
+		expect(dialog.getAttribute('aria-modal')).toBe('true');
+		expect(dialog.getAttribute('aria-labelledby')).toBe('new-asset-modal-title');
+		expect(screen.getByText('Dodaj nowy majątek')).toBeTruthy();
+	});
+
+	it('renders the name and value inputs', () => {
+		render(NewAssetModal, { props: { onCreate: vi.fn(), onClose: vi.fn() } });
+		expect(screen.getByLabelText('Nazwa *')).toBeTruthy();
+		expect(screen.getByLabelText('Wartość początkowa')).toBeTruthy();
+	});
+
+	it('calls onCreate when the confirm button is clicked', async () => {
+		const onCreate = vi.fn();
+		render(NewAssetModal, { props: { onCreate, onClose: vi.fn() } });
+		await fireEvent.click(screen.getByText('Utwórz majątek'));
+		expect(onCreate).toHaveBeenCalledOnce();
+	});
+
+	it('disables the confirm button while creating', () => {
+		render(NewAssetModal, { props: { creating: true, onCreate: vi.fn(), onClose: vi.fn() } });
+		const button = screen.getByText('Tworzenie...') as HTMLButtonElement;
+		expect(button.disabled).toBe(true);
+	});
+
+	it('closes via the × button', async () => {
+		const onClose = vi.fn();
+		render(NewAssetModal, { props: { onCreate: vi.fn(), onClose } });
+		await fireEvent.click(screen.getByTitle('Zamknij'));
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('closes on Escape', async () => {
+		const onClose = vi.fn();
+		render(NewAssetModal, { props: { onCreate: vi.fn(), onClose } });
+		await fireEvent.keyDown(window, { key: 'Escape' });
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('closes on backdrop click', async () => {
+		const onClose = vi.fn();
+		const { container } = render(NewAssetModal, { props: { onCreate: vi.fn(), onClose } });
+		const backdrop = container.querySelector('[role="presentation"]');
+		expect(backdrop).not.toBeNull();
+		await fireEvent.click(backdrop as Element);
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('stays open when the dialog body is clicked', async () => {
+		const onClose = vi.fn();
+		render(NewAssetModal, { props: { onCreate: vi.fn(), onClose } });
+		await fireEvent.click(screen.getByRole('dialog'));
+		expect(onClose).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/components/snapshot/ValueRow.svelte
+++ b/src/lib/components/snapshot/ValueRow.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	export let inputId: string;
+	export let label: string;
+	export let meta = '';
+	export let value: number;
+	export let onRemove: () => void;
+</script>
+
+<div class="form-group-with-remove">
+	<div class="form-group">
+		<label for={inputId} class="form-label">
+			{label}
+			{#if meta}
+				<span class="label-meta">{meta}</span>
+			{/if}
+		</label>
+		<input
+			id={inputId}
+			type="number"
+			step="0.01"
+			bind:value
+			placeholder="0.00"
+			class="form-input"
+		/>
+	</div>
+	<button type="button" class="btn-remove" on:click={onRemove} title="Usuń pole"> × </button>
+</div>
+
+<style>
+	.form-group {
+		margin-bottom: var(--size-4);
+	}
+
+	.form-group:last-child {
+		margin-bottom: 0;
+	}
+
+	.form-label {
+		display: block;
+		font-weight: var(--font-weight-6);
+		margin-bottom: var(--size-2);
+		color: var(--color-text);
+	}
+
+	.label-meta {
+		color: var(--color-text-secondary);
+		font-weight: var(--font-weight-4);
+		font-size: var(--font-size-1);
+	}
+
+	.form-input {
+		width: 100%;
+		padding: var(--size-3);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-2);
+		background: var(--color-bg);
+		color: var(--color-text);
+		font-size: var(--font-size-2);
+		font-family: inherit;
+		transition: all 0.2s;
+		min-height: var(--tap-target-min);
+	}
+
+	.form-input:focus {
+		outline: none;
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 2px rgba(94, 129, 172, 0.2);
+	}
+
+	.form-group-with-remove {
+		display: flex;
+		gap: var(--size-2);
+		align-items: flex-start;
+		margin-bottom: var(--size-4);
+	}
+
+	.form-group-with-remove .form-group {
+		flex: 1;
+		margin-bottom: 0;
+	}
+
+	.btn-remove {
+		flex-shrink: 0;
+		width: var(--tap-target-min);
+		height: var(--tap-target-min);
+		margin-top: 28px;
+		padding: 0;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-2);
+		background: transparent;
+		color: var(--color-text-secondary);
+		font-size: var(--font-size-4);
+		line-height: 1;
+		cursor: pointer;
+		transition: all 0.2s;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.btn-remove:hover {
+		background: var(--nord11);
+		color: var(--nord6);
+		border-color: var(--nord11);
+	}
+
+	@media (max-width: 640px) {
+		.btn-remove {
+			margin-top: 32px;
+		}
+	}
+</style>

--- a/src/lib/utils/charts/metryki.test.ts
+++ b/src/lib/utils/charts/metryki.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import {
+	buildAllocationChartOption,
+	buildWrapperChartOption,
+	buildInvestmentTrendChartOption,
+	buildWrapperTrendChartOption,
+	buildYearlyRoiChartOption,
+	computeYearlyRoi,
+	type AllocationCategory,
+	type AllocationWrapper,
+	type TimeSeriesPoint
+} from './metryki';
+
+const allocationCategories: AllocationCategory[] = [
+	{ category: 'akcje', current_percentage: 42.37, target_percentage: 60 },
+	{ category: 'obligacje', current_percentage: 57.63, target_percentage: 40 }
+];
+
+const wrappers: AllocationWrapper[] = [
+	{ wrapper: 'IKE', value: 12000 },
+	{ wrapper: 'IKZE', value: 8000 }
+];
+
+const trendSeries: TimeSeriesPoint[] = [
+	{ date: '2023-01-31', value: 1000, contributions: 1000 },
+	{ date: '2023-12-31', value: 2200, contributions: 2000 }
+];
+
+describe('buildAllocationChartOption', () => {
+	it('builds two bar series with rounded percentages', () => {
+		const option = buildAllocationChartOption(allocationCategories);
+		const series = option.series as Array<{ name: string; type: string; data: number[] }>;
+
+		expect(series).toHaveLength(2);
+		expect(series[0].name).toBe('Obecna');
+		expect(series[0].type).toBe('bar');
+		expect(series[0].data).toEqual([42.4, 57.6]);
+		expect(series[1].name).toBe('Docelowa');
+		expect(series[1].data).toEqual([60, 40]);
+	});
+
+	it('puts categories on the x axis', () => {
+		const option = buildAllocationChartOption(allocationCategories);
+		const xAxis = option.xAxis as { data: string[] };
+		expect(xAxis.data).toEqual(['akcje', 'obligacje']);
+	});
+
+	it('handles an empty input', () => {
+		const option = buildAllocationChartOption([]);
+		const series = option.series as Array<{ data: number[] }>;
+		expect(series[0].data).toEqual([]);
+		expect(series[1].data).toEqual([]);
+	});
+});
+
+describe('buildWrapperChartOption', () => {
+	it('builds a single pie series from wrappers', () => {
+		const option = buildWrapperChartOption(wrappers);
+		const series = option.series as Array<{
+			type: string;
+			data: Array<{ name: string; value: number }>;
+		}>;
+
+		expect(series).toHaveLength(1);
+		expect(series[0].type).toBe('pie');
+		expect(series[0].data).toEqual([
+			{ name: 'IKE', value: 12000 },
+			{ name: 'IKZE', value: 8000 }
+		]);
+	});
+
+	it('handles an empty input', () => {
+		const option = buildWrapperChartOption([]);
+		const series = option.series as Array<{ data: unknown[] }>;
+		expect(series[0].data).toEqual([]);
+	});
+});
+
+describe('buildInvestmentTrendChartOption', () => {
+	it('builds contribution and value line series', () => {
+		const option = buildInvestmentTrendChartOption(trendSeries);
+		const series = option.series as Array<{ name: string; type: string; data: number[] }>;
+
+		expect(series).toHaveLength(2);
+		expect(series[0].name).toBe('Wpłaty');
+		expect(series[0].data).toEqual([1000, 2000]);
+		expect(series[1].name).toBe('Wartość portfela');
+		expect(series[1].data).toEqual([1000, 2200]);
+	});
+
+	it('puts dates on the x axis', () => {
+		const option = buildInvestmentTrendChartOption(trendSeries);
+		const xAxis = option.xAxis as { data: string[] };
+		expect(xAxis.data).toEqual(['2023-01-31', '2023-12-31']);
+	});
+
+	it('defaults missing values to zero', () => {
+		const option = buildInvestmentTrendChartOption([{ date: '2023-01-31' }]);
+		const series = option.series as Array<{ data: number[] }>;
+		expect(series[0].data).toEqual([0]);
+		expect(series[1].data).toEqual([0]);
+	});
+
+	it('handles an empty input', () => {
+		const option = buildInvestmentTrendChartOption([]);
+		const series = option.series as Array<{ data: number[] }>;
+		expect(series[0].data).toEqual([]);
+	});
+});
+
+describe('buildWrapperTrendChartOption', () => {
+	it('uses the provided title', () => {
+		const option = buildWrapperTrendChartOption('IKE w czasie', trendSeries);
+		const title = option.title as { text: string };
+		expect(title.text).toBe('IKE w czasie');
+	});
+
+	it('builds contribution and value line series', () => {
+		const option = buildWrapperTrendChartOption('IKE w czasie', trendSeries);
+		const series = option.series as Array<{ name: string; data: number[] }>;
+		expect(series[0].data).toEqual([1000, 2000]);
+		expect(series[1].data).toEqual([1000, 2200]);
+	});
+
+	it('handles an empty input', () => {
+		const option = buildWrapperTrendChartOption('Puste', []);
+		const series = option.series as Array<{ data: number[] }>;
+		expect(series[0].data).toEqual([]);
+	});
+});
+
+describe('computeYearlyRoi', () => {
+	it('computes ROI per year using modified Dietz', () => {
+		const series: TimeSeriesPoint[] = [
+			{ date: '2022-01-31', value: 1000, contributions: 1000 },
+			{ date: '2022-12-31', value: 1100, contributions: 1000 },
+			{ date: '2023-12-31', value: 1300, contributions: 1100 }
+		];
+		const roi = computeYearlyRoi(series);
+		expect(roi.get(2022)).toBe(10);
+		expect(roi.get(2023)).toBeCloseTo(8.7, 1);
+	});
+
+	it('skips a first year that starts with a zero placeholder', () => {
+		const series: TimeSeriesPoint[] = [
+			{ date: '2022-01-31', value: 0, contributions: 0 },
+			{ date: '2022-12-31', value: 500, contributions: 500 }
+		];
+		const roi = computeYearlyRoi(series);
+		expect(roi.has(2022)).toBe(false);
+	});
+
+	it('handles an empty input', () => {
+		expect(computeYearlyRoi([]).size).toBe(0);
+	});
+});
+
+describe('buildYearlyRoiChartOption', () => {
+	const stock: TimeSeriesPoint[] = [
+		{ date: '2022-01-31', value: 1000, contributions: 1000 },
+		{ date: '2022-12-31', value: 1100, contributions: 1000 }
+	];
+	const bond: TimeSeriesPoint[] = [
+		{ date: '2023-01-31', value: 2000, contributions: 2000 },
+		{ date: '2023-12-31', value: 2100, contributions: 2000 }
+	];
+
+	it('builds three bar series aligned across all years', () => {
+		const option = buildYearlyRoiChartOption(stock, bond, []);
+		const series = option.series as Array<{ name: string; type: string; data: unknown[] }>;
+		const xAxis = option.xAxis as { data: string[] };
+
+		expect(series.map((s) => s.name)).toEqual(['Akcje', 'Obligacje', 'PPK']);
+		expect(series.every((s) => s.type === 'bar')).toBe(true);
+		expect(xAxis.data).toEqual(['2022', '2023']);
+		expect(series[0].data).toHaveLength(2);
+	});
+
+	it('handles all-empty inputs', () => {
+		const option = buildYearlyRoiChartOption([], [], []);
+		const xAxis = option.xAxis as { data: string[] };
+		const series = option.series as Array<{ data: unknown[] }>;
+		expect(xAxis.data).toEqual([]);
+		expect(series[0].data).toEqual([]);
+	});
+});

--- a/src/lib/utils/charts/metryki.ts
+++ b/src/lib/utils/charts/metryki.ts
@@ -1,0 +1,574 @@
+import type { BarSeriesOption, EChartsOption } from 'echarts';
+import type { CallbackDataParams, TopLevelFormatterParams } from 'echarts/types/dist/shared';
+
+type AxisTooltipItem = CallbackDataParams & { axisValue: string };
+
+// ECharts supports a callback for bar `label.position` at runtime, but the
+// shipped type definition omits the function form. This narrows the label
+// type to add it without resorting to `any`.
+type RoiLabel = Omit<NonNullable<BarSeriesOption['label']>, 'position'> & {
+	position: (params: { value: unknown }) => 'top' | 'bottom';
+};
+
+type RoiBarSeries = Omit<BarSeriesOption, 'label'> & { label: RoiLabel };
+
+export interface AllocationCategory {
+	category: string;
+	current_percentage: number;
+	target_percentage: number;
+}
+
+export interface AllocationWrapper {
+	wrapper: string;
+	value: number;
+}
+
+export interface TimeSeriesPoint {
+	date: string;
+	value?: number;
+	total_value?: number;
+	contributions?: number;
+	cumulative_contributions?: number;
+}
+
+const formatPLN = (val: number): string =>
+	val.toLocaleString('pl-PL', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+
+export function buildAllocationChartOption(byCategory: AllocationCategory[]): EChartsOption {
+	const categories = byCategory.map((item) => item.category);
+	const currentValues = byCategory.map((item) => parseFloat(item.current_percentage.toFixed(1)));
+	const targetValues = byCategory.map((item) => parseFloat(item.target_percentage.toFixed(1)));
+
+	return {
+		backgroundColor: 'transparent',
+		title: {
+			text: 'Alokacja inwestycyjna: Obecna vs Docelowa',
+			left: 'center',
+			top: 10,
+			textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
+		},
+		tooltip: {
+			trigger: 'axis',
+			axisPointer: { type: 'shadow' },
+			backgroundColor: 'rgba(255, 255, 255, 0.95)',
+			borderColor: '#d8dee9',
+			textStyle: { color: '#2e3440' },
+			formatter: '{b}<br/>{a0}: {c0}%<br/>{a1}: {c1}%'
+		},
+		legend: {
+			data: ['Obecna', 'Docelowa'],
+			bottom: 10,
+			textStyle: { color: '#2e3440', fontSize: 14 }
+		},
+		grid: {
+			left: 60,
+			right: 40,
+			bottom: 60,
+			top: 80,
+			containLabel: false
+		},
+		xAxis: {
+			type: 'category',
+			data: categories,
+			axisLabel: {
+				color: '#2e3440',
+				fontSize: 14,
+				fontWeight: 'bold',
+				formatter: function (value: string) {
+					return value.charAt(0).toUpperCase() + value.slice(1);
+				}
+			},
+			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
+			axisTick: { show: false }
+		},
+		yAxis: {
+			type: 'value',
+			name: 'Procent (%)',
+			nameLocation: 'middle',
+			nameGap: 50,
+			nameTextStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
+			max: 100,
+			axisLabel: {
+				color: '#2e3440',
+				fontSize: 13,
+				fontWeight: 'bold',
+				formatter: '{value}%'
+			},
+			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
+			splitLine: { lineStyle: { color: '#e5e9f0', type: 'dashed' } }
+		},
+		series: [
+			{
+				name: 'Obecna',
+				type: 'bar',
+				data: currentValues,
+				barWidth: '35%',
+				itemStyle: { color: '#88c0d0', borderRadius: [4, 4, 0, 0] },
+				label: {
+					show: true,
+					position: 'top',
+					distance: 5,
+					formatter: '{c}%',
+					color: '#2e3440',
+					fontSize: 14,
+					fontWeight: 'bold'
+				}
+			},
+			{
+				name: 'Docelowa',
+				type: 'bar',
+				data: targetValues,
+				barWidth: '35%',
+				itemStyle: { color: '#81a1c1', borderRadius: [4, 4, 0, 0] },
+				label: {
+					show: true,
+					position: 'top',
+					distance: 5,
+					formatter: '{c}%',
+					color: '#2e3440',
+					fontSize: 14,
+					fontWeight: 'bold'
+				}
+			}
+		]
+	};
+}
+
+export function buildWrapperChartOption(byWrapper: AllocationWrapper[]): EChartsOption {
+	const wrapperData = byWrapper.map((item) => ({
+		name: item.wrapper,
+		value: item.value
+	}));
+
+	return {
+		backgroundColor: 'transparent',
+		title: {
+			text: 'Podział według kont (IKE/IKZE/PPK)',
+			left: 'center',
+			top: 10,
+			textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
+		},
+		tooltip: {
+			trigger: 'item',
+			backgroundColor: 'rgba(255, 255, 255, 0.95)',
+			borderColor: '#d8dee9',
+			textStyle: { color: '#2e3440' },
+			formatter: function (params) {
+				const single = Array.isArray(params) ? params[0] : params;
+				const value = (single.value as number).toLocaleString('pl-PL', {
+					minimumFractionDigits: 0,
+					maximumFractionDigits: 0
+				});
+				return `${single.name}: ${value} PLN (${(single.percent ?? 0).toFixed(1)}%)`;
+			}
+		},
+		legend: {
+			orient: 'vertical',
+			left: 20,
+			top: 'middle',
+			textStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
+			itemGap: 15
+		},
+		series: [
+			{
+				type: 'pie',
+				radius: ['40%', '65%'],
+				center: ['50%', '50%'],
+				avoidLabelOverlap: true,
+				minShowLabelAngle: 1,
+				data: wrapperData,
+				color: ['#88c0d0', '#81a1c1', '#5e81ac', '#b48ead'],
+				emphasis: {
+					itemStyle: {
+						shadowBlur: 10,
+						shadowOffsetX: 0,
+						shadowColor: 'rgba(0, 0, 0, 0.5)'
+					},
+					label: {
+						show: true,
+						fontSize: 18,
+						fontWeight: 'bold'
+					}
+				},
+				label: {
+					show: true,
+					position: 'outside',
+					alignTo: 'edge',
+					margin: 20,
+					edgeDistance: '15%',
+					color: '#000000',
+					fontSize: 15,
+					fontWeight: 'bold',
+					formatter: function (params) {
+						return `${params.name}\n${(params.percent ?? 0).toFixed(1)}%`;
+					},
+					overflow: 'none'
+				},
+				labelLine: {
+					show: true,
+					length: 25,
+					length2: 20,
+					smooth: 0.2,
+					lineStyle: {
+						color: '#2e3440',
+						width: 2
+					}
+				},
+				labelLayout: {
+					hideOverlap: false,
+					moveOverlap: 'shiftY'
+				}
+			}
+		]
+	};
+}
+
+export function buildInvestmentTrendChartOption(series: TimeSeriesPoint[]): EChartsOption {
+	const dates = series.map((item) => item.date);
+	const values = series.map((item) => item.value ?? 0);
+	const contributions = series.map((item) => item.contributions ?? 0);
+
+	return {
+		backgroundColor: 'transparent',
+		title: {
+			text: 'Inwestycje w czasie',
+			left: 'center',
+			top: 10,
+			textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
+		},
+		tooltip: {
+			trigger: 'axis',
+			backgroundColor: 'rgba(255, 255, 255, 0.95)',
+			borderColor: '#d8dee9',
+			textStyle: { color: '#2e3440' },
+			formatter: function (params: TopLevelFormatterParams) {
+				const items = (Array.isArray(params) ? params : [params]) as AxisTooltipItem[];
+				const date = items[0].axisValue;
+				const contributed = items[0].value as number;
+				const value = items[1].value as number;
+				const returns = value - contributed;
+
+				return `${date}<br/>
+					<span style="color:#5e81ac">●</span> Wartość portfela: <b>${formatPLN(value)} PLN</b><br/>
+					<span style="color:#88c0d0">■</span> Wpłaty: ${formatPLN(contributed)} PLN<br/>
+					<span style="color:#a3be8c">■</span> Zyski: ${formatPLN(returns)} PLN`;
+			}
+		},
+		legend: {
+			data: ['Wpłaty', 'Wartość portfela'],
+			bottom: 10,
+			textStyle: { color: '#2e3440', fontSize: 14 }
+		},
+		grid: {
+			left: 80,
+			right: 40,
+			bottom: 80,
+			top: 80,
+			containLabel: false
+		},
+		xAxis: {
+			type: 'category',
+			data: dates,
+			axisLabel: {
+				color: '#2e3440',
+				fontSize: 12,
+				rotate: 45
+			},
+			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
+			boundaryGap: false
+		},
+		yAxis: {
+			type: 'value',
+			name: 'Wartość (PLN)',
+			nameLocation: 'middle',
+			nameGap: 60,
+			nameTextStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
+			axisLabel: {
+				color: '#2e3440',
+				fontSize: 12,
+				formatter: function (value: number) {
+					return (value / 1000).toFixed(0) + 'k';
+				}
+			},
+			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
+			splitLine: { lineStyle: { color: '#e5e9f0', type: 'dashed' } }
+		},
+		series: [
+			{
+				name: 'Wpłaty',
+				type: 'line',
+				data: contributions,
+				smooth: true,
+				lineStyle: { width: 0 },
+				showSymbol: false,
+				areaStyle: {
+					color: '#88c0d0',
+					opacity: 0.8
+				},
+				emphasis: {
+					focus: 'series'
+				}
+			},
+			{
+				name: 'Wartość portfela',
+				type: 'line',
+				data: values,
+				smooth: true,
+				lineStyle: { width: 3, color: '#5e81ac' },
+				showSymbol: false,
+				emphasis: {
+					focus: 'series'
+				}
+			}
+		]
+	};
+}
+
+export function buildWrapperTrendChartOption(
+	title: string,
+	series: TimeSeriesPoint[]
+): EChartsOption {
+	const dates = series.map((item) => item.date);
+	const contributions = series.map((item) => item.contributions ?? 0);
+	const values = series.map((item) => item.value ?? 0);
+
+	return {
+		backgroundColor: 'transparent',
+		title: {
+			text: title,
+			left: 'center',
+			top: 10,
+			textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
+		},
+		tooltip: {
+			trigger: 'axis',
+			backgroundColor: 'rgba(255, 255, 255, 0.95)',
+			borderColor: '#d8dee9',
+			textStyle: { color: '#2e3440' },
+			formatter: function (params: TopLevelFormatterParams) {
+				const items = (Array.isArray(params) ? params : [params]) as AxisTooltipItem[];
+				const date = items[0].axisValue;
+				const contributed = items[0].value as number;
+				const value = items[1].value as number;
+				const returns = value - contributed;
+
+				return `${date}<br/>
+					<span style="color:#5e81ac">●</span> Wartość: <b>${formatPLN(value)} PLN</b><br/>
+					<span style="color:#88c0d0">■</span> Wpłaty: ${formatPLN(contributed)} PLN<br/>
+					<span style="color:#a3be8c">■</span> Zyski: ${formatPLN(returns)} PLN`;
+			}
+		},
+		legend: {
+			data: ['Wpłaty', 'Wartość portfela'],
+			bottom: 10,
+			textStyle: { color: '#2e3440', fontSize: 14 }
+		},
+		grid: {
+			left: 80,
+			right: 40,
+			bottom: 80,
+			top: 80,
+			containLabel: false
+		},
+		xAxis: {
+			type: 'category',
+			data: dates,
+			axisLabel: {
+				color: '#2e3440',
+				fontSize: 11,
+				rotate: 45
+			},
+			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
+			boundaryGap: false
+		},
+		yAxis: {
+			type: 'value',
+			name: 'Wartość (PLN)',
+			nameLocation: 'middle',
+			nameGap: 60,
+			nameTextStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
+			axisLabel: {
+				color: '#2e3440',
+				fontSize: 11,
+				formatter: function (value: number) {
+					return (value / 1000).toFixed(0) + 'k';
+				}
+			},
+			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
+			splitLine: { lineStyle: { color: '#e5e9f0', type: 'dashed' } }
+		},
+		series: [
+			{
+				name: 'Wpłaty',
+				type: 'line',
+				data: contributions,
+				smooth: true,
+				lineStyle: { width: 0 },
+				showSymbol: false,
+				areaStyle: {
+					color: '#88c0d0',
+					opacity: 0.8
+				},
+				emphasis: {
+					focus: 'series'
+				}
+			},
+			{
+				name: 'Wartość portfela',
+				type: 'line',
+				data: values,
+				smooth: true,
+				lineStyle: { width: 3, color: '#5e81ac' },
+				showSymbol: false,
+				emphasis: {
+					focus: 'series'
+				}
+			}
+		]
+	};
+}
+
+// Computes year-over-year ROI using the modified Dietz method: the
+// denominator weights mid-period contributions to approximate average
+// invested capital. The first year is skipped when it begins with a
+// zero-value placeholder entry.
+export function computeYearlyRoi(series: TimeSeriesPoint[]): Map<number, number> {
+	type Pt = { date: string; value: number; contribs: number };
+	const byYear = new Map<number, { first: Pt; last: Pt }>();
+	for (const point of series) {
+		const year = new Date(point.date).getFullYear();
+		const val = point.value ?? point.total_value ?? 0;
+		const contrib = point.contributions ?? point.cumulative_contributions ?? 0;
+		const pt: Pt = { date: point.date, value: val, contribs: contrib };
+		const existing = byYear.get(year);
+		if (!existing) {
+			byYear.set(year, { first: pt, last: pt });
+		} else {
+			if (point.date < existing.first.date) existing.first = pt;
+			if (point.date > existing.last.date) existing.last = pt;
+		}
+	}
+	const years = [...byYear.keys()].sort((a, b) => a - b);
+	const result = new Map<number, number>();
+	for (let i = 0; i < years.length; i++) {
+		const { first, last: end } = byYear.get(years[i])!;
+		let start: Pt;
+		if (i === 0) {
+			if (first.value === 0) continue;
+			start = first;
+		} else {
+			start = byYear.get(years[i - 1])!.last;
+		}
+		const yearContribs = end.contribs - start.contribs;
+		const denom = start.value + yearContribs / 2;
+		const roi = denom > 0 ? ((end.value - start.value - yearContribs) / denom) * 100 : 0;
+		result.set(years[i], parseFloat(roi.toFixed(2)));
+	}
+	return result;
+}
+
+export function buildYearlyRoiChartOption(
+	stockSeries: TimeSeriesPoint[],
+	bondSeries: TimeSeriesPoint[],
+	ppkSeries: TimeSeriesPoint[]
+): EChartsOption {
+	const stockRoi = computeYearlyRoi(stockSeries);
+	const bondRoi = computeYearlyRoi(bondSeries);
+	const ppkRoi = computeYearlyRoi(ppkSeries);
+	const allYears = [...new Set([...stockRoi.keys(), ...bondRoi.keys(), ...ppkRoi.keys()])].sort(
+		(a, b) => a - b
+	);
+
+	const labelPosition = (params: { value: unknown }): 'top' | 'bottom' =>
+		Number(params.value) >= 0 ? 'top' : 'bottom';
+
+	const roiSeries: RoiBarSeries[] = [
+		{
+			name: 'Akcje',
+			type: 'bar',
+			barWidth: '25%',
+			data: allYears.map((y) => stockRoi.get(y) ?? null),
+			itemStyle: { color: '#a3be8c' },
+			label: {
+				show: true,
+				position: labelPosition,
+				formatter: '{c}%',
+				color: '#2e3440',
+				fontSize: 11
+			},
+			markLine: {
+				silent: true,
+				symbol: 'none',
+				data: [{ yAxis: 0 }],
+				lineStyle: { color: '#4c566a', type: 'solid', width: 1 }
+			}
+		},
+		{
+			name: 'Obligacje',
+			type: 'bar',
+			barWidth: '25%',
+			data: allYears.map((y) => bondRoi.get(y) ?? null),
+			itemStyle: { color: '#d08770' },
+			label: {
+				show: true,
+				position: labelPosition,
+				formatter: '{c}%',
+				color: '#2e3440',
+				fontSize: 11
+			}
+		},
+		{
+			name: 'PPK',
+			type: 'bar',
+			barWidth: '25%',
+			data: allYears.map((y) => ppkRoi.get(y) ?? null),
+			itemStyle: { color: '#88c0d0' },
+			label: {
+				show: true,
+				position: labelPosition,
+				formatter: '{c}%',
+				color: '#2e3440',
+				fontSize: 11
+			}
+		}
+	];
+
+	return {
+		backgroundColor: 'transparent',
+		title: {
+			text: 'Roczny ROI: Akcje, Obligacje, PPK',
+			left: 'center',
+			top: 10,
+			textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
+		},
+		tooltip: {
+			trigger: 'axis',
+			axisPointer: { type: 'shadow' },
+			backgroundColor: 'rgba(255, 255, 255, 0.95)',
+			borderColor: '#d8dee9',
+			textStyle: { color: '#2e3440' },
+			formatter: function (params: TopLevelFormatterParams) {
+				const items = (Array.isArray(params) ? params : [params]) as CallbackDataParams[];
+				return items
+					.map((p) => `${p.seriesName}: ${p.value != null ? p.value + '%' : 'brak danych'}`)
+					.join('<br/>');
+			}
+		},
+		legend: {
+			top: 40,
+			textStyle: { color: '#2e3440' }
+		},
+		grid: { top: 80, left: 60, right: 30, bottom: 60 },
+		xAxis: {
+			type: 'category',
+			data: allYears.map(String),
+			axisLabel: { color: '#4c566a' }
+		},
+		yAxis: {
+			type: 'value',
+			axisLabel: { formatter: '{value}%', color: '#4c566a' },
+			splitLine: { lineStyle: { color: '#e5e9f0' } }
+		},
+		series: roiSeries as unknown as BarSeriesOption[]
+	};
+}

--- a/src/lib/utils/charts/simulations.test.ts
+++ b/src/lib/utils/charts/simulations.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { buildRetirementProjectionOption, type AccountSimulation } from './simulations';
+
+function makeSimulation(name: string, balances: number[]): AccountSimulation {
+	return {
+		account_name: name,
+		starting_balance: balances[0] ?? 0,
+		total_contributions: 0,
+		total_returns: 0,
+		total_tax_savings: 0,
+		final_balance: balances[balances.length - 1] ?? 0,
+		yearly_projections: balances.map((balance, idx) => ({
+			year: 2025 + idx,
+			age: 30 + idx,
+			annual_contribution: 0,
+			balance_end_of_year: balance,
+			cumulative_contributions: 0,
+			cumulative_returns: 0,
+			annual_limit: 0,
+			limit_utilized_pct: 0,
+			tax_savings: 0
+		}))
+	};
+}
+
+describe('buildRetirementProjectionOption', () => {
+	it('builds one line series per simulation', () => {
+		const simulations = [
+			makeSimulation('IKE Marcin', [1000, 2000, 3000]),
+			makeSimulation('IKZE Ewa', [500, 1500, 2500])
+		];
+		const option = buildRetirementProjectionOption(simulations);
+		const series = option.series as Array<{ name: string; type: string; data: number[] }>;
+
+		expect(series).toHaveLength(2);
+		expect(series[0].name).toBe('IKE Marcin');
+		expect(series[0].type).toBe('line');
+		expect(series[0].data).toEqual([1000, 2000, 3000]);
+		expect(series[1].data).toEqual([500, 1500, 2500]);
+	});
+
+	it('derives x axis years from the first simulation', () => {
+		const option = buildRetirementProjectionOption([makeSimulation('IKE Marcin', [1000, 2000])]);
+		const xAxis = option.xAxis as { data: number[]; name: string };
+		expect(xAxis.data).toEqual([2025, 2026]);
+		expect(xAxis.name).toBe('Rok');
+	});
+
+	it('sets the legend from account names', () => {
+		const option = buildRetirementProjectionOption([
+			makeSimulation('IKE Marcin', [1000]),
+			makeSimulation('PPK Ewa', [2000])
+		]);
+		const legend = option.legend as { data: string[] };
+		expect(legend.data).toEqual(['IKE Marcin', 'PPK Ewa']);
+	});
+
+	it('sets the chart title', () => {
+		const option = buildRetirementProjectionOption([]);
+		const title = option.title as { text: string };
+		expect(title.text).toBe('Projekcja wartości kont emerytalnych');
+	});
+
+	it('handles an empty simulation list', () => {
+		const option = buildRetirementProjectionOption([]);
+		const series = option.series as unknown[];
+		const xAxis = option.xAxis as { data: number[] };
+		expect(series).toEqual([]);
+		expect(xAxis.data).toEqual([]);
+	});
+});

--- a/src/lib/utils/charts/simulations.ts
+++ b/src/lib/utils/charts/simulations.ts
@@ -1,0 +1,72 @@
+import type { EChartsOption, LineSeriesOption } from 'echarts';
+import type { TopLevelFormatterParams } from 'echarts/types/dist/shared';
+
+export interface YearlyProjection {
+	year: number;
+	age: number;
+	annual_contribution: number;
+	balance_end_of_year: number;
+	cumulative_contributions: number;
+	cumulative_returns: number;
+	annual_limit: number;
+	limit_utilized_pct: number;
+	tax_savings: number;
+	government_subsidies?: number;
+	monthly_salary?: number;
+	return_rate?: number;
+}
+
+export interface AccountSimulation {
+	account_name: string;
+	starting_balance: number;
+	total_contributions: number;
+	total_returns: number;
+	total_tax_savings: number;
+	total_subsidies?: number;
+	final_balance: number;
+	yearly_projections: YearlyProjection[];
+}
+
+const SERIES_COLORS = ['#5E81AC', '#81A1C1', '#88C0D0', '#8FBCBB', '#B48EAD', '#A3BE8C'];
+
+export function buildRetirementProjectionOption(simulations: AccountSimulation[]): EChartsOption {
+	const years = simulations.length > 0 ? simulations[0].yearly_projections.map((p) => p.year) : [];
+
+	const series: LineSeriesOption[] = simulations.map((sim, idx) => ({
+		name: sim.account_name,
+		type: 'line',
+		data: sim.yearly_projections.map((p) => p.balance_end_of_year),
+		smooth: true,
+		itemStyle: { color: SERIES_COLORS[idx % SERIES_COLORS.length] }
+	}));
+
+	return {
+		title: { text: 'Projekcja wartości kont emerytalnych' },
+		tooltip: {
+			trigger: 'axis',
+			formatter: (params: TopLevelFormatterParams) => {
+				const items = Array.isArray(params) ? params : [params];
+				let result = `<strong>Rok ${items[0].name}</strong><br/>`;
+				items.forEach((param) => {
+					const value = (param.value as number).toLocaleString('pl-PL');
+					result += `${param.seriesName}: ${value} PLN<br/>`;
+				});
+				return result;
+			}
+		},
+		legend: {
+			data: simulations.map((s) => s.account_name),
+			bottom: 0
+		},
+		grid: { left: '3%', right: '4%', bottom: '15%', containLabel: true },
+		xAxis: { type: 'category', data: years, name: 'Rok' },
+		yAxis: {
+			type: 'value',
+			name: 'Wartość (PLN)',
+			axisLabel: {
+				formatter: (value: number) => `${(value / 1000).toFixed(0)}k`
+			}
+		},
+		series
+	};
+}

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -3,6 +3,13 @@
 	import * as echarts from 'echarts';
 	import MetricCard from '$lib/components/MetricCard.svelte';
 	import { TrendingUp, CheckCircle2, Lightbulb } from 'lucide-svelte';
+	import {
+		buildAllocationChartOption,
+		buildWrapperChartOption,
+		buildInvestmentTrendChartOption,
+		buildWrapperTrendChartOption,
+		buildYearlyRoiChartOption
+	} from '$lib/utils/charts/metryki';
 
 	export let data;
 
@@ -25,573 +32,51 @@
 	let yearlyRoiChart: HTMLDivElement;
 
 	onMount(() => {
-		// Allocation by category chart (current vs target)
 		const allocationChartInstance = echarts.init(allocationChart);
-		const categories = allocationAnalysis.by_category.map((item: any) => item.category);
-		const currentValues = allocationAnalysis.by_category.map((item: any) =>
-			parseFloat(item.current_percentage.toFixed(1))
-		);
-		const targetValues = allocationAnalysis.by_category.map((item: any) =>
-			parseFloat(item.target_percentage.toFixed(1))
-		);
+		allocationChartInstance.setOption(buildAllocationChartOption(allocationAnalysis.by_category));
 
-		allocationChartInstance.setOption({
-			backgroundColor: 'transparent',
-			title: {
-				text: 'Alokacja inwestycyjna: Obecna vs Docelowa',
-				left: 'center',
-				top: 10,
-				textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
-			},
-			tooltip: {
-				trigger: 'axis',
-				axisPointer: { type: 'shadow' },
-				backgroundColor: 'rgba(255, 255, 255, 0.95)',
-				borderColor: '#d8dee9',
-				textStyle: { color: '#2e3440' },
-				formatter: '{b}<br/>{a0}: {c0}%<br/>{a1}: {c1}%'
-			},
-			legend: {
-				data: ['Obecna', 'Docelowa'],
-				bottom: 10,
-				textStyle: { color: '#2e3440', fontSize: 14 }
-			},
-			grid: {
-				left: 60,
-				right: 40,
-				bottom: 60,
-				top: 80,
-				containLabel: false
-			},
-			xAxis: {
-				type: 'category',
-				data: categories,
-				axisLabel: {
-					color: '#2e3440',
-					fontSize: 14,
-					fontWeight: 'bold',
-					formatter: function (value: string) {
-						return value.charAt(0).toUpperCase() + value.slice(1);
-					}
-				},
-				axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
-				axisTick: { show: false }
-			},
-			yAxis: {
-				type: 'value',
-				name: 'Procent (%)',
-				nameLocation: 'middle',
-				nameGap: 50,
-				nameTextStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
-				max: 100,
-				axisLabel: {
-					color: '#2e3440',
-					fontSize: 13,
-					fontWeight: 'bold',
-					formatter: '{value}%'
-				},
-				axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
-				splitLine: { lineStyle: { color: '#e5e9f0', type: 'dashed' } }
-			},
-			series: [
-				{
-					name: 'Obecna',
-					type: 'bar',
-					data: currentValues,
-					barWidth: '35%',
-					itemStyle: { color: '#88c0d0', borderRadius: [4, 4, 0, 0] },
-					label: {
-						show: true,
-						position: 'top',
-						distance: 5,
-						formatter: '{c}%',
-						color: '#2e3440',
-						fontSize: 14,
-						fontWeight: 'bold'
-					}
-				},
-				{
-					name: 'Docelowa',
-					type: 'bar',
-					data: targetValues,
-					barWidth: '35%',
-					itemStyle: { color: '#81a1c1', borderRadius: [4, 4, 0, 0] },
-					label: {
-						show: true,
-						position: 'top',
-						distance: 5,
-						formatter: '{c}%',
-						color: '#2e3440',
-						fontSize: 14,
-						fontWeight: 'bold'
-					}
-				}
-			]
-		});
-
-		// Wrapper breakdown chart
 		const wrapperChartInstance = echarts.init(wrapperChart);
-		const wrapperData = allocationAnalysis.by_wrapper.map((item: any) => ({
-			name: item.wrapper,
-			value: item.value
-		}));
+		wrapperChartInstance.setOption(buildWrapperChartOption(allocationAnalysis.by_wrapper));
 
-		wrapperChartInstance.setOption({
-			backgroundColor: 'transparent',
-			title: {
-				text: 'Podział według kont (IKE/IKZE/PPK)',
-				left: 'center',
-				top: 10,
-				textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
-			},
-			tooltip: {
-				trigger: 'item',
-				backgroundColor: 'rgba(255, 255, 255, 0.95)',
-				borderColor: '#d8dee9',
-				textStyle: { color: '#2e3440' },
-				formatter: function (params: any) {
-					const value = params.value.toLocaleString('pl-PL', {
-						minimumFractionDigits: 0,
-						maximumFractionDigits: 0
-					});
-					return `${params.name}: ${value} PLN (${params.percent.toFixed(1)}%)`;
-				}
-			},
-			legend: {
-				orient: 'vertical',
-				left: 20,
-				top: 'middle',
-				textStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
-				itemGap: 15
-			},
-			series: [
-				{
-					type: 'pie',
-					radius: ['40%', '65%'],
-					center: ['50%', '50%'],
-					avoidLabelOverlap: true,
-					minShowLabelAngle: 1,
-					data: wrapperData,
-					color: ['#88c0d0', '#81a1c1', '#5e81ac', '#b48ead'],
-					emphasis: {
-						itemStyle: {
-							shadowBlur: 10,
-							shadowOffsetX: 0,
-							shadowColor: 'rgba(0, 0, 0, 0.5)'
-						},
-						label: {
-							show: true,
-							fontSize: 18,
-							fontWeight: 'bold'
-						}
-					},
-					label: {
-						show: true,
-						position: 'outside',
-						alignTo: 'edge',
-						margin: 20,
-						edgeDistance: '15%',
-						color: '#000000',
-						fontSize: 15,
-						fontWeight: 'bold',
-						formatter: function (params: any) {
-							return `${params.name}\n${params.percent.toFixed(1)}%`;
-						},
-						overflow: 'none'
-					},
-					labelLine: {
-						show: true,
-						length: 25,
-						length2: 20,
-						smooth: 0.2,
-						lineStyle: {
-							color: '#2e3440',
-							width: 2
-						}
-					},
-					labelLayout: {
-						hideOverlap: false,
-						moveOverlap: 'shiftY'
-					}
-				}
-			]
-		});
-
-		// Investment trend chart (value, contributions, returns over time)
 		const investmentTrendChartInstance = echarts.init(investmentTrendChart);
-		const dates = investmentTimeSeries.map((item: any) => item.date);
-		const values = investmentTimeSeries.map((item: any) => item.value);
-		const contributions = investmentTimeSeries.map((item: any) => item.contributions);
+		investmentTrendChartInstance.setOption(buildInvestmentTrendChartOption(investmentTimeSeries));
 
-		investmentTrendChartInstance.setOption({
-			backgroundColor: 'transparent',
-			title: {
-				text: 'Inwestycje w czasie',
-				left: 'center',
-				top: 10,
-				textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
-			},
-			tooltip: {
-				trigger: 'axis',
-				backgroundColor: 'rgba(255, 255, 255, 0.95)',
-				borderColor: '#d8dee9',
-				textStyle: { color: '#2e3440' },
-				formatter: function (params: any) {
-					const date = params[0].axisValue;
-					const contributions = params[0].value;
-					const value = params[1].value;
-					const returns = value - contributions;
-
-					const formatPLN = (val: number) =>
-						val.toLocaleString('pl-PL', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
-
-					return `${date}<br/>
-						<span style="color:#5e81ac">●</span> Wartość portfela: <b>${formatPLN(value)} PLN</b><br/>
-						<span style="color:#88c0d0">■</span> Wpłaty: ${formatPLN(contributions)} PLN<br/>
-						<span style="color:#a3be8c">■</span> Zyski: ${formatPLN(returns)} PLN`;
-				}
-			},
-			legend: {
-				data: ['Wpłaty', 'Wartość portfela'],
-				bottom: 10,
-				textStyle: { color: '#2e3440', fontSize: 14 }
-			},
-			grid: {
-				left: 80,
-				right: 40,
-				bottom: 80,
-				top: 80,
-				containLabel: false
-			},
-			xAxis: {
-				type: 'category',
-				data: dates,
-				axisLabel: {
-					color: '#2e3440',
-					fontSize: 12,
-					rotate: 45
-				},
-				axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
-				boundaryGap: false
-			},
-			yAxis: {
-				type: 'value',
-				name: 'Wartość (PLN)',
-				nameLocation: 'middle',
-				nameGap: 60,
-				nameTextStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
-				axisLabel: {
-					color: '#2e3440',
-					fontSize: 12,
-					formatter: function (value: number) {
-						return (value / 1000).toFixed(0) + 'k';
-					}
-				},
-				axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
-				splitLine: { lineStyle: { color: '#e5e9f0', type: 'dashed' } }
-			},
-			series: [
-				{
-					name: 'Wpłaty',
-					type: 'line',
-					data: contributions,
-					smooth: true,
-					lineStyle: { width: 0 },
-					showSymbol: false,
-					areaStyle: {
-						color: '#88c0d0',
-						opacity: 0.8
-					},
-					emphasis: {
-						focus: 'series'
-					}
-				},
-				{
-					name: 'Wartość portfela',
-					type: 'line',
-					data: values,
-					smooth: true,
-					lineStyle: { width: 3, color: '#5e81ac' },
-					showSymbol: false,
-					emphasis: {
-						focus: 'series'
-					}
-				}
-			]
-		});
-
-		// Helper function to create wrapper chart config
-		const createWrapperChart = (chartElement: HTMLDivElement, title: string, data: any[]) => {
+		const createWrapperChart = (
+			chartElement: HTMLDivElement,
+			title: string,
+			series: Parameters<typeof buildWrapperTrendChartOption>[1]
+		) => {
 			const chartInstance = echarts.init(chartElement);
-			const dates = data.map((item: any) => item.date);
-			const contributions = data.map((item: any) => item.contributions);
-			const values = data.map((item: any) => item.value);
-
-			chartInstance.setOption({
-				backgroundColor: 'transparent',
-				title: {
-					text: title,
-					left: 'center',
-					top: 10,
-					textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
-				},
-				tooltip: {
-					trigger: 'axis',
-					backgroundColor: 'rgba(255, 255, 255, 0.95)',
-					borderColor: '#d8dee9',
-					textStyle: { color: '#2e3440' },
-					formatter: function (params: any) {
-						const date = params[0].axisValue;
-						const contributions = params[0].value;
-						const value = params[1].value;
-						const returns = value - contributions;
-
-						const formatPLN = (val: number) =>
-							val.toLocaleString('pl-PL', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
-
-						return `${date}<br/>
-							<span style="color:#5e81ac">●</span> Wartość: <b>${formatPLN(value)} PLN</b><br/>
-							<span style="color:#88c0d0">■</span> Wpłaty: ${formatPLN(contributions)} PLN<br/>
-							<span style="color:#a3be8c">■</span> Zyski: ${formatPLN(returns)} PLN`;
-					}
-				},
-				legend: {
-					data: ['Wpłaty', 'Wartość portfela'],
-					bottom: 10,
-					textStyle: { color: '#2e3440', fontSize: 14 }
-				},
-				grid: {
-					left: 80,
-					right: 40,
-					bottom: 80,
-					top: 80,
-					containLabel: false
-				},
-				xAxis: {
-					type: 'category',
-					data: dates,
-					axisLabel: {
-						color: '#2e3440',
-						fontSize: 11,
-						rotate: 45
-					},
-					axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
-					boundaryGap: false
-				},
-				yAxis: {
-					type: 'value',
-					name: 'Wartość (PLN)',
-					nameLocation: 'middle',
-					nameGap: 60,
-					nameTextStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
-					axisLabel: {
-						color: '#2e3440',
-						fontSize: 11,
-						formatter: function (value: number) {
-							return (value / 1000).toFixed(0) + 'k';
-						}
-					},
-					axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
-					splitLine: { lineStyle: { color: '#e5e9f0', type: 'dashed' } }
-				},
-				series: [
-					{
-						name: 'Wpłaty',
-						type: 'line',
-						data: contributions,
-						smooth: true,
-						lineStyle: { width: 0 },
-						showSymbol: false,
-						areaStyle: {
-							color: '#88c0d0',
-							opacity: 0.8
-						},
-						emphasis: {
-							focus: 'series'
-						}
-					},
-					{
-						name: 'Wartość portfela',
-						type: 'line',
-						data: values,
-						smooth: true,
-						lineStyle: { width: 3, color: '#5e81ac' },
-						showSymbol: false,
-						emphasis: {
-							focus: 'series'
-						}
-					}
-				]
-			});
-
+			chartInstance.setOption(buildWrapperTrendChartOption(title, series));
 			return chartInstance;
 		};
 
-		// IKE chart
 		const ikeChartInstance = createWrapperChart(ikeChart, 'IKE w czasie', wrapperTimeSeries.ike);
-
-		// IKZE chart
 		const ikzeChartInstance = createWrapperChart(
 			ikzeChart,
 			'IKZE w czasie',
 			wrapperTimeSeries.ikze
 		);
-
-		// PPK chart
 		const ppkChartInstance = createWrapperChart(ppkChart, 'PPK w czasie', wrapperTimeSeries.ppk);
-
-		// Stock chart
 		const stockChartInstance = createWrapperChart(
 			stockChart,
 			'Akcje w czasie',
 			categoryTimeSeries.stock
 		);
-
-		// Bond chart
 		const bondChartInstance = createWrapperChart(
 			bondChart,
 			'Obligacje w czasie',
 			categoryTimeSeries.bond
 		);
 
-		// Yearly ROI chart
-		function computeYearlyROI(
-			series: Array<{
-				date: string;
-				value?: number;
-				total_value?: number;
-				contributions?: number;
-				cumulative_contributions?: number;
-			}>
-		): Map<number, number> {
-			type Pt = { date: string; value: number; contribs: number };
-			const byYear = new Map<number, { first: Pt; last: Pt }>();
-			for (const point of series) {
-				const year = new Date(point.date).getFullYear();
-				const val = point.value ?? point.total_value ?? 0;
-				const contrib = point.contributions ?? point.cumulative_contributions ?? 0;
-				const pt: Pt = { date: point.date, value: val, contribs: contrib };
-				const existing = byYear.get(year);
-				if (!existing) {
-					byYear.set(year, { first: pt, last: pt });
-				} else {
-					if (point.date < existing.first.date) existing.first = pt;
-					if (point.date > existing.last.date) existing.last = pt;
-				}
-			}
-			const years = [...byYear.keys()].sort((a, b) => a - b);
-			const result = new Map<number, number>();
-			for (let i = 0; i < years.length; i++) {
-				const { first, last: end } = byYear.get(years[i])!;
-				let start: Pt;
-				if (i === 0) {
-					// Skip first year if it starts with value=0 (placeholder entry)
-					if (first.value === 0) continue;
-					start = first;
-				} else {
-					start = byYear.get(years[i - 1])!.last;
-				}
-				const yearContribs = end.contribs - start.contribs;
-				const denom = start.value + yearContribs / 2;
-				const roi = denom > 0 ? ((end.value - start.value - yearContribs) / denom) * 100 : 0;
-				result.set(years[i], parseFloat(roi.toFixed(2)));
-			}
-			return result;
-		}
-
-		const stockRoi = computeYearlyROI(categoryTimeSeries.stock);
-		const bondRoi = computeYearlyROI(categoryTimeSeries.bond);
-		const ppkRoi = computeYearlyROI(wrapperTimeSeries.ppk);
-		const allYears = [...new Set([...stockRoi.keys(), ...bondRoi.keys(), ...ppkRoi.keys()])].sort(
-			(a, b) => a - b
-		);
-
 		const yearlyRoiChartInstance = echarts.init(yearlyRoiChart);
-		yearlyRoiChartInstance.setOption({
-			backgroundColor: 'transparent',
-			title: {
-				text: 'Roczny ROI: Akcje, Obligacje, PPK',
-				left: 'center',
-				top: 10,
-				textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
-			},
-			tooltip: {
-				trigger: 'axis',
-				axisPointer: { type: 'shadow' },
-				backgroundColor: 'rgba(255, 255, 255, 0.95)',
-				borderColor: '#d8dee9',
-				textStyle: { color: '#2e3440' },
-				formatter: (params: Array<{ seriesName: string; value: number }>) =>
-					params
-						.map((p) => `${p.seriesName}: ${p.value != null ? p.value + '%' : 'brak danych'}`)
-						.join('<br/>')
-			},
-			legend: {
-				top: 40,
-				textStyle: { color: '#2e3440' }
-			},
-			grid: { top: 80, left: 60, right: 30, bottom: 60 },
-			xAxis: {
-				type: 'category',
-				data: allYears.map(String),
-				axisLabel: { color: '#4c566a' }
-			},
-			yAxis: {
-				type: 'value',
-				axisLabel: { formatter: '{value}%', color: '#4c566a' },
-				splitLine: { lineStyle: { color: '#e5e9f0' } }
-			},
-			series: [
-				{
-					name: 'Akcje',
-					type: 'bar',
-					barWidth: '25%',
-					data: allYears.map((y) => stockRoi.get(y) ?? null),
-					itemStyle: { color: '#a3be8c' },
-					label: {
-						show: true,
-						position: (params: { value: number }) => (params.value >= 0 ? 'top' : 'bottom'),
-						formatter: '{c}%',
-						color: '#2e3440',
-						fontSize: 11
-					},
-					markLine: {
-						silent: true,
-						symbol: 'none',
-						data: [{ yAxis: 0 }],
-						lineStyle: { color: '#4c566a', type: 'solid', width: 1 }
-					}
-				},
-				{
-					name: 'Obligacje',
-					type: 'bar',
-					barWidth: '25%',
-					data: allYears.map((y) => bondRoi.get(y) ?? null),
-					itemStyle: { color: '#d08770' },
-					label: {
-						show: true,
-						position: (params: { value: number }) => (params.value >= 0 ? 'top' : 'bottom'),
-						formatter: '{c}%',
-						color: '#2e3440',
-						fontSize: 11
-					}
-				},
-				{
-					name: 'PPK',
-					type: 'bar',
-					barWidth: '25%',
-					data: allYears.map((y) => ppkRoi.get(y) ?? null),
-					itemStyle: { color: '#88c0d0' },
-					label: {
-						show: true,
-						position: (params: { value: number }) => (params.value >= 0 ? 'top' : 'bottom'),
-						formatter: '{c}%',
-						color: '#2e3440',
-						fontSize: 11
-					}
-				}
-			]
-		});
+		yearlyRoiChartInstance.setOption(
+			buildYearlyRoiChartOption(
+				categoryTimeSeries.stock,
+				categoryTimeSeries.bond,
+				wrapperTimeSeries.ppk
+			)
+		);
 
 		return () => {
 			allocationChartInstance.dispose();

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -3,34 +3,11 @@
 	import { browser } from '$app/environment';
 	import { env } from '$env/dynamic/public';
 	import * as echarts from 'echarts';
-	import type { EChartsOption } from 'echarts';
 	import type { PageData } from './$types';
-
-	interface YearlyProjection {
-		year: number;
-		age: number;
-		annual_contribution: number;
-		balance_end_of_year: number;
-		cumulative_contributions: number;
-		cumulative_returns: number;
-		annual_limit: number;
-		limit_utilized_pct: number;
-		tax_savings: number;
-		government_subsidies?: number;
-		monthly_salary?: number;
-		return_rate?: number;
-	}
-
-	interface AccountSimulation {
-		account_name: string;
-		starting_balance: number;
-		total_contributions: number;
-		total_returns: number;
-		total_tax_savings: number;
-		total_subsidies?: number;
-		final_balance: number;
-		yearly_projections: YearlyProjection[];
-	}
+	import {
+		buildRetirementProjectionOption,
+		type AccountSimulation
+	} from '$lib/utils/charts/simulations';
 
 	interface SimulationSummary {
 		total_final_balance: number;
@@ -251,47 +228,7 @@
 			return;
 		}
 
-		const years = results.simulations[0].yearly_projections.map((p) => p.year);
-		const series = results.simulations.map((sim, idx) => {
-			const colors = ['#5E81AC', '#81A1C1', '#88C0D0', '#8FBCBB', '#B48EAD', '#A3BE8C'];
-			return {
-				name: sim.account_name,
-				type: 'line' as const,
-				data: sim.yearly_projections.map((p) => p.balance_end_of_year),
-				smooth: true,
-				itemStyle: { color: colors[idx % colors.length] }
-			};
-		});
-
-		const option: EChartsOption = {
-			title: { text: 'Projekcja wartości kont emerytalnych' },
-			tooltip: {
-				trigger: 'axis',
-				formatter: (params: any) => {
-					let result = `<strong>Rok ${params[0].name}</strong><br/>`;
-					params.forEach((param: any) => {
-						result += `${param.seriesName}: ${param.value.toLocaleString('pl-PL')} PLN<br/>`;
-					});
-					return result;
-				}
-			},
-			legend: {
-				data: results.simulations.map((s) => s.account_name),
-				bottom: 0
-			},
-			grid: { left: '3%', right: '4%', bottom: '15%', containLabel: true },
-			xAxis: { type: 'category', data: years, name: 'Rok' },
-			yAxis: {
-				type: 'value',
-				name: 'Wartość (PLN)',
-				axisLabel: {
-					formatter: (value: number) => `${(value / 1000).toFixed(0)}k`
-				}
-			},
-			series
-		};
-
-		chart.setOption(option);
+		chart.setOption(buildRetirementProjectionOption(results.simulations));
 	}
 
 	onMount(() => {


### PR DESCRIPTION
## Motivation

Closes #334. Several Svelte files were 700-1269 lines mixing data mapping, chart config, forms, modals, and styles - hard to review and easy to regress.

> Changelog: refactor(frontend): split oversized views

## Implementation information

**Chart builders extracted to typed utility modules:**
- `src/lib/utils/charts/metryki.ts` - 5 pure `EChartsOption` builders + `computeYearlyRoi` helper, with `metryki.test.ts`.
- `src/lib/utils/charts/simulations.ts` - retirement projection builder, with `simulations.test.ts`.
- `metryki/+page.svelte`: 1157 -> 642 lines. `simulations/+page.svelte`: 876 -> 813 lines. `onMount` now just inits ECharts and calls the builders.

**SnapshotForm split:**
- Extracted `NewAccountModal`, `NewAssetModal`, and a reusable `ValueRow` into `src/lib/components/snapshot/`, with focused tests.
- Parent keeps all business logic; modal input state stays via `bind:` props so submit/create payloads are byte-identical.
- `SnapshotForm.svelte`: 1269 -> 893 lines.

All `any` in extracted code replaced with proper ECharts/domain types. No behavior, chart, or DOM change - pure refactor. The five SnapshotForm account sections diverge enough that a unified section component was intentionally left out to avoid behavior drift; the clean wins were the rows and modals.

Verified: `npm run check` (0 warnings), `npm run lint` (0 errors), `npm run build`, `vitest run --coverage` (116 passing, coverage 70.96% statements / 53.68% branches - up from the enforced thresholds).

## Supporting documentation

Issue #334 (parent #327).