### PR TITLE
feat(dev): seed demo data on mise dev startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ DEFAULT_OWNER=Marcin
 PUBLIC_API_URL=http://localhost:8000
 PUBLIC_OWNER_NAMES=Marcin,Ewa,Shared
 PUBLIC_DEFAULT_OWNER=Marcin
+
+# Dev only: seed demo data on empty database (idempotent — skipped if accounts exist).
+# To re-seed: docker-compose -f docker-compose.dev.yml down -v && mise run dev
+SEED_DEV_DATA=true

--- a/backend/alembic/versions/0002_add_cpi_index.py
+++ b/backend/alembic/versions/0002_add_cpi_index.py
@@ -9,6 +9,7 @@ Create Date: 2026-05-20
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 from alembic import op
 
@@ -19,6 +20,10 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    # Baseline 0001 uses ``Base.metadata.create_all`` against current metadata,
+    # which already creates ``cpi_index`` on fresh databases. Skip when present.
+    if inspect(op.get_bind()).has_table("cpi_index"):
+        return
     op.create_table(
         "cpi_index",
         sa.Column("year", sa.Integer(), primary_key=True),

--- a/backend/app/core/init_db.py
+++ b/backend/app/core/init_db.py
@@ -9,6 +9,7 @@ from sqlalchemy import func, inspect, select
 from alembic import command
 from app.core.database import SessionLocal, engine
 from app.core.enums import Wrapper
+from app.core.seed_dev import seed_dev_data, should_seed
 from app.models import Persona, RetirementLimit
 
 logger = logging.getLogger(__name__)
@@ -92,6 +93,8 @@ def _seed_defaults() -> None:
 def _init_db_sync() -> None:
     _run_migrations()
     _seed_defaults()
+    if should_seed():
+        seed_dev_data()
 
 
 async def init_db() -> None:

--- a/backend/app/core/seed_dev.py
+++ b/backend/app/core/seed_dev.py
@@ -1,0 +1,511 @@
+"""Demo data seeder for development.
+
+Activated by setting ``SEED_DEV_DATA=true``. Idempotent: bails out if any
+``Account`` rows already exist so a populated database survives restarts.
+The seed builds a coherent ~24 months of household finance history so every
+dashboard widget — net worth chart, allocation, goals, salaries, retirement,
+inflation — has data to render.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+
+from sqlalchemy import func, select
+
+from app.core.database import SessionLocal
+from app.core.enums import (
+    AccountType,
+    Category,
+    ContractType,
+    DebtType,
+    Purpose,
+    TransactionType,
+    Wrapper,
+)
+from app.models import (
+    Account,
+    AppConfig,
+    Asset,
+    CpiIndex,
+    Debt,
+    DebtPayment,
+    Goal,
+    SalaryRecord,
+    Snapshot,
+    SnapshotValue,
+    Transaction,
+)
+
+logger = logging.getLogger(__name__)
+
+SEED_ENV_VAR = "SEED_DEV_DATA"
+
+
+def should_seed() -> bool:
+    return os.getenv(SEED_ENV_VAR, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _today() -> date:
+    return datetime.now(UTC).date()
+
+
+def _month_end(year: int, month: int) -> date:
+    if month == 12:
+        return date(year, 12, 31)
+    return date(year, month + 1, 1) - timedelta(days=1)
+
+
+def _months_back(reference: date, count: int) -> list[date]:
+    """Last-day-of-month dates for the ``count`` months ending at ``reference``'s month."""
+    months: list[date] = []
+    year, month = reference.year, reference.month
+    for _ in range(count):
+        months.append(_month_end(year, month))
+        month -= 1
+        if month == 0:
+            month = 12
+            year -= 1
+    months.reverse()
+    return months
+
+
+def _seed_app_config(db) -> None:
+    if (db.scalar(select(func.count()).select_from(AppConfig)) or 0) > 0:
+        return
+    db.add(
+        AppConfig(
+            id=1,
+            birth_date=date(1990, 6, 15),
+            retirement_age=65,
+            retirement_monthly_salary=Decimal("12000.00"),
+            allocation_real_estate=30,
+            allocation_stocks=40,
+            allocation_bonds=15,
+            allocation_gold=10,
+            allocation_commodities=5,
+            monthly_expenses=Decimal("9500.00"),
+            monthly_mortgage_payment=Decimal("3200.00"),
+        )
+    )
+    db.commit()
+
+
+def _seed_cpi(db) -> None:
+    if (db.scalar(select(func.count()).select_from(CpiIndex)) or 0) > 0:
+        return
+    # Polish CPI y/y rates (GUS published values, base = previous year = 100).
+    rates = {
+        2018: Decimal("101.6"),
+        2019: Decimal("102.3"),
+        2020: Decimal("103.4"),
+        2021: Decimal("105.1"),
+        2022: Decimal("114.4"),
+        2023: Decimal("111.4"),
+        2024: Decimal("103.6"),
+        2025: Decimal("103.5"),
+        2026: Decimal("103.2"),
+    }
+    db.add_all(
+        CpiIndex(year=year, yoy_rate=rate, source="seed-dev", fetched_at=datetime.now(UTC))
+        for year, rate in rates.items()
+    )
+    db.commit()
+
+
+def _seed_accounts_and_assets(db) -> tuple[dict[str, Account], dict[str, Asset]]:
+    accounts_spec = [
+        # Banking
+        ("Konto Marcin", AccountType.ASSET, Category.BANK, "Marcin", None, Purpose.GENERAL),
+        ("Konto Ewa", AccountType.ASSET, Category.BANK, "Ewa", None, Purpose.GENERAL),
+        (
+            "Oszczędności Shared",
+            AccountType.ASSET,
+            Category.SAVING_ACCOUNT,
+            "Shared",
+            None,
+            Purpose.EMERGENCY_FUND,
+        ),
+        # Retirement wrappers
+        (
+            "IKE Marcin",
+            AccountType.ASSET,
+            Category.STOCK,
+            "Marcin",
+            Wrapper.IKE,
+            Purpose.RETIREMENT,
+        ),
+        ("IKE Ewa", AccountType.ASSET, Category.STOCK, "Ewa", Wrapper.IKE, Purpose.RETIREMENT),
+        (
+            "IKZE Marcin",
+            AccountType.ASSET,
+            Category.BOND,
+            "Marcin",
+            Wrapper.IKZE,
+            Purpose.RETIREMENT,
+        ),
+        ("IKZE Ewa", AccountType.ASSET, Category.BOND, "Ewa", Wrapper.IKZE, Purpose.RETIREMENT),
+        ("PPK Marcin", AccountType.ASSET, Category.PPK, "Marcin", Wrapper.PPK, Purpose.RETIREMENT),
+        ("PPK Ewa", AccountType.ASSET, Category.PPK, "Ewa", Wrapper.PPK, Purpose.RETIREMENT),
+        # Brokerage
+        ("Akcje Shared", AccountType.ASSET, Category.STOCK, "Shared", None, Purpose.GENERAL),
+        ("Obligacje Shared", AccountType.ASSET, Category.BOND, "Shared", None, Purpose.GENERAL),
+        # Tangibles
+        ("Mieszkanie", AccountType.ASSET, Category.REAL_ESTATE, "Shared", None, Purpose.GENERAL),
+        ("Samochód", AccountType.ASSET, Category.VEHICLE, "Shared", None, Purpose.GENERAL),
+        # Liabilities
+        ("Hipoteka", AccountType.LIABILITY, Category.MORTGAGE, "Shared", None, Purpose.GENERAL),
+        (
+            "Raty 0% RTV",
+            AccountType.LIABILITY,
+            Category.INSTALLMENT,
+            "Marcin",
+            None,
+            Purpose.GENERAL,
+        ),
+    ]
+
+    accounts: dict[str, Account] = {}
+    for name, type_, category, owner, wrapper, purpose in accounts_spec:
+        square_meters = Decimal("62.50") if category == Category.REAL_ESTATE else None
+        receives_contributions = type_ == AccountType.ASSET and category != Category.VEHICLE
+        account = Account(
+            name=name,
+            type=type_.value,
+            category=category.value,
+            owner=owner,
+            currency="PLN",
+            account_wrapper=wrapper.value if wrapper else None,
+            purpose=purpose.value,
+            square_meters=square_meters,
+            is_active=True,
+            receives_contributions=receives_contributions,
+        )
+        db.add(account)
+        accounts[name] = account
+
+    assets = {
+        "Złoto inwestycyjne": Asset(name="Złoto inwestycyjne", is_active=True),
+        "Kryptowaluty": Asset(name="Kryptowaluty", is_active=True),
+    }
+    db.add_all(assets.values())
+
+    db.commit()
+    for account in accounts.values():
+        db.refresh(account)
+    for asset in assets.values():
+        db.refresh(asset)
+    return accounts, assets
+
+
+def _seed_debts_and_payments(db, accounts: dict[str, Account]) -> None:
+    mortgage = Debt(
+        account_id=accounts["Hipoteka"].id,
+        name="Hipoteka mieszkanie",
+        debt_type=DebtType.MORTGAGE.value,
+        start_date=date(2021, 9, 1),
+        initial_amount=Decimal("420000.00"),
+        interest_rate=Decimal("7.25"),
+        currency="PLN",
+        notes="Mortgage on the apartment",
+        is_active=True,
+    )
+    installments = Debt(
+        account_id=accounts["Raty 0% RTV"].id,
+        name="Raty 0% pralka + lodówka",
+        debt_type=DebtType.INSTALLMENT_0PERCENT.value,
+        start_date=date(2025, 8, 15),
+        initial_amount=Decimal("8400.00"),
+        interest_rate=Decimal("0.00"),
+        currency="PLN",
+        notes="24-month 0% installment plan",
+        is_active=True,
+    )
+    db.add_all([mortgage, installments])
+    db.commit()
+
+    today = _today()
+    payment_months = _months_back(today, 24)
+    payments: list[DebtPayment] = []
+    for snapshot_date in payment_months:
+        payments.append(
+            DebtPayment(
+                account_id=accounts["Hipoteka"].id,
+                amount=Decimal("3200.00"),
+                date=snapshot_date,
+                owner="Shared",
+                is_active=True,
+            )
+        )
+    # Installments only since the start_date
+    for snapshot_date in payment_months:
+        if snapshot_date >= date(2025, 8, 1):
+            payments.append(
+                DebtPayment(
+                    account_id=accounts["Raty 0% RTV"].id,
+                    amount=Decimal("350.00"),
+                    date=snapshot_date,
+                    owner="Marcin",
+                    is_active=True,
+                )
+            )
+    db.add_all(payments)
+    db.commit()
+
+
+def _seed_goals(db) -> None:
+    today = _today()
+    db.add_all(
+        [
+            Goal(
+                name="Fundusz awaryjny",
+                target_amount=Decimal("60000.00"),
+                target_date=date(today.year, 12, 31),
+                current_amount=Decimal("42000.00"),
+                monthly_contribution=Decimal("2000.00"),
+                is_completed=False,
+            ),
+            Goal(
+                name="Wakacje Japonia",
+                target_amount=Decimal("25000.00"),
+                target_date=date(today.year + 1, 5, 1),
+                current_amount=Decimal("8000.00"),
+                monthly_contribution=Decimal("1500.00"),
+                is_completed=False,
+            ),
+            Goal(
+                name="Wkład własny na działkę",
+                target_amount=Decimal("120000.00"),
+                target_date=date(today.year + 3, 6, 1),
+                current_amount=Decimal("18000.00"),
+                monthly_contribution=Decimal("2500.00"),
+                is_completed=False,
+            ),
+            Goal(
+                name="Nowy laptop",
+                target_amount=Decimal("9000.00"),
+                target_date=date(today.year - 1, 6, 1),
+                current_amount=Decimal("9000.00"),
+                monthly_contribution=Decimal("0.00"),
+                is_completed=True,
+            ),
+        ]
+    )
+    db.commit()
+
+
+def _seed_salaries(db) -> None:
+    today = _today()
+    months = _months_back(today, 24)
+    records: list[SalaryRecord] = []
+    for i, month_end in enumerate(months):
+        # Marcin: B2B with annual raise
+        marcin_gross = Decimal("18000.00") + Decimal("250.00") * (i // 12)
+        records.append(
+            SalaryRecord(
+                date=month_end,
+                gross_amount=marcin_gross,
+                contract_type=ContractType.B2B.value,
+                company="Acme Software sp. z o.o.",
+                owner="Marcin",
+                is_active=True,
+            )
+        )
+        # Ewa: UOP
+        ewa_gross = Decimal("9500.00") + Decimal("200.00") * (i // 12)
+        records.append(
+            SalaryRecord(
+                date=month_end,
+                gross_amount=ewa_gross,
+                contract_type=ContractType.UOP.value,
+                company="Beta Healthcare S.A.",
+                owner="Ewa",
+                is_active=True,
+            )
+        )
+    db.add_all(records)
+    db.commit()
+
+
+def _seed_transactions(db, accounts: dict[str, Account]) -> None:
+    today = _today()
+    months = _months_back(today, 24)
+    txs: list[Transaction] = []
+
+    # IKE: lump-sum employee contribution every January
+    for owner, account_name in (("Marcin", "IKE Marcin"), ("Ewa", "IKE Ewa")):
+        account = accounts[account_name]
+        for month_end in months:
+            if month_end.month == 1:
+                txs.append(
+                    Transaction(
+                        account_id=account.id,
+                        amount=Decimal("23472.00"),
+                        date=month_end,
+                        owner=owner,
+                        transaction_type=TransactionType.EMPLOYEE.value,
+                        is_active=True,
+                    )
+                )
+
+    # IKZE: monthly employee contributions
+    for owner, account_name in (("Marcin", "IKZE Marcin"), ("Ewa", "IKZE Ewa")):
+        account = accounts[account_name]
+        for month_end in months:
+            txs.append(
+                Transaction(
+                    account_id=account.id,
+                    amount=Decimal("780.00"),
+                    date=month_end,
+                    owner=owner,
+                    transaction_type=TransactionType.EMPLOYEE.value,
+                    is_active=True,
+                )
+            )
+
+    # PPK: employee + employer + government contributions
+    for owner, account_name, monthly_employee in (
+        ("Marcin", "PPK Marcin", Decimal("360.00")),
+        ("Ewa", "PPK Ewa", Decimal("190.00")),
+    ):
+        account = accounts[account_name]
+        for month_end in months:
+            txs.append(
+                Transaction(
+                    account_id=account.id,
+                    amount=monthly_employee,
+                    date=month_end,
+                    owner=owner,
+                    transaction_type=TransactionType.EMPLOYEE.value,
+                    is_active=True,
+                )
+            )
+            txs.append(
+                Transaction(
+                    account_id=account.id,
+                    amount=monthly_employee * Decimal("0.75"),
+                    date=month_end,
+                    owner=owner,
+                    transaction_type=TransactionType.EMPLOYER.value,
+                    is_active=True,
+                )
+            )
+            # Government welcome bonus once per year (April)
+            if month_end.month == 4:
+                txs.append(
+                    Transaction(
+                        account_id=account.id,
+                        amount=Decimal("240.00"),
+                        date=month_end,
+                        owner=owner,
+                        transaction_type=TransactionType.GOVERNMENT.value,
+                        is_active=True,
+                    )
+                )
+
+    db.add_all(txs)
+    db.commit()
+
+
+def _seed_snapshots(db, accounts: dict[str, Account], assets: dict[str, Asset]) -> None:
+    today = _today()
+    months = _months_back(today, 24)
+
+    # Per-account starting balances and monthly growth (PLN/month).
+    profiles: dict[str, tuple[Decimal, Decimal]] = {
+        "Konto Marcin": (Decimal("8000"), Decimal("150")),
+        "Konto Ewa": (Decimal("5000"), Decimal("80")),
+        "Oszczędności Shared": (Decimal("28000"), Decimal("1200")),
+        "IKE Marcin": (Decimal("32000"), Decimal("450")),
+        "IKE Ewa": (Decimal("18000"), Decimal("420")),
+        "IKZE Marcin": (Decimal("12000"), Decimal("780")),
+        "IKZE Ewa": (Decimal("8000"), Decimal("780")),
+        "PPK Marcin": (Decimal("4500"), Decimal("640")),
+        "PPK Ewa": (Decimal("2200"), Decimal("330")),
+        "Akcje Shared": (Decimal("45000"), Decimal("900")),
+        "Obligacje Shared": (Decimal("22000"), Decimal("400")),
+        "Mieszkanie": (Decimal("680000"), Decimal("1500")),
+        "Samochód": (Decimal("78000"), Decimal("-450")),
+        "Hipoteka": (Decimal("395000"), Decimal("-1100")),
+        "Raty 0% RTV": (Decimal("0"), Decimal("0")),
+    }
+
+    asset_profiles: dict[str, tuple[Decimal, Decimal]] = {
+        "Złoto inwestycyjne": (Decimal("12000"), Decimal("260")),
+        "Kryptowaluty": (Decimal("6500"), Decimal("180")),
+    }
+
+    for index, month_end in enumerate(months):
+        snapshot = Snapshot(
+            date=month_end,
+            notes=f"Seeded snapshot for {month_end.isoformat()}",
+        )
+        db.add(snapshot)
+        db.flush()
+
+        values: list[SnapshotValue] = []
+        # Small deterministic seasonality so charts aren't a perfect line.
+        wobble = Decimal(str(round(math.sin(index / 2.0) * 250, 2)))
+
+        for account_name, (start, monthly_delta) in profiles.items():
+            # Installments debt only exists from Aug 2025 onward.
+            if account_name == "Raty 0% RTV":
+                if month_end < date(2025, 8, 1):
+                    continue
+                months_since = (month_end.year - 2025) * 12 + month_end.month - 8
+                installment_value = max(
+                    Decimal("0"),
+                    Decimal("8400") - Decimal("350") * Decimal(str(months_since)),
+                )
+                value = installment_value
+            else:
+                value = start + monthly_delta * Decimal(str(index)) + wobble
+                if value < 0:
+                    value = Decimal("0")
+            values.append(
+                SnapshotValue(
+                    snapshot_id=snapshot.id,
+                    account_id=accounts[account_name].id,
+                    value=value.quantize(Decimal("0.01")),
+                )
+            )
+
+        for asset_name, (start, monthly_delta) in asset_profiles.items():
+            value = start + monthly_delta * Decimal(str(index)) + wobble / 2
+            if value < 0:
+                value = Decimal("0")
+            values.append(
+                SnapshotValue(
+                    snapshot_id=snapshot.id,
+                    asset_id=assets[asset_name].id,
+                    value=value.quantize(Decimal("0.01")),
+                )
+            )
+
+        db.add_all(values)
+    db.commit()
+
+
+def seed_dev_data() -> None:
+    """Idempotent demo seed. Bails out if any account already exists."""
+    db = SessionLocal()
+    try:
+        if (db.scalar(select(func.count()).select_from(Account)) or 0) > 0:
+            logger.info("Dev seed skipped: accounts already present")
+            return
+        logger.info("Seeding development demo data")
+        _seed_app_config(db)
+        _seed_cpi(db)
+        accounts, assets = _seed_accounts_and_assets(db)
+        _seed_debts_and_payments(db, accounts)
+        _seed_goals(db)
+        _seed_salaries(db)
+        _seed_transactions(db, accounts)
+        _seed_snapshots(db, accounts, assets)
+        logger.info("Development demo data seeded")
+    finally:
+        db.close()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3,6 +3,20 @@ revision = 3
 requires-python = ">=3.14"
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -30,6 +44,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
 ]
 
 [[package]]
@@ -165,7 +191,10 @@ name = "finance-buddy-api"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "alembic" },
+    { name = "apscheduler" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "psycopg2-binary" },
@@ -177,7 +206,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -187,7 +215,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.16.0" },
+    { name = "apscheduler", specifier = ">=3.11.0" },
     { name = "fastapi", specifier = ">=0.128.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
@@ -199,8 +230,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "pyrefly", specifier = "==0.55.0" },
+    { name = "pyrefly", specifier = "==1.0.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.14.13" },
@@ -281,6 +311,48 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -467,18 +539,19 @@ wheels = [
 
 [[package]]
 name = "pyrefly"
-version = "0.55.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c4/76e0797215e62d007f81f86c9c4fb5d6202685a3f5e70810f3fd94294f92/pyrefly-0.55.0.tar.gz", hash = "sha256:434c3282532dd4525c4840f2040ed0eb79b0ec8224fe18d957956b15471f2441", size = 5135682, upload-time = "2026-03-03T00:46:38.122Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/3a/9045b0097ac58979c7c30a4fa0e673db942d4adbc7b6d439bd54ae58c441/pyrefly-1.0.0.tar.gz", hash = "sha256:5c2b810ffcebd84be71de5df1223651edee951653a66935c6f091e957c452455", size = 5677995, upload-time = "2026-05-12T20:12:46.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/b0/16e50cf716784513648e23e726a24f71f9544aa4f86103032dcaa5ff71a2/pyrefly-0.55.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:49aafcefe5e2dd4256147db93e5b0ada42bff7d9a60db70e03d1f7055338eec9", size = 12210073, upload-time = "2026-03-03T00:46:15.51Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ad/89500c01bac3083383011600370289fbc67700c5be46e781787392628a3a/pyrefly-0.55.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2827426e6b28397c13badb93c0ede0fb0f48046a7a89e3d774cda04e8e2067cd", size = 11767474, upload-time = "2026-03-03T00:46:18.003Z" },
-    { url = "https://files.pythonhosted.org/packages/78/68/4c66b260f817f304ead11176ff13985625f7c269e653304b4bdb546551af/pyrefly-0.55.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7346b2d64dc575bd61aa3bca854fbf8b5a19a471cbdb45e0ca1e09861b63488c", size = 33260395, upload-time = "2026-03-03T00:46:20.509Z" },
-    { url = "https://files.pythonhosted.org/packages/47/09/10bd48c9f860064f29f412954126a827d60f6451512224912c265e26bbe6/pyrefly-0.55.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:233b861b4cff008b1aff62f4f941577ed752e4d0060834229eb9b6826e6973c9", size = 35848269, upload-time = "2026-03-03T00:46:23.418Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/39/bc65cdd5243eb2dfea25dd1321f9a5a93e8d9c3a308501c4c6c05d011585/pyrefly-0.55.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5aa85657d76da1d25d081a49f0e33c8fc3ec91c1a0f185a8ed393a5a3d9e178", size = 38449820, upload-time = "2026-03-03T00:46:26.309Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/64/58b38963b011af91209e87f868cc85cfc762ec49a4568ce610c45e7a5f40/pyrefly-0.55.0-py3-none-win32.whl", hash = "sha256:23f786a78536a56fed331b245b7d10ec8945bebee7b723491c8d66fdbc155fe6", size = 11259415, upload-time = "2026-03-03T00:46:30.875Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/0b/a4aa519ff632a1ea69eec942566951670b870b99b5c08407e1387b85b6a4/pyrefly-0.55.0-py3-none-win_amd64.whl", hash = "sha256:d465b49e999b50eeb069ad23f0f5710651cad2576f9452a82991bef557df91ee", size = 12043581, upload-time = "2026-03-03T00:46:33.674Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/51/89017636fbe1ffd166ad478990c6052df615b926182fa6d3c0842b407e89/pyrefly-0.55.0-py3-none-win_arm64.whl", hash = "sha256:732ff490e0e863b296e7c0b2471e08f8ba7952f9fa6e9de09d8347fd67dde77f", size = 11548076, upload-time = "2026-03-03T00:46:36.193Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c6/90788819bac9c61dd7bacba53b79f3c12d47ccbe5e51b3d6d89f2387e1d2/pyrefly-1.0.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e355a0908555348ed4b9585ef25c76ff566673e345c866c325f1633f44d890b6", size = 13122950, upload-time = "2026-05-12T20:12:20.711Z" },
+    { url = "https://files.pythonhosted.org/packages/82/91/a3cf2a1e87d336eaa804a1e6fc93266faf6dc2a97eecdbc7eae289628022/pyrefly-1.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a7038efc3a40f8294edee339895633cf22db268c0d434cdbcbefc34f78a9ecc3", size = 12599494, upload-time = "2026-05-12T20:12:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ab/74d1e11e737e99b1c003ecc5d7d2e846c4ea1f328966bfdbbd0ac63fad0a/pyrefly-1.0.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da331ca515ed1c08791da2b5f664cf9c1294c48fd802133262e7d5d51e0f4416", size = 12995507, upload-time = "2026-05-12T20:12:25.951Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ac/2df0899f8464c97e5d995f994c97c5cb5b0f58610432aa90d26d924e1db5/pyrefly-1.0.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c74219d8f3e63cdaa5501a0b21d1c9d37011820f9606728d0ed06f09ae86a878", size = 13947693, upload-time = "2026-05-12T20:12:29.188Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3e/b247c24321e36f04b7d51f9ccf3df93e5009e4b29939524b36ec2e17dc2a/pyrefly-1.0.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c0d05543b1bb6ee6d64149eb5d6b2fb15aa72d3962d6a97abca0afaca8b0c131", size = 13925803, upload-time = "2026-05-12T20:12:31.904Z" },
+    { url = "https://files.pythonhosted.org/packages/61/16/cfa2d61a4aa1e1f7bca48bb37acd01c6a09db4864b16a54f9587092765ff/pyrefly-1.0.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1382d5b1fcdb49a4de9f34d112d2bddf290a78ff93ee8149492ad5f1077ddffc", size = 13470398, upload-time = "2026-05-12T20:12:35.302Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/6372c7dddb326223e24a46b17efd0d4bd7b4fe22c821e523157577eed2d2/pyrefly-1.0.0-py3-none-win32.whl", hash = "sha256:aa8b5d0e47080e3202a2547b39f7a5a61d2c781c712b3b67884f745ca2c759d2", size = 12222643, upload-time = "2026-05-12T20:12:38.618Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ad/1d23be700b6b2ddaeb362360c7145917a8edbbf7240ae428d40541772fce/pyrefly-1.0.0-py3-none-win_amd64.whl", hash = "sha256:c8abcb0f2082e83c890375128f9cff4aa4d3f210b85eea7b3046c1ae764e77f5", size = 13146369, upload-time = "2026-05-12T20:12:41.423Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/38/16589134f3012fd097a10dcc85771555f1a5fb76e04b682597180743af30/pyrefly-1.0.0-py3-none-win_arm64.whl", hash = "sha256:d150fa9e40e8392832be81c3bcfc0497c146674ce4d0f8e04e1ec29e775ffb8c", size = 12538326, upload-time = "2026-05-12T20:12:43.996Z" },
 ]
 
 [[package]]
