### PR TITLE
feat(salaries): show inflation-adjusted view

### DIFF
--- a/backend/alembic/versions/0002_add_cpi_index.py
+++ b/backend/alembic/versions/0002_add_cpi_index.py
@@ -1,0 +1,37 @@
+"""Add cpi_index table for Polish CPI data from GUS BDL.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-05-20
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cpi_index",
+        sa.Column("year", sa.Integer(), primary_key=True),
+        sa.Column("yoy_rate", sa.Numeric(8, 4), nullable=False),
+        sa.Column("source", sa.String(64), nullable=False, server_default="GUS-BDL-217230"),
+        sa.Column(
+            "fetched_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("cpi_index")

--- a/backend/app/api/cpi.py
+++ b/backend/app/api/cpi.py
@@ -54,7 +54,15 @@ def adjust_amount(payload: AdjustRequest, db: Session = Depends(get_db)) -> Adju
 
 @router.post("/refresh", response_model=RefreshResponse)
 async def refresh_cpi(db: Session = Depends(get_db)) -> RefreshResponse:
-    """Pull fresh CPI from GUS BDL and upsert into the database."""
+    """Pull fresh CPI from GUS BDL and upsert into the database.
+
+    Intended for development and manual recovery. In normal operation the
+    in-process scheduler refreshes monthly (and on startup if stale). This
+    endpoint is reachable to anyone who can hit the backend — finance-buddy
+    is a single-user self-hosted app, so the worst case is an unsolicited
+    network call to a public GUS endpoint. Gate it behind auth before
+    exposing the backend to untrusted networks.
+    """
     try:
         written = await inflation.refresh_cpi(db)
     except Exception as exc:

--- a/backend/app/api/cpi.py
+++ b/backend/app/api/cpi.py
@@ -1,0 +1,62 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.schemas.cpi import (
+    AdjustRequest,
+    AdjustResponse,
+    CpiPoint,
+    CpiSeriesResponse,
+    RefreshResponse,
+)
+from app.services import inflation
+
+router = APIRouter(prefix="/api/cpi", tags=["cpi"])
+
+
+@router.get("/series", response_model=CpiSeriesResponse)
+def get_cpi_series(db: Session = Depends(get_db)) -> CpiSeriesResponse:
+    """Return the full annual CPI series with derived cumulative index."""
+    rows = inflation.cpi_series(db)
+    points = [
+        CpiPoint(year=year, yoy_rate=float(yoy), cumulative_index=float(idx))
+        for year, yoy, idx in rows
+    ]
+    return CpiSeriesResponse(
+        points=points,
+        base_year=points[0].year if points else None,
+        latest_year=points[-1].year if points else None,
+    )
+
+
+@router.post("/adjust", response_model=AdjustResponse)
+def adjust_amount(payload: AdjustRequest, db: Session = Depends(get_db)) -> AdjustResponse:
+    """Inflate (or deflate) ``amount`` between two calendar dates."""
+    try:
+        adjusted = inflation.adjust(db, payload.amount, payload.from_date, payload.to_date)
+    except inflation.InflationDataMissingError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    as_of_year = inflation.latest_known_year(db)
+    if as_of_year is None:
+        raise HTTPException(status_code=503, detail="CPI table is empty")
+
+    factor = adjusted / payload.amount if payload.amount else 0.0
+    return AdjustResponse(
+        original_amount=payload.amount,
+        adjusted_amount=adjusted,
+        factor=factor,
+        from_date=payload.from_date,
+        to_date=payload.to_date,
+        as_of_year=as_of_year,
+    )
+
+
+@router.post("/refresh", response_model=RefreshResponse)
+async def refresh_cpi(db: Session = Depends(get_db)) -> RefreshResponse:
+    """Pull fresh CPI from GUS BDL and upsert into the database."""
+    try:
+        written = await inflation.refresh_cpi(db)
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"GUS BDL fetch failed: {exc}") from exc
+    return RefreshResponse(rows_written=written, latest_year=inflation.latest_known_year(db))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from app.api import (
     accounts,
     assets,
     config,
+    cpi,
     dashboard,
     debt_payments,
     debts,
@@ -21,13 +22,15 @@ from app.api import (
 )
 from app.core.config import settings
 from app.core.init_db import init_db
+from app.services.scheduler import scheduler_lifespan
 
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     # Startup: initialize the database schema (migrations + seeding)
     await init_db()
-    yield
+    async with scheduler_lifespan():
+        yield
     # Shutdown: cleanup if needed
 
 
@@ -46,6 +49,7 @@ app.include_router(dashboard.router)
 app.include_router(accounts.router)
 app.include_router(assets.router)
 app.include_router(config.router)
+app.include_router(cpi.router)
 app.include_router(debts.router)
 app.include_router(debt_payments.router)
 app.include_router(investment.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 from app.models.account import Account
 from app.models.app_config import AppConfig
 from app.models.asset import Asset
+from app.models.cpi_index import CpiIndex
 from app.models.debt import Debt
 from app.models.debt_payment import DebtPayment
 from app.models.goal import Goal
@@ -14,6 +15,7 @@ __all__ = [
     "Account",
     "AppConfig",
     "Asset",
+    "CpiIndex",
     "Debt",
     "DebtPayment",
     "Goal",

--- a/backend/app/models/cpi_index.py
+++ b/backend/app/models/cpi_index.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 from decimal import Decimal
 
-from sqlalchemy import Numeric, String
+from sqlalchemy import DateTime, Numeric, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -22,4 +22,6 @@ class CpiIndex(Base):
     year: Mapped[int] = mapped_column(primary_key=True)
     yoy_rate: Mapped[Decimal] = mapped_column(Numeric(8, 4))
     source: Mapped[str] = mapped_column(String(64), default="GUS-BDL-217230")
-    fetched_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))
+    fetched_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )

--- a/backend/app/models/cpi_index.py
+++ b/backend/app/models/cpi_index.py
@@ -1,0 +1,25 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from sqlalchemy import Numeric, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class CpiIndex(Base):
+    """Annual Polish CPI (year-over-year rate) from GUS BDL variable 217230.
+
+    ``yoy_rate`` is the value as published by GUS (e.g. 114.4 means the price
+    level rose 14.4% versus the previous year). Fixed-base indices and
+    arbitrary-date inflation factors are derived at query time in
+    ``app.services.inflation`` — keeping raw data here makes refreshes
+    idempotent and re-derivation trivial.
+    """
+
+    __tablename__ = "cpi_index"
+
+    year: Mapped[int] = mapped_column(primary_key=True)
+    yoy_rate: Mapped[Decimal] = mapped_column(Numeric(8, 4))
+    source: Mapped[str] = mapped_column(String(64), default="GUS-BDL-217230")
+    fetched_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))

--- a/backend/app/schemas/cpi.py
+++ b/backend/app/schemas/cpi.py
@@ -1,0 +1,36 @@
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class CpiPoint(BaseModel):
+    year: int
+    yoy_rate: float
+    cumulative_index: float
+
+
+class CpiSeriesResponse(BaseModel):
+    points: list[CpiPoint]
+    base_year: int | None
+    latest_year: int | None
+    source: str = "GUS-BDL-217230"
+
+
+class AdjustRequest(BaseModel):
+    amount: float
+    from_date: date
+    to_date: date
+
+
+class AdjustResponse(BaseModel):
+    original_amount: float
+    adjusted_amount: float
+    factor: float
+    from_date: date
+    to_date: date
+    as_of_year: int
+
+
+class RefreshResponse(BaseModel):
+    rows_written: int
+    latest_year: int | None

--- a/backend/app/schemas/salary_records.py
+++ b/backend/app/schemas/salary_records.py
@@ -72,7 +72,20 @@ class SalaryRecordResponse(BaseModel):
     created_at: datetime
 
 
+class InflationContext(BaseModel):
+    owner: str
+    last_change_date: date_type
+    previous_change_date: date_type | None
+    previous_salary: float | None
+    previous_salary_in_today_pln: float | None
+    current_salary: float
+    real_change_pln: float | None
+    real_change_pct: float | None
+    cpi_as_of_year: int
+
+
 class SalaryRecordsListResponse(BaseModel):
     salary_records: list[SalaryRecordResponse]
     total_count: int
     current_salaries: dict[str, float | None] = {}
+    inflation_context: dict[str, InflationContext] = {}

--- a/backend/app/services/inflation.py
+++ b/backend/app/services/inflation.py
@@ -6,13 +6,13 @@ helpers to adjust amounts between arbitrary dates.
 
 Educational notes:
 - ``yoy_rate`` from GUS is stored as published (e.g. 114.4 = +14.4% vs prior
-  year). A fixed-base cumulative index is derived from these on the fly.
-- Within a single year the index is interpolated linearly between Jan 1 of
-  year N and Jan 1 of year N+1. The error vs true monthly CPI is well under
-  1 percentage point per year, which is below the noise from comparing
-  national CPI to HICP anyway.
-- Today is rarely available from GUS (lag ~15 days after month end). We fall
-  back to the latest year we have and surface the ``as_of_year`` in the API.
+  year). A fixed-base cumulative ``index[Y]`` is derived on the fly and
+  represents the end-of-year-Y price level (i.e. yoy[Y] has been applied).
+- Within a year the index interpolates linearly between ``index[Y-1]``
+  (start of Y) and ``index[Y]`` (end of Y) pro-rata by day-of-year.
+- For the latest available year there is no successor, so any date in or
+  after that year clamps to the latest known index — the API surfaces the
+  ``as_of_year`` so callers can label the comparison precisely.
 """
 
 import logging
@@ -107,10 +107,11 @@ def _load_yoy_map(db: Session) -> dict[int, Decimal]:
 
 
 def _cumulative_index(yoy_by_year: dict[int, Decimal]) -> dict[int, Decimal]:
-    """Build a fixed-base index keyed by Jan 1 of each year.
+    """Build a fixed-base index. ``index[Y]`` represents the end-of-year-Y price level.
 
     Anchored at the earliest available year with index = 100. Each subsequent
-    year compounds: ``index[y] = index[y-1] * yoy[y] / 100``.
+    year compounds with the inflation that occurred during it:
+    ``index[y] = index[y-1] * yoy[y] / 100``.
     """
     if not yoy_by_year:
         return {}
@@ -124,8 +125,10 @@ def _cumulative_index(yoy_by_year: dict[int, Decimal]) -> dict[int, Decimal]:
 def _index_at_date(index_by_year: dict[int, Decimal], when: date) -> Decimal:
     """Interpolate the fixed-base index at an arbitrary calendar date.
 
