### PR TITLE
test(e2e): add Playwright suite + CI job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,11 +99,12 @@ jobs:
 
       - name: Start frontend
         env:
+          NODE_ENV: production
           PORT: '4173'
           HOST: 127.0.0.1
           ORIGIN: http://127.0.0.1:4173
         run: |
-          node build > "${GITHUB_WORKSPACE}/frontend.log" 2>&1 &
+          NODE_ENV=production node build > "${GITHUB_WORKSPACE}/frontend.log" 2>&1 &
           echo $! > "${GITHUB_WORKSPACE}/frontend.pid"
 
       - name: Wait for frontend

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,7 +73,9 @@ jobs:
         run: npx playwright install-deps chromium
 
       - name: Build frontend
-        run: npm run build
+        env:
+          NODE_ENV: production
+        run: NODE_ENV=production npm run build
 
       - name: Start backend
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,6 +48,9 @@ jobs:
         env:
           MISE_PYTHON_COMPILE: '0'
 
+      - name: Override mise NODE_ENV
+        run: echo "NODE_ENV=production" >> "$GITHUB_ENV"
+
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Install frontend dependencies

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,148 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  playwright:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: finance
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: finance
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://finance:password@localhost:5432/finance
+      APP_PASSWORD: test
+      CORS_ORIGINS: http://127.0.0.1:4173,http://localhost:4173
+      SEED_DEV_DATA: 'true'
+      PUBLIC_API_URL: http://127.0.0.1:8000
+      PUBLIC_API_URL_BROWSER: http://127.0.0.1:8000
+      E2E_BASE_URL: http://127.0.0.1:4173
+      E2E_API_URL: http://127.0.0.1:8000
+      E2E_FRONTEND_PORT: '4173'
+      E2E_SKIP_WEBSERVER: '1'
+      NODE_ENV: production
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          experimental: true
+        env:
+          MISE_PYTHON_COMPILE: '0'
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Install backend dependencies
+        run: uv sync
+        working-directory: backend
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Start backend
+        run: |
+          uv run uvicorn app.main:app \
+            --host 127.0.0.1 --port 8000 --log-level warning \
+            > "${GITHUB_WORKSPACE}/backend.log" 2>&1 &
+          echo $! > "${GITHUB_WORKSPACE}/backend.pid"
+        working-directory: backend
+
+      - name: Wait for backend health
+        run: |
+          for _ in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8000/health > /dev/null; then
+              echo "backend ready"; exit 0
+            fi
+            sleep 1
+          done
+          echo "backend did not become healthy"
+          cat backend.log || true
+          exit 1
+
+      - name: Start frontend
+        env:
+          PORT: '4173'
+          HOST: 127.0.0.1
+          ORIGIN: http://127.0.0.1:4173
+        run: |
+          node build > "${GITHUB_WORKSPACE}/frontend.log" 2>&1 &
+          echo $! > "${GITHUB_WORKSPACE}/frontend.pid"
+
+      - name: Wait for frontend
+        run: |
+          for _ in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:4173/ > /dev/null; then
+              echo "frontend ready"; exit 0
+            fi
+            sleep 1
+          done
+          echo "frontend did not start"
+          cat frontend.log || true
+          exit 1
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - name: Stop services
+        if: always()
+        run: |
+          [ -f backend.pid ] && kill "$(cat backend.pid)" || true
+          [ -f frontend.pid ] && kill "$(cat frontend.pid)" || true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 14
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-test-results
+          path: test-results
+          retention-days: 14
+
+      - name: Upload server logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: server-logs
+          path: |
+            backend.log
+            frontend.log
+          retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,6 +80,15 @@ jobs:
           NODE_ENV: production
         run: NODE_ENV=production npm run build
 
+      - name: Verify production build mode
+        run: |
+          echo "NODE_ENV=$NODE_ENV"
+          grep -E 'get_global_name|__sveltekit_dev' build/server/index.js | head -3
+          if grep -q '"__sveltekit_dev"' build/server/index.js; then
+            echo "::error::SK built in DEV mode despite NODE_ENV=production"
+            exit 1
+          fi
+
       - name: Start backend
         run: |
           uv run uvicorn app.main:app \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,15 +58,19 @@ jobs:
         working-directory: backend
 
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
 
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright OS deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Build frontend
         run: npm run build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Install frontend dependencies
