### PR TITLE
feat(salaries): inflation line, toggles, filter

### DIFF
--- a/backend/app/api/salary_records.py
+++ b/backend/app/api/salary_records.py
@@ -22,9 +22,10 @@ def get_all_salary_records(
     owner: str | None = Query(None),
     date_from: date | None = Query(None),
     date_to: date | None = Query(None),
+    company: str | None = Query(None),
 ) -> SalaryRecordsListResponse:
     """Get all active salary records with optional filters"""
-    return salary_records.get_all_salary_records(db, owner, date_from, date_to)
+    return salary_records.get_all_salary_records(db, owner, date_from, date_to, company)
 
 
 @router.get("/salaries/{salary_id}", response_model=SalaryRecordResponse)

--- a/backend/app/schemas/salary_records.py
+++ b/backend/app/schemas/salary_records.py
@@ -89,3 +89,4 @@ class SalaryRecordsListResponse(BaseModel):
     total_count: int
     current_salaries: dict[str, float | None] = {}
     inflation_context: dict[str, InflationContext] = {}
+    available_companies: list[str] = []

--- a/backend/app/services/salary_records.py
+++ b/backend/app/services/salary_records.py
@@ -23,6 +23,7 @@ def get_all_salary_records(
     owner: str | None = None,
     date_from: date | None = None,
     date_to: date | None = None,
+    company: str | None = None,
 ) -> SalaryRecordsListResponse:
     """Get all active salary records with optional filters"""
     query = select(SalaryRecord).where(SalaryRecord.is_active.is_(True))
@@ -33,6 +34,8 @@ def get_all_salary_records(
         query = query.where(SalaryRecord.date >= date_from)
     if date_to is not None:
         query = query.where(SalaryRecord.date <= date_to)
+    if company is not None:
+        query = query.where(SalaryRecord.company == company)
 
     results = db.execute(query.order_by(desc(SalaryRecord.date))).scalars().all()
 
@@ -50,6 +53,19 @@ def get_all_salary_records(
         for record in results
     ]
 
+    # Distinct companies across all active records (unfiltered) so the filter
+    # dropdown stays usable even when the current filter narrows results.
+    available_companies = list(
+        db.execute(
+            select(SalaryRecord.company)
+            .where(SalaryRecord.is_active.is_(True))
+            .distinct()
+            .order_by(SalaryRecord.company)
+        )
+        .scalars()
+        .all()
+    )
+
     # Get current salaries for all personas
     today = datetime.now(UTC).date()
     personas = db.execute(select(Persona).order_by(Persona.name)).scalars().all()
@@ -61,6 +77,7 @@ def get_all_salary_records(
         total_count=len(salary_list),
         current_salaries=current_salaries,
         inflation_context=inflation_context,
+        available_companies=available_companies,
     )
 
 

--- a/backend/tests/test_services_salary_records.py
+++ b/backend/tests/test_services_salary_records.py
@@ -96,6 +96,48 @@ def test_get_all_salary_records_with_filters(test_db_session):
     assert result.salary_records[0].owner == "Marcin"
 
 
+def test_get_all_salary_records_company_filter(test_db_session):
+    """Filtering by company returns only matching records"""
+    test_db_session.add(Persona(name="Marcin"))
+    test_db_session.commit()
+
+    create_test_salary_record(test_db_session, company="Kong")
+    create_test_salary_record(
+        test_db_session,
+        salary_date=date(2024, 6, 1),
+        gross_amount=8000.0,
+        company="Acme",
+    )
+
+    result = get_all_salary_records(test_db_session, company="Kong")
+
+    assert result.total_count == 1
+    assert result.salary_records[0].company == "Kong"
+
+
+def test_get_all_salary_records_available_companies(test_db_session):
+    """available_companies returns distinct sorted companies across all active records"""
+    test_db_session.add(Persona(name="Marcin"))
+    test_db_session.commit()
+
+    create_test_salary_record(test_db_session, company="Kong")
+    create_test_salary_record(
+        test_db_session,
+        salary_date=date(2024, 3, 1),
+        company="Acme",
+    )
+    create_test_salary_record(
+        test_db_session,
+        salary_date=date(2024, 6, 1),
+        company="Kong",
+    )
+
+    # Filtering by one company must not shrink available_companies.
+    result = get_all_salary_records(test_db_session, company="Kong")
+
+    assert result.available_companies == ["Acme", "Kong"]
+
+
 def test_get_salary_record(test_db_session):
     """Test getting a single salary record"""
     record = create_test_salary_record(test_db_session, company="Test Company")

--- a/src/lib/types/salaries.ts
+++ b/src/lib/types/salaries.ts
@@ -26,4 +26,5 @@ export interface SalariesData {
 	total_count: number;
 	current_salaries: Record<string, number | null>;
 	inflation_context: Record<string, InflationContext>;
+	available_companies: string[];
 }

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -35,6 +35,10 @@
 	const inflationContext = $derived(data.salaries.inflation_context ?? {});
 	const inflationEntries = $derived(Object.values(inflationContext));
 
+	let showNominal = $state(true);
+	let showReal = $state(false);
+	let showInflationTracked = $state(false);
+
 	const monthNamesPL = [
 		'styczeń',
 		'luty',
@@ -63,10 +67,12 @@
 	}
 
 	let chartContainer: HTMLDivElement;
+	let chart: echarts.ECharts | undefined;
 
 	let filterOwner = $state(untrack(() => data.filters.owner || ''));
 	let filterDateFrom = $state(untrack(() => data.filters.date_from || ''));
 	let filterDateTo = $state(untrack(() => data.filters.date_to || ''));
+	let filterCompany = $state(untrack(() => data.filters.company || ''));
 
 	let showNewSalaryModal = $state(false);
 	let editingSalary: SalaryRecord | null = $state(null);
@@ -85,6 +91,7 @@
 		if (filterOwner) params.set('owner', filterOwner);
 		if (filterDateFrom) params.set('date_from', filterDateFrom);
 		if (filterDateTo) params.set('date_to', filterDateTo);
+		if (filterCompany) params.set('company', filterCompany);
 
 		goto(`/salaries?${params.toString()}`);
 	}
