### PR TITLE
feat(goals): activate Goal model with API + UI

### DIFF
--- a/backend/alembic/versions/0003_goal_account_and_category.py
+++ b/backend/alembic/versions/0003_goal_account_and_category.py
@@ -1,0 +1,43 @@
+"""Add account_id and category columns to goals table.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-05-20
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    inspector = inspect(op.get_bind())
+    existing = {col["name"] for col in inspector.get_columns("goals")}
+
+    if "account_id" not in existing:
+        op.add_column("goals", sa.Column("account_id", sa.Integer(), nullable=True))
+        op.create_foreign_key(
+            "fk_goals_account_id",
+            "goals",
+            "accounts",
+            ["account_id"],
+            ["id"],
+        )
+
+    if "category" not in existing:
+        op.add_column("goals", sa.Column("category", sa.String(length=100), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_goals_account_id", "goals", type_="foreignkey")
+    op.drop_column("goals", "account_id")
+    op.drop_column("goals", "category")

--- a/backend/app/api/goals.py
+++ b/backend/app/api/goals.py
@@ -1,0 +1,44 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.schemas.goals import GoalCreate, GoalResponse, GoalsListResponse, GoalUpdate
+from app.services import goals
+
+router = APIRouter(prefix="/api/goals", tags=["goals"])
+
+
+@router.get("", response_model=GoalsListResponse)
+def get_goals(db: Annotated[Session, Depends(get_db)]) -> GoalsListResponse:
+    """Get all goals with progress and projected hit date."""
+    return goals.get_all_goals(db)
+
+
+@router.post("", response_model=GoalResponse, status_code=201)
+def create_goal(data: GoalCreate, db: Annotated[Session, Depends(get_db)]) -> GoalResponse:
+    """Create a new goal."""
+    return goals.create_goal(db, data)
+
+
+@router.get("/{goal_id}", response_model=GoalResponse)
+def get_goal(goal_id: int, db: Annotated[Session, Depends(get_db)]) -> GoalResponse:
+    """Get a single goal by ID."""
+    return goals.get_goal(db, goal_id)
+
+
+@router.put("/{goal_id}", response_model=GoalResponse)
+def update_goal(
+    goal_id: int,
+    data: GoalUpdate,
+    db: Annotated[Session, Depends(get_db)],
+) -> GoalResponse:
+    """Update a goal."""
+    return goals.update_goal(db, goal_id, data)
+
+
+@router.delete("/{goal_id}", status_code=204)
+def delete_goal(goal_id: int, db: Annotated[Session, Depends(get_db)]) -> None:
+    """Delete a goal."""
+    goals.delete_goal(db, goal_id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from app.api import (
     dashboard,
     debt_payments,
     debts,
+    goals,
     investment,
     personas,
     retirement,
@@ -52,6 +53,7 @@ app.include_router(config.router)
 app.include_router(cpi.router)
 app.include_router(debts.router)
 app.include_router(debt_payments.router)
+app.include_router(goals.router)
 app.include_router(investment.router)
 app.include_router(personas.router)
 app.include_router(retirement.router)

--- a/backend/app/models/goal.py
+++ b/backend/app/models/goal.py
@@ -1,7 +1,7 @@
 from datetime import UTC, date, datetime
 from decimal import Decimal
 
-from sqlalchemy import Boolean, Date, Numeric, String
+from sqlalchemy import Boolean, Date, ForeignKey, Numeric, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -17,4 +17,8 @@ class Goal(Base):
     current_amount: Mapped[Decimal] = mapped_column(Numeric(precision=15, scale=2), default=0)
     monthly_contribution: Mapped[Decimal] = mapped_column(Numeric(precision=15, scale=2), default=0)
     is_completed: Mapped[bool] = mapped_column(Boolean, default=False)
+    account_id: Mapped[int | None] = mapped_column(
+        ForeignKey("accounts.id"), nullable=True, default=None
+    )
+    category: Mapped[str | None] = mapped_column(String(100), nullable=True, default=None)
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC))

--- a/backend/app/schemas/goals.py
+++ b/backend/app/schemas/goals.py
@@ -1,0 +1,99 @@
+from datetime import date, datetime
+
+from pydantic import BaseModel, field_validator
+
+from app.core.enums import Category
+from app.utils.validators import validate_non_negative_amount, validate_not_empty_string
+
+
+class GoalCreate(BaseModel):
+    name: str
+    target_amount: float
+    target_date: date
+    current_amount: float = 0
+    monthly_contribution: float = 0
+    is_completed: bool = False
+    account_id: int | None = None
+    category: Category | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        return validate_not_empty_string(v)
+
+    @field_validator("target_amount")
+    @classmethod
+    def validate_target_amount(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError("Target amount must be greater than 0")
+        return v
+
+    @field_validator("current_amount")
+    @classmethod
+    def validate_current_amount(cls, v: float) -> float:
+        return validate_non_negative_amount(v, "Current amount")
+
+    @field_validator("monthly_contribution")
+    @classmethod
+    def validate_monthly_contribution(cls, v: float) -> float:
+        return validate_non_negative_amount(v, "Monthly contribution")
+
+
+class GoalUpdate(BaseModel):
+    name: str | None = None
+    target_amount: float | None = None
+    target_date: date | None = None
+    current_amount: float | None = None
+    monthly_contribution: float | None = None
+    is_completed: bool | None = None
+    account_id: int | None = None
+    category: Category | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str | None) -> str | None:
+        return validate_not_empty_string(v)
+
+    @field_validator("target_amount")
+    @classmethod
+    def validate_target_amount(cls, v: float | None) -> float | None:
+        if v is not None and v <= 0:
+            raise ValueError("Target amount must be greater than 0")
+        return v
+
+    @field_validator("current_amount")
+    @classmethod
+    def validate_current_amount(cls, v: float | None) -> float | None:
+        if v is not None:
+            return validate_non_negative_amount(v, "Current amount")
+        return v
+
+    @field_validator("monthly_contribution")
+    @classmethod
+    def validate_monthly_contribution(cls, v: float | None) -> float | None:
+        if v is not None:
+            return validate_non_negative_amount(v, "Monthly contribution")
+        return v
+
+
+class GoalResponse(BaseModel):
+    id: int
+    name: str
+    target_amount: float
+    target_date: date
+    current_amount: float
+    monthly_contribution: float
+    is_completed: bool
+    account_id: int | None
+    account_name: str | None
+    category: Category | None
+    created_at: datetime
+    progress_percent: float
+    remaining_amount: float
+    projected_hit_date: date | None
+
+
+class GoalsListResponse(BaseModel):
+    goals: list[GoalResponse]
+    total_count: int
+    completed_count: int

--- a/backend/app/services/goals.py
+++ b/backend/app/services/goals.py
@@ -1,5 +1,6 @@
-from datetime import UTC, date, datetime, timedelta
-from decimal import Decimal
+import calendar
+from datetime import UTC, date, datetime
+from decimal import ROUND_CEILING, Decimal
 
 from fastapi import HTTPException
 from sqlalchemy import select
@@ -15,6 +16,15 @@ from app.schemas.goals import (
 from app.utils.db_helpers import get_or_404
 
 
+def _add_months(d: date, months: int) -> date:
+    """Add calendar months to a date, clamping day to last day of target month."""
+    month_index = d.month - 1 + months
+    year = d.year + month_index // 12
+    month = month_index % 12 + 1
+    day = min(d.day, calendar.monthrange(year, month)[1])
+    return date(year, month, day)
+
+
 def _project_hit_date(
     target_amount: Decimal,
     current_amount: Decimal,
@@ -23,7 +33,8 @@ def _project_hit_date(
 ) -> date | None:
     """Project the date when a goal will be hit at current contribution rate.
 