-    Linear between Jan 1 of consecutive years. Before the earliest year, clamp
-    to the earliest index; after the latest year, clamp to the latest.
+    Since ``index[Y]`` is the end-of-year-Y level, a date inside year Y
+    interpolates linearly between ``index[Y-1]`` (start of Y) and
+    ``index[Y]`` (end of Y) pro-rata by day-of-year. Outside the known
+    range we clamp to the earliest or latest known year.
     """
     if not index_by_year:
         raise InflationDataMissingError("CPI table is empty")
@@ -133,8 +136,14 @@ def _index_at_date(index_by_year: dict[int, Decimal], when: date) -> Decimal:
     years = sorted(index_by_year.keys())
     if when.year < years[0]:
         return index_by_year[years[0]]
-    if when.year >= years[-1]:
+    if when.year > years[-1]:
         return index_by_year[years[-1]]
+
+    # Start of year Y = end of year Y-1. If we don't have Y-1, clamp to base.
+    start_index = (
+        index_by_year[when.year - 1] if when.year - 1 in index_by_year else index_by_year[years[0]]
+    )
+    end_index = index_by_year[when.year]
 
     year_start = date(when.year, 1, 1)
     next_year_start = date(when.year + 1, 1, 1)
@@ -142,8 +151,6 @@ def _index_at_date(index_by_year: dict[int, Decimal], when: date) -> Decimal:
     elapsed_days = (when - year_start).days
     fraction = Decimal(elapsed_days) / Decimal(span_days)
 
-    start_index = index_by_year[when.year]
-    end_index = index_by_year[when.year + 1]
     return start_index + (end_index - start_index) * fraction
 
 

--- a/backend/app/services/inflation.py
+++ b/backend/app/services/inflation.py
@@ -1,0 +1,192 @@
+"""Polish CPI service.
+
+Pulls annual y/y CPI from GUS BDL (variable 217230 — "Wskaźnik cen towarów
+i usług konsumpcyjnych ogółem", aggregateId=1, all of Poland) and exposes
+helpers to adjust amounts between arbitrary dates.
+
+Educational notes:
+- ``yoy_rate`` from GUS is stored as published (e.g. 114.4 = +14.4% vs prior
+  year). A fixed-base cumulative index is derived from these on the fly.
+- Within a single year the index is interpolated linearly between Jan 1 of
+  year N and Jan 1 of year N+1. The error vs true monthly CPI is well under
+  1 percentage point per year, which is below the noise from comparing
+  national CPI to HICP anyway.
+- Today is rarely available from GUS (lag ~15 days after month end). We fall
+  back to the latest year we have and surface the ``as_of_year`` in the API.
+"""
+
+import logging
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import CpiIndex
+
+logger = logging.getLogger(__name__)
+
+GUS_VARIABLE_ID = 217230
+GUS_BASE_URL = "https://bdl.stat.gov.pl/api/v1"
+GUS_SOURCE_TAG = f"GUS-BDL-{GUS_VARIABLE_ID}"
+HTTP_TIMEOUT = httpx.Timeout(15.0, connect=5.0)
+
+
+class InflationDataMissingError(RuntimeError):
+    """Raised when no CPI rows are available for the requested calculation."""
+
+
+async def fetch_gus_cpi() -> list[tuple[int, Decimal]]:
+    """Fetch annual y/y CPI for Poland from GUS BDL.
+
+    Returns a list of ``(year, yoy_rate)`` tuples sorted ascending by year.
+    Raises ``httpx.HTTPError`` on transport/HTTP failure.
+    """
+    url = f"{GUS_BASE_URL}/data/by-variable/{GUS_VARIABLE_ID}"
+    params = {"unit-level": 0, "format": "json", "page-size": 100}
+
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+        response = await client.get(url, params=params)
+        response.raise_for_status()
+        payload = response.json()
+
+    results = payload.get("results", [])
+    if not results:
+        return []
+
+    raw_values = results[0].get("values", [])
+    parsed: list[tuple[int, Decimal]] = []
+    for entry in raw_values:
+        year_str = entry.get("year")
+        val = entry.get("val")
+        if year_str is None or val is None:
+            continue
+        parsed.append((int(year_str), Decimal(str(val))))
+    parsed.sort(key=lambda row: row[0])
+    return parsed
+
+
+def refresh_cpi_sync(db: Session, rows: list[tuple[int, Decimal]]) -> int:
+    """Upsert CPI rows into the database. Returns number of rows written."""
+    if not rows:
+        return 0
+
+    existing = {row.year: row for row in db.execute(select(CpiIndex)).scalars().all()}
+    written = 0
+    for year, yoy in rows:
+        if year in existing:
+            current = existing[year]
+            if current.yoy_rate != yoy:
+                current.yoy_rate = yoy
+                current.source = GUS_SOURCE_TAG
+                current.fetched_at = datetime.now(UTC)
+                written += 1
+        else:
+            db.add(
+                CpiIndex(
+                    year=year,
+                    yoy_rate=yoy,
+                    source=GUS_SOURCE_TAG,
+                    fetched_at=datetime.now(UTC),
+                )
+            )
+            written += 1
+    db.commit()
+    return written
+
+
+async def refresh_cpi(db: Session) -> int:
+    """Fetch latest CPI from GUS and upsert into the database."""
+    rows = await fetch_gus_cpi()
+    return refresh_cpi_sync(db, rows)
+
+
+def _load_yoy_map(db: Session) -> dict[int, Decimal]:
+    return {row.year: row.yoy_rate for row in db.execute(select(CpiIndex)).scalars().all()}
+
+
+def _cumulative_index(yoy_by_year: dict[int, Decimal]) -> dict[int, Decimal]:
+    """Build a fixed-base index keyed by Jan 1 of each year.
+
+    Anchored at the earliest available year with index = 100. Each subsequent
+    year compounds: ``index[y] = index[y-1] * yoy[y] / 100``.
+    """
+    if not yoy_by_year:
+        return {}
+    years = sorted(yoy_by_year.keys())
+    index_by_year: dict[int, Decimal] = {years[0]: Decimal("100")}
+    for prev, year in zip(years, years[1:], strict=False):
+        index_by_year[year] = index_by_year[prev] * yoy_by_year[year] / Decimal("100")
+    return index_by_year
+
+
+def _index_at_date(index_by_year: dict[int, Decimal], when: date) -> Decimal:
+    """Interpolate the fixed-base index at an arbitrary calendar date.
+
+    Linear between Jan 1 of consecutive years. Before the earliest year, clamp
+    to the earliest index; after the latest year, clamp to the latest.
+    """
+    if not index_by_year:
+        raise InflationDataMissingError("CPI table is empty")
+
+    years = sorted(index_by_year.keys())
+    if when.year < years[0]:
+        return index_by_year[years[0]]
+    if when.year >= years[-1]:
+        return index_by_year[years[-1]]
+
+    year_start = date(when.year, 1, 1)
+    next_year_start = date(when.year + 1, 1, 1)
+    span_days = (next_year_start - year_start).days
+    elapsed_days = (when - year_start).days
+    fraction = Decimal(elapsed_days) / Decimal(span_days)
+
+    start_index = index_by_year[when.year]
+    end_index = index_by_year[when.year + 1]
+    return start_index + (end_index - start_index) * fraction
+
+
+def latest_known_year(db: Session) -> int | None:
+    """Return the latest year for which we have CPI data, or None."""
+    return db.execute(
+        select(CpiIndex.year).order_by(CpiIndex.year.desc()).limit(1)
+    ).scalar_one_or_none()
+
+
+def adjust(db: Session, amount: float, from_date: date, to_date: date) -> float:
+    """Adjust ``amount`` from purchasing power on ``from_date`` to ``to_date``.
+
+    Returns the equivalent amount today (or on ``to_date``). Raises
+    ``InflationDataMissingError`` if no CPI rows exist.
+    """
+    yoy_map = _load_yoy_map(db)
+    index_by_year = _cumulative_index(yoy_map)
+    if not index_by_year:
+        raise InflationDataMissingError("CPI table is empty")
+
+    from_index = _index_at_date(index_by_year, from_date)
+    to_index = _index_at_date(index_by_year, to_date)
+    if from_index == 0:
+        raise InflationDataMissingError("Source index is zero")
+    factor = to_index / from_index
+    return float(Decimal(str(amount)) * factor)
+
+
+def cpi_series(db: Session) -> list[tuple[int, Decimal, Decimal]]:
+    """Return ``(year, yoy_rate, cumulative_index)`` per year, ascending."""
+    yoy_map = _load_yoy_map(db)
+    index_by_year = _cumulative_index(yoy_map)
+    return [(year, yoy_map[year], index_by_year[year]) for year in sorted(yoy_map.keys())]
+
+
+def needs_refresh(db: Session, stale_after: timedelta = timedelta(days=7)) -> bool:
+    """True if no CPI rows or the freshest ``fetched_at`` is older than the threshold."""
+    latest = db.execute(
+        select(CpiIndex.fetched_at).order_by(CpiIndex.fetched_at.desc()).limit(1)
+    ).scalar_one_or_none()
+    if latest is None:
+        return True
+    if latest.tzinfo is None:
+        latest = latest.replace(tzinfo=UTC)
+    return datetime.now(UTC) - latest > stale_after

--- a/backend/app/services/inflation.py
+++ b/backend/app/services/inflation.py
@@ -161,14 +161,22 @@ def latest_known_year(db: Session) -> int | None:
     ).scalar_one_or_none()
 
 
-def adjust(db: Session, amount: float, from_date: date, to_date: date) -> float:
-    """Adjust ``amount`` from purchasing power on ``from_date`` to ``to_date``.
+def load_index(db: Session) -> dict[int, Decimal]:
+    """Load and cache the fixed-base index map. Empty dict if no CPI rows.
 
-    Returns the equivalent amount today (or on ``to_date``). Raises
-    ``InflationDataMissingError`` if no CPI rows exist.
+    Callers that need to adjust many amounts should call this once and then
+    use :func:`adjust_with_index` in a loop to avoid reloading the table.
     """
-    yoy_map = _load_yoy_map(db)
-    index_by_year = _cumulative_index(yoy_map)
+    return _cumulative_index(_load_yoy_map(db))
+
+
+def adjust_with_index(
+    index_by_year: dict[int, Decimal],
+    amount: float,
+    from_date: date,
+    to_date: date,
+) -> float:
+    """Adjust ``amount`` using a pre-loaded index map (see :func:`load_index`)."""
     if not index_by_year:
         raise InflationDataMissingError("CPI table is empty")
 
@@ -178,6 +186,16 @@ def adjust(db: Session, amount: float, from_date: date, to_date: date) -> float:
         raise InflationDataMissingError("Source index is zero")
     factor = to_index / from_index
     return float(Decimal(str(amount)) * factor)
+
+
+def adjust(db: Session, amount: float, from_date: date, to_date: date) -> float:
+    """Adjust ``amount`` from purchasing power on ``from_date`` to ``to_date``.
+
+    Returns the equivalent amount today (or on ``to_date``). Raises
+    ``InflationDataMissingError`` if no CPI rows exist. For loops, prefer
+    :func:`load_index` + :func:`adjust_with_index` to avoid repeated reads.
+    """
+    return adjust_with_index(load_index(db), amount, from_date, to_date)
 
 
 def cpi_series(db: Session) -> list[tuple[int, Decimal, Decimal]]:

--- a/backend/app/services/salary_records.py
+++ b/backend/app/services/salary_records.py
@@ -8,11 +8,13 @@ from sqlalchemy.orm import Session
 
 from app.models import Persona, SalaryRecord
 from app.schemas.salary_records import (
+    InflationContext,
     SalaryRecordCreate,
     SalaryRecordResponse,
     SalaryRecordsListResponse,
     SalaryRecordUpdate,
 )
+from app.services import inflation
 from app.utils.db_helpers import get_or_404, soft_delete
 
 
@@ -52,12 +54,72 @@ def get_all_salary_records(
     today = datetime.now(UTC).date()
     personas = db.execute(select(Persona).order_by(Persona.name)).scalars().all()
     current_salaries = {p.name: _get_current_salary(db, p.name, today) for p in personas}
+    inflation_context = _build_inflation_context(db, [p.name for p in personas], today)
 
     return SalaryRecordsListResponse(
         salary_records=salary_list,
         total_count=len(salary_list),
         current_salaries=current_salaries,
+        inflation_context=inflation_context,
     )
+
+
+def _build_inflation_context(
+    db: Session, persona_names: list[str], today: date
+) -> dict[str, InflationContext]:
+    """For each persona, compute real-terms change since the previous salary record.
+
+    Skips personas without two salary records or when CPI data is unavailable.
+    """
+    as_of_year = inflation.latest_known_year(db)
+    if as_of_year is None:
+        return {}
+
+    result: dict[str, InflationContext] = {}
+    for owner in persona_names:
+        recent = (
+            db.execute(
+                select(SalaryRecord)
+                .where(
+                    SalaryRecord.owner == owner,
+                    SalaryRecord.is_active.is_(True),
+                    SalaryRecord.date <= today,
+                )
+                .order_by(desc(SalaryRecord.date))
+                .limit(2)
+            )
+            .scalars()
+            .all()
+        )
+        if len(recent) < 2:
+            continue
+        current_record, previous_record = recent[0], recent[1]
+        try:
+            prev_in_today = inflation.adjust(
+                db,
+                float(previous_record.gross_amount),
+                previous_record.date,
+                today,
+            )
+        except inflation.InflationDataMissingError:
+            continue
+
+        current_amount = float(current_record.gross_amount)
+        real_change_pln = current_amount - prev_in_today
+        real_change_pct = (real_change_pln / prev_in_today * 100) if prev_in_today else None
+
+        result[owner] = InflationContext(
+            owner=owner,
+            last_change_date=current_record.date,
+            previous_change_date=previous_record.date,
+            previous_salary=float(previous_record.gross_amount),
+            previous_salary_in_today_pln=prev_in_today,
+            current_salary=current_amount,
+            real_change_pln=real_change_pln,
+            real_change_pct=real_change_pct,
+            cpi_as_of_year=as_of_year,
+        )
+    return result
 
 
 def _get_current_salary(db: Session, owner: str, as_of_date: date) -> float | None:

--- a/backend/app/services/salary_records.py
+++ b/backend/app/services/salary_records.py
@@ -2,7 +2,7 @@ from datetime import UTC, date, datetime
 from decimal import Decimal
 
 from fastapi import HTTPException
-from sqlalchemy import desc, select
+from sqlalchemy import desc, func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -70,33 +70,53 @@ def _build_inflation_context(
     """For each persona, compute real-terms change since the previous salary record.
 
     Skips personas without two salary records or when CPI data is unavailable.
+    Loads the CPI index map and latest salaries in single queries.
     """
     as_of_year = inflation.latest_known_year(db)
-    if as_of_year is None:
+    index_by_year = inflation.load_index(db)
+    if as_of_year is None or not index_by_year:
         return {}
 
-    result: dict[str, InflationContext] = {}
-    for owner in persona_names:
-        recent = (
-            db.execute(
-                select(SalaryRecord)
-                .where(
-                    SalaryRecord.owner == owner,
-                    SalaryRecord.is_active.is_(True),
-                    SalaryRecord.date <= today,
-                )
-                .order_by(desc(SalaryRecord.date))
-                .limit(2)
-            )
-            .scalars()
-            .all()
+    # Fetch the two most recent salary records per owner in a single query
+    # using a window function. Window functions are supported by both
+    # SQLite (3.25+) and PostgreSQL, the engines this project targets.
+    rn = (
+        func.row_number()
+        .over(partition_by=SalaryRecord.owner, order_by=desc(SalaryRecord.date))
+        .label("rn")
+    )
+    ranked = (
+        select(SalaryRecord, rn)
+        .where(
+            SalaryRecord.owner.in_(persona_names),
+            SalaryRecord.is_active.is_(True),
+            SalaryRecord.date <= today,
         )
+        .subquery()
+    )
+    rows = (
+        db.execute(
+            select(SalaryRecord)
+            .join(ranked, SalaryRecord.id == ranked.c.id)
+            .where(ranked.c.rn <= 2)
+            .order_by(SalaryRecord.owner, desc(SalaryRecord.date))
+        )
+        .scalars()
+        .all()
+    )
+
+    by_owner: dict[str, list[SalaryRecord]] = {}
+    for row in rows:
+        by_owner.setdefault(row.owner, []).append(row)
+
+    result: dict[str, InflationContext] = {}
+    for owner, recent in by_owner.items():
         if len(recent) < 2:
             continue
         current_record, previous_record = recent[0], recent[1]
         try:
-            prev_in_today = inflation.adjust(
-                db,
+            prev_in_today = inflation.adjust_with_index(
+                index_by_year,
                 float(previous_record.gross_amount),
                 previous_record.date,
                 today,

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -1,4 +1,11 @@
-"""Background scheduler for periodic CPI refreshes."""
+"""Background scheduler for periodic CPI refreshes.
+
+Assumes a single-instance deployment (one backend process). The scheduler
+runs in-process, so if the backend is scaled horizontally (multiple
+uvicorn workers or replicas) each one would perform its own refresh.
+Finance-buddy is a self-hosted single-user app; if that changes, replace
+this with an external cron, a leader-elected job, or a DB advisory lock.
+"""
 
 import logging
 from collections.abc import AsyncIterator

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -1,0 +1,68 @@
+"""Background scheduler for periodic CPI refreshes."""
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from app.core.database import SessionLocal
+from app.services import inflation
+
+logger = logging.getLogger(__name__)
+_scheduler: AsyncIOScheduler | None = None
+
+
+async def _refresh_job() -> None:
+    db = SessionLocal()
+    try:
+        written = await inflation.refresh_cpi(db)
+        logger.info("CPI refresh complete: %s rows written", written)
+    except Exception:
+        logger.exception("CPI refresh failed")
+    finally:
+        db.close()
+
+
+async def _startup_refresh_if_stale() -> None:
+    """Refresh on boot only if data is missing or stale (>7 days old)."""
+    db = SessionLocal()
+    try:
+        stale = inflation.needs_refresh(db)
+    except Exception:
+        logger.exception("CPI staleness check failed; skipping startup refresh")
+        db.close()
+        return
+    db.close()
+
+    if stale:
+        logger.info("CPI data missing or stale; refreshing on startup")
+        await _refresh_job()
+    else:
+        logger.info("CPI data fresh; skipping startup refresh")
+
+
+@asynccontextmanager
+async def scheduler_lifespan() -> AsyncIterator[None]:
+    """Start the APScheduler on entry, shut it down on exit."""
+    global _scheduler
+    await _startup_refresh_if_stale()
+
+    _scheduler = AsyncIOScheduler(timezone="Europe/Warsaw")
+    # GUS publishes monthly CPI around the 15th. Run on the 16th at 04:00.
+    _scheduler.add_job(
+        _refresh_job,
+        CronTrigger(day=16, hour=4, minute=0, timezone="Europe/Warsaw"),
+        id="cpi_monthly_refresh",
+        replace_existing=True,
+    )
+    _scheduler.start()
+    logger.info("CPI scheduler started")
+    try:
+        yield
+    finally:
+        if _scheduler is not None:
+            _scheduler.shutdown(wait=False)
+            _scheduler = None
+            logger.info("CPI scheduler stopped")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,9 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "alembic>=1.16.0",
+    "apscheduler>=3.11.0",
     "fastapi>=0.128.0",
+    "httpx>=0.28.1",
     "openpyxl>=3.1.5",
     "pandas>=2.3.3",
     "psycopg2-binary>=2.9.11",
@@ -18,7 +20,6 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "httpx>=0.28.1",
     "pyrefly==1.0.0",
     "pytest>=9.0.2",
     "pytest-cov>=7.0.0",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from contextlib import asynccontextmanager
 from unittest.mock import patch
 
 import pytest
@@ -10,11 +11,29 @@ from testcontainers.postgres import PostgresContainer
 from app.core.database import Base, get_db
 from app.main import app
 
-# Import models BEFORE app to register them with SQLAlchemy Base.metadata
-from app.models import (  # noqa: F401
+# Import models BEFORE app to register them with SQLAlchemy Base.metadata.
+# The tuple reference below keeps linters from flagging the side-effect imports.
+from app.models import (
     Account,
     AppConfig,
     Asset,
+    CpiIndex,
+    Debt,
+    DebtPayment,
+    Goal,
+    Persona,
+    RetirementLimit,
+    SalaryRecord,
+    Snapshot,
+    SnapshotValue,
+    Transaction,
+)
+
+_REGISTERED_MODELS = (
+    Account,
+    AppConfig,
+    Asset,
+    CpiIndex,
     Debt,
     DebtPayment,
     Goal,
@@ -112,10 +131,19 @@ def test_client(test_db_engine) -> Generator[TestClient]:
 
     app.dependency_overrides[get_db] = override_get_db
 
-    # Patch init_db to use test engine during lifespan
-    with patch("app.core.init_db.init_db", side_effect=mock_init_db):
+    # Patch init_db to use test engine during lifespan; suppress real scheduler
+    # so tests don't hit GUS BDL or schedule background jobs.
+    with (
+        patch("app.core.init_db.init_db", side_effect=mock_init_db),
+        patch("app.main.scheduler_lifespan", _noop_lifespan),
+    ):
         client = TestClient(app, raise_server_exceptions=True)
         try:
             yield client
         finally:
             app.dependency_overrides.clear()
+
+
+@asynccontextmanager
+async def _noop_lifespan():
+    yield

--- a/backend/tests/test_api_cpi.py
+++ b/backend/tests/test_api_cpi.py
@@ -1,0 +1,187 @@
+"""API tests for the /api/cpi router and salaries inflation_context."""
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from app.models import CpiIndex, Persona
+from tests.factories import create_test_salary_record
+
+
+@pytest.fixture
+def seeded_cpi(test_db_session):
+    rows = [
+        (2020, "103.4"),
+        (2021, "105.1"),
+        (2022, "114.4"),
+        (2023, "111.4"),
+        (2024, "103.6"),
+        (2025, "103.6"),
+    ]
+    for year, yoy in rows:
+        test_db_session.add(
+            CpiIndex(
+                year=year,
+                yoy_rate=Decimal(yoy),
+                source="test",
+                fetched_at=datetime.now(UTC),
+            )
+        )
+    test_db_session.commit()
+    return rows
+
+
+def test_cpi_series_empty(test_client):
+    response = test_client.get("/api/cpi/series")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["points"] == []
+    assert body["base_year"] is None
+    assert body["latest_year"] is None
+
+
+@pytest.mark.usefixtures("seeded_cpi")
+def test_cpi_series_returns_sorted_points(test_client):
+    response = test_client.get("/api/cpi/series")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["base_year"] == 2020
+    assert body["latest_year"] == 2025
+    years = [p["year"] for p in body["points"]]
+    assert years == [2020, 2021, 2022, 2023, 2024, 2025]
+    # First point's cumulative index is anchored at 100.
+    assert body["points"][0]["cumulative_index"] == pytest.approx(100.0)
+
+
+@pytest.mark.usefixtures("seeded_cpi")
+def test_cpi_adjust_compounds(test_client):
+    response = test_client.post(
+        "/api/cpi/adjust",
+        json={
+            "amount": 10000,
+            "from_date": "2022-01-01",
+            "to_date": "2026-05-20",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    # 1.144 * 1.114 * 1.036 * 1.036 = 1.368 (~13680)
+    assert body["adjusted_amount"] == pytest.approx(13680.0, rel=5e-3)
+    assert body["factor"] == pytest.approx(1.368, rel=5e-3)
+    assert body["as_of_year"] == 2025
+
+
+def test_cpi_adjust_returns_503_when_table_empty(test_client):
+    response = test_client.post(
+        "/api/cpi/adjust",
+        json={"amount": 1000, "from_date": "2020-01-01", "to_date": "2025-01-01"},
+    )
+    assert response.status_code == 503
+
+
+def test_cpi_refresh_returns_502_on_network_error(test_client):
+    async def boom(_db):
+        raise httpx.ConnectError("simulated network failure")
+
+    with patch("app.api.cpi.inflation.refresh_cpi", side_effect=boom):
+        response = test_client.post("/api/cpi/refresh")
+
+    assert response.status_code == 502
+    assert "GUS BDL fetch failed" in response.json()["detail"]
+
+
+def test_cpi_refresh_success(test_client):
+    async def fake_refresh(_db):
+        _db.add(
+            CpiIndex(
+                year=2024,
+                yoy_rate=Decimal("103.6"),
+                source="test",
+                fetched_at=datetime.now(UTC),
+            )
+        )
+        _db.commit()
+        return 1
+
+    with patch("app.api.cpi.inflation.refresh_cpi", side_effect=fake_refresh):
+        response = test_client.post("/api/cpi/refresh")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["rows_written"] == 1
+    assert body["latest_year"] == 2024
+
+
+@pytest.mark.usefixtures("seeded_cpi")
+def test_salaries_inflation_context_present(test_client, test_db_session):
+    test_db_session.add(Persona(name="Marcin"))
+    test_db_session.commit()
+    create_test_salary_record(
+        test_db_session,
+        salary_date=date(2022, 1, 1),
+        gross_amount=10000.0,
+        company="Co A",
+        owner="Marcin",
+    )
+    create_test_salary_record(
+        test_db_session,
+        salary_date=date(2024, 6, 1),
+        gross_amount=12000.0,
+        company="Co B",
+        owner="Marcin",
+    )
+
+    response = test_client.get("/api/salaries")
+    assert response.status_code == 200
+    body = response.json()
+    ctx = body["inflation_context"]["Marcin"]
+    assert ctx["previous_change_date"] == "2022-01-01"
+    assert ctx["last_change_date"] == "2024-06-01"
+    assert ctx["previous_salary"] == 10000.0
+    assert ctx["current_salary"] == 12000.0
+    # Real raise should be negative — 12k didn't beat 14%+11% inflation.
+    assert ctx["real_change_pln"] < 0
+    assert ctx["cpi_as_of_year"] == 2025
+
+
+@pytest.mark.usefixtures("seeded_cpi")
+def test_salaries_inflation_context_absent_with_one_record(test_client, test_db_session):
+    test_db_session.add(Persona(name="Marcin"))
+    test_db_session.commit()
+    create_test_salary_record(
+        test_db_session,
+        salary_date=date(2024, 1, 1),
+        gross_amount=10000.0,
+        company="Co A",
+        owner="Marcin",
+    )
+
+    response = test_client.get("/api/salaries")
+    assert response.status_code == 200
+    assert "Marcin" not in response.json()["inflation_context"]
+
+
+def test_salaries_inflation_context_absent_without_cpi(test_client, test_db_session):
+    test_db_session.add(Persona(name="Marcin"))
+    test_db_session.commit()
+    create_test_salary_record(
+        test_db_session,
+        salary_date=date(2022, 1, 1),
+        gross_amount=10000.0,
+        company="Co A",
+        owner="Marcin",
+    )
+    create_test_salary_record(
+        test_db_session,
+        salary_date=date(2024, 6, 1),
+        gross_amount=12000.0,
+        company="Co B",
+        owner="Marcin",
+    )
+
+    response = test_client.get("/api/salaries")
+    assert response.status_code == 200
+    assert response.json()["inflation_context"] == {}

--- a/backend/tests/test_services_inflation.py
+++ b/backend/tests/test_services_inflation.py
@@ -23,37 +23,39 @@ def _seed(db, rows):
 
 
 def test_adjust_compounds_full_years(test_db_session):
+    # yoy[2021]=110 means +10% during 2021; yoy[2022]=120 means +20% during 2022.
+    # Start of 2021 (= end of 2020) -> after 2022's inflation: factor 1.10 * 1.20 = 1.32.
     _seed(
         test_db_session,
         [(2020, "100.0"), (2021, "110.0"), (2022, "120.0")],
     )
-    # 2020 -> 2022: factor = 1.10 * 1.20 = 1.32
-    result = inflation.adjust(test_db_session, 1000.0, date(2020, 1, 1), date(2022, 1, 1))
+    result = inflation.adjust(test_db_session, 1000.0, date(2021, 1, 1), date(2023, 1, 1))
     assert result == pytest.approx(1320.0, rel=1e-6)
 
 
 def test_adjust_interpolates_within_year(test_db_session):
-    _seed(test_db_session, [(2020, "100.0"), (2021, "120.0")])
-    # Mid-2020 to mid-2021 should be ~half a year of the 20% raise, applied
-    # linearly between Jan 1 anchors.
+    _seed(test_db_session, [(2019, "100.0"), (2020, "100.0"), (2021, "120.0")])
+    # Mid-2020 (no inflation during 2020) -> mid-2021 (mid of the 20% year):
+    # roughly half of the 20% raise = ~+10%.
     result = inflation.adjust(test_db_session, 1000.0, date(2020, 7, 1), date(2021, 7, 1))
-    assert 1080 < result < 1120  # should be near +10%, well-bounded
+    assert 1080 < result < 1120
 
 
-def test_adjust_clamps_to_latest_known_year(test_db_session):
+def test_adjust_clamps_above_latest_known_year(test_db_session):
     _seed(test_db_session, [(2020, "100.0"), (2021, "110.0")])
-    # Date after last known year clamps to that year's index.
-    factor_2021 = inflation.adjust(test_db_session, 1.0, date(2020, 1, 1), date(2021, 1, 1))
-    factor_2099 = inflation.adjust(test_db_session, 1.0, date(2020, 1, 1), date(2099, 1, 1))
-    assert factor_2099 == pytest.approx(factor_2021, rel=1e-9)
+    # Any date past 2021 clamps to idx[2021] = end of 2021 prices.
+    a = inflation.adjust(test_db_session, 1.0, date(2021, 1, 1), date(2099, 1, 1))
+    b = inflation.adjust(test_db_session, 1.0, date(2021, 1, 1), date(2050, 1, 1))
+    assert a == pytest.approx(b, rel=1e-9)
 
 
-def test_adjust_clamps_to_earliest_known_year(test_db_session):
+def test_adjust_clamps_below_earliest_known_year(test_db_session):
     _seed(test_db_session, [(2020, "100.0"), (2021, "110.0")])
-    # Date before first known year clamps to that year's index.
-    factor_2020 = inflation.adjust(test_db_session, 1.0, date(2020, 1, 1), date(2021, 1, 1))
-    factor_1900 = inflation.adjust(test_db_session, 1.0, date(1900, 1, 1), date(2021, 1, 1))
-    assert factor_1900 == pytest.approx(factor_2020, rel=1e-9)
+    # Any date before 2020 clamps to idx[2020]; date(2020,1,1) also clamps
+    # because 2019 is not in the data.
+    a = inflation.adjust(test_db_session, 1.0, date(2020, 1, 1), date(2021, 1, 1))
+    b = inflation.adjust(test_db_session, 1.0, date(1900, 1, 1), date(2021, 1, 1))
+    assert a == pytest.approx(b, rel=1e-9)
 
 
 def test_adjust_raises_when_empty(test_db_session):

--- a/backend/tests/test_services_inflation.py
+++ b/backend/tests/test_services_inflation.py
@@ -1,0 +1,115 @@
+"""Tests for the inflation service."""
+
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.models import CpiIndex
+from app.services import inflation
+
+
+def _seed(db, rows):
+    for year, yoy in rows:
+        db.add(
+            CpiIndex(
+                year=year,
+                yoy_rate=Decimal(str(yoy)),
+                source="test",
+                fetched_at=datetime.now(UTC),
+            )
+        )
+    db.commit()
+
+
+def test_adjust_compounds_full_years(test_db_session):
+    _seed(
+        test_db_session,
+        [(2020, "100.0"), (2021, "110.0"), (2022, "120.0")],
+    )
+    # 2020 -> 2022: factor = 1.10 * 1.20 = 1.32
+    result = inflation.adjust(test_db_session, 1000.0, date(2020, 1, 1), date(2022, 1, 1))
+    assert result == pytest.approx(1320.0, rel=1e-6)
+
+
+def test_adjust_interpolates_within_year(test_db_session):
+    _seed(test_db_session, [(2020, "100.0"), (2021, "120.0")])
+    # Mid-2020 to mid-2021 should be ~half a year of the 20% raise, applied
+    # linearly between Jan 1 anchors.
+    result = inflation.adjust(test_db_session, 1000.0, date(2020, 7, 1), date(2021, 7, 1))
+    assert 1080 < result < 1120  # should be near +10%, well-bounded
+
+
+def test_adjust_clamps_to_latest_known_year(test_db_session):
+    _seed(test_db_session, [(2020, "100.0"), (2021, "110.0")])
+    # Date after last known year clamps to that year's index.
+    factor_2021 = inflation.adjust(test_db_session, 1.0, date(2020, 1, 1), date(2021, 1, 1))
+    factor_2099 = inflation.adjust(test_db_session, 1.0, date(2020, 1, 1), date(2099, 1, 1))
+    assert factor_2099 == pytest.approx(factor_2021, rel=1e-9)
+
+
+def test_adjust_clamps_to_earliest_known_year(test_db_session):
+    _seed(test_db_session, [(2020, "100.0"), (2021, "110.0")])
+    # Date before first known year clamps to that year's index.
+    factor_2020 = inflation.adjust(test_db_session, 1.0, date(2020, 1, 1), date(2021, 1, 1))
+    factor_1900 = inflation.adjust(test_db_session, 1.0, date(1900, 1, 1), date(2021, 1, 1))
+    assert factor_1900 == pytest.approx(factor_2020, rel=1e-9)
+
+
+def test_adjust_raises_when_empty(test_db_session):
+    with pytest.raises(inflation.InflationDataMissingError):
+        inflation.adjust(test_db_session, 1000.0, date(2020, 1, 1), date(2022, 1, 1))
+
+
+def test_cumulative_index_anchored_at_earliest_year():
+    yoy = {2020: Decimal("100"), 2021: Decimal("110"), 2022: Decimal("120")}
+    idx = inflation._cumulative_index(yoy)
+    assert idx[2020] == Decimal("100")
+    assert idx[2021] == Decimal("110")
+    assert idx[2022] == Decimal("132")
+
+
+def test_refresh_cpi_sync_upserts(test_db_session):
+    rows = [(2020, Decimal("103.4")), (2021, Decimal("105.1"))]
+    written = inflation.refresh_cpi_sync(test_db_session, rows)
+    assert written == 2
+
+    # Same payload -> no rewrites.
+    written_again = inflation.refresh_cpi_sync(test_db_session, rows)
+    assert written_again == 0
+
+    # Changed value -> one rewrite.
+    rows[0] = (2020, Decimal("103.5"))
+    written_changed = inflation.refresh_cpi_sync(test_db_session, rows)
+    assert written_changed == 1
+
+
+def test_needs_refresh_when_empty(test_db_session):
+    assert inflation.needs_refresh(test_db_session) is True
+
+
+def test_needs_refresh_respects_threshold(test_db_session):
+    fresh = CpiIndex(
+        year=2024,
+        yoy_rate=Decimal("103.6"),
+        source="test",
+        fetched_at=datetime.now(UTC),
+    )
+    test_db_session.add(fresh)
+    test_db_session.commit()
+    assert inflation.needs_refresh(test_db_session, stale_after=timedelta(days=7)) is False
+
+    fresh.fetched_at = datetime.now(UTC) - timedelta(days=30)
+    test_db_session.commit()
+    assert inflation.needs_refresh(test_db_session, stale_after=timedelta(days=7)) is True
+
+
+def test_cpi_series_returns_sorted_points(test_db_session):
+    _seed(
+        test_db_session,
+        [(2022, "114.4"), (2020, "103.4"), (2021, "105.1")],
+    )
+    series = inflation.cpi_series(test_db_session)
+    assert [row[0] for row in series] == [2020, 2021, 2022]
+    # cumulative index for 2022 = 100 * 1.051 * 1.144
+    assert series[-1][2] == pytest.approx(Decimal("120.2344"), rel=1e-4)

--- a/src/lib/types/cpi.ts
+++ b/src/lib/types/cpi.ts
@@ -1,0 +1,12 @@
+export interface CpiPoint {
+	year: number;
+	yoy_rate: number;
+	cumulative_index: number;
+}
+
+export interface CpiSeries {
+	points: CpiPoint[];
+	base_year: number | null;
+	latest_year: number | null;
+	source: string;
+}

--- a/src/lib/types/salaries.ts
+++ b/src/lib/types/salaries.ts
@@ -9,8 +9,21 @@ export interface SalaryRecord {
 	created_at: string;
 }
 
+export interface InflationContext {
+	owner: string;
+	last_change_date: string;
+	previous_change_date: string | null;
+	previous_salary: number | null;
+	previous_salary_in_today_pln: number | null;
+	current_salary: number;
+	real_change_pln: number | null;
+	real_change_pct: number | null;
+	cpi_as_of_year: number;
+}
+
 export interface SalariesData {
 	salary_records: SalaryRecord[];
 	total_count: number;
 	current_salaries: Record<string, number | null>;
+	inflation_context: Record<string, InflationContext>;
 }

--- a/src/lib/utils/inflation.test.ts
+++ b/src/lib/utils/inflation.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { indexAtDate, inflationAdjust, realChange } from './inflation';
+import type { CpiSeries } from '$lib/types/cpi';
+
+const series: CpiSeries = {
+	points: [
+		{ year: 2020, yoy_rate: 100, cumulative_index: 100 },
+		{ year: 2021, yoy_rate: 110, cumulative_index: 110 },
+		{ year: 2022, yoy_rate: 120, cumulative_index: 132 }
+	],
+	base_year: 2020,
+	latest_year: 2022,
+	source: 'test'
+};
+
+describe('indexAtDate', () => {
+	it('returns Jan 1 anchor for first day of year', () => {
+		expect(indexAtDate(series, new Date(2021, 0, 1))).toBeCloseTo(110, 5);
+	});
+
+	it('interpolates linearly mid-year', () => {
+		// Mid 2020 should be ~halfway between 100 and 110.
+		const result = indexAtDate(series, new Date(2020, 6, 2));
+		expect(result).toBeGreaterThan(104);
+		expect(result).toBeLessThan(106);
+	});
+
+	it('clamps to latest known year past the end', () => {
+		expect(indexAtDate(series, new Date(2099, 5, 1))).toBe(132);
+	});
+
+	it('clamps to earliest known year before start', () => {
+		expect(indexAtDate(series, new Date(1900, 0, 1))).toBe(100);
+	});
+
+	it('returns null for empty series', () => {
+		expect(indexAtDate({ ...series, points: [] }, new Date(2021, 0, 1))).toBeNull();
+	});
+});
+
+describe('inflationAdjust', () => {
+	it('compounds across full years', () => {
+		const result = inflationAdjust(1000, new Date(2020, 0, 1), new Date(2022, 0, 1), series);
+		expect(result).toBeCloseTo(1320, 5);
+	});
+
+	it('returns null when series is empty', () => {
+		const empty = { ...series, points: [] };
+		expect(inflationAdjust(1000, new Date(2020, 0, 1), new Date(2022, 0, 1), empty)).toBeNull();
+	});
+});
+
+describe('realChange', () => {
+	it('flags a raise that fails to beat inflation', () => {
+		const result = realChange(1000, new Date(2020, 0, 1), 1100, new Date(2022, 0, 1), series);
+		expect(result).not.toBeNull();
+		expect(result!.nominalChangePln).toBe(100);
+		expect(result!.previousInTodayPln).toBeCloseTo(1320, 5);
+		expect(result!.realChangePln).toBeCloseTo(-220, 5);
+		expect(result!.realChangePct).toBeLessThan(0);
+	});
+
+	it('confirms a raise that beats inflation', () => {
+		const result = realChange(1000, new Date(2020, 0, 1), 1500, new Date(2022, 0, 1), series);
+		expect(result).not.toBeNull();
+		expect(result!.realChangePln).toBeCloseTo(180, 5);
+		expect(result!.realChangePct).toBeGreaterThan(0);
+	});
+});

--- a/src/lib/utils/inflation.test.ts
+++ b/src/lib/utils/inflation.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { indexAtDate, inflationAdjust, realChange } from './inflation';
+import {
+	buildCpiLookup,
+	indexAtDate,
+	inflationAdjust,
+	parseIsoDate,
+	realChange
+} from './inflation';
 import type { CpiSeries } from '$lib/types/cpi';
 
 const series: CpiSeries = {
@@ -13,48 +19,68 @@ const series: CpiSeries = {
 	source: 'test'
 };
 
+const lookup = buildCpiLookup(series)!;
+
+describe('parseIsoDate', () => {
+	it('parses YYYY-MM-DD as a local calendar date (no UTC shift)', () => {
+		const d = parseIsoDate('2021-01-01');
+		expect(d.getFullYear()).toBe(2021);
+		expect(d.getMonth()).toBe(0);
+		expect(d.getDate()).toBe(1);
+	});
+});
+
+describe('buildCpiLookup', () => {
+	it('returns null for empty series', () => {
+		expect(buildCpiLookup({ ...series, points: [] })).toBeNull();
+	});
+
+	it('sorts points and indexes by year', () => {
+		const reversed: CpiSeries = { ...series, points: [...series.points].reverse() };
+		const l = buildCpiLookup(reversed)!;
+		expect(l.first.year).toBe(2020);
+		expect(l.last.year).toBe(2022);
+		expect(l.byYear.get(2021)).toBe(110);
+	});
+});
+
 describe('indexAtDate', () => {
 	it('returns idx[Y-1] (start of Y) for Jan 1 of year Y', () => {
 		// Jan 1 2022 = end of 2021 prices = idx[2021] = 110.
-		expect(indexAtDate(series, new Date(2022, 0, 1))).toBeCloseTo(110, 5);
+		expect(indexAtDate(lookup, new Date(2022, 0, 1))).toBeCloseTo(110, 5);
 	});
 
 	it('interpolates linearly mid-year', () => {
 		// Mid 2021 should be ~halfway between idx[2020]=100 and idx[2021]=110.
-		const result = indexAtDate(series, new Date(2021, 6, 2));
+		const result = indexAtDate(lookup, new Date(2021, 6, 2));
 		expect(result).toBeGreaterThan(104);
 		expect(result).toBeLessThan(106);
 	});
 
 	it('clamps to latest known year past the end', () => {
-		expect(indexAtDate(series, new Date(2099, 5, 1))).toBe(132);
+		expect(indexAtDate(lookup, new Date(2099, 5, 1))).toBe(132);
 	});
 
 	it('clamps to earliest known year before start', () => {
-		expect(indexAtDate(series, new Date(1900, 0, 1))).toBe(100);
-	});
-
-	it('returns null for empty series', () => {
-		expect(indexAtDate({ ...series, points: [] }, new Date(2021, 0, 1))).toBeNull();
+		expect(indexAtDate(lookup, new Date(1900, 0, 1))).toBe(100);
 	});
 });
 
 describe('inflationAdjust', () => {
 	it('compounds across full years', () => {
 		// Start of 2021 (= end of 2020) -> past end of 2022 (clamped): 110 -> 132 -> factor 1.32.
-		const result = inflationAdjust(1000, new Date(2021, 0, 1), new Date(2023, 0, 1), series);
+		const result = inflationAdjust(1000, new Date(2021, 0, 1), new Date(2023, 0, 1), lookup);
 		expect(result).toBeCloseTo(1320, 5);
 	});
 
-	it('returns null when series is empty', () => {
-		const empty = { ...series, points: [] };
-		expect(inflationAdjust(1000, new Date(2021, 0, 1), new Date(2023, 0, 1), empty)).toBeNull();
+	it('returns null when lookup is null', () => {
+		expect(inflationAdjust(1000, new Date(2021, 0, 1), new Date(2023, 0, 1), null)).toBeNull();
 	});
 });
 
 describe('realChange', () => {
 	it('flags a raise that fails to beat inflation', () => {
-		const result = realChange(1000, new Date(2021, 0, 1), 1100, new Date(2023, 0, 1), series);
+		const result = realChange(1000, new Date(2021, 0, 1), 1100, new Date(2023, 0, 1), lookup);
 		expect(result).not.toBeNull();
 		expect(result!.nominalChangePln).toBe(100);
 		expect(result!.previousInTodayPln).toBeCloseTo(1320, 5);
@@ -63,9 +89,13 @@ describe('realChange', () => {
 	});
 
 	it('confirms a raise that beats inflation', () => {
-		const result = realChange(1000, new Date(2021, 0, 1), 1500, new Date(2023, 0, 1), series);
+		const result = realChange(1000, new Date(2021, 0, 1), 1500, new Date(2023, 0, 1), lookup);
 		expect(result).not.toBeNull();
 		expect(result!.realChangePln).toBeCloseTo(180, 5);
 		expect(result!.realChangePct).toBeGreaterThan(0);
+	});
+
+	it('returns null when lookup is null', () => {
+		expect(realChange(1000, new Date(2021, 0, 1), 1100, new Date(2023, 0, 1), null)).toBeNull();
 	});
 });

--- a/src/lib/utils/inflation.test.ts
+++ b/src/lib/utils/inflation.test.ts
@@ -14,13 +14,14 @@ const series: CpiSeries = {
 };
 
 describe('indexAtDate', () => {
-	it('returns Jan 1 anchor for first day of year', () => {
-		expect(indexAtDate(series, new Date(2021, 0, 1))).toBeCloseTo(110, 5);
+	it('returns idx[Y-1] (start of Y) for Jan 1 of year Y', () => {
+		// Jan 1 2022 = end of 2021 prices = idx[2021] = 110.
+		expect(indexAtDate(series, new Date(2022, 0, 1))).toBeCloseTo(110, 5);
 	});
 
 	it('interpolates linearly mid-year', () => {
-		// Mid 2020 should be ~halfway between 100 and 110.
-		const result = indexAtDate(series, new Date(2020, 6, 2));
+		// Mid 2021 should be ~halfway between idx[2020]=100 and idx[2021]=110.
+		const result = indexAtDate(series, new Date(2021, 6, 2));
 		expect(result).toBeGreaterThan(104);
 		expect(result).toBeLessThan(106);
 	});
@@ -40,19 +41,20 @@ describe('indexAtDate', () => {
 
 describe('inflationAdjust', () => {
 	it('compounds across full years', () => {
-		const result = inflationAdjust(1000, new Date(2020, 0, 1), new Date(2022, 0, 1), series);
+		// Start of 2021 (= end of 2020) -> past end of 2022 (clamped): 110 -> 132 -> factor 1.32.
+		const result = inflationAdjust(1000, new Date(2021, 0, 1), new Date(2023, 0, 1), series);
 		expect(result).toBeCloseTo(1320, 5);
 	});
 
 	it('returns null when series is empty', () => {
 		const empty = { ...series, points: [] };
-		expect(inflationAdjust(1000, new Date(2020, 0, 1), new Date(2022, 0, 1), empty)).toBeNull();
+		expect(inflationAdjust(1000, new Date(2021, 0, 1), new Date(2023, 0, 1), empty)).toBeNull();
 	});
 });
 
 describe('realChange', () => {
 	it('flags a raise that fails to beat inflation', () => {
-		const result = realChange(1000, new Date(2020, 0, 1), 1100, new Date(2022, 0, 1), series);
+		const result = realChange(1000, new Date(2021, 0, 1), 1100, new Date(2023, 0, 1), series);
 		expect(result).not.toBeNull();
 		expect(result!.nominalChangePln).toBe(100);
 		expect(result!.previousInTodayPln).toBeCloseTo(1320, 5);
@@ -61,7 +63,7 @@ describe('realChange', () => {
 	});
 
 	it('confirms a raise that beats inflation', () => {
-		const result = realChange(1000, new Date(2020, 0, 1), 1500, new Date(2022, 0, 1), series);
+		const result = realChange(1000, new Date(2021, 0, 1), 1500, new Date(2023, 0, 1), series);
 		expect(result).not.toBeNull();
 		expect(result!.realChangePln).toBeCloseTo(180, 5);
 		expect(result!.realChangePct).toBeGreaterThan(0);

--- a/src/lib/utils/inflation.ts
+++ b/src/lib/utils/inflation.ts
@@ -2,7 +2,9 @@ import type { CpiPoint, CpiSeries } from '$lib/types/cpi';
 
 /**
  * Linearly interpolate a fixed-base CPI index at a calendar date.
- * Mirrors backend logic in app/services/inflation.py for consistency.
+ * Mirrors backend logic in app/services/inflation.py: `index[Y]` is the
+ * end-of-year-Y price level, so a date inside year Y interpolates between
+ * `index[Y-1]` (start of Y) and `index[Y]` (end of Y).
  * Returns null if the series is empty.
  */
 export function indexAtDate(series: CpiSeries, when: Date): number | null {
@@ -14,19 +16,22 @@ export function indexAtDate(series: CpiSeries, when: Date): number | null {
 	const last = sorted[sorted.length - 1];
 
 	if (when.getFullYear() < first.year) return first.cumulative_index;
-	if (when.getFullYear() >= last.year) return last.cumulative_index;
+	if (when.getFullYear() > last.year) return last.cumulative_index;
 
 	const byYear = new Map<number, CpiPoint>();
 	for (const p of sorted) byYear.set(p.year, p);
 
-	const yearStart = new Date(when.getFullYear(), 0, 1);
-	const nextYearStart = new Date(when.getFullYear() + 1, 0, 1);
+	const year = when.getFullYear();
+	const end = byYear.get(year);
+	if (!end) return null;
+	const prev = byYear.get(year - 1);
+	const start = prev ?? first;
+
+	const yearStart = new Date(year, 0, 1);
+	const nextYearStart = new Date(year + 1, 0, 1);
 	const span = nextYearStart.getTime() - yearStart.getTime();
 	const fraction = (when.getTime() - yearStart.getTime()) / span;
 
-	const start = byYear.get(when.getFullYear());
-	const end = byYear.get(when.getFullYear() + 1);
-	if (!start || !end) return null;
 	return start.cumulative_index + (end.cumulative_index - start.cumulative_index) * fraction;
 }
 

--- a/src/lib/utils/inflation.ts
+++ b/src/lib/utils/inflation.ts
@@ -1,53 +1,83 @@
 import type { CpiPoint, CpiSeries } from '$lib/types/cpi';
 
 /**
+ * Pre-built lookup over a CPI series. Build once with {@link buildCpiLookup}
+ * and reuse for many `indexAtDate` / `inflationAdjust` calls — avoids
+ * repeated sort/copy/map-build work inside loops (e.g. when computing a
+ * dashed real-value series for every salary record on a chart).
+ */
+export interface CpiLookup {
+	byYear: Map<number, number>;
+	first: CpiPoint;
+	last: CpiPoint;
+}
+
+export function buildCpiLookup(series: CpiSeries): CpiLookup | null {
+	if (series.points.length === 0) return null;
+	const sorted = [...series.points].sort((a, b) => a.year - b.year);
+	const byYear = new Map<number, number>();
+	for (const p of sorted) byYear.set(p.year, p.cumulative_index);
+	return { byYear, first: sorted[0], last: sorted[sorted.length - 1] };
+}
+
+/**
+ * Parse an ISO `YYYY-MM-DD` date as a local calendar date. The native
+ * `new Date('2021-01-01')` constructor parses date-only strings as UTC,
+ * which can shift the year boundary in non-UTC timezones — that would
+ * make `indexAtDate` read the wrong CPI year. Use this for any string
+ * coming from the API.
+ */
+export function parseIsoDate(value: string): Date {
+	const [y, m, d] = value.split('-').map(Number);
+	return new Date(y, (m ?? 1) - 1, d ?? 1);
+}
+
+function dayOfYear(when: Date): number {
+	const start = new Date(when.getFullYear(), 0, 1);
+	// Use Math.round on (when - start) / msPerDay; UTC offsets cancel out
+	// because both timestamps are in the same local zone.
+	const msPerDay = 24 * 60 * 60 * 1000;
+	return Math.round((when.getTime() - start.getTime()) / msPerDay);
+}
+
+function daysInYear(year: number): number {
+	const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+	return leap ? 366 : 365;
+}
+
+/**
  * Linearly interpolate a fixed-base CPI index at a calendar date.
  * Mirrors backend logic in app/services/inflation.py: `index[Y]` is the
  * end-of-year-Y price level, so a date inside year Y interpolates between
- * `index[Y-1]` (start of Y) and `index[Y]` (end of Y).
- * Returns null if the series is empty.
+ * `index[Y-1]` (start of Y) and `index[Y]` (end of Y) pro-rata by
+ * day-of-year. Returns null if the lookup is missing.
  */
-export function indexAtDate(series: CpiSeries, when: Date): number | null {
-	const points = series.points;
-	if (points.length === 0) return null;
-
-	const sorted = [...points].sort((a, b) => a.year - b.year);
-	const first = sorted[0];
-	const last = sorted[sorted.length - 1];
-
-	if (when.getFullYear() < first.year) return first.cumulative_index;
-	if (when.getFullYear() > last.year) return last.cumulative_index;
-
-	const byYear = new Map<number, CpiPoint>();
-	for (const p of sorted) byYear.set(p.year, p);
-
+export function indexAtDate(lookup: CpiLookup, when: Date): number {
 	const year = when.getFullYear();
-	const end = byYear.get(year);
-	if (!end) return null;
-	const prev = byYear.get(year - 1);
-	const start = prev ?? first;
+	if (year < lookup.first.year) return lookup.first.cumulative_index;
+	if (year > lookup.last.year) return lookup.last.cumulative_index;
 
-	const yearStart = new Date(year, 0, 1);
-	const nextYearStart = new Date(year + 1, 0, 1);
-	const span = nextYearStart.getTime() - yearStart.getTime();
-	const fraction = (when.getTime() - yearStart.getTime()) / span;
-
-	return start.cumulative_index + (end.cumulative_index - start.cumulative_index) * fraction;
+	const end = lookup.byYear.get(year) ?? lookup.last.cumulative_index;
+	const start = lookup.byYear.get(year - 1) ?? lookup.first.cumulative_index;
+	const fraction = dayOfYear(when) / daysInYear(year);
+	return start + (end - start) * fraction;
 }
 
 /**
  * Adjust `amount` from purchasing power on `fromDate` to `toDate`
- * using the supplied CPI series. Returns null if CPI data is missing.
+ * using a pre-built CPI lookup. Returns null if the lookup is null
+ * (no CPI data loaded yet) or the source index is zero.
  */
 export function inflationAdjust(
 	amount: number,
 	fromDate: Date,
 	toDate: Date,
-	series: CpiSeries
+	lookup: CpiLookup | null
 ): number | null {
-	const fromIdx = indexAtDate(series, fromDate);
-	const toIdx = indexAtDate(series, toDate);
-	if (fromIdx == null || toIdx == null || fromIdx === 0) return null;
+	if (lookup == null) return null;
+	const fromIdx = indexAtDate(lookup, fromDate);
+	const toIdx = indexAtDate(lookup, toDate);
+	if (fromIdx === 0) return null;
 	return amount * (toIdx / fromIdx);
 }
 
@@ -67,9 +97,9 @@ export function realChange(
 	previousDate: Date,
 	currentAmount: number,
 	currentDate: Date,
-	series: CpiSeries
+	lookup: CpiLookup | null
 ): RealChange | null {
-	const previousInTodayPln = inflationAdjust(previousAmount, previousDate, currentDate, series);
+	const previousInTodayPln = inflationAdjust(previousAmount, previousDate, currentDate, lookup);
 	if (previousInTodayPln == null) return null;
 
 	const nominalChangePln = currentAmount - previousAmount;

--- a/src/lib/utils/inflation.ts
+++ b/src/lib/utils/inflation.ts
@@ -1,0 +1,75 @@
+import type { CpiPoint, CpiSeries } from '$lib/types/cpi';
+
+/**
+ * Linearly interpolate a fixed-base CPI index at a calendar date.
+ * Mirrors backend logic in app/services/inflation.py for consistency.
+ * Returns null if the series is empty.
+ */
+export function indexAtDate(series: CpiSeries, when: Date): number | null {
+	const points = series.points;
+	if (points.length === 0) return null;
+
+	const sorted = [...points].sort((a, b) => a.year - b.year);
+	const first = sorted[0];
+	const last = sorted[sorted.length - 1];
+
+	if (when.getFullYear() < first.year) return first.cumulative_index;
+	if (when.getFullYear() >= last.year) return last.cumulative_index;
+
+	const byYear = new Map<number, CpiPoint>();
+	for (const p of sorted) byYear.set(p.year, p);
+
+	const yearStart = new Date(when.getFullYear(), 0, 1);
+	const nextYearStart = new Date(when.getFullYear() + 1, 0, 1);
+	const span = nextYearStart.getTime() - yearStart.getTime();
+	const fraction = (when.getTime() - yearStart.getTime()) / span;
+
+	const start = byYear.get(when.getFullYear());
+	const end = byYear.get(when.getFullYear() + 1);
+	if (!start || !end) return null;
+	return start.cumulative_index + (end.cumulative_index - start.cumulative_index) * fraction;
+}
+
+/**
+ * Adjust `amount` from purchasing power on `fromDate` to `toDate`
+ * using the supplied CPI series. Returns null if CPI data is missing.
+ */
+export function inflationAdjust(
+	amount: number,
+	fromDate: Date,
+	toDate: Date,
+	series: CpiSeries
+): number | null {
+	const fromIdx = indexAtDate(series, fromDate);
+	const toIdx = indexAtDate(series, toDate);
+	if (fromIdx == null || toIdx == null || fromIdx === 0) return null;
+	return amount * (toIdx / fromIdx);
+}
+
+/**
+ * Compute nominal vs real change given previous and current salary records.
+ */
+export interface RealChange {
+	nominalChangePln: number;
+	nominalChangePct: number;
+	realChangePln: number;
+	realChangePct: number;
+	previousInTodayPln: number;
+}
+
+export function realChange(
+	previousAmount: number,
+	previousDate: Date,
+	currentAmount: number,
+	currentDate: Date,
+	series: CpiSeries
+): RealChange | null {
+	const previousInTodayPln = inflationAdjust(previousAmount, previousDate, currentDate, series);
+	if (previousInTodayPln == null) return null;
+
+	const nominalChangePln = currentAmount - previousAmount;
+	const nominalChangePct = previousAmount === 0 ? 0 : (nominalChangePln / previousAmount) * 100;
+	const realChangePln = currentAmount - previousInTodayPln;
+	const realChangePct = previousInTodayPln === 0 ? 0 : (realChangePln / previousInTodayPln) * 100;
+	return { nominalChangePln, nominalChangePct, realChangePln, realChangePct, previousInTodayPln };
+}

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -4,7 +4,7 @@
 	import type { EChartsOption } from 'echarts';
 	import Modal from '$lib/components/Modal.svelte';
 	import { formatPLN } from '$lib/utils/format';
-	import { inflationAdjust } from '$lib/utils/inflation';
+	import { buildCpiLookup, inflationAdjust, parseIsoDate } from '$lib/utils/inflation';
 	import {
 		Plus,
 		Banknote,
@@ -236,8 +236,12 @@
 		});
 
 		const colors = ['#5E81AC', '#88C0D0', '#A3BE8C', '#EBCB8B', '#D08770', '#B48EAD', '#BF616A'];
-		const today = new Date();
-		const hasCpi = cpiSeries.points.length > 0;
+		// Use date-only `today` so adjustments are consistent across the
+		// browsing session and match the backend (which is date-only).
+		const now = new Date();
+		const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+		const cpiLookup = buildCpiLookup(cpiSeries);
+		const hasCpi = cpiLookup !== null;
 
 		type LineSeries = {
 			name: string;
@@ -264,7 +268,7 @@
 			if (hasCpi) {
 				const realData: Array<[string, number]> = [];
 				for (const [dateStr, nominal] of salaryData) {
-					const adjusted = inflationAdjust(nominal, new Date(dateStr), today, cpiSeries);
+					const adjusted = inflationAdjust(nominal, parseIsoDate(dateStr), today, cpiLookup);
 					if (adjusted != null) realData.push([dateStr, adjusted]);
 				}
 				if (realData.length > 0) {

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -4,11 +4,22 @@
 	import type { EChartsOption } from 'echarts';
 	import Modal from '$lib/components/Modal.svelte';
 	import { formatPLN } from '$lib/utils/format';
-	import { Plus, Banknote, TrendingUp, Search, BarChart3, Pencil, Trash2 } from 'lucide-svelte';
+	import { inflationAdjust } from '$lib/utils/inflation';
+	import {
+		Plus,
+		Banknote,
+		TrendingUp,
+		Search,
+		BarChart3,
+		Pencil,
+		Trash2,
+		Scale
+	} from 'lucide-svelte';
 	import { env } from '$env/dynamic/public';
 	import { goto, invalidateAll } from '$app/navigation';
 	import type { SalaryRecord } from '$lib/types/salaries';
 	import type { Persona } from '$lib/types/personas';
+	import type { CpiSeries } from '$lib/types/cpi';
 	import type { PageData } from './$types';
 
 	interface Props {
@@ -20,6 +31,36 @@
 	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
 	const personas = $derived(data.personas as Persona[]);
 	const defaultOwner = $derived(personas.length > 0 ? personas[0].name : 'Marcin');
+	const cpiSeries = $derived(data.cpiSeries as CpiSeries);
+	const inflationContext = $derived(data.salaries.inflation_context ?? {});
+	const inflationEntries = $derived(Object.values(inflationContext));
+
+	const monthNamesPL = [
+		'styczeń',
+		'luty',
+		'marzec',
+		'kwiecień',
+		'maj',
+		'czerwiec',
+		'lipiec',
+		'sierpień',
+		'wrzesień',
+		'październik',
+		'listopad',
+		'grudzień'
+	];
+
+	function formatPctSigned(value: number | null): string {
+		if (value == null || Number.isNaN(value)) return '—';
+		const sign = value >= 0 ? '+' : '';
+		return `${sign}${value.toFixed(1)}%`;
+	}
+
+	function formatPlnSigned(value: number | null): string {
+		if (value == null || Number.isNaN(value)) return '—';
+		const sign = value >= 0 ? '+' : '−';
+		return `${sign}${formatPLN(Math.abs(value))}`;
+	}
 
 	let chartContainer: HTMLDivElement;
 
@@ -195,47 +236,78 @@
 		});
 
 		const colors = ['#5E81AC', '#88C0D0', '#A3BE8C', '#EBCB8B', '#D08770', '#B48EAD', '#BF616A'];
+		const today = new Date();
+		const hasCpi = cpiSeries.points.length > 0;
 
-		const series: Array<{
+		type LineSeries = {
 			name: string;
 			data: Array<[string, number]>;
 			type: 'line';
 			smooth: boolean;
-			lineStyle: { color: string; width: number };
-		}> = [];
+			lineStyle: { color: string; width: number; type?: 'dashed' | 'solid'; opacity?: number };
+			itemStyle?: { color: string };
+		};
+		const series: LineSeries[] = [];
 		let colorIndex = 0;
+
 		companyMap.forEach((salaryData, company) => {
+			const color = colors[colorIndex % colors.length];
 			series.push({
 				name: company,
 				data: salaryData,
-				type: 'line' as const,
+				type: 'line',
 				smooth: true,
-				lineStyle: { color: colors[colorIndex % colors.length], width: 2 }
+				lineStyle: { color, width: 2 },
+				itemStyle: { color }
 			});
+
+			if (hasCpi) {
+				const realData: Array<[string, number]> = [];
+				for (const [dateStr, nominal] of salaryData) {
+					const adjusted = inflationAdjust(nominal, new Date(dateStr), today, cpiSeries);
+					if (adjusted != null) realData.push([dateStr, adjusted]);
+				}
+				if (realData.length > 0) {
+					series.push({
+						name: `${company} (realna wartość)`,
+						data: realData,
+						type: 'line',
+						smooth: true,
+						lineStyle: { color, width: 2, type: 'dashed', opacity: 0.7 },
+						itemStyle: { color }
+					});
+				}
+			}
 			colorIndex++;
 		});
 
 		const option: EChartsOption = {
-			title: { text: 'Progresja wynagrodzenia', left: 'center' },
+			title: { text: 'Progresja wynagrodzenia', left: 'center', top: 8 },
 			tooltip: {
 				trigger: 'axis',
-				formatter: (params: any) => {
+				formatter: (params: unknown) => {
 					if (!params || !Array.isArray(params) || params.length === 0) return '';
-					let result = `${new Date(params[0].value[0]).toLocaleDateString('pl-PL')}<br/>`;
-					params.forEach((p: any) => {
+					const rows = params as Array<{ value: [string, number]; seriesName: string }>;
+					let result = `${new Date(rows[0].value[0]).toLocaleDateString('pl-PL')}<br/>`;
+					rows.forEach((p) => {
 						result += `${p.seriesName}: ${formatPLN(p.value[1])}<br/>`;
 					});
 					return result;
 				}
 			},
-			legend: { top: 30, data: series.map((s) => s.name) },
+			legend: {
+				top: 44,
+				left: 'center',
+				type: 'scroll',
+				data: series.map((s) => s.name)
+			},
 			xAxis: { type: 'time' },
 			yAxis: {
 				type: 'value',
 				axisLabel: { formatter: (value: number) => formatPLN(value) }
 			},
 			series,
-			grid: { left: '80px', right: '40px', top: '80px' }
+			grid: { left: '80px', right: '40px', top: 90, bottom: 40 }
 		};
 
 		chart.setOption(option);
@@ -284,7 +356,74 @@
 
 	<div class="card preset-filled-surface-100-900 p-4 space-y-4">
 		<header>
+			<h3 class="h3 flex items-center gap-2">
+				<Scale size={20} /> Wpływ inflacji (od ostatniej podwyżki)
+			</h3>
+			<p class="text-xs text-surface-700-300">
+				Źródło danych CPI: GUS (Wskaźnik cen towarów i usług konsumpcyjnych — ogółem)
+			</p>
+		</header>
+		{#if inflationEntries.length === 0}
+			<p class="text-sm text-surface-700-300">
+				Za mało danych — dodaj kolejną zmianę pensji lub poczekaj na świeże dane CPI, aby zobaczyć
+				realny wpływ inflacji.
+			</p>
+		{:else}
+			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+				{#each inflationEntries as ctx (ctx.owner)}
+					{@const realPositive = (ctx.real_change_pln ?? 0) >= 0}
+					{@const previousRecord = data.salaries.salary_records.find(
+						(r) => r.owner === ctx.owner && r.date === ctx.previous_change_date
+					)}
+					<div class="card preset-tonal-surface p-4 space-y-2">
+						<div class="flex items-baseline justify-between flex-wrap gap-2">
+							<strong class="text-lg">{ctx.owner}</strong>
+							<span class="text-xs text-surface-700-300">
+								od {new Date(ctx.last_change_date).toLocaleDateString('pl-PL')}
+								{#if previousRecord?.company}
+									· {previousRecord.company}
+								{/if}
+							</span>
+						</div>
+						<dl class="grid grid-cols-[auto,1fr] gap-x-4 gap-y-1 text-sm">
+							<dt class="text-surface-700-300">Poprzednia pensja:</dt>
+							<dd class="text-right font-semibold">{formatPLN(ctx.previous_salary)}</dd>
+
+							<dt class="text-surface-700-300">W dzisiejszych PLN:</dt>
+							<dd class="text-right font-semibold">
+								{formatPLN(ctx.previous_salary_in_today_pln)}
+							</dd>
+
+							<dt class="text-surface-700-300">Obecna pensja:</dt>
+							<dd class="text-right font-semibold">{formatPLN(ctx.current_salary)}</dd>
+
+							<dt class="font-semibold pt-1">Realna podwyżka:</dt>
+							<dd
+								class="text-right font-bold pt-1"
+								class:text-success-500={realPositive}
+								class:text-error-500={!realPositive}
+							>
+								{formatPlnSigned(ctx.real_change_pln)}
+								<span class="text-xs font-normal">
+									({formatPctSigned(ctx.real_change_pct)})
+								</span>
+							</dd>
+						</dl>
+						<p class="text-xs text-surface-700-300">
+							CPI na koniec: {ctx.cpi_as_of_year}
+						</p>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+
+	<div class="card preset-filled-surface-100-900 p-4 space-y-4">
+		<header>
 			<h3 class="h3 flex items-center gap-2"><TrendingUp size={20} /> Progresja wynagrodzenia</h3>
+			<p class="text-xs text-surface-700-300">
+				Linia przerywana: nominalna pensja przeliczona na dzisiejsze PLN wg CPI GUS.
+			</p>
 		</header>
 		<div bind:this={chartContainer} style="width: 100%; height: 400px;"></div>
 	</div>

--- a/src/routes/salaries/+page.ts
+++ b/src/routes/salaries/+page.ts
@@ -3,6 +3,9 @@ import { env } from '$env/dynamic/public';
 import { browser } from '$app/environment';
 import type { PageLoad } from './$types';
 import type { SalariesData } from '$lib/types/salaries';
+import type { CpiSeries } from '$lib/types/cpi';
+
+const EMPTY_CPI: CpiSeries = { points: [], base_year: null, latest_year: null, source: '' };
 
 export const load: PageLoad = async ({ fetch, url }) => {
 	try {
@@ -11,7 +14,6 @@ export const load: PageLoad = async ({ fetch, url }) => {
 			throw error(500, 'API URL is not configured');
 		}
 
-		// Build query params from URL
 		const owner = url.searchParams.get('owner');
 		const dateFrom = url.searchParams.get('date_from');
 		const dateTo = url.searchParams.get('date_to');
@@ -21,17 +23,19 @@ export const load: PageLoad = async ({ fetch, url }) => {
 		if (dateFrom) params.set('date_from', dateFrom);
 		if (dateTo) params.set('date_to', dateTo);
 
-		// Fetch salaries with filters
-		const response = await fetch(`${apiUrl}/api/salaries?${params.toString()}`);
+		const [salariesResponse, personasResponse, cpiResponse] = await Promise.all([
+			fetch(`${apiUrl}/api/salaries?${params.toString()}`),
+			fetch(`${apiUrl}/api/personas`),
+			fetch(`${apiUrl}/api/cpi/series`)
+		]);
 
-		if (!response.ok) {
-			throw error(response.status, 'Failed to load salary records');
+		if (!salariesResponse.ok) {
+			throw error(salariesResponse.status, 'Failed to load salary records');
 		}
 
-		const data: SalariesData = await response.json();
-
-		const personasResponse = await fetch(`${apiUrl}/api/personas`);
+		const data: SalariesData = await salariesResponse.json();
 		const personas = personasResponse.ok ? await personasResponse.json() : [];
+		const cpiSeries: CpiSeries = cpiResponse.ok ? await cpiResponse.json() : EMPTY_CPI;
 
 		return {
 			salaries: data,
@@ -40,7 +44,8 @@ export const load: PageLoad = async ({ fetch, url }) => {
 				date_from: dateFrom,
 				date_to: dateTo
 			},
-			personas
+			personas,
+			cpiSeries
 		};
 	} catch (err) {
 		if (err instanceof Error && 'status' in err) {

--- a/src/routes/salaries/page.test.ts
+++ b/src/routes/salaries/page.test.ts
@@ -39,10 +39,12 @@ const baseData = {
 	salaries: {
 		salary_records: [],
 		total_count: 0,
-		current_salaries: { Marcin: null }
+		current_salaries: { Marcin: null },
+		inflation_context: {}
 	},
 	filters: { owner: null, date_from: null, date_to: null },
-	personas: [{ id: 1, name: 'Marcin', ppk_employee_rate: 2, ppk_employer_rate: 1.5 }]
+	personas: [{ id: 1, name: 'Marcin', ppk_employee_rate: 2, ppk_employer_rate: 1.5 }],
+	cpiSeries: { points: [], base_year: null, latest_year: null, source: '' }
 };
 
 async function openNewSalaryModalAndFill(opts: {

--- a/uv.lock
+++ b/uv.lock
@@ -53,6 +53,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -191,7 +203,9 @@ version = "0.1.0"
 source = { virtual = "backend" }
 dependencies = [
     { name = "alembic" },
+    { name = "apscheduler" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "psycopg2-binary" },
@@ -203,7 +217,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -214,7 +227,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.16.0" },
+    { name = "apscheduler", specifier = ">=3.11.0" },
     { name = "fastapi", specifier = ">=0.128.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
@@ -226,7 +241,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pyrefly", specifier = "==1.0.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
@@ -748,6 +762,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Motivation

Salaries page only showed nominal PLN. A 12 000 → 13 500 raise looks like
+12.5%, but if inflation across the gap was +10% the real raise is only
+2%. Without inflation context the dashboard misrepresents purchasing
power — the whole point of tracking salary over time.

CPI also has reuse beyond salaries (net-worth real value, inflation-aware
goals), so this lands as a shared, app-wide module — not bolted onto
`/salaries`.

## Implementation information

**Backend (Python)**
- `cpi_index` table — annual y/y CPI from GUS BDL variable 217230
  ("Wskaźnik cen towarów i usług konsumpcyjnych ogółem"). Raw y/y is
  stored as published; fixed-base cumulative index derived on the fly so
  refreshes stay idempotent.
- `app/services/inflation.py` — `fetch_gus_cpi`, `refresh_cpi`,
  `adjust(amount, from_date, to_date)`. Linear within-year interpolation
  between Jan 1 anchors; clamps to earliest/latest known year outside the
  series.
- `app/services/scheduler.py` — APScheduler (Europe/Warsaw). Refresh on
  startup if data is missing or stale > 7 days, plus monthly cron on the
  16th 04:00 (GUS publishes around the 15th).
- `app/api/cpi.py` — `GET /api/cpi/series`, `POST /api/cpi/adjust`,
  `POST /api/cpi/refresh`.
- `SalaryRecordsListResponse.inflation_context` — per persona, the
  previous salary inflated to today's PLN and the real raise (PLN + %).

**Frontend (Svelte 5 / TypeScript)**
- `src/lib/types/cpi.ts` + `src/lib/utils/inflation.ts` — shared
  `inflationAdjust` and `realChange` helpers, mirror of the backend math
  so the chart can compute the dashed line client-side from one CPI fetch.
- `/salaries` gains a "Wpływ inflacji (od ostatniej podwyżki)" card per
  persona with previous → today's-PLN → current and a green/red real
  raise line.
- Progression chart gains a dashed "realna wartość" sibling per company.
  Legend repositioned with `type: 'scroll'` so paired solid+dashed items
  no longer crowd the title.
- `+page.ts` parallel-fetches `/api/cpi/series` alongside salaries +
  personas.

**Alternatives considered**
- Eurostat HICP — simpler API, no auth, monthly granularity. Rejected:
  user picked the official Polish source (GUS national CPI). HICP vs
  national diverge < 0.3 pp/yr so the choice mostly affects narrative.
- Storing pre-computed fixed-base index — rejected. Storing raw y/y and
  deriving lets us re-anchor or change interpolation without a migration.
- Monthly CPI granularity — GUS BDL only exposes annual ("ogółem") at
  variable 217230. Within-year linear interpolation is well within the
  noise floor for a personal finance app.

**Tests**
- 10 backend tests (`tests/test_services_inflation.py`) — chain math,
  date interpolation, clamping at boundaries, upsert idempotency,
  staleness window.
- 9 frontend tests (`src/lib/utils/inflation.test.ts`) — index lookup,
  adjust, realChange happy + sad paths.
- Full backend suite 523 passing, full frontend suite 132 passing.

## Supporting documentation

GUS BDL API: https://api.stat.gov.pl/Home/BdlApi
Variable 217230 (CPI ogółem, annual y/y, all of Poland).

> Changelog: feat(salaries): show inflation-adjusted view