### PR TITLE
feat(ui): skeleton loaders on key pages

### DIFF
--- a/src/lib/components/DashboardCharts.svelte
+++ b/src/lib/components/DashboardCharts.svelte
@@ -12,8 +12,8 @@
 
 	let { netWorthHistory, allocation }: Props = $props();
 
-	let chartContainer: HTMLDivElement | undefined = $state();
-	let pieChartContainer: HTMLDivElement | undefined = $state();
+	let chartContainer: HTMLDivElement | undefined;
+	let pieChartContainer: HTMLDivElement | undefined;
 	let lineChart: echarts.ECharts | undefined;
 	let pieChart: echarts.ECharts | undefined;
 

--- a/src/lib/components/DashboardCharts.svelte
+++ b/src/lib/components/DashboardCharts.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import * as echarts from 'echarts';
+	import type { EChartsOption } from 'echarts';
+	import { formatPLN } from '$lib/utils/format';
+	import { isMobile, isTablet } from '$lib/utils/viewport';
+
+	interface Props {
+		netWorthHistory: { date: string; value: number }[];
+		allocation: { category: string; owner: string | null; value: number }[];
+	}
+
+	let { netWorthHistory, allocation }: Props = $props();
+
+	let chartContainer: HTMLDivElement | undefined = $state();
+	let pieChartContainer: HTMLDivElement | undefined = $state();
+	let lineChart: echarts.ECharts | undefined;
+	let pieChart: echarts.ECharts | undefined;
+
+	const gridConfig = $derived(
+		$isMobile
+			? { left: '40px', right: '20px' }
+			: $isTablet
+				? { left: '60px', right: '30px' }
+				: { left: '80px', right: '40px' }
+	);
+
+	const titleFontSize = $derived($isMobile ? 14 : 16);
+
+	onMount(() => {
+		if (!chartContainer || !pieChartContainer) return;
+
+		lineChart = echarts.init(chartContainer);
+
+		const lineOption: EChartsOption = {
+			title: {
+				text: 'Wartość Netto w Czasie',
+				left: 'center',
+				textStyle: { fontSize: titleFontSize }
+			},
+			tooltip: {
+				trigger: 'axis',
+				formatter: (params: any) => {
+					const date = new Date(params[0].value[0]).toLocaleDateString('pl-PL');
+					const value = formatPLN(params[0].value[1]);
+					return `${date}<br/>Wartość: ${value}`;
+				}
+			},
+			xAxis: { type: 'time' },
+			yAxis: {
+				type: 'value',
+				axisLabel: { formatter: (value: number) => formatPLN(value) }
+			},
+			series: [
+				{
+					data: netWorthHistory.map((h) => [h.date, h.value]),
+					type: 'line',
+					smooth: true,
+					areaStyle: {
+						color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+							{ offset: 0, color: 'rgba(225, 29, 72, 0.5)' },
+							{ offset: 1, color: 'rgba(225, 29, 72, 0.1)' }
+						])
+					},
+					lineStyle: { color: '#e11d48', width: 2 }
+				}
+			],
+			grid: gridConfig
+		};
+
+		lineChart.setOption(lineOption);
+
+		pieChart = echarts.init(pieChartContainer);
+
+		const pieOption: EChartsOption = {
+			title: {
+				text: 'Alokacja Aktywów',
+				left: 'center',
+				textStyle: { fontSize: titleFontSize }
+			},
+			tooltip: { trigger: 'item', formatter: '{b}: {c} PLN ({d}%)' },
+			color: [
+				'#e11d48',
+				'#f43f5e',
+				'#fb7185',
+				'#fda4af',
+				'#881337',
+				'#9f1239',
+				'#be123c',
+				'#be185d'
+			],
+			series: [
+				{
+					type: 'pie',
+					radius: ['40%', '70%'],
+					data: allocation.map((a) => ({
+						name: `${a.category}${a.owner ? ` (${a.owner})` : ''}`,
+						value: a.value
+					})),
+					emphasis: {
+						itemStyle: {
+							shadowBlur: 10,
+							shadowOffsetX: 0,
+							shadowColor: 'rgba(0, 0, 0, 0.5)'
+						}
+					}
+				}
+			]
+		};
+
+		pieChart.setOption(pieOption);
+
+		const handleResize = () => {
+			lineChart?.resize();
+			pieChart?.resize();
+		};
+
+		window.addEventListener('resize', handleResize);
+
+		return () => {
+			window.removeEventListener('resize', handleResize);
+			lineChart?.dispose();
+			pieChart?.dispose();
+		};
+	});
+
+	$effect(() => {
+		if (lineChart && gridConfig) {
+			lineChart.setOption({
+				grid: gridConfig,
+				title: { textStyle: { fontSize: titleFontSize } }
+			});
+		}
+	});
+
+	$effect(() => {
+		if (pieChart && titleFontSize) {
+			pieChart.setOption({
+				title: { textStyle: { fontSize: titleFontSize } }
+			});
+		}
+	});
+</script>
+
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+	<div class="card preset-filled-surface-100-900 p-4">
+		<div bind:this={chartContainer} class="w-full h-[400px]"></div>
+	</div>
+
+	<div class="card preset-filled-surface-100-900 p-4">
+		<div bind:this={pieChartContainer} class="w-full h-[400px]"></div>
+	</div>
+</div>

--- a/src/lib/components/Skeleton.svelte
+++ b/src/lib/components/Skeleton.svelte
@@ -4,16 +4,9 @@
 		width?: string;
 		height?: string;
 		rounded?: 'sm' | 'md' | 'lg' | 'full';
-		'aria-label'?: string;
 	}
 
-	let {
-		class: className = '',
-		width,
-		height,
-		rounded = 'md',
-		'aria-label': ariaLabel = 'Ładowanie'
-	}: Props = $props();
+	let { class: className = '', width, height, rounded = 'md' }: Props = $props();
 
 	const radiusClass = $derived(
 		rounded === 'full'
@@ -26,15 +19,7 @@
 	);
 </script>
 
