### PR TITLE
feat(ui): replace alert() with toast notifications

### DIFF
--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { toast, type Toast } from '$lib/stores/toast.svelte';
+	import { CheckCircle2, AlertCircle, Info, X } from 'lucide-svelte';
+
+	const items = $derived(toast.items);
+
+	function iconFor(kind: Toast['kind']) {
+		if (kind === 'success') return CheckCircle2;
+		if (kind === 'error') return AlertCircle;
+		return Info;
+	}
+
+	function classFor(kind: Toast['kind']): string {
+		if (kind === 'success') return 'preset-filled-success-500';
+		if (kind === 'error') return 'preset-filled-error-500';
+		return 'preset-filled-primary-500';
+	}
+</script>
+
+<div
+	class="pointer-events-none fixed z-50 flex flex-col gap-2 p-4
+		top-0 right-0 left-0 items-center
+		md:top-auto md:left-auto md:bottom-0 md:right-0 md:items-end"
+	role="region"
+	aria-label="Powiadomienia"
+>
+	{#each items as item (item.id)}
+		{@const Icon = iconFor(item.kind)}
+		<div
+			class="pointer-events-auto flex items-start gap-3 rounded-container px-4 py-3 shadow-lg w-full max-w-sm {classFor(
+				item.kind
+			)}"
+			role={item.kind === 'error' ? 'alert' : 'status'}
+		>
+			<Icon size={18} class="mt-0.5 shrink-0" />
+			<span class="flex-1 text-sm">{item.message}</span>
+			<button
+				type="button"
+				class="btn-icon btn-icon-sm shrink-0"
+				aria-label="Zamknij powiadomienie"
+				onclick={() => toast.dismiss(item.id)}
+			>
+				<X size={16} />
+			</button>
+		</div>
+	{/each}
+</div>

--- a/src/lib/components/Toast.test.ts
+++ b/src/lib/components/Toast.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import Toast from './Toast.svelte';
+import { toast } from '$lib/stores/toast.svelte';
+import { flushSync, tick } from 'svelte';
+
+describe('Toast', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		for (const item of [...toast.items]) toast.dismiss(item.id);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('renders nothing when there are no toasts', () => {
+		render(Toast);
+		expect(screen.queryByRole('alert')).toBeNull();
+		expect(screen.queryByRole('status')).toBeNull();
+	});
+
+	it('renders an error toast with role="alert"', async () => {
+		render(Toast);
+		toast.error('Coś poszło nie tak');
+		flushSync();
+		await tick();
+		const alert = await screen.findByRole('alert');
+		expect(alert.textContent).toContain('Coś poszło nie tak');
+	});
+
+	it('renders a success toast with role="status"', async () => {
+		render(Toast);
+		toast.success('Zapisano');
+		flushSync();
+		await tick();
+		const status = await screen.findByRole('status');
+		expect(status.textContent).toContain('Zapisano');
+	});
+
+	it('renders an info toast with role="status"', async () => {
+		render(Toast);
+		toast.info('FYI');
+		flushSync();
+		await tick();
+		const status = await screen.findByRole('status');
+		expect(status.textContent).toContain('FYI');
+	});
+
+	it('auto-dismisses after 4 seconds', async () => {
+		render(Toast);
+		toast.error('Will fade');
+		flushSync();
+		await tick();
+		expect(screen.queryByRole('alert')).not.toBeNull();
+		vi.advanceTimersByTime(4000);
+		flushSync();
+		await tick();
+		expect(screen.queryByRole('alert')).toBeNull();
+	});
+
+	it('dismisses on close-button click', async () => {
+		render(Toast);
+		toast.error('Manual close');
+		flushSync();
+		await tick();
+		await fireEvent.click(screen.getByLabelText('Zamknij powiadomienie'));
+		flushSync();
+		await tick();
+		expect(screen.queryByRole('alert')).toBeNull();
+	});
+
+	it('stacks multiple toasts', async () => {
+		render(Toast);
+		toast.error('First');
+		toast.success('Second');
+		toast.info('Third');
+		flushSync();
+		await tick();
+		expect(screen.getAllByText(/First|Second|Third/).length).toBe(3);
+	});
+});

--- a/src/lib/stores/toast.svelte.ts
+++ b/src/lib/stores/toast.svelte.ts
@@ -1,0 +1,51 @@
+export type ToastKind = 'error' | 'success' | 'info';
+
+export interface Toast {
+	id: number;
+	kind: ToastKind;
+	message: string;
+}
+
+const DEFAULT_DURATION_MS = 4000;
+
+let nextId = 0;
+const items = $state<Toast[]>([]);
+const timers = new Map<number, ReturnType<typeof setTimeout>>();
+
+function dismiss(id: number): void {
+	const index = items.findIndex((t) => t.id === id);
+	if (index !== -1) items.splice(index, 1);
+	const timer = timers.get(id);
+	if (timer) {
+		clearTimeout(timer);
+		timers.delete(id);
+	}
+}
+
+function push(kind: ToastKind, message: string, durationMs = DEFAULT_DURATION_MS): number {
+	const id = ++nextId;
+	items.push({ id, kind, message });
+	if (durationMs > 0) {
+		timers.set(
+			id,
+			setTimeout(() => dismiss(id), durationMs)
+		);
+	}
+	return id;
+}
+
+export const toast = {
+	get items(): Toast[] {
+		return items;
+	},
+	error(message: string, durationMs?: number): number {
+		return push('error', message, durationMs);
+	},
+	success(message: string, durationMs?: number): number {
+		return push('success', message, durationMs);
+	},
+	info(message: string, durationMs?: number): number {
+		return push('info', message, durationMs);
+	},
+	dismiss
+};