@@ -93,6 +100,7 @@
 		filterOwner = '';
 		filterDateFrom = '';
 		filterDateTo = '';
+		filterCompany = '';
 		goto('/salaries');
 	}
 
@@ -218,57 +226,62 @@
 		}
 	}
 
-	onMount(() => {
-		const chart = echarts.init(chartContainer);
+	type LineSeries = {
+		name: string;
+		data: Array<[string, number]>;
+		type: 'line';
+		smooth: boolean;
+		lineStyle: {
+			color: string;
+			width: number;
+			type?: 'dashed' | 'solid' | 'dotted';
+			opacity?: number;
+		};
+		itemStyle?: { color: string };
+	};
 
+	function buildSeries(): LineSeries[] {
 		const companyMap = new Map<string, Array<[string, number]>>();
 
 		data.salaries.salary_records.forEach((r) => {
 			const companyName = (r.company ?? '').trim() || 'Nieokreślona firma';
-			if (!companyMap.has(companyName)) {
-				companyMap.set(companyName, []);
-			}
+			if (!companyMap.has(companyName)) companyMap.set(companyName, []);
 			companyMap.get(companyName)!.push([r.date, r.gross_amount]);
 		});
 
-		companyMap.forEach((salaryData) => {
-			salaryData.sort((a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime());
-		});
+		companyMap.forEach((rows) =>
+			rows.sort((a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime())
+		);
 
 		const colors = ['#5E81AC', '#88C0D0', '#A3BE8C', '#EBCB8B', '#D08770', '#B48EAD', '#BF616A'];
-		// Use date-only `today` so adjustments are consistent across the
-		// browsing session and match the backend (which is date-only).
+		// Date-only `today` matches the backend (which is also date-only).
 		const now = new Date();
-		const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+		const todayDate = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 		const cpiLookup = buildCpiLookup(cpiSeries);
 		const hasCpi = cpiLookup !== null;
 
-		type LineSeries = {
-			name: string;
-			data: Array<[string, number]>;
-			type: 'line';
-			smooth: boolean;
-			lineStyle: { color: string; width: number; type?: 'dashed' | 'solid'; opacity?: number };
-			itemStyle?: { color: string };
-		};
 		const series: LineSeries[] = [];
 		let colorIndex = 0;
 
 		companyMap.forEach((salaryData, company) => {
 			const color = colors[colorIndex % colors.length];
-			series.push({
-				name: company,
-				data: salaryData,
-				type: 'line',
-				smooth: true,
-				lineStyle: { color, width: 2 },
-				itemStyle: { color }
-			});
+			colorIndex++;
 
-			if (hasCpi) {
+			if (showNominal) {
+				series.push({
+					name: company,
+					data: salaryData,
+					type: 'line',
+					smooth: true,
+					lineStyle: { color, width: 2 },
+					itemStyle: { color }
+				});
+			}
+
+			if (hasCpi && showReal) {
 				const realData: Array<[string, number]> = [];
 				for (const [dateStr, nominal] of salaryData) {
-					const adjusted = inflationAdjust(nominal, parseIsoDate(dateStr), today, cpiLookup);
+					const adjusted = inflationAdjust(nominal, parseIsoDate(dateStr), todayDate, cpiLookup);
 					if (adjusted != null) realData.push([dateStr, adjusted]);
 				}
 				if (realData.length > 0) {
@@ -282,9 +295,39 @@
 					});
 				}
 			}
-			colorIndex++;
+
+			if (hasCpi && showInflationTracked && salaryData.length > 0) {
+				const [firstDateStr, firstAmount] = salaryData[0];
+				const firstDate = parseIsoDate(firstDateStr);
+				const trackedData: Array<[string, number]> = [];
+				for (const [dateStr] of salaryData) {
+					const projected = inflationAdjust(
+						firstAmount,
+						firstDate,
+						parseIsoDate(dateStr),
+						cpiLookup
+					);
+					if (projected != null) trackedData.push([dateStr, projected]);
+				}
+				if (trackedData.length > 0) {
+					series.push({
+						name: `${company} (indeksowana inflacją)`,
+						data: trackedData,
+						type: 'line',
+						smooth: true,
+						lineStyle: { color, width: 2, type: 'dotted', opacity: 0.8 },
+						itemStyle: { color }
+					});
+				}
+			}
 		});
 
+		return series;
+	}
+
+	function applyChart() {
+		if (!chart) return;
+		const series = buildSeries();
 		const option: EChartsOption = {
 			title: { text: 'Progresja wynagrodzenia', left: 'center', top: 8 },
 			tooltip: {
@@ -303,6 +346,7 @@
 				top: 44,
 				left: 'center',
 				type: 'scroll',
+				selectedMode: false,
 				data: series.map((s) => s.name)
 			},
 			xAxis: { type: 'time' },
@@ -313,12 +357,21 @@
 			series,
 			grid: { left: '80px', right: '40px', top: 90, bottom: 40 }
 		};
+		chart.setOption(option, { notMerge: true });
+	}
 
-		chart.setOption(option);
+	$effect(() => {
+		// Touch reactive dependencies so chart redraws on data + toggle changes.
+		void [data.salaries.salary_records, cpiSeries, showNominal, showReal, showInflationTracked];
 
-		return () => {
-			chart.dispose();
-		};
+		if (!chartContainer) return;
+		if (!chart) chart = echarts.init(chartContainer);
+		applyChart();
+	});
+
+	onMount(() => () => {
+		chart?.dispose();
+		chart = undefined;
 	});
 </script>
 
@@ -426,9 +479,25 @@
 		<header>
 			<h3 class="h3 flex items-center gap-2"><TrendingUp size={20} /> Progresja wynagrodzenia</h3>
 			<p class="text-xs text-surface-700-300">
-				Linia przerywana: nominalna pensja przeliczona na dzisiejsze PLN wg CPI GUS.
+				Linia ciągła: pensja nominalna. Linia przerywana: nominalna przeliczona na dzisiejsze PLN wg
+				CPI GUS. Linia kropkowana: hipotetyczna pensja, gdyby od pierwszej zmiany rosła tylko o
+				inflację.
 			</p>
 		</header>
+		<div class="flex flex-wrap gap-4 text-sm">
+			<label class="flex items-center gap-2 cursor-pointer">
+				<input type="checkbox" class="checkbox" bind:checked={showNominal} />
+				<span>Pensja nominalna</span>
+			</label>
+			<label class="flex items-center gap-2 cursor-pointer">
+				<input type="checkbox" class="checkbox" bind:checked={showReal} />
+				<span>Realna wartość (dzisiejsze PLN)</span>
+			</label>
+			<label class="flex items-center gap-2 cursor-pointer">
+				<input type="checkbox" class="checkbox" bind:checked={showInflationTracked} />
+				<span>Indeksowana inflacją</span>
+			</label>
+		</div>
 		<div bind:this={chartContainer} style="width: 100%; height: 400px;"></div>
 	</div>
 
@@ -443,13 +512,23 @@
 				applyFilters();
 			}}
 		>
-			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
 				<label class="label">
 					<span class="font-semibold text-sm">Właściciel</span>
 					<select class="select" bind:value={filterOwner}>
 						<option value="">Wszystkie</option>
 						{#each personas as persona}
 							<option value={persona.name}>{persona.name}</option>
+						{/each}
+					</select>
+				</label>
+
+				<label class="label">
+					<span class="font-semibold text-sm">Firma</span>
+					<select class="select" bind:value={filterCompany}>
+						<option value="">Wszystkie</option>
+						{#each data.salaries.available_companies as company}
+							<option value={company}>{company}</option>
 						{/each}
 					</select>
 				</label>

--- a/src/routes/salaries/+page.ts
+++ b/src/routes/salaries/+page.ts
@@ -17,11 +17,13 @@ export const load: PageLoad = async ({ fetch, url }) => {
 		const owner = url.searchParams.get('owner');
 		const dateFrom = url.searchParams.get('date_from');
 		const dateTo = url.searchParams.get('date_to');
+		const company = url.searchParams.get('company');
 
 		const params = new URLSearchParams();
 		if (owner) params.set('owner', owner);
 		if (dateFrom) params.set('date_from', dateFrom);
 		if (dateTo) params.set('date_to', dateTo);
+		if (company) params.set('company', company);
 
 		const [salariesResponse, personasResponse, cpiResponse] = await Promise.all([
 			fetch(`${apiUrl}/api/salaries?${params.toString()}`),
@@ -42,7 +44,8 @@ export const load: PageLoad = async ({ fetch, url }) => {
 			filters: {
 				owner,
 				date_from: dateFrom,
-				date_to: dateTo
+				date_to: dateTo,
+				company
 			},
 			personas,
 			cpiSeries

--- a/src/routes/salaries/page.test.ts
+++ b/src/routes/salaries/page.test.ts
@@ -40,9 +40,10 @@ const baseData = {
 		salary_records: [],
 		total_count: 0,
 		current_salaries: { Marcin: null },
-		inflation_context: {}
+		inflation_context: {},
+		available_companies: []
 	},
-	filters: { owner: null, date_from: null, date_to: null },
+	filters: { owner: null, date_from: null, date_to: null, company: null },
 	personas: [{ id: 1, name: 'Marcin', ppk_employee_rate: 2, ppk_employer_rate: 1.5 }],
 	cpiSeries: { points: [], base_year: null, latest_year: null, source: '' }
 };
@@ -56,7 +57,7 @@ async function openNewSalaryModalAndFill(opts: {
 
 	const dateInput = screen.getByLabelText(/Data zmiany/) as HTMLInputElement;
 	const amountInput = screen.getByLabelText(/Pensja brutto/) as HTMLInputElement;
-	const companyInput = screen.getByLabelText(/^Firma/) as HTMLInputElement;
+	const companyInput = screen.getByLabelText(/Firma\*/) as HTMLInputElement;
 
 	if (opts.date !== undefined) await fireEvent.input(dateInput, { target: { value: opts.date } });
 	if (opts.gross_amount !== undefined)


### PR DESCRIPTION
## Motivation

The salary progression chart did not let you answer the core question "did my raises actually beat inflation, or just track it?" The dashed real-value line shows what *past* salaries are worth today, but there was no baseline showing what each company's *first* salary would be today if it had only grown by CPI. The per-series legend also became noisy with multiple companies, and there was no way to filter by company at all.

Closes #412

## Implementation information

- New dotted "indeksowana inflacją" line per company. Each company's first salary is projected forward by CPI to every subsequent record date — if actual raises beat CPI, the solid line lands above this baseline.
- Three global checkboxes (Pensja nominalna / Realna wartość / Indeksowana inflacją) replace per-series legend toggling. Default: only nominal visible. ECharts legend is now display-only (`selectedMode: false`).
- Chart is now reactive via `$effect` so filter changes redraw it; `onMount` returns cleanup that disposes the ECharts instance.
- Company filter end-to-end:
  - Backend: `company` query param on `GET /api/salaries`; new `available_companies` field on the response carrying a distinct list across *all* active records (unfiltered) so the dropdown does not shrink as the user narrows results.
  - Frontend: new `<select>` in the filter form, wired through `applyFilters` / `clearFilters`; load function passes the param through.
- Alternatives considered: a single inflation-tracked line per persona (across companies) was rejected because job changes typically include a step raise, making the per-company baseline the more useful comparison.

## Supporting documentation

- Issue #412.
- CPI helper: `src/lib/utils/inflation.ts` (`inflationAdjust(amount, fromDate, toDate, lookup)`).
- Tests: `backend/tests/test_services_salary_records.py` adds `test_get_all_salary_records_company_filter` and `test_get_all_salary_records_available_companies` (verifies dropdown list does not shrink under filter).

> Changelog: feat(salaries): inflation line, toggles, filter