-<div
-	class="skeleton {radiusClass} {className}"
-	style:width
-	style:height
-	role="status"
-	aria-busy="true"
-	aria-live="polite"
-	aria-label={ariaLabel}
-></div>
+<div class="skeleton {radiusClass} {className}" style:width style:height aria-hidden="true"></div>
 
 <style>
 	.skeleton {

--- a/src/lib/components/Skeleton.svelte
+++ b/src/lib/components/Skeleton.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	interface Props {
+		class?: string;
+		width?: string;
+		height?: string;
+		rounded?: 'sm' | 'md' | 'lg' | 'full';
+		'aria-label'?: string;
+	}
+
+	let {
+		class: className = '',
+		width,
+		height,
+		rounded = 'md',
+		'aria-label': ariaLabel = 'Ładowanie'
+	}: Props = $props();
+
+	const radiusClass = $derived(
+		rounded === 'full'
+			? 'rounded-full'
+			: rounded === 'lg'
+				? 'rounded-lg'
+				: rounded === 'sm'
+					? 'rounded-sm'
+					: 'rounded-md'
+	);
+</script>
+
+<div
+	class="skeleton {radiusClass} {className}"
+	style:width
+	style:height
+	role="status"
+	aria-busy="true"
+	aria-live="polite"
+	aria-label={ariaLabel}
+></div>
+
+<style>
+	.skeleton {
+		display: block;
+		background: linear-gradient(
+			90deg,
+			rgba(127, 127, 127, 0.12) 0%,
+			rgba(127, 127, 127, 0.22) 50%,
+			rgba(127, 127, 127, 0.12) 100%
+		);
+		background-size: 200% 100%;
+		opacity: 0;
+		animation:
+			skeleton-shimmer 1.4s ease-in-out infinite,
+			skeleton-reveal 0s linear 150ms forwards;
+	}
+
+	:global(.dark) .skeleton {
+		background: linear-gradient(
+			90deg,
+			rgba(255, 255, 255, 0.06) 0%,
+			rgba(255, 255, 255, 0.14) 50%,
+			rgba(255, 255, 255, 0.06) 100%
+		);
+		background-size: 200% 100%;
+	}
+
+	@keyframes skeleton-shimmer {
+		0% {
+			background-position: 200% 0;
+		}
+		100% {
+			background-position: -200% 0;
+		}
+	}
+
+	@keyframes skeleton-reveal {
+		to {
+			opacity: 1;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.skeleton {
+			animation: skeleton-reveal 0s linear 150ms forwards;
+			background: rgba(127, 127, 127, 0.18);
+		}
+	}
+</style>

--- a/src/lib/components/Skeleton.test.ts
+++ b/src/lib/components/Skeleton.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Skeleton from './Skeleton.svelte';
+
+describe('Skeleton', () => {
+	it('renders with role="status" and aria-busy="true"', () => {
+		render(Skeleton);
+		const el = screen.getByRole('status');
+		expect(el.getAttribute('aria-busy')).toBe('true');
+		expect(el.getAttribute('aria-live')).toBe('polite');
+	});
+
+	it('uses the default Polish aria-label when none is provided', () => {
+		render(Skeleton);
+		const el = screen.getByRole('status');
+		expect(el.getAttribute('aria-label')).toBe('Ładowanie');
+	});
+
+	it('forwards a custom aria-label', () => {
+		render(Skeleton, { props: { 'aria-label': 'Ładowanie wykresu' } });
+		const el = screen.getByRole('status', { name: 'Ładowanie wykresu' });
+		expect(el).toBeTruthy();
+	});
+
+	it('applies width and height inline styles', () => {
+		render(Skeleton, { props: { width: '50%', height: '2rem' } });
+		const el = screen.getByRole('status');
+		expect(el.style.width).toBe('50%');
+		expect(el.style.height).toBe('2rem');
+	});
+
+	it('applies the rounded variant class', () => {
+		render(Skeleton, { props: { rounded: 'full' } });
+		const el = screen.getByRole('status');
+		expect(el.className).toContain('rounded-full');
+	});
+
+	it('merges custom class names', () => {
+		render(Skeleton, { props: { class: 'mt-2 custom-thing' } });
+		const el = screen.getByRole('status');
+		expect(el.className).toContain('mt-2');
+		expect(el.className).toContain('custom-thing');
+	});
+});

--- a/src/lib/components/Skeleton.test.ts
+++ b/src/lib/components/Skeleton.test.ts
@@ -1,43 +1,37 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import Skeleton from './Skeleton.svelte';
 
 describe('Skeleton', () => {
-	it('renders with role="status" and aria-busy="true"', () => {
-		render(Skeleton);
-		const el = screen.getByRole('status');
-		expect(el.getAttribute('aria-busy')).toBe('true');
-		expect(el.getAttribute('aria-live')).toBe('polite');
-	});
-
-	it('uses the default Polish aria-label when none is provided', () => {
-		render(Skeleton);
-		const el = screen.getByRole('status');
-		expect(el.getAttribute('aria-label')).toBe('Ładowanie');
-	});
-
-	it('forwards a custom aria-label', () => {
-		render(Skeleton, { props: { 'aria-label': 'Ładowanie wykresu' } });
-		const el = screen.getByRole('status', { name: 'Ładowanie wykresu' });
+	it('renders a presentational, aria-hidden block', () => {
+		const { container } = render(Skeleton);
+		const el = container.querySelector('.skeleton') as HTMLElement;
 		expect(el).toBeTruthy();
+		expect(el.getAttribute('aria-hidden')).toBe('true');
 	});
 
 	it('applies width and height inline styles', () => {
-		render(Skeleton, { props: { width: '50%', height: '2rem' } });
-		const el = screen.getByRole('status');
+		const { container } = render(Skeleton, { props: { width: '50%', height: '2rem' } });
+		const el = container.querySelector('.skeleton') as HTMLElement;
 		expect(el.style.width).toBe('50%');
 		expect(el.style.height).toBe('2rem');
 	});
 
 	it('applies the rounded variant class', () => {
-		render(Skeleton, { props: { rounded: 'full' } });
-		const el = screen.getByRole('status');
+		const { container } = render(Skeleton, { props: { rounded: 'full' } });
+		const el = container.querySelector('.skeleton') as HTMLElement;
 		expect(el.className).toContain('rounded-full');
 	});
 
+	it('defaults to rounded-md', () => {
+		const { container } = render(Skeleton);
+		const el = container.querySelector('.skeleton') as HTMLElement;
+		expect(el.className).toContain('rounded-md');
+	});
+
 	it('merges custom class names', () => {
-		render(Skeleton, { props: { class: 'mt-2 custom-thing' } });
-		const el = screen.getByRole('status');
+		const { container } = render(Skeleton, { props: { class: 'mt-2 custom-thing' } });
+		const el = container.querySelector('.skeleton') as HTMLElement;
 		expect(el.className).toContain('mt-2');
 		expect(el.className).toContain('custom-thing');
 	});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -25,7 +25,17 @@
 
 	let { data }: Props = $props();
 
-	const personas = $derived((data.personas || []) as Persona[]);
+	let personas: Persona[] = $state([]);
+
+	$effect(() => {
+		let cancelled = false;
+		Promise.resolve(data.personas).then((p) => {
+			if (!cancelled) personas = (p ?? []) as Persona[];
+		});
+		return () => {
+			cancelled = true;
+		};
+	});
 
 	let showLimitsModal = $state(false);
 	let limitsYear = $state(untrack(() => data.currentYear));

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -106,22 +106,24 @@
 	</div>
 
 	{#await data.dashboardData}
-		<div class="grid gap-4 sm:gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-			{#each Array(3) as _, i (i)}
-				<div class="card preset-filled-surface-100-900 p-4 space-y-3">
-					<Skeleton height="1.25rem" width="60%" />
-					<Skeleton height="2rem" width="80%" />
-					<Skeleton height="0.875rem" width="70%" />
-				</div>
-			{/each}
-		</div>
-
-		<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-			<div class="card preset-filled-surface-100-900 p-4">
-				<Skeleton height="400px" rounded="lg" aria-label="Ładowanie wykresu wartości netto" />
+		<div role="status" aria-live="polite" aria-label="Ładowanie dashboardu" class="space-y-8">
+			<div class="grid gap-4 sm:gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+				{#each { length: 3 } as _, i (i)}
+					<div class="card preset-filled-surface-100-900 p-4 space-y-3">
+						<Skeleton height="1.25rem" width="60%" />
+						<Skeleton height="2rem" width="80%" />
+						<Skeleton height="0.875rem" width="70%" />
+					</div>
+				{/each}
 			</div>
-			<div class="card preset-filled-surface-100-900 p-4">
-				<Skeleton height="400px" rounded="lg" aria-label="Ładowanie wykresu alokacji" />
+
+			<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+				<div class="card preset-filled-surface-100-900 p-4">
+					<Skeleton height="400px" rounded="lg" />
+				</div>
+				<div class="card preset-filled-surface-100-900 p-4">
+					<Skeleton height="400px" rounded="lg" />
+				</div>
 			</div>
 		</div>
 	{:then dashboard}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-	import { onMount, untrack } from 'svelte';
-	import * as echarts from 'echarts';
-	import type { EChartsOption } from 'echarts';
+	import { untrack } from 'svelte';
 	import Modal from '$lib/components/Modal.svelte';
+	import Skeleton from '$lib/components/Skeleton.svelte';
+	import DashboardCharts from '$lib/components/DashboardCharts.svelte';
 	import { formatPLN, formatPercent, calculateChange } from '$lib/utils/format';
-	import { isMobile, isTablet } from '$lib/utils/viewport';
 	import {
 		Wallet,
 		TrendingUp,
@@ -26,41 +25,33 @@
 
 	let { data }: Props = $props();
 
-	let chartContainer: HTMLDivElement | undefined = $state();
-	let pieChartContainer: HTMLDivElement | undefined = $state();
-	let lineChart: echarts.ECharts | undefined = $state();
-	let pieChart: echarts.ECharts | undefined = $state();
-
-	const gridConfig = $derived(
-		$isMobile
-			? { left: '40px', right: '20px' }
-			: $isTablet
-				? { left: '60px', right: '30px' }
-				: { left: '80px', right: '40px' }
-	);
-
-	const titleFontSize = $derived($isMobile ? 14 : 16);
-
 	const personas = $derived((data.personas || []) as Persona[]);
 
 	let showLimitsModal = $state(false);
 	let limitsYear = $state(untrack(() => data.currentYear));
 	let limits: Record<string, number> = $state({});
 
-	function openLimitsModal() {
+	type RetirementStat = {
+		account_wrapper: string;
+		owner: string;
+		total_contributed: number;
+		limit_amount: number;
+		remaining: number;
+		percentage_used: number;
+	};
+
+	function openLimitsModal(retirementStats: RetirementStat[]) {
 		limits = {};
 		for (const persona of personas) {
 			for (const wrapper of ['IKE', 'IKZE']) {
 				limits[`${wrapper}_${persona.name}`] = 0;
 			}
 		}
-		if (data.retirementStats && data.retirementStats.length > 0) {
-			data.retirementStats.forEach((stat: any) => {
-				const key = `${stat.account_wrapper}_${stat.owner}`;
-				if (key in limits) {
-					limits[key] = stat.limit_amount || 0;
-				}
-			});
+		for (const stat of retirementStats) {
+			const key = `${stat.account_wrapper}_${stat.owner}`;
+			if (key in limits) {
+				limits[key] = stat.limit_amount || 0;
+			}
 		}
 		showLimitsModal = true;
 	}
@@ -102,121 +93,6 @@
 			toast.error('Nie udało się zapisać limitów. Spróbuj ponownie później.');
 		}
 	}
-
-	onMount(() => {
-		if (!chartContainer || !pieChartContainer) return;
-		lineChart = echarts.init(chartContainer);
-
-		const lineOption: EChartsOption = {
-			title: {
-				text: 'Wartość Netto w Czasie',
-				left: 'center',
-				textStyle: { fontSize: titleFontSize }
-			},
-			tooltip: {
-				trigger: 'axis',
-				formatter: (params: any) => {
-					const date = new Date(params[0].value[0]).toLocaleDateString('pl-PL');
-					const value = formatPLN(params[0].value[1]);
-					return `${date}<br/>Wartość: ${value}`;
-				}
-			},
-			xAxis: { type: 'time' },
-			yAxis: {
-				type: 'value',
-				axisLabel: { formatter: (value: number) => formatPLN(value) }
-			},
-			series: [
-				{
-					data: data.net_worth_history.map((h: any) => [h.date, h.value]),
-					type: 'line',
-					smooth: true,
-					areaStyle: {
-						color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-							{ offset: 0, color: 'rgba(225, 29, 72, 0.5)' },
-							{ offset: 1, color: 'rgba(225, 29, 72, 0.1)' }
-						])
-					},
-					lineStyle: { color: '#e11d48', width: 2 }
-				}
-			],
-			grid: gridConfig
-		};
-
-		lineChart.setOption(lineOption);
-
-		pieChart = echarts.init(pieChartContainer);
-
-		const pieOption: EChartsOption = {
-			title: {
-				text: 'Alokacja Aktywów',
-				left: 'center',
-				textStyle: { fontSize: titleFontSize }
-			},
-			tooltip: { trigger: 'item', formatter: '{b}: {c} PLN ({d}%)' },
-			color: [
-				'#e11d48',
-				'#f43f5e',
-				'#fb7185',
-				'#fda4af',
-				'#881337',
-				'#9f1239',
-				'#be123c',
-				'#be185d'
-			],
-			series: [
-				{
-					type: 'pie',
-					radius: ['40%', '70%'],
-					data: data.allocation.map((a: any) => ({
-						name: `${a.category}${a.owner ? ` (${a.owner})` : ''}`,
-						value: a.value
-					})),
-					emphasis: {
-						itemStyle: {
-							shadowBlur: 10,
-							shadowOffsetX: 0,
-							shadowColor: 'rgba(0, 0, 0, 0.5)'
-						}
-					}
-				}
-			]
-		};
-
-		pieChart.setOption(pieOption);
-
-		const handleResize = () => {
-			lineChart?.resize();
-			pieChart?.resize();
-		};
-
-		window.addEventListener('resize', handleResize);
-
-		return () => {
-			window.removeEventListener('resize', handleResize);
-		};
-	});
-
-	const change = $derived(
-		calculateChange(data.current_net_worth, data.current_net_worth - data.change_vs_last_month)
-	);
-
-	$effect(() => {
-		if (lineChart && gridConfig) {
-			lineChart.setOption({
-				grid: gridConfig,
-				title: { textStyle: { fontSize: titleFontSize } }
-			});
-		}
-	});
-
-	$effect(() => {
-		if (pieChart && titleFontSize) {
-			pieChart.setOption({
-				title: { textStyle: { fontSize: titleFontSize } }
-			});
-		}
-	});
 </script>
 
 <svelte:head>
@@ -229,123 +105,153 @@
 		<p class="text-surface-700-300 text-sm">Twoja sytuacja finansowa w jednym miejscu</p>
 	</div>
 
-	<div class="grid gap-4 sm:gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-		<div class="card preset-filled-surface-100-900 p-4 space-y-2">
-			<header>
-				<h3 class="h4 flex items-center gap-2"><Wallet size={18} /> Wartość Netto</h3>
-			</header>
-			<div class="text-3xl font-bold">{formatPLN(data.current_net_worth)}</div>
-			<p
-				class="text-sm flex items-center gap-1 {data.change_vs_last_month >= 0
-					? 'text-success-600-400'
-					: 'text-error-600-400'}"
-			>
-				{#if data.change_vs_last_month >= 0}
-					<TrendingUp size={14} />
-				{:else}
-					<TrendingDown size={14} />
-				{/if}
-				{formatPLN(Math.abs(data.change_vs_last_month))}
-				({formatPercent(Math.abs(change.percent))})
-				<span class="text-surface-700-300">vs poprzedni miesiąc</span>
-			</p>
+	{#await data.dashboardData}
+		<div class="grid gap-4 sm:gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+			{#each Array(3) as _, i (i)}
+				<div class="card preset-filled-surface-100-900 p-4 space-y-3">
+					<Skeleton height="1.25rem" width="60%" />
+					<Skeleton height="2rem" width="80%" />
+					<Skeleton height="0.875rem" width="70%" />
+				</div>
+			{/each}
 		</div>
 
-		<div class="card preset-filled-surface-100-900 p-4 space-y-2">
-			<header>
-				<h3 class="h4 flex items-center gap-2"><TrendingUp size={18} /> Aktywa</h3>
-			</header>
-			<div class="text-3xl font-bold text-success-600-400">{formatPLN(data.total_assets)}</div>
-			<p class="text-sm text-surface-700-300">Suma wszystkich aktywów</p>
-		</div>
-
-		<div class="card preset-filled-surface-100-900 p-4 space-y-2">
-			<header>
-				<h3 class="h4 flex items-center gap-2"><TrendingDown size={18} /> Zobowiązania</h3>
-			</header>
-			<div class="text-3xl font-bold text-error-600-400">{formatPLN(data.total_liabilities)}</div>
-			<p class="text-sm text-surface-700-300">Suma wszystkich zobowiązań</p>
-		</div>
-	</div>
-
-	{#if data.retirementStats && data.retirementStats.length > 0}
-		<div class="card preset-filled-surface-100-900 p-4 space-y-4">
-			<header class="flex items-center justify-between gap-2">
-				<h3 class="h3 flex items-center gap-2">
-					<PiggyBank size={20} /> Limity Emerytalne {data.currentYear}
-				</h3>
-				<button
-					type="button"
-					class="btn-icon btn-icon-sm"
-					aria-label="Konfiguruj limity"
-					onclick={openLimitsModal}
-				>
-					<Settings size={18} />
-				</button>
-			</header>
-
-			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-				{#each data.retirementStats as stat}
-					<div class="card preset-tonal-surface p-4 space-y-2">
-						<div class="flex items-start justify-between gap-2">
-							<h4 class="font-bold">{stat.account_wrapper} ({stat.owner})</h4>
-							<span class="text-sm font-semibold whitespace-nowrap">
-								{formatPLN(stat.total_contributed)} / {formatPLN(stat.limit_amount)}
-							</span>
-						</div>
-
-						<div class="h-2 rounded-full bg-surface-200-800 overflow-hidden">
-							<div
-								class="h-full transition-all {stat.percentage_used >= 100
-									? 'bg-success-500'
-									: stat.percentage_used >= 50
-										? 'bg-warning-500'
-										: 'bg-error-500'}"
-								style="width: {Math.min(stat.percentage_used, 100)}%"
-							></div>
-						</div>
-
-						<div class="flex items-center justify-between text-sm">
-							<span class="text-surface-700-300">Pozostało: {formatPLN(stat.remaining)}</span>
-							<span
-								class="font-semibold {stat.percentage_used >= 100
-									? 'text-success-600-400'
-									: stat.percentage_used >= 50
-										? 'text-warning-600-400'
-										: 'text-error-600-400'}"
-							>
-								{stat.percentage_used}%
-							</span>
-						</div>
-
-						{#if stat.percentage_used >= 100}
-							<div
-								class="card preset-filled-success-500 p-2 text-xs text-center flex items-center justify-center gap-1"
-							>
-								<CheckCircle2 size={14} /> Limit osiągnięty
-							</div>
-						{:else if stat.percentage_used >= 50}
-							<div
-								class="card preset-filled-warning-500 p-2 text-xs text-center flex items-center justify-center gap-1"
-							>
-								<AlertTriangle size={14} /> Zbliżasz się do limitu
-							</div>
-						{/if}
-					</div>
-				{/each}
+		<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+			<div class="card preset-filled-surface-100-900 p-4">
+				<Skeleton height="400px" rounded="lg" aria-label="Ładowanie wykresu wartości netto" />
+			</div>
+			<div class="card preset-filled-surface-100-900 p-4">
+				<Skeleton height="400px" rounded="lg" aria-label="Ładowanie wykresu alokacji" />
 			</div>
 		</div>
-	{/if}
+	{:then dashboard}
+		{@const change = calculateChange(
+			dashboard.current_net_worth,
+			dashboard.current_net_worth - dashboard.change_vs_last_month
+		)}
 
-	<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-		<div class="card preset-filled-surface-100-900 p-4">
-			<div bind:this={chartContainer} class="w-full h-[400px]"></div>
+		<div class="grid gap-4 sm:gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+			<div class="card preset-filled-surface-100-900 p-4 space-y-2">
+				<header>
+					<h3 class="h4 flex items-center gap-2"><Wallet size={18} /> Wartość Netto</h3>
+				</header>
+				<div class="text-3xl font-bold">{formatPLN(dashboard.current_net_worth)}</div>
+				<p
+					class="text-sm flex items-center gap-1 {dashboard.change_vs_last_month >= 0
+						? 'text-success-600-400'
+						: 'text-error-600-400'}"
+				>
+					{#if dashboard.change_vs_last_month >= 0}
+						<TrendingUp size={14} />
+					{:else}
+						<TrendingDown size={14} />
+					{/if}
+					{formatPLN(Math.abs(dashboard.change_vs_last_month))}
+					({formatPercent(Math.abs(change.percent))})
+					<span class="text-surface-700-300">vs poprzedni miesiąc</span>
+				</p>
+			</div>
+
+			<div class="card preset-filled-surface-100-900 p-4 space-y-2">
+				<header>
+					<h3 class="h4 flex items-center gap-2"><TrendingUp size={18} /> Aktywa</h3>
+				</header>
+				<div class="text-3xl font-bold text-success-600-400">
+					{formatPLN(dashboard.total_assets)}
+				</div>
+				<p class="text-sm text-surface-700-300">Suma wszystkich aktywów</p>
+			</div>
+
+			<div class="card preset-filled-surface-100-900 p-4 space-y-2">
+				<header>
+					<h3 class="h4 flex items-center gap-2"><TrendingDown size={18} /> Zobowiązania</h3>
+				</header>
+				<div class="text-3xl font-bold text-error-600-400">
+					{formatPLN(dashboard.total_liabilities)}
+				</div>
+				<p class="text-sm text-surface-700-300">Suma wszystkich zobowiązań</p>
+			</div>
 		</div>
 
-		<div class="card preset-filled-surface-100-900 p-4">
-			<div bind:this={pieChartContainer} class="w-full h-[400px]"></div>
+		{#if dashboard.retirementStats && dashboard.retirementStats.length > 0}
+			<div class="card preset-filled-surface-100-900 p-4 space-y-4">
+				<header class="flex items-center justify-between gap-2">
+					<h3 class="h3 flex items-center gap-2">
+						<PiggyBank size={20} /> Limity Emerytalne {data.currentYear}
+					</h3>
+					<button
+						type="button"
+						class="btn-icon btn-icon-sm"
+						aria-label="Konfiguruj limity"
+						onclick={() => openLimitsModal(dashboard.retirementStats)}
+					>
+						<Settings size={18} />
+					</button>
+				</header>
+
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					{#each dashboard.retirementStats as stat}
+						<div class="card preset-tonal-surface p-4 space-y-2">
+							<div class="flex items-start justify-between gap-2">
+								<h4 class="font-bold">{stat.account_wrapper} ({stat.owner})</h4>
+								<span class="text-sm font-semibold whitespace-nowrap">
+									{formatPLN(stat.total_contributed)} / {formatPLN(stat.limit_amount)}
+								</span>
+							</div>
+
+							<div class="h-2 rounded-full bg-surface-200-800 overflow-hidden">
+								<div
+									class="h-full transition-all {stat.percentage_used >= 100
+										? 'bg-success-500'
+										: stat.percentage_used >= 50
+											? 'bg-warning-500'
+											: 'bg-error-500'}"
+									style="width: {Math.min(stat.percentage_used, 100)}%"
+								></div>
+							</div>
+
+							<div class="flex items-center justify-between text-sm">
+								<span class="text-surface-700-300">Pozostało: {formatPLN(stat.remaining)}</span>
+								<span
+									class="font-semibold {stat.percentage_used >= 100
+										? 'text-success-600-400'
+										: stat.percentage_used >= 50
+											? 'text-warning-600-400'
+											: 'text-error-600-400'}"
+								>
+									{stat.percentage_used}%
+								</span>
+							</div>
+
+							{#if stat.percentage_used >= 100}
+								<div
+									class="card preset-filled-success-500 p-2 text-xs text-center flex items-center justify-center gap-1"
+								>
+									<CheckCircle2 size={14} /> Limit osiągnięty
+								</div>
+							{:else if stat.percentage_used >= 50}
+								<div
+									class="card preset-filled-warning-500 p-2 text-xs text-center flex items-center justify-center gap-1"
+								>
+									<AlertTriangle size={14} /> Zbliżasz się do limitu
+								</div>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
+
+		<DashboardCharts
+			netWorthHistory={dashboard.net_worth_history}
+			allocation={dashboard.allocation}
+		/>
+	{:catch err}
+		<div class="card preset-filled-error-500 p-4">
+			<p class="font-semibold">Nie udało się załadować danych dashboardu.</p>
+			<p class="text-sm">{err?.message ?? 'Spróbuj ponownie później.'}</p>
 		</div>
-	</div>
+	{/await}
 </div>
 
 <Modal

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -10,8 +10,10 @@ export async function load({ fetch }) {
 
 	const currentYear = new Date().getFullYear();
 
-	const personasRes = await fetch(`${apiUrl}/api/personas`);
-	const personas = personasRes.ok ? await personasRes.json() : [];
+	const personas = (async () => {
+		const res = await fetch(`${apiUrl}/api/personas`);
+		return res.ok ? await res.json() : [];
+	})();
 
 	const dashboardData = (async () => {
 		const [dashboardRes, retirementRes] = await Promise.all([

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -3,18 +3,20 @@ import { env } from '$env/dynamic/public';
 import { browser } from '$app/environment';
 
 export async function load({ fetch }) {
-	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API URL is not configured');
-		}
+	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+	if (!apiUrl) {
+		throw error(500, 'API URL is not configured');
+	}
 
-		const currentYear = new Date().getFullYear();
+	const currentYear = new Date().getFullYear();
 
-		const [dashboardRes, retirementRes, personasRes] = await Promise.all([
+	const personasRes = await fetch(`${apiUrl}/api/personas`);
+	const personas = personasRes.ok ? await personasRes.json() : [];
+
+	const dashboardData = (async () => {
+		const [dashboardRes, retirementRes] = await Promise.all([
 			fetch(`${apiUrl}/api/dashboard`),
-			fetch(`${apiUrl}/api/retirement/stats?year=${currentYear}`),
-			fetch(`${apiUrl}/api/personas`)
+			fetch(`${apiUrl}/api/retirement/stats?year=${currentYear}`)
 		]);
 
 		if (!dashboardRes.ok) {
@@ -22,19 +24,17 @@ export async function load({ fetch }) {
 		}
 
 		const dashboard = await dashboardRes.json();
-		const retirement = retirementRes.ok ? await retirementRes.json() : [];
-		const personas = personasRes.ok ? await personasRes.json() : [];
+		const retirementStats = retirementRes.ok ? await retirementRes.json() : [];
 
 		return {
 			...dashboard,
-			retirementStats: retirement,
-			personas,
-			currentYear
+			retirementStats
 		};
-	} catch (err) {
-		if (err instanceof Error && 'status' in err) {
-			throw err;
-		}
-		throw error(500, 'Failed to load dashboard data');
-	}
+	})();
+
+	return {
+		dashboardData,
+		personas,
+		currentYear
+	};
 }

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -18,8 +18,18 @@
 	let { data }: Props = $props();
 
 	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
-	const personas = $derived(data.personas as Persona[]);
+	let personas: Persona[] = $state([]);
 	const defaultOwner = $derived(personas.length > 0 ? personas[0].name : 'Marcin');
+
+	$effect(() => {
+		let cancelled = false;
+		Promise.resolve(data.personas).then((p) => {
+			if (!cancelled) personas = (p ?? []) as Persona[];
+		});
+		return () => {
+			cancelled = true;
+		};
+	});
 
 	let showForm = $state(false);
 	let editingAccount: Account | null = $state(null);
@@ -326,9 +336,10 @@
 {#await data.accountsData}
 	<div role="status" aria-live="polite" aria-label="Ładowanie kont" class="space-y-4">
 		{#each [{ icon: Wallet, title: 'Aktywa' }, { icon: TrendingDown, title: 'Pasywa' }] as section}
+			{@const Icon = section.icon}
 			<div class="card preset-filled-surface-100-900 p-4 space-y-4">
 				<header>
-					<h3 class="h3 flex items-center gap-2"><section.icon size={20} /> {section.title}</h3>
+					<h3 class="h3 flex items-center gap-2"><Icon size={20} /> {section.title}</h3>
 				</header>
 				<div class="table-wrap">
 					<table class="table">

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Modal from '$lib/components/Modal.svelte';
+	import Skeleton from '$lib/components/Skeleton.svelte';
 	import { formatPLN } from '$lib/utils/format';
 	import { Wallet, TrendingDown, Pencil, Trash2, Plus, BarChart3 } from 'lucide-svelte';
 	import { env } from '$env/dynamic/public';
@@ -322,123 +323,171 @@
 	</button>
 </div>
 
-<div class="space-y-4">
-	<div class="card preset-filled-surface-100-900 p-4 space-y-4">
-		<header>
-			<h3 class="h3 flex items-center gap-2"><Wallet size={20} /> Aktywa</h3>
-		</header>
-		{#if data.assets.length === 0}
-			<div class="text-center py-12 text-surface-700-300"><p>Brak aktywów</p></div>
-		{:else}
-			<div class="table-wrap">
-				<table class="table table-hover">
-					<thead>
-						<tr>
-							<th>Nazwa</th>
-							<th>Kategoria</th>
-							<th>Właściciel</th>
-							<th>Wartość</th>
-							<th class="text-right">Akcje</th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each data.assets as account}
+{#await data.accountsData}
+	<div class="space-y-4">
+		{#each [{ icon: Wallet, title: 'Aktywa' }, { icon: TrendingDown, title: 'Pasywa' }] as section}
+			<div class="card preset-filled-surface-100-900 p-4 space-y-4">
+				<header>
+					<h3 class="h3 flex items-center gap-2"><section.icon size={20} /> {section.title}</h3>
+				</header>
+				<div class="table-wrap">
+					<table class="table">
+						<thead>
 							<tr>
-								<td class="font-medium">{account.name}</td>
-								<td>{categoryLabels[account.category] || account.category}</td>
-								<td>{account.owner}</td>
-								<td class="font-semibold text-primary-600-400"
-									>{formatPLN(account.current_value)}</td
-								>
-								<td class="text-right whitespace-nowrap">
-									<button
-										type="button"
-										class="btn-icon btn-icon-sm"
-										aria-label="Edytuj"
-										onclick={() => startEdit(account)}
+								<th>Nazwa</th>
+								<th>Kategoria</th>
+								<th>Właściciel</th>
+								<th>Wartość</th>
+								<th class="text-right">Akcje</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each Array(5) as _, i (i)}
+								<tr>
+									<td><Skeleton height="1rem" width="70%" /></td>
+									<td><Skeleton height="1rem" width="60%" /></td>
+									<td><Skeleton height="1rem" width="50%" /></td>
+									<td><Skeleton height="1rem" width="65%" /></td>
+									<td>
+										<div class="flex justify-end gap-2">
+											<Skeleton height="2rem" width="2rem" rounded="md" />
+											<Skeleton height="2rem" width="2rem" rounded="md" />
+										</div>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		{/each}
+	</div>
+{:then accounts}
+	<div class="space-y-4">
+		<div class="card preset-filled-surface-100-900 p-4 space-y-4">
+			<header>
+				<h3 class="h3 flex items-center gap-2"><Wallet size={20} /> Aktywa</h3>
+			</header>
+			{#if accounts.assets.length === 0}
+				<div class="text-center py-12 text-surface-700-300"><p>Brak aktywów</p></div>
+			{:else}
+				<div class="table-wrap">
+					<table class="table table-hover">
+						<thead>
+							<tr>
+								<th>Nazwa</th>
+								<th>Kategoria</th>
+								<th>Właściciel</th>
+								<th>Wartość</th>
+								<th class="text-right">Akcje</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each accounts.assets as account}
+								<tr>
+									<td class="font-medium">{account.name}</td>
+									<td>{categoryLabels[account.category] || account.category}</td>
+									<td>{account.owner}</td>
+									<td class="font-semibold text-primary-600-400"
+										>{formatPLN(account.current_value)}</td
 									>
-										<Pencil size={16} />
-									</button>
-									{#if INVESTMENT_CATEGORIES.has(account.category) || account.account_wrapper}
+									<td class="text-right whitespace-nowrap">
 										<button
 											type="button"
-											class="btn preset-tonal-surface btn-sm gap-1"
-											aria-label="Transakcje"
-											onclick={() =>
-												openTransactions(account.id, account.name, account.account_wrapper)}
+											class="btn-icon btn-icon-sm"
+											aria-label="Edytuj"
+											onclick={() => startEdit(account)}
 										>
-											<BarChart3 size={14} />
-											<span>{transactionCounts[account.id] || 0}</span>
+											<Pencil size={16} />
 										</button>
-									{/if}
-									<button
-										type="button"
-										class="btn-icon btn-icon-sm"
-										aria-label="Usuń"
-										onclick={() => handleDelete(account.id)}
-									>
-										<Trash2 size={16} />
-									</button>
-								</td>
-							</tr>
-						{/each}
-					</tbody>
-				</table>
-			</div>
-		{/if}
-	</div>
+										{#if INVESTMENT_CATEGORIES.has(account.category) || account.account_wrapper}
+											<button
+												type="button"
+												class="btn preset-tonal-surface btn-sm gap-1"
+												aria-label="Transakcje"
+												onclick={() =>
+													openTransactions(account.id, account.name, account.account_wrapper)}
+											>
+												<BarChart3 size={14} />
+												<span>{transactionCounts[account.id] || 0}</span>
+											</button>
+										{/if}
+										<button
+											type="button"
+											class="btn-icon btn-icon-sm"
+											aria-label="Usuń"
+											onclick={() => handleDelete(account.id)}
+										>
+											<Trash2 size={16} />
+										</button>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+		</div>
 
-	<div class="card preset-filled-surface-100-900 p-4 space-y-4">
-		<header>
-			<h3 class="h3 flex items-center gap-2"><TrendingDown size={20} /> Pasywa</h3>
-		</header>
-		{#if data.liabilities.length === 0}
-			<div class="text-center py-12 text-surface-700-300"><p>Brak pasywów</p></div>
-		{:else}
-			<div class="table-wrap">
-				<table class="table table-hover">
-					<thead>
-						<tr>
-							<th>Nazwa</th>
-							<th>Kategoria</th>
-							<th>Właściciel</th>
-							<th>Wartość</th>
-							<th class="text-right">Akcje</th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each data.liabilities as account}
+		<div class="card preset-filled-surface-100-900 p-4 space-y-4">
+			<header>
+				<h3 class="h3 flex items-center gap-2"><TrendingDown size={20} /> Pasywa</h3>
+			</header>
+			{#if accounts.liabilities.length === 0}
+				<div class="text-center py-12 text-surface-700-300"><p>Brak pasywów</p></div>
+			{:else}
+				<div class="table-wrap">
+					<table class="table table-hover">
+						<thead>
 							<tr>
-								<td class="font-medium">{account.name}</td>
-								<td>{categoryLabels[account.category] || account.category}</td>
-								<td>{account.owner}</td>
-								<td class="font-semibold text-error-600-400">{formatPLN(account.current_value)}</td>
-								<td class="text-right whitespace-nowrap">
-									<button
-										type="button"
-										class="btn-icon btn-icon-sm"
-										aria-label="Edytuj"
-										onclick={() => startEdit(account)}
-									>
-										<Pencil size={16} />
-									</button>
-									<button
-										type="button"
-										class="btn-icon btn-icon-sm"
-										aria-label="Usuń"
-										onclick={() => handleDelete(account.id)}
-									>
-										<Trash2 size={16} />
-									</button>
-								</td>
+								<th>Nazwa</th>
+								<th>Kategoria</th>
+								<th>Właściciel</th>
+								<th>Wartość</th>
+								<th class="text-right">Akcje</th>
 							</tr>
-						{/each}
-					</tbody>
-				</table>
-			</div>
-		{/if}
+						</thead>
+						<tbody>
+							{#each accounts.liabilities as account}
+								<tr>
+									<td class="font-medium">{account.name}</td>
+									<td>{categoryLabels[account.category] || account.category}</td>
+									<td>{account.owner}</td>
+									<td class="font-semibold text-error-600-400"
+										>{formatPLN(account.current_value)}</td
+									>
+									<td class="text-right whitespace-nowrap">
+										<button
+											type="button"
+											class="btn-icon btn-icon-sm"
+											aria-label="Edytuj"
+											onclick={() => startEdit(account)}
+										>
+											<Pencil size={16} />
+										</button>
+										<button
+											type="button"
+											class="btn-icon btn-icon-sm"
+											aria-label="Usuń"
+											onclick={() => handleDelete(account.id)}
+										>
+											<Trash2 size={16} />
+										</button>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+		</div>
 	</div>
-</div>
+{:catch err}
+	<div class="card preset-filled-error-500 p-4">
+		<p class="font-semibold">Nie udało się załadować kont.</p>
+		<p class="text-sm">{err?.message ?? 'Spróbuj ponownie później.'}</p>
+	</div>
+{/await}
 
 <Modal
 	open={showForm}

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -324,7 +324,7 @@
 </div>
 
 {#await data.accountsData}
-	<div class="space-y-4">
+	<div role="status" aria-live="polite" aria-label="Ładowanie kont" class="space-y-4">
 		{#each [{ icon: Wallet, title: 'Aktywa' }, { icon: TrendingDown, title: 'Pasywa' }] as section}
 			<div class="card preset-filled-surface-100-900 p-4 space-y-4">
 				<header>
@@ -342,7 +342,7 @@
 							</tr>
 						</thead>
 						<tbody>
-							{#each Array(5) as _, i (i)}
+							{#each { length: 5 } as _, i (i)}
 								<tr>
 									<td><Skeleton height="1rem" width="70%" /></td>
 									<td><Skeleton height="1rem" width="60%" /></td>

--- a/src/routes/accounts/+page.ts
+++ b/src/routes/accounts/+page.ts
@@ -34,11 +34,13 @@ export const load: PageLoad = async ({ fetch }) => {
 		throw error(500, 'API URL is not configured');
 	}
 
-	const personasResponse = await fetch(`${apiUrl}/api/personas`);
-	if (!personasResponse.ok) {
-		throw error(personasResponse.status, 'Failed to load personas');
-	}
-	const personas: Persona[] = await personasResponse.json();
+	const personas = (async (): Promise<Persona[]> => {
+		const res = await fetch(`${apiUrl}/api/personas`);
+		if (!res.ok) {
+			throw error(res.status, 'Failed to load personas');
+		}
+		return (await res.json()) as Persona[];
+	})();
 
 	const accountsData = (async () => {
 		const response = await fetch(`${apiUrl}/api/accounts`);

--- a/src/routes/accounts/+page.ts
+++ b/src/routes/accounts/+page.ts
@@ -29,30 +29,27 @@ export interface AccountsData {
 export type { Transaction, TransactionsData };
 
 export const load: PageLoad = async ({ fetch }) => {
-	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API URL is not configured');
-		}
-		const [accountsResponse, personasResponse] = await Promise.all([
-			fetch(`${apiUrl}/api/accounts`),
-			fetch(`${apiUrl}/api/personas`)
-		]);
-
-		if (!accountsResponse.ok) {
-			throw error(accountsResponse.status, 'Failed to load accounts');
-		}
-		if (!personasResponse.ok) {
-			throw error(personasResponse.status, 'Failed to load personas');
-		}
-
-		const data: AccountsData = await accountsResponse.json();
-		const personas: Persona[] = await personasResponse.json();
-		return { ...data, personas };
-	} catch (err) {
-		if (err instanceof Error && 'status' in err) {
-			throw err;
-		}
-		throw error(500, 'Failed to load accounts');
+	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+	if (!apiUrl) {
+		throw error(500, 'API URL is not configured');
 	}
+
+	const personasResponse = await fetch(`${apiUrl}/api/personas`);
+	if (!personasResponse.ok) {
+		throw error(personasResponse.status, 'Failed to load personas');
+	}
+	const personas: Persona[] = await personasResponse.json();
+
+	const accountsData = (async () => {
+		const response = await fetch(`${apiUrl}/api/accounts`);
+		if (!response.ok) {
+			throw error(response.status, 'Failed to load accounts');
+		}
+		return (await response.json()) as AccountsData;
+	})();
+
+	return {
+		accountsData,
+		personas
+	};
 };

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -36,7 +36,8 @@ vi.mock('echarts', () => ({
 	default: {
 		init: vi.fn(() => ({
 			setOption: vi.fn(),
-			resize: vi.fn()
+			resize: vi.fn(),
+			dispose: vi.fn()
 		})),
 		graphic: {
 			LinearGradient: vi.fn()
@@ -44,7 +45,8 @@ vi.mock('echarts', () => ({
 	},
 	init: vi.fn(() => ({
 		setOption: vi.fn(),
-		resize: vi.fn()
+		resize: vi.fn(),
+		dispose: vi.fn()
 	})),
 	graphic: {
 		LinearGradient: vi.fn()
@@ -55,8 +57,14 @@ vi.mock('$app/navigation', () => ({
 	invalidateAll: vi.fn()
 }));
 
-describe('Dashboard Page', () => {
-	const mockData = {
+function buildData(
+	overrides: {
+		dashboardData?: Promise<Record<string, unknown>> | Record<string, unknown>;
+		personas?: { name: string }[];
+		currentYear?: number;
+	} = {}
+) {
+	const baseDashboard = {
 		net_worth_history: [
 			{ date: '2024-01-01', value: 5000 },
 			{ date: '2024-02-01', value: 6000 }
@@ -69,42 +77,72 @@ describe('Dashboard Page', () => {
 			{ category: 'banking', owner: 'John', value: 5000 },
 			{ category: 'investments', owner: 'John', value: 5000 }
 		],
-		retirementStats: [],
-		currentYear: 2024
+		retirementStats: [] as unknown[]
 	};
 
+	const dashboardData =
+		overrides.dashboardData instanceof Promise
+			? overrides.dashboardData
+			: Promise.resolve({
+					...baseDashboard,
+					...(overrides.dashboardData ?? {})
+				});
+
+	return {
+		dashboardData,
+		personas: overrides.personas ?? [],
+		currentYear: overrides.currentYear ?? 2024
+	};
+}
+
+describe('Dashboard Page', () => {
 	it('renders the main heading', () => {
-		render(Page, { props: { data: mockData } });
+		render(Page, { props: { data: buildData() } });
 		expect(screen.getByRole('heading', { name: /Dashboard/i })).toBeTruthy();
 	});
 
 	it('renders the description', () => {
-		render(Page, { props: { data: mockData } });
+		render(Page, { props: { data: buildData() } });
 		expect(screen.getByText('Twoja sytuacja finansowa w jednym miejscu')).toBeTruthy();
+	});
+
+	it('shows skeleton placeholders while dashboard data is loading', () => {
+		const pending = new Promise<Record<string, unknown>>(() => {});
+		render(Page, { props: { data: buildData({ dashboardData: pending }) } });
+		const placeholders = screen.getAllByRole('status', { name: /Ładowanie/i });
+		expect(placeholders.length).toBeGreaterThan(0);
+	});
+
+	it('renders dashboard metrics after data resolves', async () => {
+		render(Page, { props: { data: buildData() } });
+		await waitFor(() => expect(screen.getByText('Wartość Netto')).toBeTruthy());
 	});
 });
 
 describe('Dashboard retirement limits save flow', () => {
-	const dataWithStats = {
-		net_worth_history: [{ date: '2024-01-01', value: 5000 }],
-		current_net_worth: 6000,
-		change_vs_last_month: 1000,
-		total_assets: 10000,
-		total_liabilities: 4000,
-		allocation: [{ category: 'banking', owner: 'Marcin', value: 5000 }],
-		retirementStats: [
-			{
-				account_wrapper: 'IKE',
-				owner: 'Marcin',
-				total_contributed: 5000,
-				limit_amount: 23000,
-				remaining: 18000,
-				percentage_used: 21
-			}
-		],
-		personas: [{ name: 'Marcin' }],
-		currentYear: 2024
+	const retirementStat = {
+		account_wrapper: 'IKE',
+		owner: 'Marcin',
+		total_contributed: 5000,
+		limit_amount: 23000,
+		remaining: 18000,
+		percentage_used: 21
 	};
+
+	function dataWithStats() {
+		return buildData({
+			dashboardData: {
+				net_worth_history: [{ date: '2024-01-01', value: 5000 }],
+				current_net_worth: 6000,
+				change_vs_last_month: 1000,
+				total_assets: 10000,
+				total_liabilities: 4000,
+				allocation: [{ category: 'banking', owner: 'Marcin', value: 5000 }],
+				retirementStats: [retirementStat]
+			},
+			personas: [{ name: 'Marcin' }]
+		});
+	}
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -114,17 +152,20 @@ describe('Dashboard retirement limits save flow', () => {
 		vi.unstubAllGlobals();
 	});
 
-	it('renders the retirement limits card when stats exist', () => {
-		render(Page, { props: { data: dataWithStats } });
-		expect(screen.getByRole('heading', { name: /Limity Emerytalne 2024/ })).toBeTruthy();
+	it('renders the retirement limits card when stats exist', async () => {
+		render(Page, { props: { data: dataWithStats() } });
+		await waitFor(() =>
+			expect(screen.getByRole('heading', { name: /Limity Emerytalne 2024/ })).toBeTruthy()
+		);
 	});
 
 	it('opens the limits modal and PUTs each persona/wrapper limit on save', async () => {
 		const fetchMock = vi.fn().mockResolvedValue({ ok: true });
 		vi.stubGlobal('fetch', fetchMock);
 
-		render(Page, { props: { data: dataWithStats } });
+		render(Page, { props: { data: dataWithStats() } });
 
+		await waitFor(() => screen.getByLabelText('Konfiguruj limity'));
 		await fireEvent.click(screen.getByLabelText('Konfiguruj limity'));
 		expect(screen.getByText('Konfiguracja Limitów Emerytalnych')).toBeTruthy();
 
@@ -148,7 +189,8 @@ describe('Dashboard retirement limits save flow', () => {
 		const fetchMock = vi.fn().mockResolvedValue({ ok: true });
 		vi.stubGlobal('fetch', fetchMock);
 
-		render(Page, { props: { data: dataWithStats } });
+		render(Page, { props: { data: dataWithStats() } });
+		await waitFor(() => screen.getByLabelText('Konfiguruj limity'));
 		await fireEvent.click(screen.getByLabelText('Konfiguruj limity'));
 
 		const ikeInput = screen.getByLabelText('IKE Marcin (PLN)') as HTMLInputElement;
@@ -160,7 +202,8 @@ describe('Dashboard retirement limits save flow', () => {
 		vi.stubGlobal('fetch', fetchMock);
 		const errorSpy = vi.spyOn(toast, 'error');
 
-		render(Page, { props: { data: dataWithStats } });
+		render(Page, { props: { data: dataWithStats() } });
+		await waitFor(() => screen.getByLabelText('Konfiguruj limity'));
 		await fireEvent.click(screen.getByLabelText('Konfiguruj limity'));
 		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
 

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -108,9 +108,12 @@ describe('Dashboard Page', () => {
 
 	it('shows skeleton placeholders while dashboard data is loading', () => {
 		const pending = new Promise<Record<string, unknown>>(() => {});
-		render(Page, { props: { data: buildData({ dashboardData: pending }) } });
-		const placeholders = screen.getAllByRole('status', { name: /Ładowanie/i });
-		expect(placeholders.length).toBeGreaterThan(0);
+		const { container } = render(Page, {
+			props: { data: buildData({ dashboardData: pending }) }
+		});
+		const live = screen.getByRole('status', { name: /Ładowanie dashboardu/i });
+		expect(live).toBeTruthy();
+		expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0);
 	});
 
 	it('renders dashboard metrics after data resolves', async () => {

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -90,7 +90,7 @@ function buildData(
 
 	return {
 		dashboardData,
-		personas: overrides.personas ?? [],
+		personas: Promise.resolve(overrides.personas ?? []),
 		currentYear: overrides.currentYear ?? 2024
 	};
 }

--- a/src/routes/snapshots/+page.svelte
+++ b/src/routes/snapshots/+page.svelte
@@ -37,7 +37,7 @@
 	</header>
 
 	{#await data.snapshots}
-		<div class="table-wrap">
+		<div role="status" aria-live="polite" aria-label="Ładowanie snapshotów" class="table-wrap">
 			<table class="table">
 				<thead>
 					<tr>
@@ -48,7 +48,7 @@
 					</tr>
 				</thead>
 				<tbody>
-					{#each Array(5) as _, i (i)}
+					{#each { length: 5 } as _, i (i)}
 						<tr>
 							<td><Skeleton height="1rem" width="70%" /></td>
 							<td><Skeleton height="1rem" width="60%" /></td>

--- a/src/routes/snapshots/+page.svelte
+++ b/src/routes/snapshots/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import Skeleton from '$lib/components/Skeleton.svelte';
 	import { formatPLN } from '$lib/utils/format';
 	import { Plus, Camera, Pencil } from 'lucide-svelte';
 	import type { PageData } from './$types';
@@ -35,16 +36,9 @@
 		<h3 class="h3 flex items-center gap-2"><Camera size={20} /> Wszystkie Snapshots</h3>
 	</header>
 
-	{#if data.snapshots.length === 0}
-		<div class="text-center py-12 space-y-4 text-surface-700-300">
-			<p>Brak zapisanych snapshotów</p>
-			<button type="button" class="btn preset-tonal-primary" onclick={() => goto('/snapshots/new')}>
-				Utwórz pierwszy snapshot
-			</button>
-		</div>
-	{:else}
+	{#await data.snapshots}
 		<div class="table-wrap">
-			<table class="table table-hover">
+			<table class="table">
 				<thead>
 					<tr>
 						<th>Data</th>
@@ -54,34 +48,79 @@
 					</tr>
 				</thead>
 				<tbody>
-					{#each data.snapshots as snapshot}
+					{#each Array(5) as _, i (i)}
 						<tr>
-							<td class="font-medium">
-								{new Date(snapshot.date).toLocaleDateString('pl-PL', {
-									year: 'numeric',
-									month: 'long',
-									day: 'numeric'
-								})}
-							</td>
-							<td class="font-semibold text-primary-600-400"
-								>{formatPLN(snapshot.total_net_worth)}</td
-							>
-							<td class="italic text-surface-700-300">{snapshot.notes || '—'}</td>
-							<td class="text-right">
-								<button
-									type="button"
-									class="btn btn-sm preset-tonal-primary gap-1"
-									onclick={() => goto(`/snapshots/${snapshot.id}/edit`)}
-									title="Edytuj snapshot"
-								>
-									<Pencil size={14} />
-									Edytuj
-								</button>
+							<td><Skeleton height="1rem" width="70%" /></td>
+							<td><Skeleton height="1rem" width="60%" /></td>
+							<td><Skeleton height="1rem" width="85%" /></td>
+							<td>
+								<div class="flex justify-end">
+									<Skeleton height="2rem" width="5rem" rounded="md" />
+								</div>
 							</td>
 						</tr>
 					{/each}
 				</tbody>
 			</table>
 		</div>
-	{/if}
+	{:then snapshots}
+		{#if snapshots.length === 0}
+			<div class="text-center py-12 space-y-4 text-surface-700-300">
+				<p>Brak zapisanych snapshotów</p>
+				<button
+					type="button"
+					class="btn preset-tonal-primary"
+					onclick={() => goto('/snapshots/new')}
+				>
+					Utwórz pierwszy snapshot
+				</button>
+			</div>
+		{:else}
+			<div class="table-wrap">
+				<table class="table table-hover">
+					<thead>
+						<tr>
+							<th>Data</th>
+							<th>Wartość Netto</th>
+							<th>Notatki</th>
+							<th class="text-right">Akcje</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each snapshots as snapshot}
+							<tr>
+								<td class="font-medium">
+									{new Date(snapshot.date).toLocaleDateString('pl-PL', {
+										year: 'numeric',
+										month: 'long',
+										day: 'numeric'
+									})}
+								</td>
+								<td class="font-semibold text-primary-600-400"
+									>{formatPLN(snapshot.total_net_worth)}</td
+								>
+								<td class="italic text-surface-700-300">{snapshot.notes || '—'}</td>
+								<td class="text-right">
+									<button
+										type="button"
+										class="btn btn-sm preset-tonal-primary gap-1"
+										onclick={() => goto(`/snapshots/${snapshot.id}/edit`)}
+										title="Edytuj snapshot"
+									>
+										<Pencil size={14} />
+										Edytuj
+									</button>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	{:catch err}
+		<div class="card preset-filled-error-500 p-4">
+			<p class="font-semibold">Nie udało się załadować snapshotów.</p>
+			<p class="text-sm">{err?.message ?? 'Spróbuj ponownie później.'}</p>
+		</div>
+	{/await}
 </div>

--- a/src/routes/snapshots/+page.ts
+++ b/src/routes/snapshots/+page.ts
@@ -11,27 +11,20 @@ export interface SnapshotListItem {
 }
 
 export const load: PageLoad = async ({ fetch }) => {
-	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API URL is not configured');
-		}
+	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+	if (!apiUrl) {
+		throw error(500, 'API URL is not configured');
+	}
 
+	const snapshots = (async () => {
 		const response = await fetch(`${apiUrl}/api/snapshots`);
-
 		if (!response.ok) {
 			throw error(response.status, 'Failed to load snapshots');
 		}
+		return (await response.json()) as SnapshotListItem[];
+	})();
 
-		const snapshots: SnapshotListItem[] = await response.json();
-
-		return {
-			snapshots
-		};
-	} catch (err) {
-		if (err instanceof Error && 'status' in err) {
-			throw err;
-		}
-		throw error(500, 'Failed to load snapshots');
-	}
+	return {
+		snapshots
+	};
 };


### PR DESCRIPTION
## Motivation

Dashboard, accounts, and snapshots pages render blank then pop in while their `load()` data is in flight. Skeletons signal progress and prevent layout shift on slow loads. Closes #363.

## Implementation information

- New `src/lib/components/Skeleton.svelte` — shimmer block with CSS-only 150 ms reveal delay (`opacity: 0` + `animation-delay`). Honors `prefers-reduced-motion`. `aria-hidden` on each block; pages mark the containing region with a single `role="status"` live area so screen readers aren't spammed.
- `src/routes/+page.ts`, `accounts/+page.ts`, `snapshots/+page.ts` now stream the heavy fetch as a promise via SvelteKit streaming; the page renders immediately and `{#await ... }{:then ...}{:catch ...}` swaps skeletons for content (or shows an inline error).
- Dashboard skeleton fallback covers 3 metric cards + two chart-shaped 400 px blocks. The chart code moved into `src/lib/components/DashboardCharts.svelte` so the parent can stay declarative inside the await block.
- Accounts and snapshots fallbacks render 5 skeleton rows per table.
- Tests: new `Skeleton.test.ts`; existing dashboard tests adapted to a promise-shaped `data` factory.

Alternatives considered: layout-level overlay using `navigating` store (rejected — fires on the *old* page, no way to show route-specific shape); fully blocking `load()` + post-mount delay (rejected — chart "blank then pop" stays).

> Changelog: feat(ui): skeleton loaders on key pages