@@ -678,6 +751,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,6 +29,7 @@ services:
       - DATABASE_URL=postgresql://finance:${POSTGRES_PASSWORD:-password}@postgres:5432/finance
       - APP_PASSWORD=${APP_PASSWORD:-changeme}
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:5174,http://localhost:3000}
+      - SEED_DEV_DATA=${SEED_DEV_DATA:-true}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Motivation

`mise run dev` brought up an empty database, so every screen rendered placeholder state and exercising the UI required hand-entering accounts and snapshots. This adds a one-flag seed so a fresh checkout reaches a populated dashboard immediately.

## Implementation information

New `backend/app/core/seed_dev.py` runs after migrations + default seed when `SEED_DEV_DATA=true` (default for `docker-compose.dev.yml`). Idempotent — bails if any `Account` row exists, so populated databases survive restarts. To re-seed: `docker-compose -f docker-compose.dev.yml down -v && mise run dev`.

Seeded household covers every dashboard widget:

- 15 accounts (banking, IKE/IKZE/PPK retirement wrappers, brokerage, 62.5m² apartment, vehicle, mortgage, 0% installments) + 2 free-form assets (gold, crypto)
- 24 monthly snapshots with 394 values — deterministic seasonal wobble so charts aren't a flat line
- 4 goals (one completed), 2 debts with 34 payment rows
- 152 retirement transactions (IKE yearly lump, IKZE monthly, PPK employee/employer/government)
- 48 salary records (Marcin B2B + Ewa UOP, annual raises)
- 9 years (2018–2026) of real Polish CPI rates and `AppConfig` defaults

Verified end-to-end with `mise run dev`: backend healthy, all 13 dashboard metric cards populated, current net worth 758 664,82 PLN over 24 months, frontend SSR renders the dashboard at http://localhost:5174.

Alternatives considered:

- Alembic data migration — rejected: migrations are for schema, and the seed should not run in production
- pytest-style factories — rejected: needs to live in app startup, not test fixtures

Drive-by fixes found while verifying:

- `alembic 0002_add_cpi_index` collided with `0001` baseline on fresh databases (baseline uses `Base.metadata.create_all` against current metadata, which already creates `cpi_index`). Added an `inspect(...).has_table()` guard.
- `backend/uv.lock` was missing `alembic` + `apscheduler` entries declared in `pyproject.toml`. Regenerated on docker build.

## Supporting documentation

n/a

> Changelog: feat(dev): seed demo data on mise dev startup