--- a/src/lib/stores/toast.svelte.ts
+++ b/src/lib/stores/toast.svelte.ts
@@ -35,7 +35,7 @@ function push(kind: ToastKind, message: string, durationMs = DEFAULT_DURATION_MS
 }
 
 export const toast = {
-	get items(): Toast[] {
+	get items(): ReadonlyArray<Toast> {
 		return items;
 	},
 	error(message: string, durationMs?: number): number {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import '../app.css';
 	import { page } from '$app/stores';
+	import Toast from '$lib/components/Toast.svelte';
 	import {
 		LayoutDashboard,
 		TrendingUp,
@@ -34,6 +35,8 @@
 
 	let { children } = $props();
 </script>
+
+<Toast />
 
 <div class="flex min-h-screen bg-surface-50-950 text-surface-950-50">
 	<aside

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,6 +16,7 @@
 	} from 'lucide-svelte';
 	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
+	import { toast } from '$lib/stores/toast.svelte';
 	import type { Persona } from '$lib/types/personas';
 	import type { PageData } from './$types';
 
@@ -98,7 +99,7 @@
 			await invalidateAll();
 		} catch (err) {
 			console.error('Failed to save limits:', err);
-			alert('Nie udało się zapisać limitów. Spróbuj ponownie później.');
+			toast.error('Nie udało się zapisać limitów. Spróbuj ponownie później.');
 		}
 	}
 

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -167,5 +167,6 @@ describe('Dashboard retirement limits save flow', () => {
 		await waitFor(() => expect(errorSpy).toHaveBeenCalled());
 		expect(errorSpy.mock.calls[0][0]).toContain('Nie udało się zapisać limitów');
 		expect(invalidateAll).not.toHaveBeenCalled();
+		errorSpy.mockRestore();
 	});
 });

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import { vi } from 'vitest';
 import { invalidateAll } from '$app/navigation';
 import Page from './+page.svelte';
+import { toast } from '$lib/stores/toast.svelte';
 
 // Mock window.matchMedia for media query tests
 beforeAll(() => {
@@ -154,17 +155,17 @@ describe('Dashboard retirement limits save flow', () => {
 		expect(ikeInput.value).toBe('23000');
 	});
 
-	it('alerts when a limit save request fails', async () => {
+	it('shows an error toast when a limit save request fails', async () => {
 		const fetchMock = vi.fn().mockResolvedValue({ ok: false });
 		vi.stubGlobal('fetch', fetchMock);
-		const alertMock = vi.fn();
-		vi.stubGlobal('alert', alertMock);
+		const errorSpy = vi.spyOn(toast, 'error');
 
 		render(Page, { props: { data: dataWithStats } });
 		await fireEvent.click(screen.getByLabelText('Konfiguruj limity'));
 		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
 
-		await waitFor(() => expect(alertMock).toHaveBeenCalled());
+		await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+		expect(errorSpy.mock.calls[0][0]).toContain('Nie udało się zapisać limitów');
 		expect(invalidateAll).not.toHaveBeenCalled();
 	});
 });

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -17,6 +17,7 @@
 	} from 'lucide-svelte';
 	import { env } from '$env/dynamic/public';
 	import { goto, invalidateAll } from '$app/navigation';
+	import { toast } from '$lib/stores/toast.svelte';
 	import type { SalaryRecord } from '$lib/types/salaries';
 	import type { Persona } from '$lib/types/personas';
 	import type { CpiSeries } from '$lib/types/cpi';
@@ -222,7 +223,7 @@
 			await invalidateAll();
 		} catch (err) {
 			console.error('Failed to delete salary record:', err);
-			alert('Nie udało się usunąć rekordu wynagrodzenia');
+			toast.error('Nie udało się usunąć rekordu wynagrodzenia');
 		}
 	}
 

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -4,6 +4,7 @@
 	import { Plus, Landmark, Search, BarChart3, Trash2 } from 'lucide-svelte';
 	import { env } from '$env/dynamic/public';
 	import { goto, invalidateAll } from '$app/navigation';
+	import { toast } from '$lib/stores/toast.svelte';
 	import type { Persona } from '$lib/types/personas';
 	import { untrack } from 'svelte';
 	import type { PageData } from './$types';
@@ -76,7 +77,7 @@
 			await invalidateAll();
 		} catch (err) {
 			console.error('Failed to delete transaction:', err);
-			alert('Nie udało się usunąć transakcji');
+			toast.error('Nie udało się usunąć transakcji');
 		}
 	}
 


### PR DESCRIPTION
## Motivation

Three stray `alert()` calls were the last bits of blocking error UX — ugly on mobile, no auto-dismiss, halts the page. Issue #361 asks for a real toast system.

## Implementation information

- New `src/lib/stores/toast.svelte.ts` — runes-based store (`$state` requires `.svelte.ts` extension at module scope; closest fit to the spec's `toast.ts`).
- API: `toast.error(msg)`, `toast.success(msg)`, `toast.info(msg)`, `toast.dismiss(id)`.
- Auto-dismiss after 4 s (`DEFAULT_DURATION_MS`). Manual close via × button.
- New `src/lib/components/Toast.svelte` — mounted once in `src/routes/+layout.svelte`. Stacks bottom-right on `md+`, top-center on mobile.
- Error items get `role="alert"`, success/info get `role="status"` — drives the assistive-tech announcement (no doubled `aria-live` on the region).
- Replaced all 3 `alert()` calls (dashboard limits save, transactions delete, salaries delete).
- 7 component tests cover rendering by kind, auto-dismiss with fake timers, manual close, stacking. Existing `page.test.ts` updated to assert `toast.error` instead of `window.alert`.

Closes #361

> Changelog: feat(ui): replace alert() with toast notifications