### PR TITLE
fix(aggregates): filter is_active soft-deletes

### DIFF
--- a/backend/app/services/retirement.py
+++ b/backend/app/services/retirement.py
@@ -34,7 +34,9 @@ def get_yearly_stats(db: Session, year: int, owner: str | None = None) -> list[Y
             accounts = (
                 db.execute(
                     select(Account).where(
-                        Account.account_wrapper == wrapper, Account.owner == owner_name
+                        Account.account_wrapper == wrapper,
+                        Account.owner == owner_name,
+                        Account.is_active.is_(True),
                     )
                 )
                 .scalars()
@@ -193,7 +195,11 @@ def get_ppk_stats(db: Session, owner: str | None = None) -> list[PPKStatsRespons
         # Get all PPK accounts for this owner
         accounts = (
             db.execute(
-                select(Account).where(Account.account_wrapper == "PPK", Account.owner == owner_name)
+                select(Account).where(
+                    Account.account_wrapper == "PPK",
+                    Account.owner == owner_name,
+                    Account.is_active.is_(True),
+                )
             )
             .scalars()
             .all()

--- a/backend/app/services/snapshots.py
+++ b/backend/app/services/snapshots.py
@@ -110,11 +110,15 @@ def get_all_snapshots(db: Session) -> list[SnapshotListItem]:
     result = []
     for snapshot in snapshots:
         # Calculate net worth for this snapshot
-        # LEFT JOIN both Asset and Account tables
+        # LEFT JOIN both Asset and Account tables, only matching active rows so
+        # inactive (soft-deleted) Assets/Accounts contribute 0 — keeps the list
+        # totals consistent with the dashboard aggregate.
         values = db.execute(
             select(SnapshotValue, Asset, Account)
-            .outerjoin(Asset, SnapshotValue.asset_id == Asset.id)
-            .outerjoin(Account, SnapshotValue.account_id == Account.id)
+            .outerjoin(Asset, (SnapshotValue.asset_id == Asset.id) & Asset.is_active.is_(True))
+            .outerjoin(
+                Account, (SnapshotValue.account_id == Account.id) & Account.is_active.is_(True)
+            )
             .where(SnapshotValue.snapshot_id == snapshot.id)
         ).all()
 

--- a/backend/app/services/zus_calculator.py
+++ b/backend/app/services/zus_calculator.py
@@ -336,7 +336,9 @@ def get_zus_prefill(db: Session, owner: str | None = None) -> ZusPrefillResponse
     # Get salary history — all records for the owner grouped by year
     all_salaries = (
         db.execute(
-            select(SalaryRecord).where(SalaryRecord.owner == owner).order_by(SalaryRecord.date)
+            select(SalaryRecord)
+            .where(SalaryRecord.owner == owner, SalaryRecord.is_active.is_(True))
+            .order_by(SalaryRecord.date)
         )
         .scalars()
         .all()

--- a/backend/tests/test_services_retirement.py
+++ b/backend/tests/test_services_retirement.py
@@ -264,6 +264,53 @@ class TestGetYearlyStats:
         assert len(result) == 1
         assert result[0].owner == "Marcin"
 
+    def test_get_yearly_stats_inactive_accounts_excluded(self, test_db_session):
+        """Inactive IKE/IKZE accounts must not contribute to yearly totals"""
+        test_db_session.add(Persona(name="Marcin"))
+        test_db_session.commit()
+
+        active_account = create_test_account(
+            test_db_session,
+            name="IKE Active",
+            category="stock",
+            account_wrapper="IKE",
+        )
+        inactive_account = create_test_account(
+            test_db_session,
+            name="IKE Closed",
+            category="stock",
+            account_wrapper="IKE",
+            is_active=False,
+        )
+
+        limit = RetirementLimit(
+            year=2024,
+            account_wrapper="IKE",
+            owner="Marcin",
+            limit_amount=Decimal("10000.0"),
+        )
+        test_db_session.add(limit)
+        test_db_session.commit()
+
+        create_test_transaction(
+            test_db_session,
+            account_id=active_account.id,
+            amount=2000.0,
+            transaction_type="employee",
+        )
+        create_test_transaction(
+            test_db_session,
+            account_id=inactive_account.id,
+            amount=8000.0,
+            transaction_date=date(2024, 2, 10),
+            transaction_type="employee",
+        )
+
+        result = get_yearly_stats(test_db_session, 2024)
+
+        assert len(result) == 1
+        assert result[0].total_contributed == 2000.0  # inactive account excluded
+
     def test_get_yearly_stats_inactive_transactions_excluded(self, test_db_session):
         """Test that inactive transactions are excluded from calculations"""
         test_db_session.add(Persona(name="Marcin"))
@@ -580,6 +627,54 @@ class TestGetPPKStats:
         assert result[0].employer_contributed == 1500.0
         assert result[0].total_value == 2200.0
         assert result[0].returns == -300.0  # 2200 - 2500
+
+    def test_get_ppk_stats_inactive_accounts_excluded(self, test_db_session):
+        """Inactive PPK accounts must not contribute to stats totals"""
+        test_db_session.add(Persona(name="Marcin"))
+        test_db_session.commit()
+
+        active_account = create_test_account(
+            test_db_session,
+            name="PPK Active",
+            category="stock",
+            account_wrapper="PPK",
+        )
+        inactive_account = create_test_account(
+            test_db_session,
+            name="PPK Closed",
+            category="stock",
+            account_wrapper="PPK",
+            is_active=False,
+        )
+
+        create_test_transaction(
+            test_db_session,
+            account_id=active_account.id,
+            amount=1000.0,
+            transaction_date=date(2024, 1, 31),
+            transaction_type="employee",
+        )
+        create_test_transaction(
+            test_db_session,
+            account_id=inactive_account.id,
+            amount=9999.0,
+            transaction_date=date(2024, 1, 31),
+            transaction_type="employee",
+        )
+
+        snapshot = create_test_snapshot(test_db_session, snapshot_date=date(2024, 12, 31))
+        create_test_snapshot_value(
+            test_db_session, snapshot_id=snapshot.id, account_id=active_account.id, value=1200.0
+        )
+        create_test_snapshot_value(
+            test_db_session, snapshot_id=snapshot.id, account_id=inactive_account.id, value=9000.0
+        )
+
+        result = get_ppk_stats(test_db_session, owner="Marcin")
+
+        assert len(result) == 1
+        assert result[0].total_contributed == 1000.0  # inactive account excluded
+        assert result[0].total_value == 1200.0
 
     def test_get_ppk_stats_filters_by_owner(self, test_db_session):
         """Test filtering PPK stats by owner"""

--- a/backend/tests/test_services_snapshots.py
+++ b/backend/tests/test_services_snapshots.py
@@ -116,6 +116,31 @@ def test_get_all_snapshots(test_db_session):
     assert result[1].total_net_worth == 8000.0  # 10000 - 2000
 
 
+def test_get_all_snapshots_excludes_inactive_assets_and_accounts(test_db_session):
+    """get_all_snapshots must skip inactive Asset/Account values in net-worth aggregate"""
+    active_asset = create_test_account(test_db_session, name="Bank", category="bank")
+    inactive_asset = create_test_account(
+        test_db_session, name="Closed Bank", category="bank", is_active=False
+    )
+    inactive_liability = create_test_account(
+        test_db_session,
+        name="Closed Mortgage",
+        account_type="liability",
+        category="mortgage",
+        is_active=False,
+    )
+
+    snapshot = create_test_snapshot(test_db_session, snapshot_date=date(2024, 1, 31))
+    create_test_snapshot_value(test_db_session, snapshot.id, active_asset.id, Decimal("10000"))
+    create_test_snapshot_value(test_db_session, snapshot.id, inactive_asset.id, Decimal("500"))
+    create_test_snapshot_value(test_db_session, snapshot.id, inactive_liability.id, Decimal("9999"))
+
+    result = get_all_snapshots(test_db_session)
+
+    assert len(result) == 1
+    assert result[0].total_net_worth == 10000.0  # inactive rows ignored
+
+
 def test_get_snapshot_by_id(test_db_session):
     """Test getting single snapshot by ID"""
     account = create_test_account(test_db_session, name="Test Bank", category="bank")

--- a/backend/tests/test_services_zus_calculator.py
+++ b/backend/tests/test_services_zus_calculator.py
@@ -1,11 +1,14 @@
 from datetime import date
 
+from app.models.persona import Persona
 from app.schemas.zus import SalaryHistoryEntry, ZusCalculatorInputs
 from app.services.zus_calculator import (
     apply_pension_tax,
     calculate_zus_pension,
     get_life_expectancy,
+    get_zus_prefill,
 )
+from tests.factories import create_test_salary_record
 
 
 def _make_inputs(**overrides) -> ZusCalculatorInputs:
@@ -231,3 +234,32 @@ class TestKapitalPoczatkowy:
 
         assert result_with.total_capital > result_no.total_capital
         assert result_with.kapital_poczatkowy_valorized > 100000.0  # Should grow with valorization
+
+
+class TestGetZusPrefillInactiveFiltering:
+    """Regression: prefill must ignore soft-deleted salary records."""
+
+    def test_prefill_excludes_inactive_salary_history(self, test_db_session):
+        test_db_session.add(Persona(name="Marcin"))
+        test_db_session.commit()
+
+        create_test_salary_record(
+            test_db_session,
+            salary_date=date(2022, 6, 1),
+            gross_amount=8000.0,
+            owner="Marcin",
+        )
+        create_test_salary_record(
+            test_db_session,
+            salary_date=date(2023, 6, 1),
+            gross_amount=99999.0,
+            owner="Marcin",
+            is_active=False,
+        )
+
+        result = get_zus_prefill(test_db_session, owner="Marcin")
+
+        years = {entry.year for entry in result.salary_history}
+        assert years == {2022}
+        assert all(entry.annual_gross != 99999.0 * 12 for entry in result.salary_history)
+        assert result.work_start_year == 2022


### PR DESCRIPTION
## Motivation

Closes #357.

Soft-deleted (`is_active=False`) Account/SalaryRecord rows could leak into
aggregate queries that joined them by ID without an explicit filter,
risking double-counting against the dashboard totals that already filter
properly.

## Implementation information

Added `is_active=True` filters at the four miss sites flagged in the audit:

- `services/retirement.py` `get_yearly_stats` — IKE/IKZE account lookup
- `services/retirement.py` `get_ppk_stats` — PPK account lookup
- `services/zus_calculator.py` `get_zus_prefill` — salary history query
  (the "latest salary" query above it already filtered)
- `services/snapshots.py` `get_all_snapshots` — net-worth aggregate now
  joins Asset/Account only when active, so SnapshotValues pointing to a
  soft-deleted row contribute 0 (consistent with the dashboard)

Audited the rest of the surface listed in the issue (`dashboard/*`,
`investment.py`, plus the related `debts/debt_payments/transactions/
salary_records` services) — they were already filtering correctly.

Skipped the optional SQLAlchemy event/query-mixin idea: it would be a
much broader refactor for a non-issue right now, and the explicit
filters at boundaries are easier to reason about per-call.

## Supporting documentation

Regression tests added for each fix (would fail without the filter):

- `test_get_yearly_stats_inactive_accounts_excluded`
- `test_get_ppk_stats_inactive_accounts_excluded`
- `test_prefill_excludes_inactive_salary_history`
- `test_get_all_snapshots_excludes_inactive_assets_and_accounts`

Full suite: 557 passed.

> Changelog: fix(aggregates): filter is_active soft-deletes