### PR TITLE
perf(dashboard): vectorize pandas iterrows

### DIFF
--- a/backend/app/services/dashboard/metrics.py
+++ b/backend/app/services/dashboard/metrics.py
@@ -1,5 +1,6 @@
 """Metric-card calculations for the dashboard (savings rate, ratios, hourly costs)."""
 
+import numpy as np
 import pandas as pd
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -24,34 +25,26 @@ def _calculate_savings_rate(
     if len(snapshots_df) < 4:
         return None
 
-    # Get last 4 snapshots
-    last_4_snapshots = snapshots_df.tail(4).copy()
+    # Vectorized signed-value (recompute defensively — direct callers may pass a raw df)
+    last_4_ids = snapshots_df.tail(4)["id"].tolist()
+    sub = df[df["snapshot_id"].isin(last_4_ids)].copy()
+    if "signed_value" not in sub.columns:
+        has_name = sub["name"] if "name" in sub.columns else pd.Series(False, index=sub.index)
+        asset_mask = sub["asset_id"].notna() & has_name.notna()
+        account_mask = sub["account_id"].notna() & sub["type"].notna()
+        sign = np.where(
+            account_mask,
+            np.where(sub["type"] == "asset", 1, -1),
+            np.where(asset_mask, 1, 0),
+        )
+        sub["signed_value"] = sub["value"].astype(float) * sign
 
-    # Calculate signed value (same logic as main function)
-    def calculate_signed_value(row):
-        if pd.notna(row["asset_id"]) and pd.notna(row.get("name")):
-            return row["value"]
-        if pd.notna(row["account_id"]) and pd.notna(row.get("type")):
-            return row["value"] if row["type"] == "asset" else -row["value"]
-        return 0
+    nw_by_snap = sub.groupby("snapshot_id")["signed_value"].sum()
+    net_worth_values = [float(nw_by_snap.get(sid, 0.0)) for sid in last_4_ids]
 
-    # Calculate net worth for each snapshot
-    net_worth_values = []
-    for _, snapshot_row in last_4_snapshots.iterrows():
-        snapshot_id = snapshot_row["id"]
-        snapshot_df = df[df["snapshot_id"] == snapshot_id]
-
-        snapshot_df = snapshot_df.copy()
-        snapshot_df["signed_value"] = snapshot_df.apply(calculate_signed_value, axis=1)
-        net_worth = snapshot_df["signed_value"].sum()
-        net_worth_values.append(net_worth)
-
-    # Calculate deltas between consecutive months
     deltas = [
         net_worth_values[i] - net_worth_values[i - 1] for i in range(1, len(net_worth_values))
     ]
-
-    # Average the last 3 deltas
     avg_delta = sum(deltas) / len(deltas)
 
     # Get last 3 salary records

--- a/backend/app/services/dashboard/metrics.py
+++ b/backend/app/services/dashboard/metrics.py
@@ -29,8 +29,12 @@ def _calculate_savings_rate(
     last_4_ids = snapshots_df.tail(4)["id"].tolist()
     sub = df[df["snapshot_id"].isin(last_4_ids)].copy()
     if "signed_value" not in sub.columns:
-        has_name = sub["name"] if "name" in sub.columns else pd.Series(False, index=sub.index)
-        asset_mask = sub["asset_id"].notna() & has_name.notna()
+        # Asset-table rows require both asset_id and a joined name; with no name
+        # column the join never happened, so no row qualifies as asset-table.
+        if "name" in sub.columns:
+            asset_mask = sub["asset_id"].notna() & sub["name"].notna()
+        else:
+            asset_mask = pd.Series(False, index=sub.index)
         account_mask = sub["account_id"].notna() & sub["type"].notna()
         sign = np.where(
             account_mask,

--- a/backend/app/services/dashboard/service.py
+++ b/backend/app/services/dashboard/service.py
@@ -3,6 +3,7 @@ Dashboard service using pandas for financial calculations.
 Demonstrates: groupby, pivot, merge, aggregations, time series
 """
 
+import numpy as np
 import pandas as pd
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -100,21 +101,18 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             category_time_series=CategoryTimeSeries(stock=[], bond=[]),
         )
 
-    # Calculate net worth per snapshot
-    # pandas: Calculate signed value based on whether it's an asset or liability
-    # Assets (from Asset table) contribute positively
-    # Accounts depend on account.type (asset=+, liability=-)
-    # Note: Inactive accounts/assets will have NaN in name/type after LEFT JOIN, exclude them
-    def calculate_signed_value(row):
-        if pd.notna(row["asset_id"]) and pd.notna(row.get("name")):
-            # From Asset table - always positive (only if asset was in the join)
-            return row["value"]
-        if pd.notna(row["account_id"]) and pd.notna(row.get("type")):
-            # From Account table - assets positive, liabilities negative
-            return row["value"] if row["type"] == "asset" else -row["value"]
-        return 0
-
-    df["signed_value"] = df.apply(calculate_signed_value, axis=1)
+    # Vectorized signed value:
+    # - Asset table rows (asset_id + name from join) → +value
+    # - Account rows (account_id + type from join): asset → +value, liability → -value
+    # - LEFT-JOIN rows with no match (inactive) → 0
+    asset_mask = df["asset_id"].notna() & df["name"].notna()
+    account_mask = df["account_id"].notna() & df["type"].notna()
+    sign = np.where(
+        account_mask,
+        np.where(df["type"] == "asset", 1, -1),
+        np.where(asset_mask, 1, 0),
+    )
+    df["signed_value"] = df["value"].astype(float) * sign
 
     # pandas: groupby() + sum() - Aggregate net worth by date
     net_worth_by_date = df.groupby("date")["signed_value"].sum().reset_index()
@@ -123,10 +121,9 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
     # pandas: sort_values() - Order by date
     net_worth_by_date = net_worth_by_date.sort_values("date")
 
-    # Convert to response format
     net_worth_history = [
-        NetWorthPoint(date=row["date"], value=row["net_worth"])
-        for _, row in net_worth_by_date.iterrows()
+        NetWorthPoint(date=d, value=v)
+        for d, v in zip(net_worth_by_date["date"], net_worth_by_date["net_worth"], strict=True)
     ]
 
     # Current metrics (latest snapshot)
@@ -181,8 +178,13 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
         )
 
         allocation = [
-            AllocationItem(category=row["category"], owner=row["owner"], value=float(row["value"]))
-            for _, row in allocation_df.iterrows()
+            AllocationItem(category=c, owner=o, value=float(v))
+            for c, o, v in zip(
+                allocation_df["category"],
+                allocation_df["owner"],
+                allocation_df["value"],
+                strict=True,
+            )
         ]
 
         # Calculate retirement account value (accounts with purpose='retirement')
@@ -284,14 +286,9 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             investment_trans = trans_with_accounts[
                 (trans_with_accounts["purpose"] == "retirement")
                 & (trans_with_accounts["date"] <= latest_snapshot["date"])
-            ]
-            investment_trans = investment_trans.copy()
-            investment_trans["signed_amount"] = investment_trans.apply(
-                lambda row: -row["amount"]
-                if row["transaction_type"] == "withdrawal"
-                else row["amount"],
-                axis=1,
-            )
+            ].copy()
+            sign = np.where(investment_trans["transaction_type"] == "withdrawal", -1.0, 1.0)
+            investment_trans["signed_amount"] = investment_trans["amount"].astype(float) * sign
             investment_contributions = float(investment_trans["signed_amount"].sum())
 
             # Reuse already-calculated retirement account value for consistency
@@ -362,11 +359,9 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             "gold": "gold",
         }
 
-        # Calculate current allocation by category
-        allocation_by_cat = {}
-        for _, row in investment_df.iterrows():
-            alloc_group = category_map.get(row["category"], "other")
-            allocation_by_cat[alloc_group] = allocation_by_cat.get(alloc_group, 0) + row["value"]
+        # Calculate current allocation by category (vectorized groupby)
+        alloc_groups = investment_df["category"].map(category_map).fillna("other")
+        allocation_by_cat = investment_df["value"].groupby(alloc_groups).sum().to_dict()
 
         # Calculate allocation breakdown
         allocation_breakdown = []
@@ -401,10 +396,8 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             & (latest_df["category"].isin(all_investment_categories))
         ]
 
-        wrapper_breakdown = {}
-        for _, row in all_investment_df.iterrows():
-            wrapper = row["account_wrapper"] if pd.notna(row["account_wrapper"]) else "Regular"
-            wrapper_breakdown[wrapper] = wrapper_breakdown.get(wrapper, 0) + row["value"]
+        wrappers = all_investment_df["account_wrapper"].fillna("Regular")
+        wrapper_breakdown = all_investment_df["value"].groupby(wrappers).sum().to_dict()
 
         # Calculate total for percentage (includes PPK, unlike total_investment_value)
         all_investment_total = sum(wrapper_breakdown.values())
@@ -468,11 +461,11 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             accounts_df, left_on="account_id", right_on="id", how="left"
         )
         # Withdrawals reduce cumulative contributions — negate their amount
-        transactions_with_accounts_df["signed_amount"] = transactions_with_accounts_df.apply(
-            lambda row: -row["amount"]
-            if row["transaction_type"] == "withdrawal"
-            else row["amount"],
-            axis=1,
+        sign = np.where(
+            transactions_with_accounts_df["transaction_type"] == "withdrawal", -1.0, 1.0
+        )
+        transactions_with_accounts_df["signed_amount"] = (
+            transactions_with_accounts_df["amount"].astype(float) * sign
         )
     else:
         transactions_with_accounts_df = pd.DataFrame()

--- a/backend/app/services/dashboard/time_series.py
+++ b/backend/app/services/dashboard/time_series.py
@@ -1,170 +1,146 @@
 """Investment time-series builders for the dashboard (overall, per-wrapper, per-category)."""
 
+import numpy as np
 import pandas as pd
 
 from app.schemas.dashboard import CategoryTimeSeries, InvestmentTimeSeriesPoint, WrapperTimeSeries
+
+INVESTMENT_CATEGORIES = {"stock", "bond", "fund", "etf", "gold", "ppk"}
+
+
+def _cum_contributions_per_snapshot(trans_df: pd.DataFrame, snap_dates: np.ndarray) -> np.ndarray:
+    """For each snapshot date, return cumulative signed_amount of transactions on/before it.
+
+    Uses sorted transactions + cumsum + searchsorted — O((T + S) log T) instead
+    of O(T * S) for the naïve per-snapshot filter.
+    """
+    if trans_df.empty:
+        return np.zeros(len(snap_dates))
+
+    sorted_trans = trans_df.sort_values("date")
+    t_dates = sorted_trans["date"].to_numpy()
+    cum = np.cumsum(sorted_trans["signed_amount"].astype(float).to_numpy())
+
+    # idx = number of transactions with date <= snap_date, minus 1
+    idx = np.searchsorted(t_dates, snap_dates, side="right") - 1
+    return np.where(idx >= 0, cum[np.clip(idx, 0, len(cum) - 1)], 0.0)
+
+
+def _build_series(
+    df: pd.DataFrame,
+    snapshots_df: pd.DataFrame,
+    transactions_with_accounts_df: pd.DataFrame,
+    value_mask: pd.Series,
+    trans_mask: pd.Series | None,
+) -> list[InvestmentTimeSeriesPoint]:
+    """Generic per-snapshot value + cumulative-contribution series builder."""
+    if df.empty or snapshots_df.empty:
+        return []
+
+    snaps = snapshots_df.sort_values("date")
+    snap_ids = snaps["id"].to_numpy()
+    snap_dates_arr = snaps["date"].to_numpy()
+
+    val_by_snap = df.loc[value_mask].groupby("snapshot_id")["value"].sum().astype(float)
+
+    if trans_mask is not None and not transactions_with_accounts_df.empty:
+        filtered_trans = transactions_with_accounts_df.loc[trans_mask]
+        contributions = _cum_contributions_per_snapshot(filtered_trans, snap_dates_arr)
+    else:
+        contributions = np.zeros(len(snap_ids))
+
+    series: list[InvestmentTimeSeriesPoint] = []
+    for snap_id, snap_date, contrib in zip(snap_ids, snap_dates_arr, contributions, strict=True):
+        value = float(val_by_snap.get(snap_id, 0.0))
+        c = float(contrib)
+        series.append(
+            InvestmentTimeSeriesPoint(
+                date=snap_date,
+                value=value,
+                contributions=c,
+                returns=value - c,
+            )
+        )
+    return series
 
 
 def build_investment_time_series(
     df: pd.DataFrame, snapshots_df: pd.DataFrame, transactions_with_accounts_df: pd.DataFrame
 ) -> list[InvestmentTimeSeriesPoint]:
     """Cumulative investment value, contributions, and returns per snapshot."""
-    investment_time_series: list[InvestmentTimeSeriesPoint] = []
     if df.empty or snapshots_df.empty:
-        return investment_time_series
+        return []
 
-    # Define investment categories
-    investment_categories = {"stock", "bond", "fund", "etf", "gold", "ppk"}
+    value_mask = (
+        df["account_id"].notna()
+        & (df["type"] == "asset")
+        & df["category"].isin(INVESTMENT_CATEGORIES)
+    )
+    if not transactions_with_accounts_df.empty:
+        trans_mask = transactions_with_accounts_df["category"].isin(INVESTMENT_CATEGORIES)
+    else:
+        trans_mask = None
 
-    # For each snapshot, calculate investment metrics
-    for _, snapshot_row in snapshots_df.iterrows():
-        snapshot_date = snapshot_row["date"]
-        snapshot_id = snapshot_row["id"]
-
-        # Get investment values for this snapshot
-        snapshot_investments = df[
-            (df["snapshot_id"] == snapshot_id)
-            & (pd.notna(df["account_id"]))
-            & (df["type"] == "asset")
-            & (df["category"].isin(investment_categories))
-        ]
-        investment_value = float(snapshot_investments["value"].sum())
-
-        # Calculate cumulative contributions up to this snapshot date
-        cumulative_contributions = 0
-        if not transactions_with_accounts_df.empty:
-            # Filter for investment transactions up to snapshot date
-            investment_trans = transactions_with_accounts_df[
-                (transactions_with_accounts_df["category"].isin(investment_categories))
-                & (transactions_with_accounts_df["date"] <= snapshot_date)
-            ]
-            cumulative_contributions = float(investment_trans["signed_amount"].sum())
-
-        # Calculate returns
-        returns = investment_value - cumulative_contributions
-
-        investment_time_series.append(
-            InvestmentTimeSeriesPoint(
-                date=snapshot_date,
-                value=investment_value,
-                contributions=cumulative_contributions,
-                returns=returns,
-            )
-        )
-
-    return investment_time_series
+    return _build_series(df, snapshots_df, transactions_with_accounts_df, value_mask, trans_mask)
 
 
 def build_wrapper_time_series(
     df: pd.DataFrame, snapshots_df: pd.DataFrame, transactions_with_accounts_df: pd.DataFrame
 ) -> WrapperTimeSeries:
     """Per-wrapper (IKE, IKZE, PPK) investment time series."""
-    ike_series: list[InvestmentTimeSeriesPoint] = []
-    ikze_series: list[InvestmentTimeSeriesPoint] = []
-    ppk_series: list[InvestmentTimeSeriesPoint] = []
+    wrappers = {"IKE": [], "IKZE": [], "PPK": []}
 
-    if not df.empty and not snapshots_df.empty:
-        investment_categories = {"stock", "bond", "fund", "etf", "gold", "ppk"}
+    if df.empty or snapshots_df.empty:
+        return WrapperTimeSeries(ike=[], ikze=[], ppk=[])
 
-        for _, snapshot_row in snapshots_df.iterrows():
-            snapshot_date = snapshot_row["date"]
-            snapshot_id = snapshot_row["id"]
+    base_value_mask = (
+        df["account_id"].notna()
+        & (df["type"] == "asset")
+        & df["category"].isin(INVESTMENT_CATEGORIES)
+    )
+    if not transactions_with_accounts_df.empty:
+        base_trans_mask = transactions_with_accounts_df["category"].isin(INVESTMENT_CATEGORIES)
+    else:
+        base_trans_mask = None
 
-            # Calculate for each wrapper
-            for wrapper, series_list in [
-                ("IKE", ike_series),
-                ("IKZE", ikze_series),
-                ("PPK", ppk_series),
-            ]:
-                # Get investment values for this wrapper in this snapshot
-                wrapper_investments = df[
-                    (df["snapshot_id"] == snapshot_id)
-                    & (pd.notna(df["account_id"]))
-                    & (df["type"] == "asset")
-                    & (df["category"].isin(investment_categories))
-                    & (df["account_wrapper"] == wrapper)
-                ]
-                wrapper_value = float(wrapper_investments["value"].sum())
+    for wrapper in wrappers:
+        v_mask = base_value_mask & (df["account_wrapper"] == wrapper)
+        t_mask = (
+            base_trans_mask & (transactions_with_accounts_df["account_wrapper"] == wrapper)
+            if base_trans_mask is not None
+            else None
+        )
+        wrappers[wrapper] = _build_series(
+            df, snapshots_df, transactions_with_accounts_df, v_mask, t_mask
+        )
 
-                # Calculate cumulative contributions for this wrapper up to snapshot date
-                cumulative_contributions = 0
-                if not transactions_with_accounts_df.empty:
-                    wrapper_trans = transactions_with_accounts_df[
-                        (transactions_with_accounts_df["category"].isin(investment_categories))
-                        & (transactions_with_accounts_df["account_wrapper"] == wrapper)
-                        & (transactions_with_accounts_df["date"] <= snapshot_date)
-                    ]
-                    cumulative_contributions = float(wrapper_trans["signed_amount"].sum())
-
-                returns = wrapper_value - cumulative_contributions
-
-                series_list.append(
-                    InvestmentTimeSeriesPoint(
-                        date=snapshot_date,
-                        value=wrapper_value,
-                        contributions=cumulative_contributions,
-                        returns=returns,
-                    )
-                )
-
-    return WrapperTimeSeries(ike=ike_series, ikze=ikze_series, ppk=ppk_series)
+    return WrapperTimeSeries(ike=wrappers["IKE"], ikze=wrappers["IKZE"], ppk=wrappers["PPK"])
 
 
 def build_category_time_series(
     df: pd.DataFrame, snapshots_df: pd.DataFrame, transactions_with_accounts_df: pd.DataFrame
 ) -> CategoryTimeSeries:
     """Per-category-group (stock, bond) investment time series."""
-    stock_series: list[InvestmentTimeSeriesPoint] = []
-    bond_series: list[InvestmentTimeSeriesPoint] = []
+    if df.empty or snapshots_df.empty:
+        return CategoryTimeSeries(stock=[], bond=[])
 
-    if not df.empty and not snapshots_df.empty:
-        # Define category grouping (matching allocation logic)
-        # Map individual categories to their group for consistent aggregation
-        category_to_group = {
-            "stock": "stock",
-            "fund": "stock",  # fund grouped as stock
-            "etf": "stock",  # etf grouped as stock
-            "bond": "bond",
-        }
+    # stock group includes stock/fund/etf; bond group is just bond
+    group_categories = {
+        "stock": ["stock", "fund", "etf"],
+        "bond": ["bond"],
+    }
 
-        for _, snapshot_row in snapshots_df.iterrows():
-            snapshot_date = snapshot_row["date"]
-            snapshot_id = snapshot_row["id"]
+    result: dict[str, list[InvestmentTimeSeriesPoint]] = {}
+    for group, categories in group_categories.items():
+        v_mask = (
+            df["account_id"].notna() & (df["type"] == "asset") & df["category"].isin(categories)
+        )
+        if not transactions_with_accounts_df.empty:
+            t_mask = transactions_with_accounts_df["category"].isin(categories)
+        else:
+            t_mask = None
+        result[group] = _build_series(
+            df, snapshots_df, transactions_with_accounts_df, v_mask, t_mask
+        )
 
-            # Calculate for each category group
-            for target_group, series_list in [("stock", stock_series), ("bond", bond_series)]:
-                # Get all categories that map to this group
-                matching_categories = [
-                    cat for cat, group in category_to_group.items() if group == target_group
-                ]
-
-                # Get investment values for this category group in this snapshot
-                category_investments = df[
-                    (df["snapshot_id"] == snapshot_id)
-                    & (pd.notna(df["account_id"]))
-                    & (df["type"] == "asset")
-                    & (df["category"].isin(matching_categories))
-                ]
-                category_value = float(category_investments["value"].sum())
-
-                # Calculate cumulative contributions for this category group up to snapshot date
-                cumulative_contributions = 0
-                if not transactions_with_accounts_df.empty:
-                    category_trans = transactions_with_accounts_df[
-                        (transactions_with_accounts_df["category"].isin(matching_categories))
-                        & (transactions_with_accounts_df["date"] <= snapshot_date)
-                    ]
-                    cumulative_contributions = float(category_trans["signed_amount"].sum())
-
-                returns = category_value - cumulative_contributions
-
-                series_list.append(
-                    InvestmentTimeSeriesPoint(
-                        date=snapshot_date,
-                        value=category_value,
-                        contributions=cumulative_contributions,
-                        returns=returns,
-                    )
-                )
-
-    return CategoryTimeSeries(stock=stock_series, bond=bond_series)
+    return CategoryTimeSeries(stock=result["stock"], bond=result["bond"])

--- a/backend/tests/test_services_dashboard.py
+++ b/backend/tests/test_services_dashboard.py
@@ -1788,84 +1788,85 @@ def test_dashboard_performance_60_snapshots(test_db_session):
     """
     import time
 
+    from app.models import Transaction
+
     # Mix of account categories/wrappers to exercise allocation + per-wrapper +
     # per-category time series — the per-snapshot hot paths.
-    accounts = [
-        create_test_account(test_db_session, name="Checking", category="bank", owner="Marcin"),
-        create_test_account(
-            test_db_session,
-            name="Emergency",
-            category="bank",
-            owner="Marcin",
-            purpose="emergency_fund",
-        ),
-        create_test_account(
-            test_db_session,
-            name="IKE Stocks",
-            category="stock",
-            owner="Marcin",
-            account_wrapper="IKE",
-            purpose="retirement",
-        ),
-        create_test_account(
-            test_db_session,
-            name="IKZE Bonds",
-            category="bond",
-            owner="Marcin",
-            account_wrapper="IKZE",
-            purpose="retirement",
-        ),
-        create_test_account(
-            test_db_session,
-            name="PPK",
-            category="ppk",
-            owner="Marcin",
-            account_wrapper="PPK",
-            purpose="retirement",
-        ),
-        create_test_account(test_db_session, name="Regular ETF", category="etf", owner="Marcin"),
-        create_test_account(
-            test_db_session,
-            name="Mortgage",
-            account_type="liability",
-            category="mortgage",
-            owner="Shared",
-        ),
+    account_specs = [
+        {"name": "Checking", "category": "bank", "owner": "Marcin"},
+        {"name": "Emergency", "category": "bank", "owner": "Marcin", "purpose": "emergency_fund"},
+        {
+            "name": "IKE Stocks",
+            "category": "stock",
+            "owner": "Marcin",
+            "account_wrapper": "IKE",
+            "purpose": "retirement",
+        },
+        {
+            "name": "IKZE Bonds",
+            "category": "bond",
+            "owner": "Marcin",
+            "account_wrapper": "IKZE",
+            "purpose": "retirement",
+        },
+        {
+            "name": "PPK",
+            "category": "ppk",
+            "owner": "Marcin",
+            "account_wrapper": "PPK",
+            "purpose": "retirement",
+        },
+        {"name": "Regular ETF", "category": "etf", "owner": "Marcin"},
+        {"name": "Mortgage", "type": "liability", "category": "mortgage", "owner": "Shared"},
     ]
+    defaults = {"currency": "PLN", "purpose": "general", "is_active": True, "type": "asset"}
+    accounts = [Account(**{**defaults, **spec}) for spec in account_specs]
+    test_db_session.add_all(accounts)
+    test_db_session.commit()
 
-    # 60 monthly snapshots ≈ 5 years of data
-    snapshots = []
-    for i in range(60):
-        year = 2020 + i // 12
-        month = (i % 12) + 1
-        snapshots.append(create_test_snapshot(test_db_session, snapshot_date=date(year, month, 1)))
+    # Bulk-insert 60 snapshots + 420 values + 240 transactions in one commit each
+    # — factory helpers commit per row, which dominates wall-clock cost.
+    snapshots = [Snapshot(date=date(2020 + i // 12, (i % 12) + 1, 1)) for i in range(60)]
+    test_db_session.add_all(snapshots)
+    test_db_session.commit()
 
-    # ~420 SnapshotValues = 60 snapshots × 7 accounts
-    for i, snap in enumerate(snapshots):
-        for j, account in enumerate(accounts):
-            create_test_snapshot_value(
-                test_db_session, snap.id, account.id, Decimal(str(1000 * (i + 1) + 100 * j))
-            )
-
-    # Some transactions across the period to exercise cumulative contributions
-    from tests.factories import create_test_transaction
+    values = [
+        SnapshotValue(
+            snapshot_id=snap.id,
+            account_id=acct.id,
+            value=Decimal(str(1000 * (i + 1) + 100 * j)),
+        )
+        for i, snap in enumerate(snapshots)
+        for j, acct in enumerate(accounts)
+    ]
+    test_db_session.add_all(values)
 
     investment_accounts = [a for a in accounts if a.category in {"stock", "bond", "ppk", "etf"}]
-    for i in range(60):
-        year = 2020 + i // 12
-        month = (i % 12) + 1
-        for account in investment_accounts:
-            create_test_transaction(
-                test_db_session,
-                account.id,
-                amount=500.0,
-                transaction_date=date(year, month, 5),
-            )
+    transactions = [
+        Transaction(
+            account_id=acct.id,
+            amount=Decimal("500.00"),
+            date=date(2020 + i // 12, (i % 12) + 1, 5),
+            owner="Marcin",
+            is_active=True,
+        )
+        for i in range(60)
+        for acct in investment_accounts
+    ]
+    test_db_session.add_all(transactions)
+    test_db_session.commit()
 
-    # Warm-up + measure (single timed call is fine — threshold is generous vs target)
-    start = time.perf_counter()
-    result = get_dashboard_data(test_db_session)
-    elapsed_ms = (time.perf_counter() - start) * 1000
+    # Warm-up (prime pandas / sqlalchemy machinery), then time the median of 3 runs
+    # so a single GC pause or CI hiccup doesn't fail the assertion.
+    get_dashboard_data(test_db_session)
+    timings_ms = []
+    for _ in range(3):
+        start = time.perf_counter()
+        result = get_dashboard_data(test_db_session)
+        timings_ms.append((time.perf_counter() - start) * 1000)
+    median_ms = sorted(timings_ms)[1]
 
     assert len(result.net_worth_history) == 60
-    assert elapsed_ms < 200, f"Dashboard took {elapsed_ms:.1f} ms (limit: 200 ms)"
+    assert median_ms < 200, (
+        f"Dashboard median {median_ms:.1f} ms (limit: 200 ms; runs: {timings_ms})"
+    )

--- a/backend/tests/test_services_dashboard.py
+++ b/backend/tests/test_services_dashboard.py
@@ -1779,3 +1779,93 @@ def test_calculate_hour_of_life_cost_zero_salary(test_db_session):
     result = _calculate_hour_of_life_cost(test_db_session)
 
     assert result is None
+
+
+def test_dashboard_performance_60_snapshots(test_db_session):
+    """Dashboard must compute in < 200 ms with 60 snapshots (vectorized pandas).
+
+    Guards against accidental reintroduction of iterrows()-driven O(N·M) scaling.
+    """
+    import time
+
+    # Mix of account categories/wrappers to exercise allocation + per-wrapper +
+    # per-category time series — the per-snapshot hot paths.
+    accounts = [
+        create_test_account(test_db_session, name="Checking", category="bank", owner="Marcin"),
+        create_test_account(
+            test_db_session,
+            name="Emergency",
+            category="bank",
+            owner="Marcin",
+            purpose="emergency_fund",
+        ),
+        create_test_account(
+            test_db_session,
+            name="IKE Stocks",
+            category="stock",
+            owner="Marcin",
+            account_wrapper="IKE",
+            purpose="retirement",
+        ),
+        create_test_account(
+            test_db_session,
+            name="IKZE Bonds",
+            category="bond",
+            owner="Marcin",
+            account_wrapper="IKZE",
+            purpose="retirement",
+        ),
+        create_test_account(
+            test_db_session,
+            name="PPK",
+            category="ppk",
+            owner="Marcin",
+            account_wrapper="PPK",
+            purpose="retirement",
+        ),
+        create_test_account(test_db_session, name="Regular ETF", category="etf", owner="Marcin"),
+        create_test_account(
+            test_db_session,
+            name="Mortgage",
+            account_type="liability",
+            category="mortgage",
+            owner="Shared",
+        ),
+    ]
+
+    # 60 monthly snapshots ≈ 5 years of data
+    snapshots = []
+    for i in range(60):
+        year = 2020 + i // 12
+        month = (i % 12) + 1
+        snapshots.append(create_test_snapshot(test_db_session, snapshot_date=date(year, month, 1)))
+
+    # ~420 SnapshotValues = 60 snapshots × 7 accounts
+    for i, snap in enumerate(snapshots):
+        for j, account in enumerate(accounts):
+            create_test_snapshot_value(
+                test_db_session, snap.id, account.id, Decimal(str(1000 * (i + 1) + 100 * j))
+            )
+
+    # Some transactions across the period to exercise cumulative contributions
+    from tests.factories import create_test_transaction
+
+    investment_accounts = [a for a in accounts if a.category in {"stock", "bond", "ppk", "etf"}]
+    for i in range(60):
+        year = 2020 + i // 12
+        month = (i % 12) + 1
+        for account in investment_accounts:
+            create_test_transaction(
+                test_db_session,
+                account.id,
+                amount=500.0,
+                transaction_date=date(year, month, 5),
+            )
+
+    # Warm-up + measure (single timed call is fine — threshold is generous vs target)
+    start = time.perf_counter()
+    result = get_dashboard_data(test_db_session)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+
+    assert len(result.net_worth_history) == 60
+    assert elapsed_ms < 200, f"Dashboard took {elapsed_ms:.1f} ms (limit: 200 ms)"


### PR DESCRIPTION
## Motivation

Closes #358.

Dashboard endpoint used `iterrows()` / row-wise `.apply()` on growing
DataFrames; latency scaled linearly with snapshot count (≈1 s at
60 snapshots).

## Implementation information

- `service.py`
  - `signed_value`: row-wise `.apply` → `np.where` with masks
  - Transaction `signed_amount` (2 sites): vectorized `np.where`
  - `allocation_by_cat` / `wrapper_breakdown` iterrows loops →
    `groupby().sum().to_dict()`
  - `net_worth_history` / `allocation` builders: iterrows → `zip`
- `time_series.py`: rewritten with `_build_series` helper using one
  `groupby("snapshot_id").sum()` for values + `sort + cumsum +
  searchsorted` for per-snapshot cumulative contributions
  (O((T+S)·log T) vs O(T·S))
- `metrics.py`: `_calculate_savings_rate` collapses per-snapshot
  loop into a single `groupby` on precomputed `signed_value`
  (defensive fallback when called with raw `df` from unit tests)

Benchmark `test_dashboard_performance_60_snapshots` enforces
<200 ms; measured ~24 ms locally.

## Supporting documentation

Issue: Automaat/finance-buddy#358

## Test plan

- [x] `uv run pytest tests/test_services_dashboard.py` — 36/36 pass
- [x] `uv run pytest` — 553/553 pass
- [x] `uv run ruff check` clean
- [x] `uv run pyrefly check app/services/dashboard/` clean
- [x] New benchmark test < 200 ms with 60 snapshots