-    Returns None if already completed, target already reached, or no contribution.
+    Returns today if already completed or target already reached.
+    Returns None if there is no positive monthly contribution to project from.
     """
     today = datetime.now(UTC).date()
     if is_completed or current_amount >= target_amount:
@@ -32,10 +43,9 @@ def _project_hit_date(
         return None
 
     remaining = target_amount - current_amount
-    # Ceil division for whole months needed
-    months_needed = int((remaining + monthly_contribution - Decimal("0.01")) / monthly_contribution)
-    # Approximate days per month (30.44) for projected calendar date
-    return today + timedelta(days=int(months_needed * 30.44))
+    months_decimal = remaining / monthly_contribution
+    months_needed = int(months_decimal.to_integral_value(rounding=ROUND_CEILING))
+    return _add_months(today, months_needed)
 
 
 def _to_response(goal: Goal, account_name: str | None) -> GoalResponse:

--- a/backend/app/services/goals.py
+++ b/backend/app/services/goals.py
@@ -1,0 +1,169 @@
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import Account, Goal
+from app.schemas.goals import (
+    GoalCreate,
+    GoalResponse,
+    GoalsListResponse,
+    GoalUpdate,
+)
+from app.utils.db_helpers import get_or_404
+
+
+def _project_hit_date(
+    target_amount: Decimal,
+    current_amount: Decimal,
+    monthly_contribution: Decimal,
+    is_completed: bool,
+) -> date | None:
+    """Project the date when a goal will be hit at current contribution rate.
+
+    Returns None if already completed, target already reached, or no contribution.
+    """
+    today = datetime.now(UTC).date()
+    if is_completed or current_amount >= target_amount:
+        return today
+    if monthly_contribution <= 0:
+        return None
+
+    remaining = target_amount - current_amount
+    # Ceil division for whole months needed
+    months_needed = int((remaining + monthly_contribution - Decimal("0.01")) / monthly_contribution)
+    # Approximate days per month (30.44) for projected calendar date
+    return today + timedelta(days=int(months_needed * 30.44))
+
+
+def _to_response(goal: Goal, account_name: str | None) -> GoalResponse:
+    target = float(goal.target_amount)
+    current = float(goal.current_amount)
+    remaining = max(0.0, target - current)
+    progress = min(100.0, (current / target * 100.0)) if target > 0 else 0.0
+    projected = _project_hit_date(
+        goal.target_amount, goal.current_amount, goal.monthly_contribution, goal.is_completed
+    )
+    return GoalResponse(
+        id=goal.id,
+        name=goal.name,
+        target_amount=target,
+        target_date=goal.target_date,
+        current_amount=current,
+        monthly_contribution=float(goal.monthly_contribution),
+        is_completed=goal.is_completed,
+        account_id=goal.account_id,
+        account_name=account_name,
+        category=goal.category,
+        created_at=goal.created_at,
+        progress_percent=progress,
+        remaining_amount=remaining,
+        projected_hit_date=projected,
+    )
+
+
+def _get_account_names(db: Session, account_ids: list[int]) -> dict[int, str]:
+    if not account_ids:
+        return {}
+    rows = db.execute(select(Account.id, Account.name).where(Account.id.in_(account_ids))).all()
+    return {row[0]: row[1] for row in rows}
+
+
+def _validate_account(db: Session, account_id: int | None) -> None:
+    if account_id is None:
+        return
+    account = db.get(Account, account_id)
+    if not account:
+        raise HTTPException(status_code=404, detail=f"Account with id {account_id} not found")
+
+
+def get_all_goals(db: Session) -> GoalsListResponse:
+    """Get all goals with progress and projected hit date."""
+    goals = db.execute(select(Goal).order_by(Goal.target_date)).scalars().all()
+
+    account_ids = [g.account_id for g in goals if g.account_id is not None]
+    account_names = _get_account_names(db, account_ids)
+
+    items = [
+        _to_response(g, account_names.get(g.account_id) if g.account_id else None) for g in goals
+    ]
+    completed = sum(1 for g in goals if g.is_completed)
+
+    return GoalsListResponse(goals=items, total_count=len(items), completed_count=completed)
+
+
+def get_goal(db: Session, goal_id: int) -> GoalResponse:
+    """Get a single goal by ID."""
+    goal = get_or_404(db, Goal, goal_id)
+    account_name = None
+    if goal.account_id:
+        account = db.get(Account, goal.account_id)
+        account_name = account.name if account else None
+    return _to_response(goal, account_name)
+
+
+def create_goal(db: Session, data: GoalCreate) -> GoalResponse:
+    """Create a new goal."""
+    _validate_account(db, data.account_id)
+
+    goal = Goal(
+        name=data.name,
+        target_amount=Decimal(str(data.target_amount)),
+        target_date=data.target_date,
+        current_amount=Decimal(str(data.current_amount)),
+        monthly_contribution=Decimal(str(data.monthly_contribution)),
+        is_completed=data.is_completed,
+        account_id=data.account_id,
+        category=data.category.value if data.category else None,
+    )
+    db.add(goal)
+    db.commit()
+    db.refresh(goal)
+
+    account_name = None
+    if goal.account_id:
+        account = db.get(Account, goal.account_id)
+        account_name = account.name if account else None
+    return _to_response(goal, account_name)
+
+
+def update_goal(db: Session, goal_id: int, data: GoalUpdate) -> GoalResponse:
+    """Update an existing goal."""
+    goal = get_or_404(db, Goal, goal_id)
+    fields_set = getattr(data, "model_fields_set", set())
+
+    if data.name is not None:
+        goal.name = data.name
+    if data.target_amount is not None:
+        goal.target_amount = Decimal(str(data.target_amount))
+    if data.target_date is not None:
+        goal.target_date = data.target_date
+    if data.current_amount is not None:
+        goal.current_amount = Decimal(str(data.current_amount))
+    if data.monthly_contribution is not None:
+        goal.monthly_contribution = Decimal(str(data.monthly_contribution))
+    if data.is_completed is not None:
+        goal.is_completed = data.is_completed
+    if "account_id" in fields_set:
+        _validate_account(db, data.account_id)
+        goal.account_id = data.account_id
+    if "category" in fields_set:
+        goal.category = data.category.value if data.category else None
+
+    db.commit()
+    db.refresh(goal)
+
+    account_name = None
+    if goal.account_id:
+        account = db.get(Account, goal.account_id)
+        account_name = account.name if account else None
+    return _to_response(goal, account_name)
+
+
+def delete_goal(db: Session, goal_id: int) -> None:
+    """Hard delete a goal."""
+    goal = get_or_404(db, Goal, goal_id)
+    db.delete(goal)
+    db.commit()

--- a/backend/tests/test_api_goals.py
+++ b/backend/tests/test_api_goals.py
@@ -245,6 +245,7 @@ def test_get_all_goals_counts(test_client):
 
 def test_create_goal_target_already_reached(test_client):
     """Goal where current >= target should have projected_hit_date set to today."""
+    today_before = datetime.now(UTC).date()
     response = test_client.post(
         "/api/goals",
         json={
@@ -255,8 +256,10 @@ def test_create_goal_target_already_reached(test_client):
             "target_date": "2027-01-01",
         },
     )
+    today_after = datetime.now(UTC).date()
     assert response.status_code == 201
     data = response.json()
     assert data["progress_percent"] == 100
     assert data["remaining_amount"] == 0
-    assert data["projected_hit_date"] == datetime.now(UTC).date().isoformat()
+    # Accept either side of a UTC midnight crossover during the request
+    assert data["projected_hit_date"] in {today_before.isoformat(), today_after.isoformat()}

--- a/backend/tests/test_api_goals.py
+++ b/backend/tests/test_api_goals.py
@@ -1,0 +1,262 @@
+from datetime import UTC, datetime
+
+from tests.factories import create_test_account
+
+
+def test_get_goals_empty(test_client):
+    """GET /api/goals returns empty list when no goals exist."""
+    response = test_client.get("/api/goals")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["goals"] == []
+    assert data["total_count"] == 0
+    assert data["completed_count"] == 0
+
+
+def test_create_goal_minimal(test_client):
+    """POST /api/goals creates a goal with required fields only."""
+    payload = {
+        "name": "Emergency Fund",
+        "target_amount": 10000,
+        "target_date": "2027-12-31",
+    }
+    response = test_client.post("/api/goals", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Emergency Fund"
+    assert data["target_amount"] == 10000
+    assert data["current_amount"] == 0
+    assert data["progress_percent"] == 0
+    assert data["remaining_amount"] == 10000
+    assert data["is_completed"] is False
+    assert data["account_id"] is None
+    assert data["category"] is None
+    assert data["projected_hit_date"] is None
+
+
+def test_create_goal_with_progress(test_client):
+    """POST /api/goals computes progress_percent and remaining_amount."""
+    payload = {
+        "name": "Vacation",
+        "target_amount": 5000,
+        "current_amount": 1500,
+        "target_date": "2026-12-31",
+    }
+    response = test_client.post("/api/goals", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["progress_percent"] == 30.0
+    assert data["remaining_amount"] == 3500
+
+
+def test_create_goal_with_projection(test_client):
+    """POST /api/goals projects hit date when monthly_contribution > 0."""
+    payload = {
+        "name": "Down Payment",
+        "target_amount": 50000,
+        "current_amount": 10000,
+        "monthly_contribution": 1000,
+        "target_date": "2030-01-01",
+    }
+    response = test_client.post("/api/goals", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["projected_hit_date"] is not None
+
+
+def test_create_goal_with_account(test_client, test_db_session):
+    """POST /api/goals links to an existing account."""
+    account = create_test_account(test_db_session, name="Savings", category="saving_account")
+    payload = {
+        "name": "House",
+        "target_amount": 100000,
+        "target_date": "2030-01-01",
+        "account_id": account.id,
+        "category": "saving_account",
+    }
+    response = test_client.post("/api/goals", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["account_id"] == account.id
+    assert data["account_name"] == "Savings"
+    assert data["category"] == "saving_account"
+
+
+def test_create_goal_invalid_account(test_client):
+    """POST /api/goals with non-existent account_id returns 404."""
+    payload = {
+        "name": "Bad",
+        "target_amount": 1000,
+        "target_date": "2027-01-01",
+        "account_id": 9999,
+    }
+    response = test_client.post("/api/goals", json=payload)
+    assert response.status_code == 404
+
+
+def test_create_goal_empty_name(test_client):
+    payload = {
+        "name": "",
+        "target_amount": 1000,
+        "target_date": "2027-01-01",
+    }
+    response = test_client.post("/api/goals", json=payload)
+    assert response.status_code == 422
+
+
+def test_create_goal_zero_target(test_client):
+    payload = {
+        "name": "Zero",
+        "target_amount": 0,
+        "target_date": "2027-01-01",
+    }
+    response = test_client.post("/api/goals", json=payload)
+    assert response.status_code == 422
+
+
+def test_create_goal_negative_current(test_client):
+    payload = {
+        "name": "Neg",
+        "target_amount": 1000,
+        "current_amount": -10,
+        "target_date": "2027-01-01",
+    }
+    response = test_client.post("/api/goals", json=payload)
+    assert response.status_code == 422
+
+
+def test_get_goal_by_id(test_client):
+    create = test_client.post(
+        "/api/goals",
+        json={"name": "X", "target_amount": 100, "target_date": "2027-01-01"},
+    )
+    goal_id = create.json()["id"]
+
+    response = test_client.get(f"/api/goals/{goal_id}")
+    assert response.status_code == 200
+    assert response.json()["name"] == "X"
+
+
+def test_get_goal_not_found(test_client):
+    response = test_client.get("/api/goals/9999")
+    assert response.status_code == 404
+
+
+def test_update_goal(test_client):
+    create = test_client.post(
+        "/api/goals",
+        json={"name": "Old", "target_amount": 1000, "target_date": "2027-01-01"},
+    )
+    goal_id = create.json()["id"]
+
+    response = test_client.put(
+        f"/api/goals/{goal_id}",
+        json={"name": "New", "current_amount": 500, "monthly_contribution": 100},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "New"
+    assert data["current_amount"] == 500
+    assert data["monthly_contribution"] == 100
+    assert data["projected_hit_date"] is not None
+
+
+def test_update_goal_mark_completed(test_client):
+    create = test_client.post(
+        "/api/goals",
+        json={"name": "Almost", "target_amount": 1000, "target_date": "2027-01-01"},
+    )
+    goal_id = create.json()["id"]
+
+    response = test_client.put(
+        f"/api/goals/{goal_id}",
+        json={"is_completed": True, "current_amount": 1000},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_completed"] is True
+    assert data["progress_percent"] == 100
+
+
+def test_update_goal_unlink_account(test_client, test_db_session):
+    account = create_test_account(test_db_session, name="Linked")
+    create = test_client.post(
+        "/api/goals",
+        json={
+            "name": "Linked Goal",
+            "target_amount": 1000,
+            "target_date": "2027-01-01",
+            "account_id": account.id,
+        },
+    )
+    goal_id = create.json()["id"]
+
+    response = test_client.put(f"/api/goals/{goal_id}", json={"account_id": None})
+    assert response.status_code == 200
+    assert response.json()["account_id"] is None
+
+
+def test_update_goal_not_found(test_client):
+    response = test_client.put("/api/goals/9999", json={"name": "X"})
+    assert response.status_code == 404
+
+
+def test_delete_goal(test_client):
+    create = test_client.post(
+        "/api/goals",
+        json={"name": "To Delete", "target_amount": 100, "target_date": "2027-01-01"},
+    )
+    goal_id = create.json()["id"]
+
+    response = test_client.delete(f"/api/goals/{goal_id}")
+    assert response.status_code == 204
+
+    get_response = test_client.get(f"/api/goals/{goal_id}")
+    assert get_response.status_code == 404
+
+
+def test_delete_goal_not_found(test_client):
+    response = test_client.delete("/api/goals/9999")
+    assert response.status_code == 404
+
+
+def test_get_all_goals_counts(test_client):
+    test_client.post(
+        "/api/goals",
+        json={"name": "G1", "target_amount": 100, "target_date": "2027-01-01"},
+    )
+    test_client.post(
+        "/api/goals",
+        json={
+            "name": "G2",
+            "target_amount": 100,
+            "current_amount": 100,
+            "is_completed": True,
+            "target_date": "2026-06-30",
+        },
+    )
+
+    response = test_client.get("/api/goals")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] == 2
+    assert data["completed_count"] == 1
+
+
+def test_create_goal_target_already_reached(test_client):
+    """Goal where current >= target should have projected_hit_date set to today."""
+    response = test_client.post(
+        "/api/goals",
+        json={
+            "name": "Done",
+            "target_amount": 1000,
+            "current_amount": 1500,
+            "monthly_contribution": 0,
+            "target_date": "2027-01-01",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["progress_percent"] == 100
+    assert data["remaining_amount"] == 0
+    assert data["projected_hit_date"] == datetime.now(UTC).date().isoformat()

--- a/src/lib/utils/goals.test.ts
+++ b/src/lib/utils/goals.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { goalProgress, goalRemaining, projectGoalHitDate } from './goals';
+
+describe('goalProgress', () => {
+	it('calculates percent when current < target', () => {
+		expect(goalProgress(1500, 5000)).toBe(30);
+	});
+
+	it('caps at 100 when current >= target', () => {
+		expect(goalProgress(6000, 5000)).toBe(100);
+	});
+
+	it('returns 0 when target is 0', () => {
+		expect(goalProgress(100, 0)).toBe(0);
+	});
+
+	it('returns 0 when both are 0', () => {
+		expect(goalProgress(0, 0)).toBe(0);
+	});
+
+	it('handles current = 0', () => {
+		expect(goalProgress(0, 1000)).toBe(0);
+	});
+});
+
+describe('goalRemaining', () => {
+	it('returns positive remaining', () => {
+		expect(goalRemaining(2000, 5000)).toBe(3000);
+	});
+
+	it('returns 0 when target reached', () => {
+		expect(goalRemaining(5000, 5000)).toBe(0);
+	});
+
+	it('returns 0 when current exceeds target', () => {
+		expect(goalRemaining(6000, 5000)).toBe(0);
+	});
+});
+
+describe('projectGoalHitDate', () => {
+	const today = new Date('2026-01-15');
+
+	it('returns today when target already reached', () => {
+		const result = projectGoalHitDate(5000, 5000, 100, today);
+		expect(result).toEqual(today);
+	});
+
+	it('returns null when monthly contribution is 0', () => {
+		expect(projectGoalHitDate(1000, 5000, 0, today)).toBe(null);
+	});
+
+	it('returns null when monthly contribution is negative', () => {
+		expect(projectGoalHitDate(1000, 5000, -100, today)).toBe(null);
+	});
+
+	it('projects future date for partial progress', () => {
+		// 4000 remaining / 1000 per month = 4 months
+		const result = projectGoalHitDate(1000, 5000, 1000, today);
+		expect(result).not.toBe(null);
+		expect(result!.getMonth()).toBe(4); // May (0-indexed)
+		expect(result!.getFullYear()).toBe(2026);
+	});
+
+	it('rounds up months for partial last month', () => {
+		// 1500 remaining / 1000 per month = 1.5 → 2 months
+		const result = projectGoalHitDate(3500, 5000, 1000, today);
+		expect(result).not.toBe(null);
+		expect(result!.getMonth()).toBe(2); // March
+	});
+});

--- a/src/lib/utils/goals.ts
+++ b/src/lib/utils/goals.ts
@@ -1,0 +1,23 @@
+export function goalProgress(current: number, target: number): number {
+	if (target <= 0) return 0;
+	return Math.min(100, (current / target) * 100);
+}
+
+export function goalRemaining(current: number, target: number): number {
+	return Math.max(0, target - current);
+}
+
+export function projectGoalHitDate(
+	current: number,
+	target: number,
+	monthlyContribution: number,
+	today: Date = new Date()
+): Date | null {
+	if (current >= target) return today;
+	if (monthlyContribution <= 0) return null;
+	const remaining = target - current;
+	const monthsNeeded = Math.ceil(remaining / monthlyContribution);
+	const result = new Date(today);
+	result.setMonth(result.getMonth() + monthsNeeded);
+	return result;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
 		Camera,
 		Banknote,
 		Settings,
+		Target,
 		User,
 		ShieldCheck
 	} from 'lucide-svelte';
@@ -24,6 +25,7 @@
 		{ href: '/transactions', label: 'Transakcje', icon: ArrowRightLeft },
 		{ href: '/assets', label: 'Majątek', icon: Home },
 		{ href: '/debts', label: 'Zobowiązania', icon: ClipboardList },
+		{ href: '/goals', label: 'Cele', icon: Target },
 		{ href: '/snapshots', label: 'Snapshoty', icon: Camera },
 		{ href: '/salaries', label: 'Wynagrodzenia', icon: Banknote },
 		{ href: '/config', label: 'Konfiguracja', icon: Settings },

--- a/src/routes/goals/+page.svelte
+++ b/src/routes/goals/+page.svelte
@@ -1,0 +1,358 @@
+<script lang="ts">
+	import Modal from '$lib/components/Modal.svelte';
+	import { formatPLN, formatDate } from '$lib/utils/format';
+	import { Target, Plus, Pencil, Trash2, CheckCircle2, Calendar } from 'lucide-svelte';
+	import { env } from '$env/dynamic/public';
+	import { invalidateAll } from '$app/navigation';
+	import type { Goal, AccountOption } from './+page';
+	import type { PageData } from './$types';
+
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
+
+	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+
+	const goals = $derived(data.goals as Goal[]);
+	const accounts = $derived(data.accounts as AccountOption[]);
+	const totalCount = $derived(data.total_count as number);
+	const completedCount = $derived(data.completed_count as number);
+
+	let showForm = $state(false);
+	let editingGoal: Goal | null = $state(null);
+	let showDeleteModal = $state(false);
+	let goalToDelete: number | null = $state(null);
+	let error = $state('');
+	let saving = $state(false);
+
+	const categoryLabels: Record<string, string> = {
+		bank: 'Konto bankowe',
+		saving_account: 'Konto oszczędnościowe',
+		stock: 'Akcje',
+		bond: 'Obligacje',
+		gold: 'Złoto',
+		real_estate: 'Nieruchomość',
+		ppk: 'PPK',
+		fund: 'Fundusz',
+		etf: 'ETF',
+		vehicle: 'Pojazd',
+		mortgage: 'Hipoteka',
+		installment: 'Raty',
+		other: 'Inne'
+	};
+
+	const emptyForm = () => ({
+		name: '',
+		target_amount: 0,
+		target_date: new Date().toISOString().split('T')[0],
+		current_amount: 0,
+		monthly_contribution: 0,
+		is_completed: false,
+		account_id: null as number | null,
+		category: null as string | null
+	});
+
+	let formData = $state(emptyForm());
+
+	$effect(() => {
+		if (editingGoal) {
+			formData = {
+				name: editingGoal.name,
+				target_amount: editingGoal.target_amount,
+				target_date: editingGoal.target_date,
+				current_amount: editingGoal.current_amount,
+				monthly_contribution: editingGoal.monthly_contribution,
+				is_completed: editingGoal.is_completed,
+				account_id: editingGoal.account_id,
+				category: editingGoal.category
+			};
+		} else if (showForm) {
+			formData = emptyForm();
+		}
+	});
+
+	function startCreate() {
+		editingGoal = null;
+		showForm = true;
+	}
+
+	function startEdit(goal: Goal) {
+		editingGoal = goal;
+		showForm = true;
+	}
+
+	function cancelForm() {
+		showForm = false;
+		editingGoal = null;
+		error = '';
+	}
+
+	async function handleSubmit() {
+		error = '';
+		saving = true;
+		try {
+			const endpoint = editingGoal
+				? `${apiUrl}/api/goals/${editingGoal.id}`
+				: `${apiUrl}/api/goals`;
+			const method = editingGoal ? 'PUT' : 'POST';
+			const response = await fetch(endpoint, {
+				method,
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(formData)
+			});
+			if (!response.ok) {
+				const errorData = await response.json();
+				throw new Error(errorData.detail || 'Nie udało się zapisać celu');
+			}
+			await invalidateAll();
+			cancelForm();
+		} catch (err) {
+			if (err instanceof Error) error = err.message;
+		} finally {
+			saving = false;
+		}
+	}
+
+	function handleDelete(goalId: number) {
+		goalToDelete = goalId;
+		showDeleteModal = true;
+	}
+
+	function cancelDelete() {
+		showDeleteModal = false;
+		goalToDelete = null;
+	}
+
+	async function confirmDelete() {
+		if (!goalToDelete) return;
+		try {
+			const response = await fetch(`${apiUrl}/api/goals/${goalToDelete}`, { method: 'DELETE' });
+			if (!response.ok) throw new Error('Nie udało się usunąć celu');
+			await invalidateAll();
+		} catch (err) {
+			if (err instanceof Error) error = err.message;
+		} finally {
+			showDeleteModal = false;
+			goalToDelete = null;
+		}
+	}
+
+	function progressColor(percent: number, isCompleted: boolean): string {
+		if (isCompleted || percent >= 100) return 'bg-success-500';
+		if (percent >= 66) return 'bg-primary-500';
+		if (percent >= 33) return 'bg-warning-500';
+		return 'bg-surface-400-600';
+	}
+</script>
+
+<div class="space-y-6">
+	<header class="flex items-center justify-between gap-4 flex-wrap">
+		<div class="flex items-center gap-3">
+			<Target class="text-primary-500" size={28} />
+			<div>
+				<h1 class="h2 font-bold">Cele finansowe</h1>
+				<p class="text-sm text-surface-700-300">
+					{completedCount} z {totalCount}
+					{totalCount === 1 ? 'cel ukończony' : 'celów ukończonych'}
+				</p>
+			</div>
+		</div>
+		<button type="button" class="btn preset-filled-primary-500" onclick={startCreate}>
+			<Plus size={18} />
+			<span>Nowy cel</span>
+		</button>
+	</header>
+
+	{#if error}
+		<div class="card preset-tonal-error-500 p-3 text-sm" role="alert">{error}</div>
+	{/if}
+
+	{#if goals.length === 0}
+		<div class="card preset-tonal-surface p-8 text-center">
+			<Target class="mx-auto mb-3 text-surface-500" size={40} />
+			<p class="text-surface-700-300">Brak celów. Dodaj pierwszy cel finansowy.</p>
+		</div>
+	{:else}
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+			{#each goals as goal (goal.id)}
+				<article class="card preset-tonal-surface p-4 space-y-3">
+					<div class="flex items-start justify-between gap-2">
+						<div class="min-w-0">
+							<h2 class="h5 font-bold flex items-center gap-2">
+								{goal.name}
+								{#if goal.is_completed}
+									<CheckCircle2 class="text-success-500" size={18} />
+								{/if}
+							</h2>
+							<p class="text-xs text-surface-700-300">
+								Cel: {formatPLN(goal.target_amount)} do {formatDate(goal.target_date)}
+							</p>
+						</div>
+						<div class="flex gap-1 shrink-0">
+							<button
+								type="button"
+								class="btn-icon btn-icon-sm"
+								aria-label="Edytuj"
+								onclick={() => startEdit(goal)}
+							>
+								<Pencil size={16} />
+							</button>
+							<button
+								type="button"
+								class="btn-icon btn-icon-sm preset-tonal-error"
+								aria-label="Usuń"
+								onclick={() => handleDelete(goal.id)}
+							>
+								<Trash2 size={16} />
+							</button>
+						</div>
+					</div>
+
+					<div>
+						<div class="flex justify-between text-sm mb-1">
+							<span>{formatPLN(goal.current_amount)}</span>
+							<span class="font-mono">{goal.progress_percent.toFixed(1)}%</span>
+						</div>
+						<div class="h-3 bg-surface-200-800 rounded-full overflow-hidden">
+							<div
+								class="h-full transition-all {progressColor(
+									goal.progress_percent,
+									goal.is_completed
+								)}"
+								style="width: {Math.min(100, goal.progress_percent)}%"
+								role="progressbar"
+								aria-valuenow={goal.progress_percent}
+								aria-valuemin="0"
+								aria-valuemax="100"
+							></div>
+						</div>
+						<p class="text-xs text-surface-700-300 mt-1">
+							Pozostało: {formatPLN(goal.remaining_amount)}
+						</p>
+					</div>
+
+					<div class="grid grid-cols-2 gap-2 text-xs">
+						<div>
+							<span class="text-surface-700-300">Miesięcznie</span>
+							<p class="font-semibold">{formatPLN(goal.monthly_contribution)}</p>
+						</div>
+						<div>
+							<span class="text-surface-700-300 flex items-center gap-1">
+								<Calendar size={12} />
+								Prognoza
+							</span>
+							<p class="font-semibold">
+								{goal.projected_hit_date ? formatDate(goal.projected_hit_date) : '—'}
+							</p>
+						</div>
+						{#if goal.account_name}
+							<div class="col-span-2">
+								<span class="text-surface-700-300">Konto</span>
+								<p class="font-semibold">{goal.account_name}</p>
+							</div>
+						{/if}
+						{#if goal.category}
+							<div class="col-span-2">
+								<span class="text-surface-700-300">Kategoria</span>
+								<p class="font-semibold">{categoryLabels[goal.category] ?? goal.category}</p>
+							</div>
+						{/if}
+					</div>
+				</article>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<Modal
+	open={showForm}
+	title={editingGoal ? 'Edytuj cel' : 'Nowy cel'}
+	confirmText={saving ? 'Zapisywanie...' : 'Zapisz'}
+	confirmDisabled={saving || !formData.name || formData.target_amount <= 0}
+	onConfirm={handleSubmit}
+	onCancel={cancelForm}
+>
+	<form class="space-y-3" onsubmit={(e) => e.preventDefault()}>
+		<label class="label">
+			<span>Nazwa</span>
+			<input class="input" type="text" bind:value={formData.name} required />
+		</label>
+		<div class="grid grid-cols-2 gap-3">
+			<label class="label">
+				<span>Cel (PLN)</span>
+				<input
+					class="input"
+					type="number"
+					min="0.01"
+					step="0.01"
+					bind:value={formData.target_amount}
+					required
+				/>
+			</label>
+			<label class="label">
+				<span>Data celu</span>
+				<input class="input" type="date" bind:value={formData.target_date} required />
+			</label>
+		</div>
+		<div class="grid grid-cols-2 gap-3">
+			<label class="label">
+				<span>Obecna kwota</span>
+				<input
+					class="input"
+					type="number"
+					min="0"
+					step="0.01"
+					bind:value={formData.current_amount}
+				/>
+			</label>
+			<label class="label">
+				<span>Wkład miesięczny</span>
+				<input
+					class="input"
+					type="number"
+					min="0"
+					step="0.01"
+					bind:value={formData.monthly_contribution}
+				/>
+			</label>
+		</div>
+		<label class="label">
+			<span>Konto (opcjonalnie)</span>
+			<select class="select" bind:value={formData.account_id}>
+				<option value={null}>—</option>
+				{#each accounts as account (account.id)}
+					<option value={account.id}>{account.name}</option>
+				{/each}
+			</select>
+		</label>
+		<label class="label">
+			<span>Kategoria (opcjonalnie)</span>
+			<select class="select" bind:value={formData.category}>
+				<option value={null}>—</option>
+				{#each Object.entries(categoryLabels) as [value, label] (value)}
+					<option {value}>{label}</option>
+				{/each}
+			</select>
+		</label>
+		<label class="flex items-center gap-2 cursor-pointer">
+			<input type="checkbox" class="checkbox" bind:checked={formData.is_completed} />
+			<span>Cel ukończony</span>
+		</label>
+		{#if error}
+			<div class="card preset-tonal-error-500 p-2 text-sm" role="alert">{error}</div>
+		{/if}
+	</form>
+</Modal>
+
+<Modal
+	open={showDeleteModal}
+	title="Usunąć cel?"
+	confirmText="Usuń"
+	confirmVariant="danger"
+	onConfirm={confirmDelete}
+	onCancel={cancelDelete}
+>
+	<p>Czy na pewno chcesz usunąć ten cel? Tej operacji nie da się cofnąć.</p>
+</Modal>

--- a/src/routes/goals/+page.svelte
+++ b/src/routes/goals/+page.svelte
@@ -145,6 +145,18 @@
 		if (percent >= 33) return 'bg-warning-500';
 		return 'bg-surface-400-600';
 	}
+
+	function polishPlural(n: number, one: string, few: string, many: string): string {
+		const mod10 = n % 10;
+		const mod100 = n % 100;
+		if (n === 1) return one;
+		if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return few;
+		return many;
+	}
+
+	const completedLabel = $derived(
+		`${polishPlural(completedCount, 'cel ukończony', 'cele ukończone', 'celów ukończonych')}`
+	);
 </script>
 
 <div class="space-y-6">
@@ -155,7 +167,7 @@
 				<h1 class="h2 font-bold">Cele finansowe</h1>
 				<p class="text-sm text-surface-700-300">
 					{completedCount} z {totalCount}
-					{totalCount === 1 ? 'cel ukończony' : 'celów ukończonych'}
+					{completedLabel}
 				</p>
 			</div>
 		</div>

--- a/src/routes/goals/+page.ts
+++ b/src/routes/goals/+page.ts
@@ -1,0 +1,56 @@
+import { browser } from '$app/environment';
+import { error } from '@sveltejs/kit';
+import { env } from '$env/dynamic/public';
+import type { PageLoad } from './$types';
+
+export interface Goal {
+	id: number;
+	name: string;
+	target_amount: number;
+	target_date: string;
+	current_amount: number;
+	monthly_contribution: number;
+	is_completed: boolean;
+	account_id: number | null;
+	account_name: string | null;
+	category: string | null;
+	created_at: string;
+	progress_percent: number;
+	remaining_amount: number;
+	projected_hit_date: string | null;
+}
+
+export interface GoalsListResponse {
+	goals: Goal[];
+	total_count: number;
+	completed_count: number;
+}
+
+export interface AccountOption {
+	id: number;
+	name: string;
+}
+
+export const load: PageLoad = async ({ fetch }) => {
+	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+	if (!apiUrl) {
+		throw error(500, 'API URL is not configured');
+	}
+	const [goalsResponse, accountsResponse] = await Promise.all([
+		fetch(`${apiUrl}/api/goals`),
+		fetch(`${apiUrl}/api/accounts`)
+	]);
+	if (!goalsResponse.ok) {
+		throw error(goalsResponse.status, 'Failed to load goals');
+	}
+	const goalsData: GoalsListResponse = await goalsResponse.json();
+	const accounts: AccountOption[] = accountsResponse.ok
+		? await accountsResponse
+				.json()
+				.then((d: { assets: AccountOption[]; liabilities: AccountOption[] }) => [
+					...d.assets,
+					...d.liabilities
+				])
+		: [];
+	return { ...goalsData, accounts };
+};


### PR DESCRIPTION
## Motivation

Closes #356. Goal model + tests existed but were orphaned — no API endpoint, no `/goals` route, only referenced in unit tests.

## Implementation information

**Backend**
- `backend/app/models/goal.py` — added optional `account_id` (FK to `accounts`) and `category` columns
- `backend/app/schemas/goals.py` — `GoalCreate`/`GoalUpdate`/`GoalResponse`/`GoalsListResponse`
- `backend/app/services/goals.py` — CRUD + projected-hit-date (ceil months at current contribution rate)
- `backend/app/api/goals.py` — `/api/goals` GET/POST/GET-id/PUT/DELETE
- `backend/alembic/versions/0003_goal_account_and_category.py` — migration for new columns
- `backend/tests/test_api_goals.py` — 19 API tests (CRUD, validation, progress/projection)

**Frontend**
- `src/lib/utils/goals.ts` — `goalProgress`, `goalRemaining`, `projectGoalHitDate` + 13 unit tests
- `src/routes/goals/+page.{ts,svelte}` — Polish UI: progress bars, projected hit dates, create/edit/delete modals
- `src/routes/+layout.svelte` — added "Cele" nav entry

**Alternatives considered**
- Hard vs soft delete for goals: chose hard delete (no `is_active` on Goal model) since goals are target-based and rarely audited historically.
- Adding `is_active` column for parity with other entities: rejected as unnecessary complexity for this domain.

## Supporting documentation

Issue: #356