### PR TITLE
perf(db): add indices on hot query paths

### DIFF
--- a/backend/alembic/versions/0004_add_perf_indices.py
+++ b/backend/alembic/versions/0004_add_perf_indices.py
@@ -1,0 +1,49 @@
+"""Add performance indices on hot query paths.
+
+Indices target full-table scans confirmed via EXPLAIN ANALYZE:
+- transactions(account_id, date) — date-range filters in /api/transactions
+- accounts(owner) — owner groupby in dashboard aggregates
+- snapshot_values(asset_id) — asset lookups when computing allocation
+
+Snapshot(date) is already covered by the existing UNIQUE index, which
+PostgreSQL uses bidirectionally (backward index scan for ``ORDER BY date DESC``).
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-05-20
+
+"""
+
+from collections.abc import Sequence
+
+from sqlalchemy import inspect
+
+from alembic import op
+
+revision: str = "0004"
+down_revision: str | None = "0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_INDICES: tuple[tuple[str, str, list[str]], ...] = (
+    ("ix_transactions_account_id_date", "transactions", ["account_id", "date"]),
+    ("ix_accounts_owner", "accounts", ["owner"]),
+    ("ix_snapshot_values_asset_id", "snapshot_values", ["asset_id"]),
+)
+
+
+def upgrade() -> None:
+    inspector = inspect(op.get_bind())
+    for name, table, cols in _INDICES:
+        existing = {idx["name"] for idx in inspector.get_indexes(table)}
+        if name not in existing:
+            op.create_index(name, table, cols)
+
+
+def downgrade() -> None:
+    inspector = inspect(op.get_bind())
+    for name, table, _ in _INDICES:
+        existing = {idx["name"] for idx in inspector.get_indexes(table)}
+        if name in existing:
+            op.drop_index(name, table_name=table)

--- a/backend/app/models/account.py
+++ b/backend/app/models/account.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 from decimal import Decimal
 
-from sqlalchemy import Boolean, Numeric, String
+from sqlalchemy import Boolean, Index, Numeric, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -9,6 +9,7 @@ from app.core.database import Base
 
 class Account(Base):
     __tablename__ = "accounts"
+    __table_args__ = (Index("ix_accounts_owner", "owner"),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(255))

--- a/backend/app/models/snapshot.py
+++ b/backend/app/models/snapshot.py
@@ -1,7 +1,15 @@
 from datetime import UTC, date, datetime
 from decimal import Decimal
 
-from sqlalchemy import CheckConstraint, Date, ForeignKey, Numeric, Text, UniqueConstraint
+from sqlalchemy import (
+    CheckConstraint,
+    Date,
+    ForeignKey,
+    Index,
+    Numeric,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -26,6 +34,7 @@ class SnapshotValue(Base):
         ),
         UniqueConstraint("snapshot_id", "asset_id", name="uix_snapshot_asset"),
         UniqueConstraint("snapshot_id", "account_id", name="uix_snapshot_account"),
+        Index("ix_snapshot_values_asset_id", "asset_id"),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -1,7 +1,7 @@
 from datetime import UTC, date, datetime
 from decimal import Decimal
 
-from sqlalchemy import Boolean, ForeignKey, Numeric, String
+from sqlalchemy import Boolean, ForeignKey, Index, Numeric, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -9,6 +9,7 @@ from app.core.database import Base
 
 class Transaction(Base):
     __tablename__ = "transactions"
+    __table_args__ = (Index("ix_transactions_account_id_date", "account_id", "date"),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
     account_id: Mapped[int] = mapped_column(ForeignKey("accounts.id", ondelete="CASCADE"))


### PR DESCRIPTION
## Motivation

Hot query paths run unindexed. EXPLAIN ANALYZE confirms full table scans on date-filtered transaction queries, owner-grouped dashboard aggregates, and asset-id lookups when computing allocation.

Closes #359

## Implementation information

Adds Alembic revision `0004_add_perf_indices` with three indices, and mirrors them in the SQLAlchemy model `__table_args__` so `Base.metadata.create_all` (used by the 0001 baseline) keeps fresh DBs consistent:

- `transactions(account_id, date)` — composite, covers date-range filters scoped by account in `/api/transactions`
- `accounts(owner)` — groupby in dashboard aggregates and personas filters
- `snapshot_values(asset_id)` — non-leading lookups (existing unique index leads with `snapshot_id`)

The migration uses `inspector.get_indexes()` existence checks for idempotency (matches the pattern in 0002 / 0003) — fresh DBs created via 0001 already have the indices through model metadata, so the upgrade skips them; pre-existing DBs at 0003 get them created.

`Snapshot(date)` is already covered by the existing UNIQUE index; PostgreSQL uses it bidirectionally via backward index scan for `ORDER BY date DESC`, so no additional index is needed.

Verified locally:
- `uv run alembic upgrade head` creates indices, `downgrade 0003` drops them
- All 553 backend tests pass; ruff + pyrefly clean

> Changelog: perf(db): add indices on hot query paths