### PR TITLE
docs(docs): sync stale stack notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,11 @@
 
 Self-hosted personal finance dashboard for tracking net worth, goals, and investments. Replaces "Finansowa Forteca.xlsx" spreadsheet with automated tracking and visualizations.
 
-**Tech Stack:** SvelteKit 2.49, TypeScript 5.9, FastAPI, Python 3.14, SQLAlchemy 2.0, pandas 2.3, PostgreSQL 18
+**Tech Stack:** SvelteKit 2.60, Svelte 5 (runes), TypeScript 6, FastAPI, Python 3.14, SQLAlchemy 2.0, pandas 2.3, PostgreSQL 18
 
 **Purpose:** Track Polish personal finance (IKE/IKZE/PPK retirement accounts), monitor net worth trends, manage financial goals, analyze asset allocation.
+
+> Version numbers below are indicative. `package.json` and `backend/pyproject.toml` are the single source of truth - check them when exact versions matter.
 
 ---
 
@@ -64,8 +66,8 @@ Self-hosted personal finance dashboard for tracking net worth, goals, and invest
 
 ### Code Style
 
-- **Formatter:** prettier 3.8.0
-- **Linter:** oxlint 1.39.0
+- **Formatter:** prettier 3.8
+- **Linter:** oxlint 1.65
 - **Naming:** camelCase (variables/functions), PascalCase (components), kebab-case (CSS classes)
 - **Type safety:** Strict TypeScript, no `any` type
 - **Indentation:** Tabs (Svelte convention)
@@ -174,7 +176,7 @@ describe('calculateMonthsRemaining', () => {
 
 - **Formatter:** ruff format
 - **Linter:** ruff check (line-length: 100, target py3.12+)
-- **Type checker:** pyrefly 0.48.1
+- **Type checker:** pyrefly 1.0
 - **Naming:** snake_case (functions/variables), PascalCase (classes)
 - **Type hints:** Required for all functions
 - **Indentation:** 4 spaces

--- a/README.md
+++ b/README.md
@@ -4,37 +4,54 @@ Self-hosted personal finance web app - beautiful dashboard for tracking net wort
 
 ## Tech Stack
 
-- **Framework:** SvelteKit 2.x + TypeScript
-- **Database:** PostgreSQL + Drizzle ORM
-- **UI:** shadcn-svelte + Tailwind CSS
-- **Charts:** Apache ECharts
-- **Deployment:** Docker
+- **Frontend:** SvelteKit 2.60 + Svelte 5 (runes) + TypeScript 6
+- **Backend:** FastAPI + SQLAlchemy 2.0 + pandas (Python 3.14)
+- **Database:** PostgreSQL 18, Alembic migrations
+- **UI:** Tailwind CSS + OpenProps design tokens
+- **Charts:** Apache ECharts 6
+- **Deployment:** Docker Compose
+
+> Exact versions live in `package.json` and `backend/pyproject.toml` -
+> those manifests are the single source of truth.
 
 ## Development
 
 ### Prerequisites
 
-- Node.js 20+
-- Python 3.12+ (for Excel migration script)
-- PostgreSQL (or use Docker Compose)
-- [mise](https://mise.jdx.dev/) (optional, for tool version management)
+- Node.js 24+
+- Python 3.14+
+- PostgreSQL 18 (or use Docker Compose)
+- [mise](https://mise.jdx.dev/) - manages tool versions and runs tasks
+- [uv](https://docs.astral.sh/uv/) - Python dependency manager
 
 ### Setup
 
-1. Install dependencies:
+1. Install frontend dependencies:
 
 ```bash
 npm install
 ```
 
-2. Copy environment variables:
+2. Install backend dependencies:
+
+```bash
+cd backend && uv sync && cd ..
+```
+
+3. Copy environment variables:
 
 ```bash
 cp .env.example .env
-# Edit .env with your PostgreSQL credentials
+# Edit .env - set POSTGRES_PASSWORD and APP_PASSWORD
 ```
 
-3. Run development server:
+4. Run all services (frontend, backend, PostgreSQL):
+
+```bash
+mise run dev
+```
+
+Or run the frontend dev server alone:
 
 ```bash
 npm run dev
@@ -51,32 +68,28 @@ npm run dev
 
 ## Deployment
 
-### Docker
+### Docker Compose
 
-Build and run with Docker:
-
-```bash
-docker build -t finance-buddy .
-docker run -d \
-  --name finance-buddy \
-  -p 3000:3000 \
-  -e DATABASE_URL="postgresql://user:pass@host:5432/finance" \
-  -e ORIGIN="https://finance.yourdomain.com" \
-  -e APP_PASSWORD="your-secure-password" \
-  finance-buddy
-```
-
-Or use Docker Compose:
+`docker-compose.yml` runs the frontend, backend, and PostgreSQL together
+from the published `ghcr.io/automaat/finance-buddy-*` images.
 
 ```bash
+# Required env vars (no defaults - the stack fails fast without them)
+export POSTGRES_PASSWORD="a-strong-password"
+export APP_PASSWORD="your-secure-password"
+
 docker-compose up -d
 ```
 
+`ORIGIN`, `CORS_ORIGINS`, and `PUBLIC_API_URL_BROWSER` can be overridden
+for deployments behind a custom domain.
+
 ## Project Status
 
-🚧 **Work in Progress** - Currently in Phase 1 (Project Setup)
+Actively used. Dashboard, snapshots, accounts, assets, debts, retirement
+metrics, and salary/mortgage/ZUS simulations are all in place.
 
-See [plan.md](./plan.md) for full implementation roadmap.
+See [plan.md](./plan.md) for the original implementation roadmap.
 
 ## License
 


### PR DESCRIPTION
## Motivation

Closes #328. `README.md` and `CLAUDE.md` described Drizzle ORM, shadcn-svelte, Node 20, and Python 3.12 while the repo actually runs FastAPI + SQLAlchemy, Node 24, Python 3.14, SvelteKit 2.60, and TypeScript 6 - misleading for onboarding and for agents picking up conventions.

> Changelog: skip

## Implementation information

- `README.md`: rewrote the tech stack (SvelteKit 2.60 / Svelte 5 runes / TS 6 frontend, FastAPI / SQLAlchemy 2.0 / Python 3.14 backend, Tailwind + OpenProps, ECharts 6), prerequisites (Node 24, Python 3.14, mise, uv), setup (added backend `uv sync` and `mise run dev`), and deployment (Docker Compose with the published images and required `POSTGRES_PASSWORD`/`APP_PASSWORD`). Refreshed the stale "Phase 1" project status.
- `CLAUDE.md`: bumped the tech-stack line to SvelteKit 2.60 / Svelte 5 / TS 6 and corrected formatter/linter/type-checker versions (prettier 3.8, oxlint 1.65, pyrefly 1.0).
- Removed all Drizzle/shadcn references and added a "single source of truth" note pointing to `package.json` and `backend/pyproject.toml`.

`plan.md` is left as-is - it is the original frozen implementation roadmap, not current convention docs.

## Supporting documentation

Issue #328 (parent #327).