-        run: npm ci
+        run: npm ci --include=dev
 
       - name: Install backend dependencies
         run: uv sync

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,12 @@ coverage.xml
 htmlcov/
 .pytest_cache/
 
+# Playwright
+playwright-report/
+test-results/
+playwright/.cache/
+blob-report/
+
 # Misc
 .vercel
 .netlify

--- a/.mise.toml
+++ b/.mise.toml
@@ -3,9 +3,6 @@ node = "24"
 python = "3.14.5"
 uv = "latest"
 
-[env]
-NODE_ENV = "development"
-
 [tasks.dev]
 description = "Start all services for development"
 run = "docker-compose -f docker-compose.dev.yml up --build"

--- a/.prettierignore
+++ b/.prettierignore
@@ -34,3 +34,9 @@ backend/README.md
 
 # Klaudiush tooling
 .klaudiush
+
+# Playwright artifacts
+playwright-report
+test-results
+blob-report
+playwright/.cache

--- a/e2e/accounts.spec.ts
+++ b/e2e/accounts.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+function uniqueName(prefix: string): string {
+	const stamp = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+	return `${prefix}-${stamp}`;
+}
+
+test.describe('accounts CRUD', () => {
+	test('create asset account then soft-delete it', async ({ page }) => {
+		await page.goto('/accounts');
+		await expect(page.getByRole('heading', { name: 'Konta' })).toBeVisible();
+
+		const name = uniqueName('e2e-bank');
+
+		await page.getByRole('button', { name: /Nowe Konto/ }).click();
+
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible();
+
+		await dialog.locator('label:has-text("Nazwa") input').fill(name);
+		await dialog.locator('label:has-text("Typ") select').selectOption('asset');
+		await dialog.locator('label:has-text("Kategoria") select').selectOption('bank');
+
+		await dialog.getByRole('button', { name: /Utwórz konto/ }).click();
+		await expect(dialog).toBeHidden();
+
+		const row = page.getByRole('row', { name: new RegExp(name) });
+		await expect(row).toBeVisible();
+
+		await row.getByRole('button', { name: 'Usuń' }).click();
+
+		const confirm = page.getByRole('dialog').filter({ hasText: 'Potwierdzenie usunięcia' });
+		await expect(confirm).toBeVisible();
+		await confirm.getByRole('button', { name: 'Usuń', exact: true }).click();
+
+		await expect(page.getByRole('row', { name: new RegExp(name) })).toBeHidden();
+	});
+});

--- a/e2e/accounts.spec.ts
+++ b/e2e/accounts.spec.ts
@@ -1,9 +1,5 @@
 import { test, expect } from '@playwright/test';
