### PR TITLE
refactor(svelte): migrate legacy syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,17 @@ Self-hosted personal finance dashboard for tracking net worth, goals, and invest
 - OpenProps CSS variables: `var(--size-4)`, `var(--color-text-1)`
 - ECharts for visualizations (see src/routes/+page.svelte)
 
+### Svelte 5 Runes (mandatory — no legacy syntax)
+
+- **Props:** `let { foo, bar = default }: Props = $props()` with typed `interface Props`. Pages: `data: PageData` from `./$types`.
+- **State:** reassigned UI-driving locals use `$state(...)`. Bare `let` only for non-reactive values (e.g. `bind:this` refs read only in `onMount`).
+- **Derived:** `const x = $derived(expr)` for pure computed values; `$derived.by(() => {...})` for multi-statement.
+- **Effects:** `$effect(() => {...})` for side effects. Never read+write the same state inside one effect (infinite loop).
+- **Events:** attributes not directives — `onclick={fn}`, `onsubmit={fn}`. No modifiers: call `event.preventDefault()` inside the handler.
+- **Bindable:** child-written props need `$bindable(default)` (e.g. snapshot modal `bind:` props).
+- **One-time prop reads** in `$state(...)` initializers: wrap in `untrack(() => ...)` to avoid `state_referenced_locally`.
+- `Modal.svelte` and snapshot modals are reference runes implementations.
+
 ### Error Handling
 
 ```typescript

--- a/src/lib/components/SalaryCalculator.svelte
+++ b/src/lib/components/SalaryCalculator.svelte
@@ -14,7 +14,11 @@
 		findBreakEvenAmount
 	} from '$lib/utils/compensation';
 
-	export let data: { latestSalaries: SalaryRecord[] };
+	interface Props {
+		data: { latestSalaries: SalaryRecord[] };
+	}
+
+	let { data }: Props = $props();
 
 	function mapContractType(dbType: string): ContractType | null {
 		if (dbType === 'B2B') return ContractType.B2B_MONTHLY;
@@ -67,12 +71,12 @@
 		offers = [...offers];
 	}
 
-	let offers: OfferInput[] = [emptyOffer('Oferta 1'), emptyOffer('Oferta 2')];
-	let results: OfferBreakdown[] | null = null;
-	let winner: OfferBreakdown | null = null;
-	let breakEvens: Map<number, number> = new Map();
+	let offers = $state<OfferInput[]>([emptyOffer('Oferta 1'), emptyOffer('Oferta 2')]);
+	let results = $state<OfferBreakdown[] | null>(null);
+	let winner = $state<OfferBreakdown | null>(null);
+	let breakEvens = $state<Map<number, number>>(new Map());
 
-	let chartContainer: HTMLDivElement;
+	let chartContainer: HTMLDivElement | undefined = $state();
 	let chart: echarts.ECharts | null = null;
 
 	function addOffer() {
@@ -157,7 +161,7 @@
 		{ label: 'Ekwiwalent urlopowy', value: (b) => fmt(b.vacationEquivalent) }
 	];
 
-	$: baseline = results?.find((r) => r.isCurrentJob) ?? null;
+	const baseline = $derived(results?.find((r) => r.isCurrentJob) ?? null);
 
 	function fmt(v: number): string {
 		return v.toLocaleString('pl-PL', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
@@ -250,7 +254,7 @@
 							placeholder="Nazwa oferty"
 						/>
 						{#if offers.length > 1}
-							<button class="remove-btn" on:click={() => removeOffer(i)}>✕</button>
+							<button class="remove-btn" onclick={() => removeOffer(i)}>✕</button>
 						{/if}
 					</div>
 
@@ -321,7 +325,7 @@
 							<input
 								type="checkbox"
 								checked={offer.isCurrentJob}
-								on:change={() => toggleCurrentJob(i)}
+								onchange={() => toggleCurrentJob(i)}
 							/>
 							Obecna praca
 							{#if data.latestSalaries.length === 0}
@@ -332,7 +336,7 @@
 							<label>
 								Źródło danych
 								<select
-									on:change={(e) => {
+									onchange={(e) => {
 										const sal = data.latestSalaries[Number(e.currentTarget.value)];
 										const contractType = mapContractType(sal.contract_type);
 										if (contractType === null) return;
@@ -357,8 +361,8 @@
 			{/each}
 
 			<div class="form-actions">
-				<button class="secondary-button" on:click={addOffer}>+ Dodaj ofertę</button>
-				<button class="primary-button" on:click={compare}>Porównaj</button>
+				<button class="secondary-button" onclick={addOffer}>+ Dodaj ofertę</button>
+				<button class="primary-button" onclick={compare}>Porównaj</button>
 			</div>
 		</div>
 

--- a/src/lib/components/SnapshotForm.svelte
+++ b/src/lib/components/SnapshotForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { env } from '$env/dynamic/public';
 	import { Wallet, Umbrella, TrendingUp, Home, CreditCard } from 'lucide-svelte';
@@ -7,17 +8,36 @@
 	import NewAssetModal from './snapshot/NewAssetModal.svelte';
 	import ValueRow from './snapshot/ValueRow.svelte';
 
-	export let editingSnapshot: SnapshotResponse | null = null;
-	export let assets: Account[];
-	export let liabilities: Account[];
-	export let physicalAssets: Asset[];
-	export let personas: Array<{ id: number; name: string }> = [];
+	interface Props {
+		editingSnapshot?: SnapshotResponse | null;
+		assets: Account[];
+		liabilities: Account[];
+		physicalAssets: Asset[];
+		personas?: Array<{ id: number; name: string }>;
+	}
+
+	let {
+		editingSnapshot = null,
+		assets: assetsProp,
+		liabilities: liabilitiesProp,
+		physicalAssets: physicalAssetsProp,
+		personas = []
+	}: Props = $props();
+
+	// Accounts/assets created in-component, merged with the prop-provided ones
+	let addedAccounts = $state<Account[]>([]);
+	let addedLiabilities = $state<Account[]>([]);
+	let addedAssets = $state<Asset[]>([]);
+
+	const assets = $derived([...assetsProp, ...addedAccounts]);
+	const liabilities = $derived([...liabilitiesProp, ...addedLiabilities]);
+	const physicalAssets = $derived([...physicalAssetsProp, ...addedAssets]);
 
 	// Initialize form state
-	let snapshotDate = new Date().toISOString().split('T')[0];
-	let notes = '';
-	let loading = false;
-	let error = '';
+	let snapshotDate = $state(new Date().toISOString().split('T')[0]);
+	let notes = $state('');
+	let loading = $state(false);
+	let error = $state('');
 
 	// Section grouping
 	const RETIREMENT_WRAPPERS = ['PPK', 'IKE', 'IKZE'] as const;
@@ -25,75 +45,78 @@
 	const FINANCIAL_CATEGORIES = ['bank', 'saving_account'];
 	const MAJATEK_CATEGORIES = ['real_estate', 'vehicle', 'other'];
 
-	$: retirementAccounts = assets.filter((a) => a.account_wrapper);
-	$: investmentAccounts = assets.filter(
-		(a) => !a.account_wrapper && INVESTMENT_CATEGORIES.includes(a.category)
+	const retirementAccounts = $derived(assets.filter((a) => a.account_wrapper));
+	const investmentAccounts = $derived(
+		assets.filter((a) => !a.account_wrapper && INVESTMENT_CATEGORIES.includes(a.category))
 	);
-	$: financialAccounts = assets.filter(
-		(a) => !a.account_wrapper && FINANCIAL_CATEGORIES.includes(a.category)
+	const financialAccounts = $derived(
+		assets.filter((a) => !a.account_wrapper && FINANCIAL_CATEGORIES.includes(a.category))
 	);
-	$: majatekAccounts = assets.filter(
-		(a) => !a.account_wrapper && MAJATEK_CATEGORIES.includes(a.category)
+	const majatekAccounts = $derived(
+		assets.filter((a) => !a.account_wrapper && MAJATEK_CATEGORIES.includes(a.category))
 	);
 
-	$: retirementByWrapper = RETIREMENT_WRAPPERS.map((w) => ({
-		wrapper: w,
-		accounts: retirementAccounts.filter((a) => a.account_wrapper === w)
-	})).filter((g) => g.accounts.length > 0);
+	const retirementByWrapper = $derived(
+		RETIREMENT_WRAPPERS.map((w) => ({
+			wrapper: w,
+			accounts: retirementAccounts.filter((a) => a.account_wrapper === w)
+		})).filter((g) => g.accounts.length > 0)
+	);
 
 	// Track visible accounts and assets
-	let visibleAccountIds = new Set<number>();
-	let visibleAssetIds = new Set<number>();
+	let visibleAccountIds = $state(new Set<number>());
+	let visibleAssetIds = $state(new Set<number>());
 
 	// Initialize values
-	let accountValues: Record<number, number> = {};
-	let assetValues: Record<number, number> = {};
+	let accountValues: Record<number, number> = $state({});
+	let assetValues: Record<number, number> = $state({});
 
 	// Populate form from editingSnapshot or defaults
 	function populateForm() {
+		const nextAccountValues: Record<number, number> = {};
+		const nextAssetValues: Record<number, number> = {};
+		const nextVisibleAccountIds = new Set<number>();
+		const nextVisibleAssetIds = new Set<number>();
+
 		if (editingSnapshot) {
 			snapshotDate = editingSnapshot.date;
 			notes = editingSnapshot.notes || '';
 
-			// Reset values
-			accountValues = {};
-			assetValues = {};
-			visibleAccountIds = new Set();
-			visibleAssetIds = new Set();
-
 			// Populate from snapshot values
 			editingSnapshot.values.forEach((v) => {
 				if (v.account_id !== null && v.account_id !== undefined) {
-					accountValues[v.account_id] = v.value;
-					visibleAccountIds.add(v.account_id);
+					nextAccountValues[v.account_id] = v.value;
+					nextVisibleAccountIds.add(v.account_id);
 				}
 				if (v.asset_id !== null && v.asset_id !== undefined) {
-					assetValues[v.asset_id] = v.value;
-					visibleAssetIds.add(v.asset_id);
+					nextAssetValues[v.asset_id] = v.value;
+					nextVisibleAssetIds.add(v.asset_id);
 				}
 			});
-			visibleAccountIds = new Set(visibleAccountIds);
-			visibleAssetIds = new Set(visibleAssetIds);
 		} else {
 			// Create mode - initialize from current values
-			visibleAccountIds = new Set(
-				[...assets, ...liabilities].filter((a) => a.current_value > 0).map((a) => a.id)
-			);
-			visibleAssetIds = new Set(physicalAssets.filter((a) => a.current_value > 0).map((a) => a.id));
-
 			[...assets, ...liabilities].forEach((account) => {
-				accountValues[account.id] = account.current_value;
+				nextAccountValues[account.id] = account.current_value;
+				if (account.current_value > 0) nextVisibleAccountIds.add(account.id);
 			});
 			physicalAssets.forEach((asset) => {
-				assetValues[asset.id] = asset.current_value;
+				nextAssetValues[asset.id] = asset.current_value;
+				if (asset.current_value > 0) nextVisibleAssetIds.add(asset.id);
 			});
 		}
+
+		accountValues = nextAccountValues;
+		assetValues = nextAssetValues;
+		visibleAccountIds = nextVisibleAccountIds;
+		visibleAssetIds = nextVisibleAssetIds;
 	}
 
 	// Reactive population
-	$: if (editingSnapshot || assets || liabilities || physicalAssets) {
-		populateForm();
-	}
+	$effect(() => {
+		if (editingSnapshot || assets || liabilities || physicalAssets) {
+			populateForm();
+		}
+	});
 
 	function removeAccount(accountId: number) {
 		visibleAccountIds.delete(accountId);
@@ -118,18 +141,18 @@
 	type NewAccountSection = 'financial' | 'retirement' | 'investment' | 'majatek' | 'liabilities';
 
 	// New item creation state
-	let showNewAccountForm = false;
-	let showNewAssetForm = false;
-	let newAccountSection: NewAccountSection = 'financial';
-	let newAccountName = '';
-	let newAccountCategory = '';
-	let newAccountWrapper: '' | 'PPK' | 'IKE' | 'IKZE' = '';
-	let newAccountOwner = personas.length > 0 ? personas[0].name : '';
-	let newAccountValue = 0;
-	let creatingAccount = false;
-	let newAssetName = '';
-	let newAssetValue = 0;
-	let creatingAsset = false;
+	let showNewAccountForm = $state(false);
+	let showNewAssetForm = $state(false);
+	let newAccountSection: NewAccountSection = $state('financial');
+	let newAccountName = $state('');
+	let newAccountCategory = $state('');
+	let newAccountWrapper: '' | 'PPK' | 'IKE' | 'IKZE' = $state('');
+	let newAccountOwner = $state(untrack(() => (personas.length > 0 ? personas[0].name : '')));
+	let newAccountValue = $state(0);
+	let creatingAccount = $state(false);
+	let newAssetName = $state('');
+	let newAssetValue = $state(0);
+	let creatingAsset = $state(false);
 
 	async function createNewAccount() {
 		if (!newAccountName.trim()) {
@@ -175,9 +198,9 @@
 			const newAccount: Account = await response.json();
 
 			if (newAccountSection === 'liabilities') {
-				liabilities = [...liabilities, newAccount];
+				addedLiabilities = [...addedLiabilities, newAccount];
 			} else {
-				assets = [...assets, newAccount];
+				addedAccounts = [...addedAccounts, newAccount];
 			}
 
 			// Set initial value and mark as visible
@@ -248,7 +271,7 @@
 
 			const newAsset: Asset = await response.json();
 
-			physicalAssets = [...physicalAssets, newAsset];
+			addedAssets = [...addedAssets, newAsset];
 
 			assetValues[newAsset.id] = newAssetValue;
 			visibleAssetIds.add(newAsset.id);
@@ -264,7 +287,8 @@
 		}
 	}
 
-	async function handleSubmit() {
+	async function handleSubmit(event: SubmitEvent) {
+		event.preventDefault();
 		loading = true;
 		error = '';
 
@@ -387,7 +411,7 @@
 	}
 </script>
 
-<form on:submit|preventDefault={handleSubmit} class="snapshot-form">
+<form onsubmit={handleSubmit} class="snapshot-form">
 	<!-- Date & Notes -->
 	<div class="card preset-filled-surface-100-900 p-4 space-y-4">
 		<header class="space-y-1">
@@ -437,7 +461,7 @@
 								<button
 									type="button"
 									class="btn-add-account"
-									on:click={() => addAccount(account.id)}
+									onclick={() => addAccount(account.id)}
 								>
 									{account.name}
 									<span class="label-meta"
@@ -451,7 +475,7 @@
 				<button
 					type="button"
 					class="btn-new-account"
-					on:click={() => openNewAccountForm('financial')}
+					onclick={() => openNewAccountForm('financial')}
 				>
 					+ Dodaj nowe konto
 				</button>
@@ -488,7 +512,7 @@
 									<button
 										type="button"
 										class="btn-add-account"
-										on:click={() => addAccount(account.id)}
+										onclick={() => addAccount(account.id)}
 									>
 										{account.name}
 										<span class="label-meta">({account.account_wrapper})</span>
@@ -500,7 +524,7 @@
 					<button
 						type="button"
 						class="btn-new-account"
-						on:click={() => openNewAccountForm('retirement')}
+						onclick={() => openNewAccountForm('retirement')}
 					>
 						+ Dodaj nowe konto
 					</button>
@@ -534,7 +558,7 @@
 								<button
 									type="button"
 									class="btn-add-account"
-									on:click={() => addAccount(account.id)}
+									onclick={() => addAccount(account.id)}
 								>
 									{account.name}
 									<span class="label-meta"
@@ -548,7 +572,7 @@
 				<button
 					type="button"
 					class="btn-new-account"
-					on:click={() => openNewAccountForm('investment')}
+					onclick={() => openNewAccountForm('investment')}
 				>
 					+ Dodaj nowe konto
 				</button>
@@ -590,7 +614,7 @@
 								<button
 									type="button"
 									class="btn-add-account"
-									on:click={() => addAccount(account.id)}
+									onclick={() => addAccount(account.id)}
 								>
 									{account.name}
 									<span class="label-meta"
@@ -599,21 +623,17 @@
 								</button>
 							{/each}
 							{#each physicalAssets.filter((a) => !visibleAssetIds.has(a.id)) as asset}
-								<button type="button" class="btn-add-account" on:click={() => addAsset(asset.id)}>
+								<button type="button" class="btn-add-account" onclick={() => addAsset(asset.id)}>
 									{asset.name}
 								</button>
 							{/each}
 						</div>
 					</details>
 				{/if}
-				<button
-					type="button"
-					class="btn-new-account"
-					on:click={() => openNewAccountForm('majatek')}
-				>
+				<button type="button" class="btn-new-account" onclick={() => openNewAccountForm('majatek')}>
 					+ Dodaj nowe konto
 				</button>
-				<button type="button" class="btn-new-account" on:click={() => (showNewAssetForm = true)}>
+				<button type="button" class="btn-new-account" onclick={() => (showNewAssetForm = true)}>
 					+ Dodaj nowy majątek
 				</button>
 			</div>
@@ -646,7 +666,7 @@
 									<button
 										type="button"
 										class="btn-add-account"
-										on:click={() => addAccount(account.id)}
+										onclick={() => addAccount(account.id)}
 									>
 										{account.name}
 										<span class="label-meta">({categoryLabels[account.category]})</span>
@@ -658,7 +678,7 @@
 					<button
 						type="button"
 						class="btn-new-account"
-						on:click={() => openNewAccountForm('liabilities')}
+						onclick={() => openNewAccountForm('liabilities')}
 					>
 						+ Dodaj nowe konto
 					</button>
@@ -704,7 +724,7 @@
 		<button type="submit" disabled={loading} class="btn btn-primary">
 			{loading ? 'Zapisywanie...' : '💾 Zapisz Snapshot'}
 		</button>
-		<button type="button" on:click={() => goto('/')} class="btn btn-secondary"> Anuluj </button>
+		<button type="button" onclick={() => goto('/')} class="btn btn-secondary"> Anuluj </button>
 	</div>
 </form>
 

--- a/src/lib/components/snapshot/NewAccountModal.svelte
+++ b/src/lib/components/snapshot/NewAccountModal.svelte
@@ -1,16 +1,31 @@
 <script lang="ts">
 	type NewAccountSection = 'financial' | 'retirement' | 'investment' | 'majatek' | 'liabilities';
 
-	export let section: NewAccountSection;
-	export let name = '';
-	export let category = '';
-	export let wrapper: '' | 'PPK' | 'IKE' | 'IKZE' = '';
-	export let owner = '';
-	export let value = 0;
-	export let creating = false;
-	export let personas: Array<{ id: number; name: string }> = [];
-	export let onCreate: () => void;
-	export let onClose: () => void;
+	interface Props {
+		section: NewAccountSection;
+		name?: string;
+		category?: string;
+		wrapper?: '' | 'PPK' | 'IKE' | 'IKZE';
+		owner?: string;
+		value?: number;
+		creating?: boolean;
+		personas?: Array<{ id: number; name: string }>;
+		onCreate: () => void;
+		onClose: () => void;
+	}
+
+	let {
+		section,
+		name = $bindable(''),
+		category = $bindable(''),
+		wrapper = $bindable(''),
+		owner = $bindable(''),
+		value = $bindable(0),
+		creating = false,
+		personas = [],
+		onCreate,
+		onClose
+	}: Props = $props();
 
 	function closeOnBackdrop(event: MouseEvent) {
 		if (event.target === event.currentTarget) onClose();
@@ -21,9 +36,9 @@
 	}
 </script>
 
-<svelte:window on:keydown={closeOnEscape} />
+<svelte:window onkeydown={closeOnEscape} />
 
-<div class="modal-overlay" role="presentation" on:click={closeOnBackdrop}>
+<div class="modal-overlay" role="presentation" onclick={closeOnBackdrop}>
 	<div
 		class="modal"
 		role="dialog"
@@ -33,7 +48,7 @@
 	>
 		<div class="modal-header">
 			<h2 id="new-account-modal-title">Dodaj nowe konto</h2>
-			<button type="button" class="btn-close" on:click={onClose} title="Zamknij"> × </button>
+			<button type="button" class="btn-close" onclick={onClose} title="Zamknij"> × </button>
 		</div>
 		<div class="modal-content">
 			<div class="form-group">
@@ -112,8 +127,8 @@
 			</div>
 		</div>
 		<div class="modal-footer">
-			<button type="button" class="btn btn-secondary" on:click={onClose}> Anuluj </button>
-			<button type="button" class="btn btn-primary" disabled={creating} on:click={onCreate}>
+			<button type="button" class="btn btn-secondary" onclick={onClose}> Anuluj </button>
+			<button type="button" class="btn btn-primary" disabled={creating} onclick={onCreate}>
 				{creating ? 'Tworzenie...' : 'Utwórz konto'}
 			</button>
 		</div>

--- a/src/lib/components/snapshot/NewAssetModal.svelte
+++ b/src/lib/components/snapshot/NewAssetModal.svelte
@@ -1,9 +1,19 @@
 <script lang="ts">
-	export let name = '';
-	export let value = 0;
-	export let creating = false;
-	export let onCreate: () => void;
-	export let onClose: () => void;
+	interface Props {
+		name?: string;
+		value?: number;
+		creating?: boolean;
+		onCreate: () => void;
+		onClose: () => void;
+	}
+
+	let {
+		name = $bindable(''),
+		value = $bindable(0),
+		creating = false,
+		onCreate,
+		onClose
+	}: Props = $props();
 
 	function closeOnBackdrop(event: MouseEvent) {
 		if (event.target === event.currentTarget) onClose();
@@ -14,9 +24,9 @@
 	}
 </script>
 
-<svelte:window on:keydown={closeOnEscape} />
+<svelte:window onkeydown={closeOnEscape} />
 
-<div class="modal-overlay" role="presentation" on:click={closeOnBackdrop}>
+<div class="modal-overlay" role="presentation" onclick={closeOnBackdrop}>
 	<div
 		class="modal"
 		role="dialog"
@@ -26,7 +36,7 @@
 	>
 		<div class="modal-header">
 			<h2 id="new-asset-modal-title">Dodaj nowy majątek</h2>
-			<button type="button" class="btn-close" on:click={onClose} title="Zamknij"> × </button>
+			<button type="button" class="btn-close" onclick={onClose} title="Zamknij"> × </button>
 		</div>
 		<div class="modal-content">
 			<div class="form-group">
@@ -54,8 +64,8 @@
 			</div>
 		</div>
 		<div class="modal-footer">
-			<button type="button" class="btn btn-secondary" on:click={onClose}> Anuluj </button>
-			<button type="button" class="btn btn-primary" disabled={creating} on:click={onCreate}>
+			<button type="button" class="btn btn-secondary" onclick={onClose}> Anuluj </button>
+			<button type="button" class="btn btn-primary" disabled={creating} onclick={onCreate}>
 				{creating ? 'Tworzenie...' : 'Utwórz majątek'}
 			</button>
 		</div>

--- a/src/lib/components/snapshot/ValueRow.svelte
+++ b/src/lib/components/snapshot/ValueRow.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
-	export let inputId: string;
-	export let label: string;
-	export let meta = '';
-	export let value: number;
-	export let onRemove: () => void;
+	interface Props {
+		inputId: string;
+		label: string;
+		meta?: string;
+		value: number;
+		onRemove: () => void;
+	}
+
+	let { inputId, label, meta = '', value = $bindable(), onRemove }: Props = $props();
 </script>
 
 <div class="form-group-with-remove">
@@ -23,7 +27,7 @@
 			class="form-input"
 		/>
 	</div>
-	<button type="button" class="btn-remove" on:click={onRemove} title="Usuń pole"> × </button>
+	<button type="button" class="btn-remove" onclick={onRemove} title="Usuń pole"> × </button>
 </div>
 
 <style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
 	import Modal from '$lib/components/Modal.svelte';
@@ -17,27 +17,34 @@
 	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
 	import type { Persona } from '$lib/types/personas';
+	import type { PageData } from './$types';
 
-	export let data;
+	interface Props {
+		data: PageData;
+	}
 
-	let chartContainer: HTMLDivElement;
-	let pieChartContainer: HTMLDivElement;
-	let lineChart: echarts.ECharts;
-	let pieChart: echarts.ECharts;
+	let { data }: Props = $props();
 
-	$: gridConfig = $isMobile
-		? { left: '40px', right: '20px' }
-		: $isTablet
-			? { left: '60px', right: '30px' }
-			: { left: '80px', right: '40px' };
+	let chartContainer: HTMLDivElement | undefined = $state();
+	let pieChartContainer: HTMLDivElement | undefined = $state();
+	let lineChart: echarts.ECharts | undefined = $state();
+	let pieChart: echarts.ECharts | undefined = $state();
 
-	$: titleFontSize = $isMobile ? 14 : 16;
+	const gridConfig = $derived(
+		$isMobile
+			? { left: '40px', right: '20px' }
+			: $isTablet
+				? { left: '60px', right: '30px' }
+				: { left: '80px', right: '40px' }
+	);
 
-	$: personas = (data.personas || []) as Persona[];
+	const titleFontSize = $derived($isMobile ? 14 : 16);
 
-	let showLimitsModal = false;
-	let limitsYear = data.currentYear;
-	let limits: Record<string, number> = {};
+	const personas = $derived((data.personas || []) as Persona[]);
+
+	let showLimitsModal = $state(false);
+	let limitsYear = $state(untrack(() => data.currentYear));
+	let limits: Record<string, number> = $state({});
 
 	function openLimitsModal() {
 		limits = {};
@@ -96,6 +103,7 @@
 	}
 
 	onMount(() => {
+		if (!chartContainer || !pieChartContainer) return;
 		lineChart = echarts.init(chartContainer);
 
 		const lineOption: EChartsOption = {
@@ -177,8 +185,8 @@
 		pieChart.setOption(pieOption);
 
 		const handleResize = () => {
-			lineChart.resize();
-			pieChart.resize();
+			lineChart?.resize();
+			pieChart?.resize();
 		};
 
 		window.addEventListener('resize', handleResize);
@@ -188,23 +196,26 @@
 		};
 	});
 
-	const change = calculateChange(
-		data.current_net_worth,
-		data.current_net_worth - data.change_vs_last_month
+	const change = $derived(
+		calculateChange(data.current_net_worth, data.current_net_worth - data.change_vs_last_month)
 	);
 
-	$: if (lineChart && gridConfig) {
-		lineChart.setOption({
-			grid: gridConfig,
-			title: { textStyle: { fontSize: titleFontSize } }
-		});
-	}
+	$effect(() => {
+		if (lineChart && gridConfig) {
+			lineChart.setOption({
+				grid: gridConfig,
+				title: { textStyle: { fontSize: titleFontSize } }
+			});
+		}
+	});
 
-	$: if (pieChart && titleFontSize) {
-		pieChart.setOption({
-			title: { textStyle: { fontSize: titleFontSize } }
-		});
-	}
+	$effect(() => {
+		if (pieChart && titleFontSize) {
+			pieChart.setOption({
+				title: { textStyle: { fontSize: titleFontSize } }
+			});
+		}
+	});
 </script>
 
 <svelte:head>
@@ -266,7 +277,7 @@
 					type="button"
 					class="btn-icon btn-icon-sm"
 					aria-label="Konfiguruj limity"
-					on:click={openLimitsModal}
+					onclick={openLimitsModal}
 				>
 					<Settings size={18} />
 				</button>
@@ -343,7 +354,13 @@
 	onConfirm={saveLimits}
 	confirmText="Zapisz"
 >
-	<form on:submit|preventDefault={saveLimits} class="space-y-4">
+	<form
+		onsubmit={(event) => {
+			event.preventDefault();
+			saveLimits();
+		}}
+		class="space-y-4"
+	>
 		<label class="label">
 			<span class="font-semibold text-sm">Rok</span>
 			<select class="select" bind:value={limitsYear}>

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -4,36 +4,41 @@
 	import { Wallet, TrendingDown, Pencil, Trash2, Plus, BarChart3 } from 'lucide-svelte';
 	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { INVESTMENT_CATEGORIES } from '$lib/constants';
 	import type { Account, TransactionsData } from './+page';
 	import type { Persona } from '$lib/types/personas';
+	import type { PageData } from './$types';
 
-	export let data;
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
 
 	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
-	$: personas = data.personas as Persona[];
-	$: defaultOwner = personas.length > 0 ? personas[0].name : 'Marcin';
+	const personas = $derived(data.personas as Persona[]);
+	const defaultOwner = $derived(personas.length > 0 ? personas[0].name : 'Marcin');
 
-	let showForm = false;
-	let editingAccount: Account | null = null;
-	let showDeleteModal = false;
-	let accountToDelete: number | null = null;
-	let transactionCounts: Record<number, number> = {};
+	let showForm = $state(false);
+	let editingAccount: Account | null = $state(null);
+	let showDeleteModal = $state(false);
+	let accountToDelete: number | null = $state(null);
+	let transactionCounts: Record<number, number> = $state({});
 
-	let showTransactionsModal = false;
-	let selectedAccountId: number | null = null;
-	let selectedAccountName = '';
-	let selectedAccountWrapper: string | null = null;
-	let transactionsData: TransactionsData | null = null;
-	let transactionFormData = {
+	let showTransactionsModal = $state(false);
+	let selectedAccountId: number | null = $state(null);
+	let selectedAccountName = $state('');
+	let selectedAccountWrapper: string | null = $state(null);
+	let transactionsData: TransactionsData | null = $state(null);
+	let transactionFormData = $state({
 		amount: 0,
 		date: new Date().toISOString().split('T')[0],
-		owner: defaultOwner,
+		owner: untrack(() => defaultOwner),
 		transaction_type: null as string | null
-	};
-	let transactionError = '';
-	let savingTransaction = false;
+	});
+	let transactionError = $state('');
+	let savingTransaction = $state(false);
 
 	const categoryLabels: Record<string, string> = {
 		bank: 'Konto bankowe',
@@ -66,46 +71,48 @@
 		editingAccount = null;
 	}
 
-	let formData = {
+	let formData = $state({
 		name: '',
 		type: 'asset',
 		category: 'bank',
-		owner: defaultOwner,
+		owner: untrack(() => defaultOwner),
 		currency: 'PLN',
 		account_wrapper: null as string | null,
 		purpose: 'general',
 		receives_contributions: true,
 		square_meters: null as number | null
-	};
+	});
 
-	let error = '';
-	let saving = false;
+	let error = $state('');
+	let saving = $state(false);
 
-	$: if (editingAccount) {
-		formData = {
-			name: editingAccount.name,
-			type: editingAccount.type,
-			category: editingAccount.category,
-			owner: editingAccount.owner,
-			currency: editingAccount.currency,
-			account_wrapper: editingAccount.account_wrapper,
-			purpose: editingAccount.purpose,
-			receives_contributions: editingAccount.receives_contributions,
-			square_meters: editingAccount.square_meters
-		};
-	} else if (showForm) {
-		formData = {
-			name: '',
-			type: 'asset',
-			category: 'bank',
-			owner: defaultOwner,
-			currency: 'PLN',
-			account_wrapper: null,
-			purpose: 'general',
-			receives_contributions: true,
-			square_meters: null
-		};
-	}
+	$effect(() => {
+		if (editingAccount) {
+			formData = {
+				name: editingAccount.name,
+				type: editingAccount.type,
+				category: editingAccount.category,
+				owner: editingAccount.owner,
+				currency: editingAccount.currency,
+				account_wrapper: editingAccount.account_wrapper,
+				purpose: editingAccount.purpose,
+				receives_contributions: editingAccount.receives_contributions,
+				square_meters: editingAccount.square_meters
+			};
+		} else if (showForm) {
+			formData = {
+				name: '',
+				type: 'asset',
+				category: 'bank',
+				owner: defaultOwner,
+				currency: 'PLN',
+				account_wrapper: null,
+				purpose: 'general',
+				receives_contributions: true,
+				square_meters: null
+			};
+		}
+	});
 
 	async function handleSubmit() {
 		error = '';
@@ -308,7 +315,7 @@
 	<button
 		type="button"
 		class="btn preset-filled-primary-500 w-full sm:w-auto gap-2"
-		on:click={startCreate}
+		onclick={startCreate}
 	>
 		<Plus size={16} />
 		Nowe Konto
@@ -348,7 +355,7 @@
 										type="button"
 										class="btn-icon btn-icon-sm"
 										aria-label="Edytuj"
-										on:click={() => startEdit(account)}
+										onclick={() => startEdit(account)}
 									>
 										<Pencil size={16} />
 									</button>
@@ -357,7 +364,7 @@
 											type="button"
 											class="btn preset-tonal-surface btn-sm gap-1"
 											aria-label="Transakcje"
-											on:click={() =>
+											onclick={() =>
 												openTransactions(account.id, account.name, account.account_wrapper)}
 										>
 											<BarChart3 size={14} />
@@ -368,7 +375,7 @@
 										type="button"
 										class="btn-icon btn-icon-sm"
 										aria-label="Usuń"
-										on:click={() => handleDelete(account.id)}
+										onclick={() => handleDelete(account.id)}
 									>
 										<Trash2 size={16} />
 									</button>
@@ -411,7 +418,7 @@
 										type="button"
 										class="btn-icon btn-icon-sm"
 										aria-label="Edytuj"
-										on:click={() => startEdit(account)}
+										onclick={() => startEdit(account)}
 									>
 										<Pencil size={16} />
 									</button>
@@ -419,7 +426,7 @@
 										type="button"
 										class="btn-icon btn-icon-sm"
 										aria-label="Usuń"
-										on:click={() => handleDelete(account.id)}
+										onclick={() => handleDelete(account.id)}
 									>
 										<Trash2 size={16} />
 									</button>
@@ -441,7 +448,13 @@
 	confirmText={saving ? 'Zapisywanie...' : editingAccount ? 'Zapisz zmiany' : 'Utwórz konto'}
 	confirmDisabled={saving}
 >
-	<form on:submit|preventDefault={handleSubmit} class="space-y-4">
+	<form
+		onsubmit={(event) => {
+			event.preventDefault();
+			handleSubmit();
+		}}
+		class="space-y-4"
+	>
 		{#if error}
 			<div class="card preset-filled-error-500 p-3 text-sm">{error}</div>
 		{/if}
@@ -614,7 +627,7 @@
 											type="button"
 											class="btn-icon btn-icon-sm"
 											aria-label="Usuń"
-											on:click={() => deleteTransaction(transaction.id)}
+											onclick={() => deleteTransaction(transaction.id)}
 										>
 											<Trash2 size={16} />
 										</button>
@@ -628,7 +641,13 @@
 
 			<div class="space-y-3 pt-4 border-t border-surface-200-800">
 				<h3 class="h4">Dodaj transakcję</h3>
-				<form on:submit|preventDefault={addTransaction} class="space-y-4">
+				<form
+					onsubmit={(event) => {
+						event.preventDefault();
+						addTransaction();
+					}}
+					class="space-y-4"
+				>
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 						<label class="label">
 							<span class="font-semibold text-sm">Kwota (PLN)</span>

--- a/src/routes/assets/+page.svelte
+++ b/src/routes/assets/+page.svelte
@@ -5,15 +5,20 @@
 	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
 	import type { Asset } from './+page';
+	import type { PageData } from './$types';
 
-	export let data;
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
 
 	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
 
-	let showForm = false;
-	let editingAsset: Asset | null = null;
-	let showDeleteModal = false;
-	let assetToDelete: number | null = null;
+	let showForm = $state(false);
+	let editingAsset: Asset | null = $state(null);
+	let showDeleteModal = $state(false);
+	let assetToDelete: number | null = $state(null);
 
 	function startCreate() {
 		editingAsset = null;
@@ -30,15 +35,17 @@
 		editingAsset = null;
 	}
 
-	let formData = { name: '' };
-	let error = '';
-	let saving = false;
+	let formData = $state({ name: '' });
+	let error = $state('');
+	let saving = $state(false);
 
-	$: if (editingAsset) {
-		formData = { name: editingAsset.name };
-	} else if (showForm) {
-		formData = { name: '' };
-	}
+	$effect(() => {
+		if (editingAsset) {
+			formData = { name: editingAsset.name };
+		} else if (showForm) {
+			formData = { name: '' };
+		}
+	});
 
 	async function handleSubmit() {
 		error = '';
@@ -119,7 +126,7 @@
 	<button
 		type="button"
 		class="btn preset-filled-primary-500 w-full sm:w-auto gap-2"
-		on:click={startCreate}
+		onclick={startCreate}
 	>
 		<Plus size={16} />
 		Nowy Majątek
@@ -138,7 +145,13 @@
 					{/if}
 				</h3>
 			</header>
-			<form class="space-y-4" on:submit|preventDefault={handleSubmit}>
+			<form
+				class="space-y-4"
+				onsubmit={(event) => {
+					event.preventDefault();
+					handleSubmit();
+				}}
+			>
 				{#if error}
 					<div class="card preset-filled-error-500 p-3 text-sm">{error}</div>
 				{/if}
@@ -158,7 +171,7 @@
 					<button
 						type="button"
 						class="btn preset-tonal-surface"
-						on:click={cancelForm}
+						onclick={cancelForm}
 						disabled={saving}>Anuluj</button
 					>
 					<button type="submit" class="btn preset-filled-primary-500" disabled={saving}>
@@ -198,7 +211,7 @@
 										type="button"
 										class="btn-icon btn-icon-sm"
 										aria-label="Edytuj"
-										on:click={() => startEdit(asset)}
+										onclick={() => startEdit(asset)}
 									>
 										<Pencil size={16} />
 									</button>
@@ -206,7 +219,7 @@
 										type="button"
 										class="btn-icon btn-icon-sm"
 										aria-label="Usuń"
-										on:click={() => handleDelete(asset.id)}
+										onclick={() => handleDelete(asset.id)}
 									>
 										<Trash2 size={16} />
 									</button>

--- a/src/routes/config/+page.svelte
+++ b/src/routes/config/+page.svelte
@@ -13,8 +13,14 @@
 	} from 'lucide-svelte';
 	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
+	import { untrack } from 'svelte';
+	import type { PageData } from './$types';
 
-	export let data;
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
 
 	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
 
@@ -29,40 +35,51 @@
 		allocation_commodities: 3
 	};
 
-	let birthDate = data.config?.birth_date ?? defaults.birth_date;
-	let retirementAge = data.config?.retirement_age ?? defaults.retirement_age;
-	let retirementMonthlySalary =
-		data.config?.retirement_monthly_salary ?? defaults.retirement_monthly_salary;
-	let allocationRealEstate = data.config?.allocation_real_estate ?? defaults.allocation_real_estate;
-	let allocationStocks = data.config?.allocation_stocks ?? defaults.allocation_stocks;
-	let allocationBonds = data.config?.allocation_bonds ?? defaults.allocation_bonds;
-	let allocationGold = data.config?.allocation_gold ?? defaults.allocation_gold;
-	let allocationCommodities =
-		data.config?.allocation_commodities ?? defaults.allocation_commodities;
-	let monthlyExpenses = data.config?.monthly_expenses ?? 0;
-	let monthlyMortgagePayment = data.config?.monthly_mortgage_payment ?? 0;
+	const config = untrack(() => data.config);
+	let birthDate = $state(config?.birth_date ?? defaults.birth_date);
+	let retirementAge = $state(config?.retirement_age ?? defaults.retirement_age);
+	let retirementMonthlySalary = $state(
+		config?.retirement_monthly_salary ?? defaults.retirement_monthly_salary
+	);
+	let allocationRealEstate = $state(
+		config?.allocation_real_estate ?? defaults.allocation_real_estate
+	);
+	let allocationStocks = $state(config?.allocation_stocks ?? defaults.allocation_stocks);
+	let allocationBonds = $state(config?.allocation_bonds ?? defaults.allocation_bonds);
+	let allocationGold = $state(config?.allocation_gold ?? defaults.allocation_gold);
+	let allocationCommodities = $state(
+		config?.allocation_commodities ?? defaults.allocation_commodities
+	);
+	let monthlyExpenses = $state(config?.monthly_expenses ?? 0);
+	let monthlyMortgagePayment = $state(config?.monthly_mortgage_payment ?? 0);
 
-	let error = '';
-	let saving = false;
+	let error = $state('');
+	let saving = $state(false);
 
-	$: marketSum = allocationStocks + allocationBonds + allocationGold + allocationCommodities;
-	$: isValidAllocation = marketSum === 100;
+	const marketSum = $derived(
+		allocationStocks + allocationBonds + allocationGold + allocationCommodities
+	);
+	const isValidAllocation = $derived(marketSum === 100);
 
-	$: currentAge = birthDate
-		? Math.max(
-				0,
-				Math.floor(
-					(new Date().getTime() - new Date(birthDate).getTime()) / (365.25 * 24 * 60 * 60 * 1000)
+	const currentAge = $derived(
+		birthDate
+			? Math.max(
+					0,
+					Math.floor(
+						(new Date().getTime() - new Date(birthDate).getTime()) / (365.25 * 24 * 60 * 60 * 1000)
+					)
 				)
-			)
-		: 0;
-	$: yearsUntilRetirement = Math.max(0, retirementAge - currentAge);
+			: 0
+	);
+	const yearsUntilRetirement = $derived(Math.max(0, retirementAge - currentAge));
 
-	$: requiredCapital = retirementMonthlySalary * 12 * 25;
+	const requiredCapital = $derived(retirementMonthlySalary * 12 * 25);
 
-	$: remainingCapital = Math.max(0, requiredCapital - (data.retirementAccountValue ?? 0));
+	const remainingCapital = $derived(
+		Math.max(0, requiredCapital - (data.retirementAccountValue ?? 0))
+	);
 
-	$: monthlySavingsNeeded = (() => {
+	const monthlySavingsNeeded = $derived.by(() => {
 		if (yearsUntilRetirement <= 0) return 0;
 
 		const annualReturnRate = 0.07;
@@ -76,7 +93,7 @@
 		if (adjustedTarget === 0) return 0;
 
 		return (adjustedTarget * monthlyRate) / (Math.pow(1 + monthlyRate, months) - 1);
-	})();
+	});
 
 	async function saveConfig() {
 		if (!isValidAllocation) return;
@@ -321,7 +338,7 @@
 	<button
 		type="button"
 		class="btn preset-filled-primary-500 w-full sm:w-auto"
-		on:click={saveConfig}
+		onclick={saveConfig}
 		disabled={!isValidAllocation || saving}
 	>
 		{saving ? 'Zapisywanie...' : 'Zapisz konfigurację'}

--- a/src/routes/debts/+page.svelte
+++ b/src/routes/debts/+page.svelte
@@ -4,37 +4,42 @@
 	import { ClipboardList, Plus, Pencil, Trash2, Wallet, CircleDollarSign } from 'lucide-svelte';
 	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import type { Debt, DebtPayment } from './+page';
 	import type { Persona } from '$lib/types/personas';
+	import type { PageData } from './$types';
 
-	export let data;
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
 
 	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
-	$: personas = data.personas as Persona[];
-	$: defaultOwner = personas.length > 0 ? personas[0].name : 'Marcin';
+	const personas = $derived(data.personas as Persona[]);
+	const defaultOwner = $derived(personas.length > 0 ? personas[0].name : 'Marcin');
 
-	let showForm = false;
-	let editingDebt: Debt | null = null;
-	let showDeleteModal = false;
-	let debtToDelete: number | null = null;
-	let paymentCounts: Record<number, number> = {};
+	let showForm = $state(false);
+	let editingDebt: Debt | null = $state(null);
+	let showDeleteModal = $state(false);
+	let debtToDelete: number | null = $state(null);
+	let paymentCounts: Record<number, number> = $state({});
 
-	let selectedDebt: Debt | null = null;
+	let selectedDebt: Debt | null = $state(null);
 	let paymentsData: {
 		payments: DebtPayment[];
 		total_paid: number;
 		payment_count: number;
-	} | null = null;
-	let paymentFormData = {
+	} | null = $state(null);
+	let paymentFormData = $state({
 		amount: 0,
 		date: new Date().toISOString().split('T')[0],
-		owner: defaultOwner
-	};
-	let paymentError = '';
-	let savingPayment = false;
-	let showDeletePaymentModal = false;
-	let paymentToDelete: number | null = null;
+		owner: untrack(() => defaultOwner)
+	});
+	let paymentError = $state('');
+	let savingPayment = $state(false);
+	let showDeletePaymentModal = $state(false);
+	let paymentToDelete: number | null = $state(null);
 
 	const debtTypeLabels: Record<string, string> = {
 		mortgage: 'Hipoteka',
@@ -56,7 +61,7 @@
 		editingDebt = null;
 	}
 
-	let formData = {
+	let formData = $state({
 		name: '',
 		debt_type: 'mortgage',
 		start_date: new Date().toISOString().split('T')[0],
@@ -64,32 +69,34 @@
 		interest_rate: 0,
 		currency: 'PLN',
 		notes: null as string | null
-	};
+	});
 
-	let error = '';
-	let saving = false;
+	let error = $state('');
+	let saving = $state(false);
 
-	$: if (editingDebt) {
-		formData = {
-			name: editingDebt.name,
-			debt_type: editingDebt.debt_type,
-			start_date: editingDebt.start_date,
-			initial_amount: editingDebt.initial_amount,
-			interest_rate: editingDebt.interest_rate,
-			currency: editingDebt.currency,
-			notes: editingDebt.notes
-		};
-	} else if (showForm) {
-		formData = {
-			name: '',
-			debt_type: 'mortgage',
-			start_date: new Date().toISOString().split('T')[0],
-			initial_amount: 0,
-			interest_rate: 0,
-			currency: 'PLN',
-			notes: null
-		};
-	}
+	$effect(() => {
+		if (editingDebt) {
+			formData = {
+				name: editingDebt.name,
+				debt_type: editingDebt.debt_type,
+				start_date: editingDebt.start_date,
+				initial_amount: editingDebt.initial_amount,
+				interest_rate: editingDebt.interest_rate,
+				currency: editingDebt.currency,
+				notes: editingDebt.notes
+			};
+		} else if (showForm) {
+			formData = {
+				name: '',
+				debt_type: 'mortgage',
+				start_date: new Date().toISOString().split('T')[0],
+				initial_amount: 0,
+				interest_rate: 0,
+				currency: 'PLN',
+				notes: null
+			};
+		}
+	});
 
 	async function handleSubmit() {
 		error = '';
@@ -310,7 +317,7 @@
 	<button
 		type="button"
 		class="btn preset-filled-primary-500 w-full sm:w-auto gap-2"
-		on:click={startCreate}
+		onclick={startCreate}
 	>
 		<Plus size={16} />
 		Nowe Zobowiązanie
@@ -372,7 +379,7 @@
 										type="button"
 										class="btn preset-tonal-surface btn-sm gap-1"
 										aria-label="Historia wpłat"
-										on:click={() => openPayments(debt)}
+										onclick={() => openPayments(debt)}
 									>
 										<CircleDollarSign size={14} />
 										<span>{paymentCounts[debt.account_id] || 0}</span>
@@ -381,7 +388,7 @@
 										type="button"
 										class="btn-icon btn-icon-sm"
 										aria-label="Edytuj"
-										on:click={() => startEdit(debt)}
+										onclick={() => startEdit(debt)}
 									>
 										<Pencil size={16} />
 									</button>
@@ -389,7 +396,7 @@
 										type="button"
 										class="btn-icon btn-icon-sm"
 										aria-label="Usuń"
-										on:click={() => handleDelete(debt.id)}
+										onclick={() => handleDelete(debt.id)}
 									>
 										<Trash2 size={16} />
 									</button>
@@ -410,7 +417,13 @@
 				</h3>
 			</header>
 
-			<form class="space-y-4" on:submit|preventDefault={addPayment}>
+			<form
+				class="space-y-4"
+				onsubmit={(event) => {
+					event.preventDefault();
+					addPayment();
+				}}
+			>
 				<div class="grid grid-cols-1 md:grid-cols-3 gap-4">
 					<label class="label">
 						<span class="font-semibold text-sm">Kwota</span>
@@ -486,7 +499,7 @@
 											type="button"
 											class="btn-icon btn-icon-sm"
 											aria-label="Usuń wpłatę"
-											on:click={() => handleDeletePayment(payment.id)}
+											onclick={() => handleDeletePayment(payment.id)}
 										>
 											<Trash2 size={16} />
 										</button>
@@ -509,7 +522,13 @@
 	confirmText={saving ? 'Zapisywanie...' : 'Zapisz'}
 	confirmDisabled={saving}
 >
-	<form on:submit|preventDefault={handleSubmit} class="space-y-4">
+	<form
+		onsubmit={(event) => {
+			event.preventDefault();
+			handleSubmit();
+		}}
+		class="space-y-4"
+	>
 		{#if error}
 			<div class="card preset-filled-error-500 p-3 text-sm">{error}</div>
 		{/if}

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import * as echarts from 'echarts';
 	import MetricCard from '$lib/components/MetricCard.svelte';
 	import { TrendingUp, CheckCircle2, Lightbulb } from 'lucide-svelte';
@@ -11,7 +11,13 @@
 		buildYearlyRoiChartOption
 	} from '$lib/utils/charts/metryki';
 
-	export let data;
+	import type { PageData } from './$types';
+
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
 
 	const {
 		metricCards,
@@ -19,7 +25,7 @@
 		investmentTimeSeries,
 		wrapperTimeSeries,
 		categoryTimeSeries
-	} = data;
+	} = untrack(() => data);
 
 	let allocationChart: HTMLDivElement;
 	let wrapperChart: HTMLDivElement;

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
 	import Modal from '$lib/components/Modal.svelte';
@@ -9,30 +9,35 @@
 	import { goto, invalidateAll } from '$app/navigation';
 	import type { SalaryRecord } from '$lib/types/salaries';
 	import type { Persona } from '$lib/types/personas';
+	import type { PageData } from './$types';
 
-	export let data;
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
 
 	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
-	$: personas = data.personas as Persona[];
-	$: defaultOwner = personas.length > 0 ? personas[0].name : 'Marcin';
+	const personas = $derived(data.personas as Persona[]);
+	const defaultOwner = $derived(personas.length > 0 ? personas[0].name : 'Marcin');
 
 	let chartContainer: HTMLDivElement;
 
-	let filterOwner = data.filters.owner || '';
-	let filterDateFrom = data.filters.date_from || '';
-	let filterDateTo = data.filters.date_to || '';
+	let filterOwner = $state(untrack(() => data.filters.owner || ''));
+	let filterDateFrom = $state(untrack(() => data.filters.date_from || ''));
+	let filterDateTo = $state(untrack(() => data.filters.date_to || ''));
 
-	let showNewSalaryModal = false;
-	let editingSalary: SalaryRecord | null = null;
-	let salaryFormData = {
+	let showNewSalaryModal = $state(false);
+	let editingSalary: SalaryRecord | null = $state(null);
+	let salaryFormData = $state({
 		date: new Date().toISOString().split('T')[0],
 		gross_amount: 0,
 		contract_type: 'UOP',
 		company: '',
-		owner: defaultOwner
-	};
-	let salaryError = '';
-	let savingSalary = false;
+		owner: untrack(() => defaultOwner)
+	});
+	let salaryError = $state('');
+	let savingSalary = $state(false);
 
 	function applyFilters() {
 		const params = new URLSearchParams();
@@ -226,7 +231,7 @@
 	<button
 		type="button"
 		class="btn preset-filled-primary-500 w-full sm:w-auto gap-2"
-		on:click={openNewSalaryModal}
+		onclick={openNewSalaryModal}
 	>
 		<Plus size={16} />
 		Nowe Wynagrodzenie
@@ -261,7 +266,13 @@
 		<header>
 			<h3 class="h3 flex items-center gap-2"><Search size={20} /> Filtry</h3>
 		</header>
-		<form class="space-y-4" on:submit|preventDefault={applyFilters}>
+		<form
+			class="space-y-4"
+			onsubmit={(event) => {
+				event.preventDefault();
+				applyFilters();
+			}}
+		>
 			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 				<label class="label">
 					<span class="font-semibold text-sm">Właściciel</span>
@@ -286,7 +297,7 @@
 
 			<div class="flex flex-col sm:flex-row gap-2">
 				<button type="submit" class="btn preset-filled-primary-500">Filtruj</button>
-				<button type="button" class="btn preset-tonal-surface" on:click={clearFilters}
+				<button type="button" class="btn preset-tonal-surface" onclick={clearFilters}
 					>Wyczyść filtry</button
 				>
 			</div>
@@ -327,7 +338,7 @@
 										type="button"
 										class="btn-icon btn-icon-sm"
 										aria-label="Edytuj"
-										on:click={() => openEditSalaryModal(record)}
+										onclick={() => openEditSalaryModal(record)}
 									>
 										<Pencil size={16} />
 									</button>
@@ -335,7 +346,7 @@
 										type="button"
 										class="btn-icon btn-icon-sm"
 										aria-label="Usuń"
-										on:click={() => deleteSalary(record.id)}
+										onclick={() => deleteSalary(record.id)}
 									>
 										<Trash2 size={16} />
 									</button>
@@ -357,7 +368,13 @@
 	confirmText={savingSalary ? 'Zapisywanie...' : 'Zapisz'}
 	confirmDisabled={savingSalary}
 >
-	<form on:submit|preventDefault={saveSalary} class="space-y-4">
+	<form
+		onsubmit={(event) => {
+			event.preventDefault();
+			saveSalary();
+		}}
+		class="space-y-4"
+	>
 		{#if salaryError}
 			<div class="card preset-filled-error-500 p-3 text-sm">{salaryError}</div>
 		{/if}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -5,22 +5,26 @@
 	import { invalidateAll } from '$app/navigation';
 	import type { Persona } from '$lib/types/personas';
 
-	export let data: { personas: Persona[] };
+	interface Props {
+		data: { personas: Persona[] };
+	}
+
+	let { data }: Props = $props();
 
 	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
 
-	let showForm = false;
-	let editingPersona: Persona | null = null;
-	let showDeleteModal = false;
-	let personaToDelete: Persona | null = null;
-	let error = '';
-	let saving = false;
+	let showForm = $state(false);
+	let editingPersona: Persona | null = $state(null);
+	let showDeleteModal = $state(false);
+	let personaToDelete: Persona | null = $state(null);
+	let error = $state('');
+	let saving = $state(false);
 
-	let formData = {
+	let formData = $state({
 		name: '',
 		ppk_employee_rate: 2.0,
 		ppk_employer_rate: 1.5
-	};
+	});
 
 	function startCreate() {
 		editingPersona = null;
@@ -118,7 +122,7 @@
 <div class="card preset-filled-surface-100-900 p-4 space-y-4">
 	<header class="flex items-center justify-between flex-wrap gap-3">
 		<h3 class="h3">Persony</h3>
-		<button type="button" class="btn preset-filled-primary-500 gap-2" on:click={startCreate}>
+		<button type="button" class="btn preset-filled-primary-500 gap-2" onclick={startCreate}>
 			<Plus size={16} />
 			Nowa Persona
 		</button>
@@ -154,7 +158,7 @@
 									type="button"
 									class="btn-icon btn-icon-sm"
 									aria-label="Edytuj"
-									on:click={() => startEdit(persona)}
+									onclick={() => startEdit(persona)}
 								>
 									<Pencil size={16} />
 								</button>
@@ -162,7 +166,7 @@
 									type="button"
 									class="btn-icon btn-icon-sm"
 									aria-label="Usuń"
-									on:click={() => handleDelete(persona)}
+									onclick={() => handleDelete(persona)}
 								>
 									<Trash2 size={16} />
 								</button>
@@ -183,7 +187,13 @@
 	confirmText={saving ? 'Zapisywanie...' : editingPersona ? 'Zapisz zmiany' : 'Utwórz'}
 	confirmDisabled={saving}
 >
-	<form on:submit|preventDefault={handleSubmit} class="space-y-4">
+	<form
+		onsubmit={(event) => {
+			event.preventDefault();
+			handleSubmit();
+		}}
+		class="space-y-4"
+	>
 		{#if error}
 			<div class="card preset-filled-error-500 p-3 text-sm">{error}</div>
 		{/if}

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { browser } from '$app/environment';
 	import { env } from '$env/dynamic/public';
 	import * as echarts from 'echarts';
@@ -55,17 +55,21 @@
 
 	const SALARY_THRESHOLD_2026 = 5767;
 
-	export let data: PageData;
+	interface Props {
+		data: PageData;
+	}
 
-	$: personas = (data.personas || []) as Array<{ name: string }>;
+	let { data }: Props = $props();
 
-	let currentAge = data.current_age;
-	let retirementAge = data.retirement_age;
+	const personas = $derived((data.personas || []) as Array<{ name: string }>);
+
+	let currentAge = $state(untrack(() => data.current_age));
+	let retirementAge = $state(untrack(() => data.retirement_age));
 
 	// Dynamic IKE/IKZE accounts - one per persona per wrapper
-	let ikeIkzeAccounts: IkeIkzeConfig[] = [];
-	let ppkAccounts: PpkConfig[] = [];
-	let brokerageAccounts: BrokerageConfig[] = [];
+	let ikeIkzeAccounts: IkeIkzeConfig[] = $state([]);
+	let ppkAccounts: PpkConfig[] = $state([]);
+	let brokerageAccounts: BrokerageConfig[] = $state([]);
 
 	function initAccounts() {
 		ikeIkzeAccounts = [];
@@ -108,23 +112,25 @@
 		}
 	}
 
-	$: if (personas.length > 0 && ikeIkzeAccounts.length === 0) {
-		initAccounts();
-	}
+	$effect(() => {
+		if (personas.length > 0 && ikeIkzeAccounts.length === 0) {
+			initAccounts();
+		}
+	});
 
 	// Assumptions
-	let annualReturnRate = 7.0;
-	let limitGrowthRate = 5.0;
-	let expectedSalaryGrowth = 3.0;
-	let inflationRate = 3.0;
+	let annualReturnRate = $state(7.0);
+	let limitGrowthRate = $state(5.0);
+	let expectedSalaryGrowth = $state(3.0);
+	let inflationRate = $state(3.0);
 
 	// Results
-	let results: SimulationResponse | null = null;
-	let loading = false;
-	let error = '';
+	let results: SimulationResponse | null = $state(null);
+	let loading = $state(false);
+	let error = $state('');
 
 	// Chart
-	let chartContainer: HTMLDivElement;
+	let chartContainer: HTMLDivElement | undefined = $state();
 	let chart: echarts.ECharts | null = null;
 
 	async function runSimulation() {
@@ -420,7 +426,7 @@
 				</label>
 			</div>
 
-			<button class="primary-button" on:click={runSimulation} disabled={loading}>
+			<button class="primary-button" onclick={runSimulation} disabled={loading}>
 				{loading ? 'Obliczanie...' : 'Uruchom symulację'}
 			</button>
 

--- a/src/routes/simulations/kalkulator/+page.svelte
+++ b/src/routes/simulations/kalkulator/+page.svelte
@@ -2,7 +2,11 @@
 	import SalaryCalculator from '$lib/components/SalaryCalculator.svelte';
 	import type { SalaryRecord } from '$lib/types/salaries';
 
-	export let data: { latestSalaries: SalaryRecord[] };
+	interface Props {
+		data: { latestSalaries: SalaryRecord[] };
+	}
+
+	let { data }: Props = $props();
 </script>
 
 <SalaryCalculator {data} />

--- a/src/routes/simulations/mortgage/+page.svelte
+++ b/src/routes/simulations/mortgage/+page.svelte
@@ -46,21 +46,21 @@
 	}
 
 	// Form state
-	let remainingPrincipal = 300000;
-	let annualInterestRate = 6.5;
-	let remainingMonths = 240;
-	let totalMonthlyBudget = 3500;
-	let expectedAnnualReturn = 7.0;
-	let inflationRate = 3.0;
-	let enableVariableRate = false;
+	let remainingPrincipal = $state(300000);
+	let annualInterestRate = $state(6.5);
+	let remainingMonths = $state(240);
+	let totalMonthlyBudget = $state(3500);
+	let expectedAnnualReturn = $state(7.0);
+	let inflationRate = $state(3.0);
+	let enableVariableRate = $state(false);
 
 	// Results
-	let results: MortgageVsInvestResponse | null = null;
-	let loading = false;
-	let error = '';
+	let results: MortgageVsInvestResponse | null = $state(null);
+	let loading = $state(false);
+	let error = $state('');
 
 	// Chart
-	let chartContainer: HTMLDivElement;
+	let chartContainer: HTMLDivElement | undefined = $state();
 	let chart: echarts.ECharts | null = null;
 
 	async function runSimulation() {
@@ -251,7 +251,7 @@
 				</label>
 			</div>
 
-			<button class="primary-button" on:click={runSimulation} disabled={loading}>
+			<button class="primary-button" onclick={runSimulation} disabled={loading}>
 				{loading ? 'Obliczanie...' : 'Oblicz'}
 			</button>
 

--- a/src/routes/simulations/zus/+page.svelte
+++ b/src/routes/simulations/zus/+page.svelte
@@ -1,22 +1,26 @@
 <script lang="ts">
-	import { onMount, tick } from 'svelte';
+	import { onMount, tick, untrack } from 'svelte';
 	import { browser } from '$app/environment';
 	import { env } from '$env/dynamic/public';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
 
-	export let data: {
-		prefill: {
-			birth_date: string | null;
-			retirement_age: number;
-			gender: string;
-			current_gross_monthly_salary: number | null;
-			owner: string | null;
-			salary_history: { year: number; annual_gross: number }[];
-			work_start_year: number | null;
+	interface Props {
+		data: {
+			prefill: {
+				birth_date: string | null;
+				retirement_age: number;
+				gender: string;
+				current_gross_monthly_salary: number | null;
+				owner: string | null;
+				salary_history: { year: number; annual_gross: number }[];
+				work_start_year: number | null;
+			};
+			personas: { name: string }[];
 		};
-		personas: { name: string }[];
-	};
+	}
+
+	let { data }: Props = $props();
 
 	interface ZusYearlyProjection {
 		year: number;
@@ -54,26 +58,28 @@
 	}
 
 	// Form state
-	let owner = data.prefill.owner ?? data.personas[0]?.name ?? '';
-	let birthDate = data.prefill.birth_date ?? '';
-	let gender = data.prefill.gender ?? 'M';
-	let retirementAge = data.prefill.retirement_age ?? 65;
-	let currentGrossMonthly = data.prefill.current_gross_monthly_salary ?? 10000;
-	let salaryGrowthRate = 3.0;
-	let inflationRate = 3.0;
-	let valorizationKonto = 5.0;
-	let valorizationSubkonto = 4.0;
-	let hasOfe = false;
-	let kapitalPoczatkowy = 0;
-	let workStartYear = data.prefill.work_start_year ?? 2015;
+	let owner = $state(untrack(() => data.prefill.owner ?? data.personas[0]?.name ?? ''));
+	let birthDate = $state(untrack(() => data.prefill.birth_date ?? ''));
+	let gender = $state(untrack(() => data.prefill.gender ?? 'M'));
+	let retirementAge = $state(untrack(() => data.prefill.retirement_age ?? 65));
+	let currentGrossMonthly = $state(
+		untrack(() => data.prefill.current_gross_monthly_salary ?? 10000)
+	);
+	let salaryGrowthRate = $state(3.0);
+	let inflationRate = $state(3.0);
+	let valorizationKonto = $state(5.0);
+	let valorizationSubkonto = $state(4.0);
+	let hasOfe = $state(false);
+	let kapitalPoczatkowy = $state(0);
+	let workStartYear = $state(untrack(() => data.prefill.work_start_year ?? 2015));
 
 	// Results
-	let results: ZusCalculatorResponse | null = null;
-	let loading = false;
-	let error = '';
+	let results: ZusCalculatorResponse | null = $state(null);
+	let loading = $state(false);
+	let error = $state('');
 
 	// Chart
-	let chartContainer: HTMLDivElement;
+	let chartContainer: HTMLDivElement | undefined = $state();
 	let chart: echarts.ECharts | null = null;
 
 	async function runCalculation() {
@@ -295,7 +301,7 @@
 				</details>
 			{/if}
 
-			<button class="primary-button" on:click={runCalculation} disabled={loading}>
+			<button class="primary-button" onclick={runCalculation} disabled={loading}>
 				{loading ? 'Obliczanie...' : 'Oblicz emeryturę'}
 			</button>
 

--- a/src/routes/snapshots/+page.svelte
+++ b/src/routes/snapshots/+page.svelte
@@ -2,8 +2,13 @@
 	import { goto } from '$app/navigation';
 	import { formatPLN } from '$lib/utils/format';
 	import { Plus, Camera, Pencil } from 'lucide-svelte';
+	import type { PageData } from './$types';
 
-	export let data;
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
 </script>
 
 <svelte:head>
@@ -18,7 +23,7 @@
 	<button
 		type="button"
 		class="btn preset-filled-primary-500 w-full sm:w-auto gap-2"
-		on:click={() => goto('/snapshots/new')}
+		onclick={() => goto('/snapshots/new')}
 	>
 		<Plus size={16} />
 		Nowy Snapshot
@@ -33,11 +38,7 @@
 	{#if data.snapshots.length === 0}
 		<div class="text-center py-12 space-y-4 text-surface-700-300">
 			<p>Brak zapisanych snapshotów</p>
-			<button
-				type="button"
-				class="btn preset-tonal-primary"
-				on:click={() => goto('/snapshots/new')}
-			>
+			<button type="button" class="btn preset-tonal-primary" onclick={() => goto('/snapshots/new')}>
 				Utwórz pierwszy snapshot
 			</button>
 		</div>
@@ -70,7 +71,7 @@
 								<button
 									type="button"
 									class="btn btn-sm preset-tonal-primary gap-1"
-									on:click={() => goto(`/snapshots/${snapshot.id}/edit`)}
+									onclick={() => goto(`/snapshots/${snapshot.id}/edit`)}
 									title="Edytuj snapshot"
 								>
 									<Pencil size={14} />

--- a/src/routes/snapshots/[id]/edit/+page.svelte
+++ b/src/routes/snapshots/[id]/edit/+page.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 	import SnapshotForm from '$lib/components/SnapshotForm.svelte';
+	import type { PageData } from './$types';
 
-	export let data;
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
 </script>
 
 <svelte:head>

--- a/src/routes/snapshots/new/+page.svelte
+++ b/src/routes/snapshots/new/+page.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 	import SnapshotForm from '$lib/components/SnapshotForm.svelte';
+	import type { PageData } from './$types';
 
-	export let data;
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
 </script>
 
 <svelte:head>

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -5,36 +5,42 @@
 	import { env } from '$env/dynamic/public';
 	import { goto, invalidateAll } from '$app/navigation';
 	import type { Persona } from '$lib/types/personas';
+	import { untrack } from 'svelte';
+	import type { PageData } from './$types';
 
-	export let data;
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
 
 	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
-	$: personas = data.personas as Persona[];
-	$: defaultOwner = personas.length > 0 ? personas[0].name : 'Marcin';
+	const personas = $derived(data.personas as Persona[]);
+	const defaultOwner = $derived(personas.length > 0 ? personas[0].name : 'Marcin');
 
-	let filterAccountId = data.filters.account_id || '';
-	let filterOwner = data.filters.owner || '';
-	let filterDateFrom = data.filters.date_from || '';
-	let filterDateTo = data.filters.date_to || '';
+	let filterAccountId = $state(untrack(() => data.filters.account_id || ''));
+	let filterOwner = $state(untrack(() => data.filters.owner || ''));
+	let filterDateFrom = $state(untrack(() => data.filters.date_from || ''));
+	let filterDateTo = $state(untrack(() => data.filters.date_to || ''));
 
-	let showNewTransactionModal = false;
-	let newTransactionData = {
+	let showNewTransactionModal = $state(false);
+	let newTransactionData = $state({
 		account_id: '',
 		amount: 0,
 		date: new Date().toISOString().split('T')[0],
-		owner: defaultOwner
-	};
-	let transactionError = '';
-	let savingTransaction = false;
+		owner: untrack(() => defaultOwner)
+	});
+	let transactionError = $state('');
+	let savingTransaction = $state(false);
 
-	let showPPKGenerateModal = false;
-	let ppkGenerateData = {
-		owner: defaultOwner,
+	let showPPKGenerateModal = $state(false);
+	let ppkGenerateData = $state({
+		owner: untrack(() => defaultOwner),
 		month: new Date().getMonth() + 1,
 		year: new Date().getFullYear()
-	};
-	let ppkGenerateError = '';
-	let ppkGenerating = false;
+	});
+	let ppkGenerateError = $state('');
+	let ppkGenerating = $state(false);
 
 	function applyFilters() {
 		const params = new URLSearchParams();
@@ -182,14 +188,14 @@
 		<p class="text-surface-700-300 text-sm">Historia transakcji inwestycyjnych</p>
 	</div>
 	<div class="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
-		<button type="button" class="btn preset-tonal-surface gap-2" on:click={openPPKGenerateModal}>
+		<button type="button" class="btn preset-tonal-surface gap-2" onclick={openPPKGenerateModal}>
 			<Landmark size={16} />
 			Generuj wpłaty PPK
 		</button>
 		<button
 			type="button"
 			class="btn preset-filled-primary-500 gap-2"
-			on:click={openNewTransactionModal}
+			onclick={openNewTransactionModal}
 		>
 			<Plus size={16} />
 			Nowa Transakcja
@@ -202,7 +208,13 @@
 		<header>
 			<h3 class="h3 flex items-center gap-2"><Search size={20} /> Filtry</h3>
 		</header>
-		<form class="space-y-4" on:submit|preventDefault={applyFilters}>
+		<form
+			class="space-y-4"
+			onsubmit={(event) => {
+				event.preventDefault();
+				applyFilters();
+			}}
+		>
 			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
 				<label class="label">
 					<span class="font-semibold text-sm">Konto</span>
@@ -237,7 +249,7 @@
 
 			<div class="flex flex-col sm:flex-row gap-2">
 				<button type="submit" class="btn preset-filled-primary-500">Filtruj</button>
-				<button type="button" class="btn preset-tonal-surface" on:click={clearFilters}
+				<button type="button" class="btn preset-tonal-surface" onclick={clearFilters}
 					>Wyczyść filtry</button
 				>
 			</div>
@@ -282,7 +294,7 @@
 										type="button"
 										class="btn-icon btn-icon-sm"
 										aria-label="Usuń"
-										on:click={() => deleteTransaction(transaction.account_id, transaction.id)}
+										onclick={() => deleteTransaction(transaction.account_id, transaction.id)}
 									>
 										<Trash2 size={16} />
 									</button>
@@ -304,7 +316,13 @@
 	confirmText={savingTransaction ? 'Zapisywanie...' : 'Dodaj transakcję'}
 	confirmDisabled={savingTransaction}
 >
-	<form on:submit|preventDefault={createTransaction} class="space-y-4">
+	<form
+		onsubmit={(event) => {
+			event.preventDefault();
+			createTransaction();
+		}}
+		class="space-y-4"
+	>
 		{#if transactionError}
 			<div class="card preset-filled-error-500 p-3 text-sm">{transactionError}</div>
 		{/if}
@@ -362,7 +380,13 @@
 	confirmText={ppkGenerating ? 'Generowanie...' : 'Generuj'}
 	confirmDisabled={ppkGenerating}
 >
-	<form on:submit|preventDefault={generatePPKContributions} class="space-y-4">
+	<form
+		onsubmit={(event) => {
+			event.preventDefault();
+			generatePPKContributions();
+		}}
+		class="space-y-4"
+	>
 		{#if ppkGenerateError}
 			<div class="card preset-filled-error-500 p-3 text-sm">{ppkGenerateError}</div>
 		{/if}


### PR DESCRIPTION
## Motivation

Closes #333. This is a Svelte 5 app but most components still used Svelte 4 legacy props/events/reactivity, raising upgrade and onboarding cost - and every new component copied the legacy pattern.

> Changelog: refactor(svelte): migrate legacy syntax

## Implementation information

Migrated all 22 legacy `.svelte` files under `src/` to Svelte 5 runes:

- `export let` -> `$props()` with a typed `interface Props` (pages typed via `PageData` from `./$types`, preserving explicit inline types).
- `$:` reactive statements -> `$derived` / `$derived.by` for pure values, `$effect` for side effects.
- `on:` directives -> event attributes (`onclick`, `onsubmit`, ...); `|preventDefault` / `|stopPropagation` modifiers moved into handler bodies.
- Reassigned UI-driving locals -> `$state`; child-written modal props -> `$bindable()`.
- `SnapshotForm` prop-mirroring rewritten as `$derived` merges, and `populateForm` rewritten to assign sets/maps once - the naive effect read+write caused `effect_update_depth_exceeded`.

Documented the runes pattern in `CLAUDE.md` under Frontend Patterns. No behavior or DOM changes - pure refactor.

Verified: `npm run check` (0 errors / 0 warnings), `npm run lint` (0 errors), `npm run build`, `vitest run --coverage` (116 passing, coverage above enforced thresholds).

## Supporting documentation

Issue #333 (parent #327).