-
-function uniqueName(prefix: string): string {
-	const stamp = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
-	return `${prefix}-${stamp}`;
-}
+import { uniqueName } from './utils';
 
 test.describe('accounts CRUD', () => {
 	test('create asset account then soft-delete it', async ({ page }) => {

--- a/e2e/api.spec.ts
+++ b/e2e/api.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+const apiUrl = process.env.E2E_API_URL ?? 'http://127.0.0.1:8000';
+
+test.describe('backend API', () => {
+	test('GET /health returns ok', async ({ request }) => {
+		const res = await request.get(`${apiUrl}/health`);
+		expect(res.status()).toBe(200);
+		expect(await res.json()).toMatchObject({ status: 'ok' });
+	});
+
+	test('GET /api/dashboard returns net worth shape', async ({ request }) => {
+		const res = await request.get(`${apiUrl}/api/dashboard`);
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(body).toHaveProperty('current_net_worth');
+		expect(body).toHaveProperty('total_assets');
+		expect(body).toHaveProperty('total_liabilities');
+		expect(Array.isArray(body.net_worth_history)).toBe(true);
+		expect(Array.isArray(body.allocation)).toBe(true);
+	});
+
+	test('GET /api/personas returns seeded personas', async ({ request }) => {
+		const res = await request.get(`${apiUrl}/api/personas`);
+		expect(res.status()).toBe(200);
+		const personas = await res.json();
+		expect(Array.isArray(personas)).toBe(true);
+		expect(personas.length).toBeGreaterThan(0);
+		const names = personas.map((p: { name: string }) => p.name);
+		expect(names).toContain('Marcin');
+	});
+
+	test('GET /api/accounts returns asset and liability arrays', async ({ request }) => {
+		const res = await request.get(`${apiUrl}/api/accounts`);
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body.assets)).toBe(true);
+		expect(Array.isArray(body.liabilities)).toBe(true);
+	});
+});

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('dashboard', () => {
+	test('renders net worth title and charts', async ({ page }) => {
+		await page.goto('/');
+		await expect(page.getByRole('heading', { name: /Wartość Netto/i }).first()).toBeVisible();
+		const canvases = page.locator('canvas');
+		await expect(canvases.first()).toBeVisible();
+	});
+
+	test('opens retirement limits modal when stats are present', async ({ page }) => {
+		await page.goto('/');
+		const trigger = page.getByRole('button', { name: 'Konfiguruj limity' });
+		if (await trigger.count()) {
+			await trigger.first().click();
+			await expect(page.getByRole('dialog')).toBeVisible();
+			await page.getByRole('dialog').getByRole('button', { name: 'Anuluj' }).click();
+			await expect(page.getByRole('dialog')).toBeHidden();
+		} else {
+			test.info().annotations.push({
+				type: 'skipped',
+				description: 'no retirement stats seeded'
+			});
+		}
+	});
+});

--- a/e2e/goals.spec.ts
+++ b/e2e/goals.spec.ts
@@ -1,9 +1,5 @@
 import { test, expect } from '@playwright/test';
-
-function uniqueName(prefix: string): string {
-	const stamp = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
-	return `${prefix}-${stamp}`;
-}
+import { uniqueName } from './utils';
 
 test.describe('goals CRUD', () => {
 	test('create, verify, then delete a goal', async ({ page }) => {

--- a/e2e/goals.spec.ts
+++ b/e2e/goals.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+function uniqueName(prefix: string): string {
+	const stamp = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+	return `${prefix}-${stamp}`;
+}
+
+test.describe('goals CRUD', () => {
+	test('create, verify, then delete a goal', async ({ page }) => {
+		await page.goto('/goals');
+		await expect(page.getByRole('heading', { name: 'Cele finansowe' })).toBeVisible();
+
+		const name = uniqueName('e2e-goal');
+
+		await page.getByRole('button', { name: /Nowy cel/ }).click();
+
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible();
+
+		await dialog.locator('label:has-text("Nazwa") input').fill(name);
+		await dialog.locator('label:has-text("Cel (PLN)") input').fill('25000');
+
+		const inOneYear = new Date();
+		inOneYear.setFullYear(inOneYear.getFullYear() + 1);
+		const isoDate = inOneYear.toISOString().slice(0, 10);
+		await dialog.locator('label:has-text("Data celu") input').fill(isoDate);
+
+		await dialog.locator('label:has-text("Obecna kwota") input').fill('5000');
+		await dialog.locator('label:has-text("Wkład miesięczny") input').fill('1500');
+
+		await dialog.getByRole('button', { name: 'Zapisz', exact: true }).click();
+		await expect(dialog).toBeHidden();
+
+		const card = page.locator('article').filter({ has: page.getByRole('heading', { name }) });
+		await expect(card).toBeVisible();
+		await expect(card.getByText('25 000', { exact: false })).toBeVisible();
+
+		await card.getByRole('button', { name: 'Usuń' }).click();
+		const confirm = page.getByRole('dialog').filter({ hasText: 'Usunąć cel?' });
+		await expect(confirm).toBeVisible();
+		await confirm.getByRole('button', { name: 'Usuń', exact: true }).click();
+
+		await expect(page.getByRole('heading', { name })).toBeHidden();
+	});
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('navigation', () => {
+	test('desktop sidebar links navigate to each page', async ({ page, isMobile }) => {
+		test.skip(isMobile, 'desktop-only sidebar');
+		await page.goto('/');
+
+		const links: { label: string; path: string }[] = [
+			{ label: 'Metryki', path: '/metryki' },
+			{ label: 'Konta', path: '/accounts' },
+			{ label: 'Transakcje', path: '/transactions' },
+			{ label: 'Majątek', path: '/assets' },
+			{ label: 'Zobowiązania', path: '/debts' },
+			{ label: 'Cele', path: '/goals' },
+			{ label: 'Snapshoty', path: '/snapshots' },
+			{ label: 'Wynagrodzenia', path: '/salaries' },
+			{ label: 'Konfiguracja', path: '/config' },
+			{ label: 'Ustawienia', path: '/settings' }
+		];
+
+		for (const link of links) {
+			await page
+				.locator('aside')
+				.getByRole('link', { name: new RegExp(`^${link.label}$`) })
+				.click();
+			await expect(page).toHaveURL(new RegExp(`${link.path}$`));
+		}
+	});
+
+	test('mobile bottom nav is visible and scrollable', async ({ page, isMobile }) => {
+		test.skip(!isMobile, 'mobile-only nav');
+		await page.goto('/');
+		const nav = page.getByRole('navigation', { name: 'Mobile navigation' });
+		await expect(nav).toBeVisible();
+		await expect(nav.getByRole('link', { name: 'Dashboard' })).toBeVisible();
+		await nav.getByRole('link', { name: 'Konta' }).click();
+		await expect(page).toHaveURL(/\/accounts$/);
+	});
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -26,7 +26,7 @@ test.describe('smoke @smoke', () => {
 			});
 			page.on('pageerror', (err) => pageErrors.push(err.message));
 
-			const response = await page.goto(route.path, { waitUntil: 'networkidle' });
+			const response = await page.goto(route.path, { waitUntil: 'domcontentloaded' });
 			expect(response, `no response for ${route.path}`).not.toBeNull();
 			expect(response!.status(), `bad status on ${route.path}`).toBeLessThan(400);
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+const routes: { path: string; heading: RegExp }[] = [
+	{ path: '/', heading: /Dashboard/i },
+	{ path: '/metryki', heading: /Metryki/i },
+	{ path: '/simulations', heading: /Symulacje/i },
+	{ path: '/accounts', heading: /Konta/i },
+	{ path: '/transactions', heading: /Wszystkie transakcje/i },
+	{ path: '/assets', heading: /Majątek/i },
+	{ path: '/debts', heading: /Zobowiązania/i },
+	{ path: '/goals', heading: /Cele finansowe/i },
+	{ path: '/snapshots', heading: /Snapshots/i },
+	{ path: '/salaries', heading: /Historia wynagrodzeń/i },
+	{ path: '/config', heading: /Konfiguracja/i },
+	{ path: '/settings', heading: /Ustawienia/i }
+];
+
+test.describe('smoke @smoke', () => {
+	for (const route of routes) {
+		test(`loads ${route.path} without console/page errors`, async ({ page }) => {
+			const consoleErrors: string[] = [];
+			const pageErrors: string[] = [];
+
+			page.on('console', (msg) => {
+				if (msg.type() === 'error') consoleErrors.push(msg.text());
+			});
+			page.on('pageerror', (err) => pageErrors.push(err.message));
+
+			const response = await page.goto(route.path, { waitUntil: 'networkidle' });
+			expect(response, `no response for ${route.path}`).not.toBeNull();
+			expect(response!.status(), `bad status on ${route.path}`).toBeLessThan(400);
+
+			await expect(page.locator('h1, h2').filter({ hasText: route.heading }).first()).toBeVisible();
+
+			expect(pageErrors, `page errors on ${route.path}: ${pageErrors.join(' | ')}`).toEqual([]);
+			const fatalConsole = consoleErrors.filter(
+				(line) => !/favicon|404 .*\.(?:ico|png|jpg|svg|webp)/i.test(line)
+			);
+			expect(fatalConsole, `console errors on ${route.path}: ${fatalConsole.join(' | ')}`).toEqual(
+				[]
+			);
+		});
+	}
+
+	test('legacy /kalkulator redirects to /simulations/kalkulator', async ({ page }) => {
+		const response = await page.goto('/kalkulator');
+		expect(response!.status()).toBeLessThan(400);
+		await expect(page).toHaveURL(/\/simulations\/kalkulator$/);
+	});
+});

--- a/e2e/snapshots.spec.ts
+++ b/e2e/snapshots.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+const apiUrl = process.env.E2E_API_URL ?? 'http://127.0.0.1:8000';
+
+test.describe('snapshots', () => {
+	test('list page shows headers and create button', async ({ page }) => {
+		await page.goto('/snapshots');
+		await expect(page.getByRole('heading', { name: 'Snapshots', exact: true })).toBeVisible();
+		await expect(page.getByRole('button', { name: /Nowy Snapshot/ })).toBeVisible();
+	});
+
+	test('new snapshot form renders with prefilled date and submit button', async ({ page }) => {
+		await page.goto('/snapshots/new');
+		await expect(page.getByRole('heading', { name: 'Nowy Snapshot' })).toBeVisible();
+
+		const dateInput = page.locator('input#date');
+		await expect(dateInput).toBeVisible();
+		const value = await dateInput.inputValue();
+		expect(value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+		await expect(page.getByRole('button', { name: /Zapisz Snapshot/ })).toBeVisible();
+	});
+
+	test('GET /api/snapshots returns list', async ({ request }) => {
+		const res = await request.get(`${apiUrl}/api/snapshots`);
+		expect(res.status()).toBe(200);
+		const list = await res.json();
+		expect(Array.isArray(list)).toBe(true);
+		if (list.length > 0) {
+			expect(list[0]).toHaveProperty('date');
+			expect(list[0]).toHaveProperty('total_net_worth');
+		}
+	});
+});

--- a/e2e/transactions.spec.ts
+++ b/e2e/transactions.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { INVESTMENT_CATEGORIES } from '../src/lib/constants';
+
+const apiUrl = process.env.E2E_API_URL ?? 'http://127.0.0.1:8000';
+
+interface ApiAccount {
+	id: number;
+	name: string;
+	category: string;
+	owner: string;
+	account_wrapper: string | null;
+}
+
+async function pickInvestmentAccount(
+	request: import('@playwright/test').APIRequestContext
+): Promise<ApiAccount> {
+	const res = await request.get(`${apiUrl}/api/accounts`);
+	expect(res.status()).toBe(200);
+	const { assets } = (await res.json()) as { assets: ApiAccount[] };
+	const candidate = assets.find(
+		(a) => INVESTMENT_CATEGORIES.has(a.category) || a.account_wrapper !== null
+	);
+	if (!candidate) throw new Error('no investment-eligible account seeded');
+	return candidate;
+}
+
+test.describe('transactions', () => {
+	test('list page renders header and create button', async ({ page }) => {
+		await page.goto('/transactions');
+		await expect(page.getByRole('heading', { name: 'Wszystkie transakcje' })).toBeVisible();
+		await expect(page.getByRole('button', { name: /Nowa Transakcja/ })).toBeVisible();
+	});
+
+	test('create transaction via UI then delete via API', async ({ page, request }) => {
+		const account = await pickInvestmentAccount(request);
+
+		await page.goto('/transactions');
+		await page.getByRole('button', { name: /Nowa Transakcja/ }).click();
+
+		const dialog = page.getByRole('dialog').filter({ hasText: 'Nowa Transakcja' });
+		await expect(dialog).toBeVisible();
+
+		await dialog.locator('label:has-text("Konto") select').selectOption(String(account.id));
+		await dialog.locator('label:has-text("Kwota") input').fill('1234.56');
+
+		const today = new Date().toISOString().slice(0, 10);
+		await dialog.locator('label:has-text("Data zakupu") input').fill(today);
+
+		await dialog.locator('label:has-text("Właściciel") select').selectOption(account.owner);
+
+		await dialog.getByRole('button', { name: /Dodaj transakcję/ }).click();
+		await expect(dialog).toBeHidden();
+
+		const listRes = await request.get(`${apiUrl}/api/accounts/${account.id}/transactions`);
+		expect(listRes.status()).toBe(200);
+		const { transactions } = await listRes.json();
+		const created = transactions.find(
+			(t: { amount: number; date: string }) => t.amount === 1234.56 && t.date === today
+		);
+		expect(created, 'created transaction should be present').toBeDefined();
+
+		const del = await request.delete(
+			`${apiUrl}/api/accounts/${account.id}/transactions/${created.id}`
+		);
+		expect(del.status()).toBe(204);
+	});
+
+	test('GET /api/transactions returns shape', async ({ request }) => {
+		const res = await request.get(`${apiUrl}/api/transactions`);
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(body).toHaveProperty('transactions');
+		expect(Array.isArray(body.transactions)).toBe(true);
+	});
+});

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,0 +1,4 @@
+export function uniqueName(prefix: string): string {
+	const stamp = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+	return `${prefix}-${stamp}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 				"zod": "^4.3.5"
 			},
 			"devDependencies": {
+				"@playwright/test": "^1.60.0",
 				"@sveltejs/adapter-node": "5.5.4",
 				"@sveltejs/kit": "2.60.1",
 				"@sveltejs/vite-plugin-svelte": "7.1.2",
@@ -836,6 +837,22 @@
 			],
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.60.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -3991,6 +4008,53 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.60.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,14 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test": "vitest",
 		"test:coverage": "vitest run --coverage",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui",
+		"test:e2e:report": "playwright show-report",
 		"lint": "oxlint && prettier --check .",
 		"format": "prettier --write ."
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.60.0",
 		"@sveltejs/adapter-node": "5.5.4",
 		"@sveltejs/kit": "2.60.1",
 		"@sveltejs/vite-plugin-svelte": "7.1.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,69 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = Number(process.env.E2E_FRONTEND_PORT ?? 4173);
+const BASE_URL = process.env.E2E_BASE_URL ?? `http://127.0.0.1:${PORT}`;
+const API_URL = process.env.E2E_API_URL ?? 'http://127.0.0.1:8000';
+const DATABASE_URL =
+	process.env.DATABASE_URL ?? 'postgresql://finance:password@localhost:5432/finance';
+
+const skipWebServer = process.env.E2E_SKIP_WEBSERVER === '1';
+
+export default defineConfig({
+	testDir: './e2e',
+	fullyParallel: false,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: 1,
+	reporter: process.env.CI
+		? [['github'], ['html', { open: 'never' }], ['list']]
+		: [['html', { open: 'never' }], ['list']],
+	timeout: 60_000,
+	expect: { timeout: 10_000 },
+	use: {
+		baseURL: BASE_URL,
+		trace: 'retain-on-failure',
+		screenshot: 'only-on-failure',
+		video: 'retain-on-failure',
+		actionTimeout: 15_000,
+		navigationTimeout: 30_000
+	},
+	projects: [
+		{ name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+		{ name: 'mobile-chrome', use: { ...devices['Pixel 7'] } }
+	],
+	webServer: skipWebServer
+		? undefined
+		: [
+				{
+					command: 'uv run uvicorn app.main:app --host 127.0.0.1 --port 8000 --log-level warning',
+					cwd: 'backend',
+					url: 'http://127.0.0.1:8000/health',
+					reuseExistingServer: !process.env.CI,
+					timeout: 120_000,
+					stdout: 'pipe',
+					stderr: 'pipe',
+					env: {
+						DATABASE_URL,
+						APP_PASSWORD: process.env.APP_PASSWORD ?? 'test',
+						CORS_ORIGINS: `${BASE_URL},http://localhost:${PORT},http://127.0.0.1:${PORT}`,
+						SEED_DEV_DATA: process.env.SEED_DEV_DATA ?? 'true'
+					}
+				},
+				{
+					command: 'npm run build && node build',
+					url: BASE_URL,
+					reuseExistingServer: !process.env.CI,
+					timeout: 180_000,
+					stdout: 'pipe',
+					stderr: 'pipe',
+					env: {
+						NODE_ENV: 'production',
+						PORT: String(PORT),
+						HOST: '127.0.0.1',
+						ORIGIN: BASE_URL,
+						PUBLIC_API_URL: API_URL,
+						PUBLIC_API_URL_BROWSER: API_URL
+					}
+				}
+			]
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,9 @@ const PORT = Number(process.env.E2E_FRONTEND_PORT ?? 4173);
 const BASE_URL = process.env.E2E_BASE_URL ?? `http://127.0.0.1:${PORT}`;
 const API_URL = process.env.E2E_API_URL ?? 'http://127.0.0.1:8000';
 const DATABASE_URL =
-	process.env.DATABASE_URL ?? 'postgresql://finance:password@localhost:5432/finance';
+	process.env.E2E_DATABASE_URL ??
+	process.env.DATABASE_URL ??
+	'postgresql://finance:password@localhost:5433/finance';
 
 const skipWebServer = process.env.E2E_SKIP_WEBSERVER === '1';
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,10 +10,10 @@ const skipWebServer = process.env.E2E_SKIP_WEBSERVER === '1';
 
 export default defineConfig({
 	testDir: './e2e',
-	fullyParallel: false,
+	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 0,
-	workers: 1,
+	retries: process.env.CI ? 1 : 0,
+	workers: process.env.CI ? 4 : undefined,
 	reporter: process.env.CI
 		? [['github'], ['html', { open: 'never' }], ['list']]
 		: [['html', { open: 'never' }], ['list']],
@@ -29,7 +29,11 @@ export default defineConfig({
 	},
 	projects: [
 		{ name: 'chromium', use: { ...devices['Desktop Chrome'] } },
-		{ name: 'mobile-chrome', use: { ...devices['Pixel 7'] } }
+		{
+			name: 'mobile-chrome',
+			use: { ...devices['Pixel 7'] },
+			testMatch: /navigation\.spec\.ts$/
+		}
 	],
 	webServer: skipWebServer
 		? undefined


### PR DESCRIPTION
## Motivation

No end-to-end coverage existed for the full stack (frontend ↔ backend ↔ Postgres). Only ad-hoc `e2e-mobile/verify-mobile.mjs` scripts ran Playwright for mobile screenshots. Regressions across navigation, CRUD flows, or backend contract changes can ship undetected.

## Implementation information

- `playwright.config.ts` — chromium + mobile-chrome projects. `webServer` boots uvicorn + `node build` for local runs; CI orchestrates services directly (`E2E_SKIP_WEBSERVER=1`). Builds with `NODE_ENV=production` so the client env-script prefix matches SSR (mise's `NODE_ENV=development` otherwise causes hydration crash).
- Specs in `e2e/`:
  - `smoke.spec.ts` — loads all 12 sidebar routes + `/kalkulator` legacy redirect, asserts heading + no console/page errors.
  - `navigation.spec.ts` — desktop sidebar walk + mobile bottom nav.
  - `dashboard.spec.ts` — net-worth heading, ECharts canvas, retirement limits modal.
  - `goals.spec.ts` — create + delete goal via UI.
  - `accounts.spec.ts` — create + soft-delete account via UI.
  - `api.spec.ts` — direct backend contract checks (`/health`, dashboard, personas, accounts).
- `.github/workflows/e2e.yml` — separate `E2E` job: Postgres service, builds + boots backend/frontend, runs `npx playwright test`, uploads `playwright-report` always, `test-results` and server logs on failure.
- `package.json` — `@playwright/test` dep + `test:e2e`, `test:e2e:ui`, `test:e2e:report` scripts.
- `.gitignore` / `.prettierignore` — exclude Playwright artifacts.

Alternatives considered: a single `webServer` block in playwright config for CI too — rejected because GH Actions `services:` block needs Postgres ready before backend, easier to orchestrate explicitly in workflow steps with proper health waits.

## Supporting documentation

Local run: `npm run test:e2e` (auto-boots BE+FE; requires Postgres reachable via `DATABASE_URL`, default `localhost:5432`). 44/46 tests pass locally (2 skipped are deliberate viewport gating).