### PR TITLE
refactor(ui): converge legacy CSS to Tailwind/Skeleton

### DIFF
--- a/src/lib/components/SalaryCalculator.svelte
+++ b/src/lib/components/SalaryCalculator.svelte
@@ -397,13 +397,14 @@
 									{#each results as r}
 										<td class:highlight={row.bold && r === winner}>
 											{row.value(r)}
-											{#if baseline && row.delta && !r.isCurrentJob}
-												{@const d = row.delta(r, baseline)}
-												{#if d !== 0}
-													<span class="delta" class:positive={d > 0} class:negative={d < 0}>
-														{d > 0 ? '+' : ''}{fmt(d)}
-													</span>
-												{/if}
+											{#if baseline && row.delta && !r.isCurrentJob && row.delta(r, baseline) !== 0}
+												<span
+													class="delta"
+													class:positive={row.delta(r, baseline) > 0}
+													class:negative={row.delta(r, baseline) < 0}
+												>
+													{row.delta(r, baseline) > 0 ? '+' : ''}{fmt(row.delta(r, baseline))}
+												</span>
 											{/if}
 										</td>
 									{/each}

--- a/src/lib/components/SnapshotForm.svelte
+++ b/src/lib/components/SnapshotForm.svelte
@@ -411,26 +411,26 @@
 	}
 </script>
 
-<form onsubmit={handleSubmit} class="snapshot-form">
+<form onsubmit={handleSubmit} class="max-w-[800px] flex flex-col gap-6">
 	<!-- Date & Notes -->
 	<div class="card preset-filled-surface-100-900 p-4 space-y-4">
 		<header class="space-y-1">
 			<h3 class="h3">Data Snapshot</h3>
 		</header>
 		<div class="space-y-4">
-			<div class="form-group">
-				<label for="date" class="form-label">Data</label>
-				<input id="date" type="date" bind:value={snapshotDate} required class="form-input" />
+			<div class="flex flex-col gap-1">
+				<label for="date" class="text-sm font-semibold">Data</label>
+				<input id="date" type="date" bind:value={snapshotDate} required class="input" />
 			</div>
 
-			<div class="form-group">
-				<label for="notes" class="form-label">Notatki (opcjonalne)</label>
+			<div class="flex flex-col gap-1">
+				<label for="notes" class="text-sm font-semibold">Notatki (opcjonalne)</label>
 				<input
 					id="notes"
 					type="text"
 					bind:value={notes}
 					placeholder="Dodaj notatkę..."
-					class="form-input"
+					class="input"
 				/>
 			</div>
 		</div>
@@ -452,19 +452,23 @@
 				/>
 			{/each}
 
-			<div class="add-account">
+			<div class="mt-4 p-3 border border-dashed border-surface-300-700 rounded-container">
 				{#if financialAccounts.filter((a) => !visibleAccountIds.has(a.id)).length > 0}
 					<details>
-						<summary>+ Pokaż ukryte konta</summary>
-						<div class="add-account-list">
+						<summary
+							class="cursor-pointer text-primary-500 font-semibold text-sm select-none hover:text-primary-600-400"
+						>
+							+ Pokaż ukryte konta
+						</summary>
+						<div class="flex flex-col gap-2 mt-2">
 							{#each financialAccounts.filter((a) => !visibleAccountIds.has(a.id)) as account}
 								<button
 									type="button"
-									class="btn-add-account"
+									class="btn preset-tonal-surface w-full text-left text-sm"
 									onclick={() => addAccount(account.id)}
 								>
 									{account.name}
-									<span class="label-meta"
+									<span class="text-surface-600-400 font-normal ml-1"
 										>({categoryLabels[account.category] || account.category})</span
 									>
 								</button>
@@ -474,7 +478,7 @@
 				{/if}
 				<button
 					type="button"
-					class="btn-new-account"
+					class="btn w-full mt-2 border-2 border-dashed border-primary-500 text-primary-500 hover:preset-filled-primary-500"
 					onclick={() => openNewAccountForm('financial')}
 				>
 					+ Dodaj nowe konto
@@ -491,7 +495,11 @@
 			</header>
 			<div class="space-y-4">
 				{#each retirementByWrapper as group}
-					<h3 class="wrapper-subheading">{group.wrapper}</h3>
+					<h3
+						class="text-sm font-bold text-surface-600-400 uppercase tracking-wide mt-4 mb-2 pb-1 border-b border-surface-200-800"
+					>
+						{group.wrapper}
+					</h3>
 					{#each group.accounts.filter((a) => visibleAccountIds.has(a.id)) as account}
 						<ValueRow
 							inputId="account-{account.id}"
@@ -503,19 +511,25 @@
 					{/each}
 				{/each}
 
-				<div class="add-account">
+				<div class="mt-4 p-3 border border-dashed border-surface-300-700 rounded-container">
 					{#if retirementAccounts.filter((a) => !visibleAccountIds.has(a.id)).length > 0}
 						<details>
-							<summary>+ Pokaż ukryte konta</summary>
-							<div class="add-account-list">
+							<summary
+								class="cursor-pointer text-primary-500 font-semibold text-sm select-none hover:text-primary-600-400"
+							>
+								+ Pokaż ukryte konta
+							</summary>
+							<div class="flex flex-col gap-2 mt-2">
 								{#each retirementAccounts.filter((a) => !visibleAccountIds.has(a.id)) as account}
 									<button
 										type="button"
-										class="btn-add-account"
+										class="btn preset-tonal-surface w-full text-left text-sm"
 										onclick={() => addAccount(account.id)}
 									>
 										{account.name}
-										<span class="label-meta">({account.account_wrapper})</span>
+										<span class="text-surface-600-400 font-normal ml-1"
+											>({account.account_wrapper})</span
+										>
 									</button>
 								{/each}
 							</div>
@@ -523,7 +537,7 @@
 					{/if}
 					<button
 						type="button"
-						class="btn-new-account"
+						class="btn w-full mt-2 border-2 border-dashed border-primary-500 text-primary-500 hover:preset-filled-primary-500"
 						onclick={() => openNewAccountForm('retirement')}
 					>
 						+ Dodaj nowe konto
@@ -549,19 +563,23 @@
 				/>
 			{/each}
 
-			<div class="add-account">
+			<div class="mt-4 p-3 border border-dashed border-surface-300-700 rounded-container">
 				{#if investmentAccounts.filter((a) => !visibleAccountIds.has(a.id)).length > 0}
 					<details>
-						<summary>+ Pokaż ukryte konta</summary>
-						<div class="add-account-list">
+						<summary
+							class="cursor-pointer text-primary-500 font-semibold text-sm select-none hover:text-primary-600-400"
+						>
+							+ Pokaż ukryte konta
+						</summary>
+						<div class="flex flex-col gap-2 mt-2">
 							{#each investmentAccounts.filter((a) => !visibleAccountIds.has(a.id)) as account}
 								<button
 									type="button"
-									class="btn-add-account"
+									class="btn preset-tonal-surface w-full text-left text-sm"
 									onclick={() => addAccount(account.id)}
 								>
 									{account.name}
-									<span class="label-meta"
+									<span class="text-surface-600-400 font-normal ml-1"
 										>({categoryLabels[account.category] || account.category})</span
 									>
 								</button>
@@ -571,7 +589,7 @@
 				{/if}
 				<button
 					type="button"
-					class="btn-new-account"
+					class="btn w-full mt-2 border-2 border-dashed border-primary-500 text-primary-500 hover:preset-filled-primary-500"
 					onclick={() => openNewAccountForm('investment')}
 				>
 					+ Dodaj nowe konto
@@ -605,35 +623,51 @@
 				/>
 			{/each}
 
-			<div class="add-account">
+			<div class="mt-4 p-3 border border-dashed border-surface-300-700 rounded-container">
 				{#if majatekAccounts.filter((a) => !visibleAccountIds.has(a.id)).length > 0 || physicalAssets.filter((a) => !visibleAssetIds.has(a.id)).length > 0}
 					<details>
-						<summary>+ Pokaż ukryty majątek</summary>
-						<div class="add-account-list">
+						<summary
+							class="cursor-pointer text-primary-500 font-semibold text-sm select-none hover:text-primary-600-400"
+						>
+							+ Pokaż ukryty majątek
+						</summary>
+						<div class="flex flex-col gap-2 mt-2">
 							{#each majatekAccounts.filter((a) => !visibleAccountIds.has(a.id)) as account}
 								<button
 									type="button"
-									class="btn-add-account"
+									class="btn preset-tonal-surface w-full text-left text-sm"
 									onclick={() => addAccount(account.id)}
 								>
 									{account.name}
-									<span class="label-meta"
+									<span class="text-surface-600-400 font-normal ml-1"
 										>({categoryLabels[account.category] || account.category})</span
 									>
 								</button>
 							{/each}
 							{#each physicalAssets.filter((a) => !visibleAssetIds.has(a.id)) as asset}
-								<button type="button" class="btn-add-account" onclick={() => addAsset(asset.id)}>
+								<button
+									type="button"
+									class="btn preset-tonal-surface w-full text-left text-sm"
+									onclick={() => addAsset(asset.id)}
+								>
 									{asset.name}
 								</button>
 							{/each}
 						</div>
 					</details>
 				{/if}
-				<button type="button" class="btn-new-account" onclick={() => openNewAccountForm('majatek')}>
+				<button
+					type="button"
+					class="btn w-full mt-2 border-2 border-dashed border-primary-500 text-primary-500 hover:preset-filled-primary-500"
+					onclick={() => openNewAccountForm('majatek')}
+				>
 					+ Dodaj nowe konto
 				</button>
-				<button type="button" class="btn-new-account" onclick={() => (showNewAssetForm = true)}>
+				<button
+					type="button"
+					class="btn w-full mt-2 border-2 border-dashed border-primary-500 text-primary-500 hover:preset-filled-primary-500"
+					onclick={() => (showNewAssetForm = true)}
+				>
 					+ Dodaj nowy majątek
 				</button>
 			</div>
@@ -657,19 +691,25 @@
 					/>
 				{/each}
 
-				<div class="add-account">
+				<div class="mt-4 p-3 border border-dashed border-surface-300-700 rounded-container">
 					{#if liabilities.filter((a) => !visibleAccountIds.has(a.id)).length > 0}
 						<details>
-							<summary>+ Pokaż ukryte konta</summary>
-							<div class="add-account-list">
+							<summary
+								class="cursor-pointer text-primary-500 font-semibold text-sm select-none hover:text-primary-600-400"
+							>
+								+ Pokaż ukryte konta
+							</summary>
+							<div class="flex flex-col gap-2 mt-2">
 								{#each liabilities.filter((a) => !visibleAccountIds.has(a.id)) as account}
 									<button
 										type="button"
-										class="btn-add-account"
+										class="btn preset-tonal-surface w-full text-left text-sm"
 										onclick={() => addAccount(account.id)}
 									>
 										{account.name}
-										<span class="label-meta">({categoryLabels[account.category]})</span>
+										<span class="text-surface-600-400 font-normal ml-1"
+											>({categoryLabels[account.category]})</span
+										>
 									</button>
 								{/each}
 							</div>
@@ -677,7 +717,7 @@
 					{/if}
 					<button
 						type="button"
-						class="btn-new-account"
+						class="btn w-full mt-2 border-2 border-dashed border-primary-500 text-primary-500 hover:preset-filled-primary-500"
 						onclick={() => openNewAccountForm('liabilities')}
 					>
 						+ Dodaj nowe konto
@@ -716,198 +756,20 @@
 
 	<!-- Error Message -->
 	{#if error}
-		<div class="error-message">{error}</div>
+		<div class="card preset-filled-error-500 p-3 text-sm">{error}</div>
 	{/if}
 
 	<!-- Submit Buttons -->
-	<div class="button-group">
-		<button type="submit" disabled={loading} class="btn btn-primary">
+	<div class="flex flex-col-reverse sm:flex-row gap-3">
+		<button type="submit" disabled={loading} class="btn preset-filled-primary-500 sm:flex-1 w-full">
 			{loading ? 'Zapisywanie...' : '💾 Zapisz Snapshot'}
 		</button>
-		<button type="button" onclick={() => goto('/')} class="btn btn-secondary"> Anuluj </button>
+		<button
+			type="button"
+			onclick={() => goto('/')}
+			class="btn preset-tonal-surface w-full sm:w-auto"
+		>
+			Anuluj
+		</button>
 	</div>
 </form>
-
-<style>
-	.snapshot-form {
-		max-width: 800px;
-		display: flex;
-		flex-direction: column;
-		gap: var(--size-6);
-	}
-
-	.form-group {
-		margin-bottom: var(--size-4);
-	}
-
-	.form-group:last-child {
-		margin-bottom: 0;
-	}
-
-	.form-label {
-		display: block;
-		font-weight: var(--font-weight-6);
-		margin-bottom: var(--size-2);
-		color: var(--color-text);
-	}
-
-	.label-meta {
-		color: var(--color-text-secondary);
-		font-weight: var(--font-weight-4);
-		font-size: var(--font-size-1);
-	}
-
-	.wrapper-subheading {
-		margin: var(--size-4) 0 var(--size-2) 0;
-		padding-bottom: var(--size-1);
-		border-bottom: 1px solid var(--color-border);
-		font-size: var(--font-size-3);
-		font-weight: var(--font-weight-7);
-		color: var(--color-text-secondary);
-		letter-spacing: 0.05em;
-	}
-
-	.wrapper-subheading:first-child {
-		margin-top: 0;
-	}
-
-	.form-input {
-		width: 100%;
-		padding: var(--size-3);
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-2);
-		background: var(--color-bg);
-		color: var(--color-text);
-		font-size: var(--font-size-2);
-		font-family: inherit;
-		transition: all 0.2s;
-		min-height: var(--tap-target-min);
-	}
-
-	.form-input:focus {
-		outline: none;
-		border-color: var(--color-primary);
-		box-shadow: 0 0 0 2px rgba(94, 129, 172, 0.2);
-	}
-
-	.error-message {
-		padding: var(--size-3);
-		background: var(--nord11);
-		color: var(--nord6);
-		border-radius: var(--radius-2);
-		font-size: var(--font-size-2);
-	}
-
-	.button-group {
-		display: flex;
-		gap: var(--size-3);
-	}
-
-	.btn {
-		padding: var(--size-3) var(--size-5);
-		border: none;
-		border-radius: var(--radius-2);
-		font-weight: var(--font-weight-6);
-		font-size: var(--font-size-2);
-		cursor: pointer;
-		transition: all 0.2s;
-	}
-
-	.btn:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	.btn-primary {
-		background: var(--color-primary);
-		color: var(--nord6);
-		flex: 1;
-	}
-
-	.btn-primary:hover:not(:disabled) {
-		background: var(--nord9);
-	}
-
-	.btn-secondary {
-		background: transparent;
-		color: var(--color-text);
-		border: 1px solid var(--color-border);
-	}
-
-	.btn-secondary:hover {
-		background: var(--color-accent);
-	}
-
-	.add-account {
-		margin-top: var(--size-4);
-		padding: var(--size-3);
-		border: 1px dashed var(--color-border);
-		border-radius: var(--radius-2);
-	}
-
-	.add-account summary {
-		cursor: pointer;
-		color: var(--color-primary);
-		font-weight: var(--font-weight-6);
-		font-size: var(--font-size-2);
-		user-select: none;
-	}
-
-	.add-account summary:hover {
-		color: var(--nord9);
-	}
-
-	.add-account-list {
-		display: flex;
-		flex-direction: column;
-		gap: var(--size-2);
-	}
-
-	.btn-add-account {
-		width: 100%;
-		padding: var(--size-2) var(--size-3);
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-2);
-		background: var(--color-bg);
-		color: var(--color-text);
-		font-size: var(--font-size-2);
-		text-align: left;
-		cursor: pointer;
-		transition: all 0.2s;
-	}
-
-	.btn-add-account:hover {
-		background: var(--color-accent);
-		border-color: var(--color-primary);
-	}
-
-	.btn-new-account {
-		width: 100%;
-		padding: var(--size-3);
-		margin-top: var(--size-2);
-		border: 2px dashed var(--color-primary);
-		border-radius: var(--radius-2);
-		background: transparent;
-		color: var(--color-primary);
-		font-size: var(--font-size-2);
-		font-weight: var(--font-weight-6);
-		cursor: pointer;
-		transition: all 0.2s;
-	}
-
-	.btn-new-account:hover {
-		background: var(--color-primary);
-		color: var(--nord6);
-	}
-
-	@media (max-width: 640px) {
-		.button-group {
-			flex-direction: column-reverse;
-		}
-
-		.button-group .btn {
-			width: 100%;
-			flex: none;
-		}
-	}
-</style>

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -25,14 +25,13 @@
 	aria-label="Powiadomienia"
 >
 	{#each items as item (item.id)}
-		{@const Icon = iconFor(item.kind)}
 		<div
 			class="pointer-events-auto flex items-start gap-3 rounded-container px-4 py-3 shadow-lg w-full max-w-sm {classFor(
 				item.kind
 			)}"
 			role={item.kind === 'error' ? 'alert' : 'status'}
 		>
-			<Icon size={18} class="mt-0.5 shrink-0" />
+			<svelte:component this={iconFor(item.kind)} size={18} class="mt-0.5 shrink-0" />
 			<span class="flex-1 text-sm">{item.message}</span>
 			<button
 				type="button"

--- a/src/lib/components/snapshot/NewAccountModal.svelte
+++ b/src/lib/components/snapshot/NewAccountModal.svelte
@@ -38,34 +38,47 @@
 
 <svelte:window onkeydown={closeOnEscape} />
 
-<div class="modal-overlay" role="presentation" onclick={closeOnBackdrop}>
+<div
+	class="fixed inset-0 z-50 flex items-center justify-center bg-surface-950/60 backdrop-blur-sm p-4"
+	role="presentation"
+	onclick={closeOnBackdrop}
+>
 	<div
-		class="modal"
+		class="card preset-filled-surface-50-950 w-full max-w-lg max-h-[90vh] flex flex-col shadow-xl"
 		role="dialog"
 		aria-modal="true"
 		aria-labelledby="new-account-modal-title"
 		tabindex="-1"
 	>
-		<div class="modal-header">
-			<h2 id="new-account-modal-title">Dodaj nowe konto</h2>
-			<button type="button" class="btn-close" onclick={onClose} title="Zamknij"> × </button>
-		</div>
-		<div class="modal-content">
-			<div class="form-group">
-				<label for="newAccountName" class="form-label">Nazwa konta *</label>
+		<header class="flex items-center justify-between px-5 py-4 border-b border-surface-200-800">
+			<h2 id="new-account-modal-title" class="h4 font-bold">Dodaj nowe konto</h2>
+			<button
+				type="button"
+				class="btn-icon btn-icon-sm"
+				aria-label="Zamknij"
+				title="Zamknij"
+				onclick={onClose}
+			>
+				×
+			</button>
+		</header>
+
+		<div class="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+			<div class="flex flex-col gap-1">
+				<label for="newAccountName" class="text-sm font-semibold">Nazwa konta *</label>
 				<input
 					id="newAccountName"
 					type="text"
 					bind:value={name}
 					placeholder="np. Konto oszczędnościowe"
-					class="form-input"
+					class="input"
 					required
 				/>
 			</div>
 
-			<div class="form-group">
-				<label for="newAccountCategory" class="form-label">Kategoria *</label>
-				<select id="newAccountCategory" bind:value={category} class="form-input">
+			<div class="flex flex-col gap-1">
+				<label for="newAccountCategory" class="text-sm font-semibold">Kategoria *</label>
+				<select id="newAccountCategory" bind:value={category} class="select">
 					{#if section === 'financial'}
 						<option value="bank">Konto bankowe</option>
 						<option value="saving_account">Konto oszczędnościowe</option>
@@ -95,9 +108,9 @@
 			</div>
 
 			{#if section === 'retirement'}
-				<div class="form-group">
-					<label for="newAccountWrapper" class="form-label">Wrapper *</label>
-					<select id="newAccountWrapper" bind:value={wrapper} class="form-input">
+				<div class="flex flex-col gap-1">
+					<label for="newAccountWrapper" class="text-sm font-semibold">Wrapper *</label>
+					<select id="newAccountWrapper" bind:value={wrapper} class="select">
 						<option value="IKE">IKE</option>
 						<option value="IKZE">IKZE</option>
 						<option value="PPK">PPK</option>
@@ -105,175 +118,38 @@
 				</div>
 			{/if}
 
-			<div class="form-group">
-				<label for="newAccountOwner" class="form-label">Właściciel</label>
-				<select id="newAccountOwner" bind:value={owner} class="form-input">
+			<div class="flex flex-col gap-1">
+				<label for="newAccountOwner" class="text-sm font-semibold">Właściciel</label>
+				<select id="newAccountOwner" bind:value={owner} class="select">
 					{#each personas as persona}
 						<option value={persona.name}>{persona.name}</option>
 					{/each}
 				</select>
 			</div>
 
-			<div class="form-group">
-				<label for="newAccountValue" class="form-label">Wartość początkowa</label>
+			<div class="flex flex-col gap-1">
+				<label for="newAccountValue" class="text-sm font-semibold">Wartość początkowa</label>
 				<input
 					id="newAccountValue"
 					type="number"
 					step="0.01"
 					bind:value
 					placeholder="0.00"
-					class="form-input"
+					class="input"
 				/>
 			</div>
 		</div>
-		<div class="modal-footer">
-			<button type="button" class="btn btn-secondary" onclick={onClose}> Anuluj </button>
-			<button type="button" class="btn btn-primary" disabled={creating} onclick={onCreate}>
+
+		<footer class="flex justify-end gap-2 px-5 py-4 border-t border-surface-200-800">
+			<button type="button" class="btn preset-tonal-surface" onclick={onClose}>Anuluj</button>
+			<button
+				type="button"
+				class="btn preset-filled-primary-500"
+				disabled={creating}
+				onclick={onCreate}
+			>
 				{creating ? 'Tworzenie...' : 'Utwórz konto'}
 			</button>
-		</div>
+		</footer>
 	</div>
 </div>
-
-<style>
-	.form-group {
-		margin-bottom: var(--size-4);
-	}
-
-	.form-group:last-child {
-		margin-bottom: 0;
-	}
-
-	.form-label {
-		display: block;
-		font-weight: var(--font-weight-6);
-		margin-bottom: var(--size-2);
-		color: var(--color-text);
-	}
-
-	.form-input {
-		width: 100%;
-		padding: var(--size-3);
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-2);
-		background: var(--color-bg);
-		color: var(--color-text);
-		font-size: var(--font-size-2);
-		font-family: inherit;
-		transition: all 0.2s;
-		min-height: var(--tap-target-min);
-	}
-
-	.form-input:focus {
-		outline: none;
-		border-color: var(--color-primary);
-		box-shadow: 0 0 0 2px rgba(94, 129, 172, 0.2);
-	}
-
-	.btn {
-		padding: var(--size-3) var(--size-5);
-		border: none;
-		border-radius: var(--radius-2);
-		font-weight: var(--font-weight-6);
-		font-size: var(--font-size-2);
-		cursor: pointer;
-		transition: all 0.2s;
-	}
-
-	.btn:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	.btn-primary {
-		background: var(--color-primary);
-		color: var(--nord6);
-		flex: 1;
-	}
-
-	.btn-primary:hover:not(:disabled) {
-		background: var(--nord9);
-	}
-
-	.btn-secondary {
-		background: transparent;
-		color: var(--color-text);
-		border: 1px solid var(--color-border);
-	}
-
-	.btn-secondary:hover {
-		background: var(--color-accent);
-	}
-
-	.modal-overlay {
-		position: fixed;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		background: rgba(0, 0, 0, 0.5);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		z-index: 1000;
-		padding: var(--size-4);
-	}
-
-	.modal {
-		background: var(--color-bg);
-		border-radius: var(--radius-2);
-		max-width: 500px;
-		width: 100%;
-		box-shadow: var(--shadow-6);
-	}
-
-	.modal-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: var(--size-4);
-		border-bottom: 1px solid var(--color-border);
-	}
-
-	.modal-header h2 {
-		margin: 0;
-		font-size: var(--font-size-4);
-		font-weight: var(--font-weight-7);
-		color: var(--color-text);
-	}
-
-	.btn-close {
-		width: var(--tap-target-min);
-		height: var(--tap-target-min);
-		padding: 0;
-		border: none;
-		background: transparent;
-		color: var(--color-text-secondary);
-		font-size: var(--font-size-5);
-		line-height: 1;
-		cursor: pointer;
-		transition: all 0.2s;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-	}
-
-	.btn-close:hover {
-		color: var(--nord11);
-	}
-
-	.modal-content {
-		padding: var(--size-4);
-	}
-
-	.modal-footer {
-		display: flex;
-		gap: var(--size-3);
-		padding: var(--size-4);
-		border-top: 1px solid var(--color-border);
-	}
-
-	.modal-footer .btn {
-		flex: 1;
-	}
-</style>

--- a/src/lib/components/snapshot/NewAssetModal.svelte
+++ b/src/lib/components/snapshot/NewAssetModal.svelte
@@ -26,191 +26,67 @@
 
 <svelte:window onkeydown={closeOnEscape} />
 
-<div class="modal-overlay" role="presentation" onclick={closeOnBackdrop}>
+<div
+	class="fixed inset-0 z-50 flex items-center justify-center bg-surface-950/60 backdrop-blur-sm p-4"
+	role="presentation"
+	onclick={closeOnBackdrop}
+>
 	<div
-		class="modal"
+		class="card preset-filled-surface-50-950 w-full max-w-lg max-h-[90vh] flex flex-col shadow-xl"
 		role="dialog"
 		aria-modal="true"
 		aria-labelledby="new-asset-modal-title"
 		tabindex="-1"
 	>
-		<div class="modal-header">
-			<h2 id="new-asset-modal-title">Dodaj nowy majątek</h2>
-			<button type="button" class="btn-close" onclick={onClose} title="Zamknij"> × </button>
-		</div>
-		<div class="modal-content">
-			<div class="form-group">
-				<label for="newAssetName" class="form-label">Nazwa *</label>
+		<header class="flex items-center justify-between px-5 py-4 border-b border-surface-200-800">
+			<h2 id="new-asset-modal-title" class="h4 font-bold">Dodaj nowy majątek</h2>
+			<button
+				type="button"
+				class="btn-icon btn-icon-sm"
+				aria-label="Zamknij"
+				title="Zamknij"
+				onclick={onClose}
+			>
+				×
+			</button>
+		</header>
+
+		<div class="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+			<div class="flex flex-col gap-1">
+				<label for="newAssetName" class="text-sm font-semibold">Nazwa *</label>
 				<input
 					id="newAssetName"
 					type="text"
 					bind:value={name}
 					placeholder="np. Mieszkanie Poznań, Rower"
-					class="form-input"
+					class="input"
 					required
 				/>
 			</div>
 
-			<div class="form-group">
-				<label for="newAssetValue" class="form-label">Wartość początkowa</label>
+			<div class="flex flex-col gap-1">
+				<label for="newAssetValue" class="text-sm font-semibold">Wartość początkowa</label>
 				<input
 					id="newAssetValue"
 					type="number"
 					step="0.01"
 					bind:value
 					placeholder="0.00"
-					class="form-input"
+					class="input"
 				/>
 			</div>
 		</div>
-		<div class="modal-footer">
-			<button type="button" class="btn btn-secondary" onclick={onClose}> Anuluj </button>
-			<button type="button" class="btn btn-primary" disabled={creating} onclick={onCreate}>
+
+		<footer class="flex justify-end gap-2 px-5 py-4 border-t border-surface-200-800">
+			<button type="button" class="btn preset-tonal-surface" onclick={onClose}>Anuluj</button>
+			<button
+				type="button"
+				class="btn preset-filled-primary-500"
+				disabled={creating}
+				onclick={onCreate}
+			>
 				{creating ? 'Tworzenie...' : 'Utwórz majątek'}
 			</button>
-		</div>
+		</footer>
 	</div>
 </div>
-
-<style>
-	.form-group {
-		margin-bottom: var(--size-4);
-	}
-
-	.form-group:last-child {
-		margin-bottom: 0;
-	}
-
-	.form-label {
-		display: block;
-		font-weight: var(--font-weight-6);
-		margin-bottom: var(--size-2);
-		color: var(--color-text);
-	}
-
-	.form-input {
-		width: 100%;
-		padding: var(--size-3);
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-2);
-		background: var(--color-bg);
-		color: var(--color-text);
-		font-size: var(--font-size-2);
-		font-family: inherit;
-		transition: all 0.2s;
-		min-height: var(--tap-target-min);
-	}
-
-	.form-input:focus {
-		outline: none;
-		border-color: var(--color-primary);
-		box-shadow: 0 0 0 2px rgba(94, 129, 172, 0.2);
-	}
-
-	.btn {
-		padding: var(--size-3) var(--size-5);
-		border: none;
-		border-radius: var(--radius-2);
-		font-weight: var(--font-weight-6);
-		font-size: var(--font-size-2);
-		cursor: pointer;
-		transition: all 0.2s;
-	}
-
-	.btn:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	.btn-primary {
-		background: var(--color-primary);
-		color: var(--nord6);
-		flex: 1;
-	}
-
-	.btn-primary:hover:not(:disabled) {
-		background: var(--nord9);
-	}
-
-	.btn-secondary {
-		background: transparent;
-		color: var(--color-text);
-		border: 1px solid var(--color-border);
-	}
-
-	.btn-secondary:hover {
-		background: var(--color-accent);
-	}
-
-	.modal-overlay {
-		position: fixed;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		background: rgba(0, 0, 0, 0.5);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		z-index: 1000;
-		padding: var(--size-4);
-	}
-
-	.modal {
-		background: var(--color-bg);
-		border-radius: var(--radius-2);
-		max-width: 500px;
-		width: 100%;
-		box-shadow: var(--shadow-6);
-	}
-
-	.modal-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: var(--size-4);
-		border-bottom: 1px solid var(--color-border);
-	}
-
-	.modal-header h2 {
-		margin: 0;
-		font-size: var(--font-size-4);
-		font-weight: var(--font-weight-7);
-		color: var(--color-text);
-	}
-
-	.btn-close {
-		width: var(--tap-target-min);
-		height: var(--tap-target-min);
-		padding: 0;
-		border: none;
-		background: transparent;
-		color: var(--color-text-secondary);
-		font-size: var(--font-size-5);
-		line-height: 1;
-		cursor: pointer;
-		transition: all 0.2s;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-	}
-
-	.btn-close:hover {
-		color: var(--nord11);
-	}
-
-	.modal-content {
-		padding: var(--size-4);
-	}
-
-	.modal-footer {
-		display: flex;
-		gap: var(--size-3);
-		padding: var(--size-4);
-		border-top: 1px solid var(--color-border);
-	}
-
-	.modal-footer .btn {
-		flex: 1;
-	}
-</style>

--- a/src/lib/components/snapshot/ValueRow.svelte
+++ b/src/lib/components/snapshot/ValueRow.svelte
@@ -10,107 +10,22 @@
 	let { inputId, label, meta = '', value = $bindable(), onRemove }: Props = $props();
 </script>
 
-<div class="form-group-with-remove">
-	<div class="form-group">
-		<label for={inputId} class="form-label">
+<div class="flex gap-2 items-end mb-4">
+	<div class="flex flex-col gap-1 flex-1">
+		<label for={inputId} class="text-sm font-semibold">
 			{label}
 			{#if meta}
-				<span class="label-meta">{meta}</span>
+				<span class="text-surface-600-400 font-normal">{meta}</span>
 			{/if}
 		</label>
-		<input
-			id={inputId}
-			type="number"
-			step="0.01"
-			bind:value
-			placeholder="0.00"
-			class="form-input"
-		/>
+		<input id={inputId} type="number" step="0.01" bind:value placeholder="0.00" class="input" />
 	</div>
-	<button type="button" class="btn-remove" onclick={onRemove} title="Usuń pole"> × </button>
+	<button
+		type="button"
+		class="btn-icon btn-icon-sm preset-tonal-error shrink-0"
+		onclick={onRemove}
+		title="Usuń pole"
+	>
+		×
+	</button>
 </div>
-
-<style>
-	.form-group {
-		margin-bottom: var(--size-4);
-	}
-
-	.form-group:last-child {
-		margin-bottom: 0;
-	}
-
-	.form-label {
-		display: block;
-		font-weight: var(--font-weight-6);
-		margin-bottom: var(--size-2);
-		color: var(--color-text);
-	}
-
-	.label-meta {
-		color: var(--color-text-secondary);
-		font-weight: var(--font-weight-4);
-		font-size: var(--font-size-1);
-	}
-
-	.form-input {
-		width: 100%;
-		padding: var(--size-3);
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-2);
-		background: var(--color-bg);
-		color: var(--color-text);
-		font-size: var(--font-size-2);
-		font-family: inherit;
-		transition: all 0.2s;
-		min-height: var(--tap-target-min);
-	}
-
-	.form-input:focus {
-		outline: none;
-		border-color: var(--color-primary);
-		box-shadow: 0 0 0 2px rgba(94, 129, 172, 0.2);
-	}
-
-	.form-group-with-remove {
-		display: flex;
-		gap: var(--size-2);
-		align-items: flex-start;
-		margin-bottom: var(--size-4);
-	}
-
-	.form-group-with-remove .form-group {
-		flex: 1;
-		margin-bottom: 0;
-	}
-
-	.btn-remove {
-		flex-shrink: 0;
-		width: var(--tap-target-min);
-		height: var(--tap-target-min);
-		margin-top: 28px;
-		padding: 0;
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-2);
-		background: transparent;
-		color: var(--color-text-secondary);
-		font-size: var(--font-size-4);
-		line-height: 1;
-		cursor: pointer;
-		transition: all 0.2s;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-	}
-
-	.btn-remove:hover {
-		background: var(--nord11);
-		color: var(--nord6);
-		border-color: var(--nord11);
-	}
-
-	@media (max-width: 640px) {
-		.btn-remove {
-			margin-top: 32px;
-		}
-	}
-</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -34,6 +34,12 @@
 	];
 
 	let { children } = $props();
+
+	function isActive(href: string): boolean {
+		return href === '/simulations'
+			? $page.url.pathname.startsWith('/simulations')
+			: $page.url.pathname === href;
+	}
 </script>
 
 <Toast />
@@ -48,19 +54,15 @@
 		</div>
 		<nav class="flex-1 overflow-y-auto p-2 space-y-1">
 			{#each navItems as item}
-				{@const active =
-					item.href === '/simulations'
-						? $page.url.pathname.startsWith('/simulations')
-						: $page.url.pathname === item.href}
-				{@const Icon = item.icon}
 				<a
 					href={item.href}
-					class="flex items-center gap-3 px-3 py-2 rounded-container text-sm transition-colors
-						{active
+					class="flex items-center gap-3 px-3 py-2 rounded-container text-sm transition-colors {isActive(
+						item.href
+					)
 						? 'preset-filled-primary-500 font-semibold'
 						: 'hover:preset-tonal-primary text-surface-800-200'}"
 				>
-					<Icon size={18} />
+					<svelte:component this={item.icon} size={18} />
 					<span>{item.label}</span>
 				</a>
 			{/each}
@@ -86,17 +88,15 @@
 			aria-label="Mobile navigation"
 		>
 			{#each navItems as item}
-				{@const active =
-					item.href === '/simulations'
-						? $page.url.pathname.startsWith('/simulations')
-						: $page.url.pathname === item.href}
-				{@const Icon = item.icon}
 				<a
 					href={item.href}
-					class="flex flex-col items-center justify-center gap-1 min-w-16 shrink-0 px-3 py-2 text-[10px]
-						{active ? 'text-primary-500 font-semibold' : 'text-surface-700-300'}"
+					class="flex flex-col items-center justify-center gap-1 min-w-16 shrink-0 px-3 py-2 text-[10px] {isActive(
+						item.href
+					)
+						? 'text-primary-500 font-semibold'
+						: 'text-surface-700-300'}"
 				>
-					<Icon size={20} />
+					<svelte:component this={item.icon} size={20} />
 					<span class="whitespace-nowrap">{item.label}</span>
 				</a>
 			{/each}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -137,11 +137,6 @@
 			</div>
 		</div>
 	{:then dashboard}
-		{@const change = calculateChange(
-			dashboard.current_net_worth,
-			dashboard.current_net_worth - dashboard.change_vs_last_month
-		)}
-
 		<div class="grid gap-4 sm:gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
 			<div class="card preset-filled-surface-100-900 p-4 space-y-2">
 				<header>
@@ -159,7 +154,14 @@
 						<TrendingDown size={14} />
 					{/if}
 					{formatPLN(Math.abs(dashboard.change_vs_last_month))}
-					({formatPercent(Math.abs(change.percent))})
+					({formatPercent(
+						Math.abs(
+							calculateChange(
+								dashboard.current_net_worth,
+								dashboard.current_net_worth - dashboard.change_vs_last_month
+							).percent
+						)
+					)})
 					<span class="text-surface-700-300">vs poprzedni miesiąc</span>
 				</p>
 			</div>

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -336,10 +336,12 @@
 {#await data.accountsData}
 	<div role="status" aria-live="polite" aria-label="Ładowanie kont" class="space-y-4">
 		{#each [{ icon: Wallet, title: 'Aktywa' }, { icon: TrendingDown, title: 'Pasywa' }] as section}
-			{@const Icon = section.icon}
 			<div class="card preset-filled-surface-100-900 p-4 space-y-4">
 				<header>
-					<h3 class="h3 flex items-center gap-2"><Icon size={20} /> {section.title}</h3>
+					<h3 class="h3 flex items-center gap-2">
+						<svelte:component this={section.icon} size={20} />
+						{section.title}
+					</h3>
 				</header>
 				<div class="table-wrap">
 					<table class="table">

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -409,31 +409,31 @@
 
 	<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
 		<div class="card preset-filled-surface-100-900 p-4">
-			<div bind:this={allocationChart} class="w-full h-[400px] sm:h-[280px]"></div>
+			<div bind:this={allocationChart} class="w-full h-[280px] sm:h-[400px]"></div>
 		</div>
 
 		<div class="card preset-filled-surface-100-900 p-4">
-			<div bind:this={wrapperChart} class="w-full h-[400px] sm:h-[280px]"></div>
+			<div bind:this={wrapperChart} class="w-full h-[280px] sm:h-[400px]"></div>
 		</div>
 	</div>
 
 	<h2 class="h2">Wzrost inwestycji w czasie</h2>
 
 	<div class="card preset-filled-surface-100-900 p-4 mb-8">
-		<div bind:this={investmentTrendChart} class="w-full h-[500px] sm:h-[320px]"></div>
+		<div bind:this={investmentTrendChart} class="w-full h-[320px] sm:h-[500px]"></div>
 	</div>
 
 	<h2 class="h2">Wzrost według typu konta</h2>
 
 	<div class="grid grid-cols-1 gap-4 mb-8">
 		<div class="card preset-filled-surface-100-900 p-4">
-			<div bind:this={ikeChart} class="w-full h-[400px] sm:h-[280px]"></div>
+			<div bind:this={ikeChart} class="w-full h-[280px] sm:h-[400px]"></div>
 		</div>
 		<div class="card preset-filled-surface-100-900 p-4">
-			<div bind:this={ikzeChart} class="w-full h-[400px] sm:h-[280px]"></div>
+			<div bind:this={ikzeChart} class="w-full h-[280px] sm:h-[400px]"></div>
 		</div>
 		<div class="card preset-filled-surface-100-900 p-4">
-			<div bind:this={ppkChart} class="w-full h-[400px] sm:h-[280px]"></div>
+			<div bind:this={ppkChart} class="w-full h-[280px] sm:h-[400px]"></div>
 		</div>
 	</div>
 
@@ -441,16 +441,16 @@
 
 	<div class="grid grid-cols-1 gap-4 mb-8">
 		<div class="card preset-filled-surface-100-900 p-4">
-			<div bind:this={stockChart} class="w-full h-[400px] sm:h-[280px]"></div>
+			<div bind:this={stockChart} class="w-full h-[280px] sm:h-[400px]"></div>
 		</div>
 		<div class="card preset-filled-surface-100-900 p-4">
-			<div bind:this={bondChart} class="w-full h-[400px] sm:h-[280px]"></div>
+			<div bind:this={bondChart} class="w-full h-[280px] sm:h-[400px]"></div>
 		</div>
 	</div>
 
 	<h2 class="h2">Roczny ROI według klasy aktywów</h2>
 
 	<div class="card preset-filled-surface-100-900 p-4 mb-8">
-		<div bind:this={yearlyRoiChart} class="w-full h-[500px] sm:h-[320px]"></div>
+		<div bind:this={yearlyRoiChart} class="w-full h-[320px] sm:h-[500px]"></div>
 	</div>
 </div>

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -102,25 +102,27 @@
 	<title>Metryki - Finance Buddy</title>
 </svelte:head>
 
-<div class="container">
-	<h1>Metryki</h1>
+<div class="space-y-6">
+	<h1 class="h1">Metryki</h1>
 
-	<h2>Jak inwestować nowe pieniądze</h2>
+	<h2 class="h2">Jak inwestować nowe pieniądze</h2>
 
 	{#if allocationAnalysis.rebalancing.length > 0}
-		<div class="rebalancing-container">
-			<p class="rebalancing-intro">
+		<div class="card preset-filled-surface-100-900 p-5">
+			<p class="mb-4 text-surface-600-400">
 				Aby osiągnąć docelową alokację portfela, wpłać nowe środki w następujący sposób:
 			</p>
 
-			<div class="rebalancing-list">
+			<div class="flex flex-col gap-3 mb-4">
 				{#each allocationAnalysis.rebalancing as suggestion}
-					<div class="rebalancing-item buy">
-						<span class="action-label inline-flex items-center gap-1"
+					<div
+						class="flex items-center gap-4 p-3 rounded-container border border-success-500 bg-success-500/10"
+					>
+						<span class="font-bold min-w-[120px] text-success-500 inline-flex items-center gap-1"
 							><TrendingUp size={14} /> KUP</span
 						>
-						<span class="category-name">{suggestion.category}</span>
-						<span class="amount">
+						<span class="flex-1 capitalize">{suggestion.category}</span>
+						<span class="font-bold">
 							{suggestion.amount.toLocaleString('pl-PL', {
 								minimumFractionDigits: 0,
 								maximumFractionDigits: 0
@@ -130,7 +132,7 @@
 				{/each}
 			</div>
 
-			<p class="rebalancing-note inline-flex items-center gap-1">
+			<p class="italic text-surface-600-400 mt-4 inline-flex items-center gap-1">
 				<Lightbulb size={14} /> Całkowita wartość portfela inwestycyjnego: {allocationAnalysis.total_investment_value.toLocaleString(
 					'pl-PL',
 					{ minimumFractionDigits: 0, maximumFractionDigits: 0 }
@@ -138,14 +140,16 @@
 			</p>
 		</div>
 	{:else}
-		<div class="no-rebalancing inline-flex items-center gap-2">
+		<div
+			class="card preset-filled-surface-100-900 p-4 flex items-center gap-2 text-success-500 font-semibold"
+		>
 			<CheckCircle2 size={16} /> Portfel jest zgodny z docelową alokacją (różnice mniejsze niż 1%)
 		</div>
 	{/if}
 
-	<h2>Przegląd finansowy</h2>
+	<h2 class="h2">Przegląd finansowy</h2>
 
-	<div class="metrics-grid">
+	<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 		<MetricCard
 			label="Ile metrów mieszkania jest nasze"
 			value={metricCards.property_sqm}
@@ -262,10 +266,10 @@
 
 	<!-- PPK Stats Section -->
 	{#if data.ppkStats && data.ppkStats.length > 0}
-		<h2>Podsumowanie PPK</h2>
+		<h2 class="h2">Podsumowanie PPK</h2>
 		{#each data.ppkStats as ppkStat}
-			<h3 class="ppk-owner-title">{ppkStat.owner}</h3>
-			<div class="metrics-grid">
+			<h3 class="h4 font-semibold mt-4 mb-3">{ppkStat.owner}</h3>
+			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 				<MetricCard
 					label="PPK - Wartość całkowita"
 					value={ppkStat.total_value}
@@ -327,8 +331,8 @@
 
 	<!-- Stock Stats Section -->
 	{#if data.stockStats}
-		<h2>Podsumowanie Akcji</h2>
-		<div class="metrics-grid">
+		<h2 class="h2">Podsumowanie Akcji</h2>
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 			<MetricCard
 				label="Akcje - Wartość całkowita"
 				value={data.stockStats.total_value}
@@ -365,8 +369,8 @@
 
 	<!-- Bond Stats Section -->
 	{#if data.bondStats}
-		<h2>Podsumowanie Obligacji</h2>
-		<div class="metrics-grid">
+		<h2 class="h2">Podsumowanie Obligacji</h2>
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 			<MetricCard
 				label="Obligacje - Wartość całkowita"
 				value={data.bondStats.total_value}
@@ -401,248 +405,52 @@
 		</div>
 	{/if}
 
-	<h2>Struktura portfela inwestycyjnego</h2>
+	<h2 class="h2">Struktura portfela inwestycyjnego</h2>
 
-	<div class="charts-grid">
-		<div class="chart-container">
-			<div bind:this={allocationChart} class="chart"></div>
+	<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+		<div class="card preset-filled-surface-100-900 p-4">
+			<div bind:this={allocationChart} class="w-full h-[400px] sm:h-[280px]"></div>
 		</div>
 
-		<div class="chart-container">
-			<div bind:this={wrapperChart} class="chart"></div>
-		</div>
-	</div>
-
-	<h2>Wzrost inwestycji w czasie</h2>
-
-	<div class="chart-container-wide">
-		<div bind:this={investmentTrendChart} class="chart-wide"></div>
-	</div>
-
-	<h2>Wzrost według typu konta</h2>
-
-	<div class="wrapper-charts-grid">
-		<div class="chart-container">
-			<div bind:this={ikeChart} class="chart"></div>
-		</div>
-		<div class="chart-container">
-			<div bind:this={ikzeChart} class="chart"></div>
-		</div>
-		<div class="chart-container">
-			<div bind:this={ppkChart} class="chart"></div>
+		<div class="card preset-filled-surface-100-900 p-4">
+			<div bind:this={wrapperChart} class="w-full h-[400px] sm:h-[280px]"></div>
 		</div>
 	</div>
 
-	<h2>Wzrost według typu inwestycji</h2>
+	<h2 class="h2">Wzrost inwestycji w czasie</h2>
 
-	<div class="wrapper-charts-grid">
-		<div class="chart-container">
-			<div bind:this={stockChart} class="chart"></div>
+	<div class="card preset-filled-surface-100-900 p-4 mb-8">
+		<div bind:this={investmentTrendChart} class="w-full h-[500px] sm:h-[320px]"></div>
+	</div>
+
+	<h2 class="h2">Wzrost według typu konta</h2>
+
+	<div class="grid grid-cols-1 gap-4 mb-8">
+		<div class="card preset-filled-surface-100-900 p-4">
+			<div bind:this={ikeChart} class="w-full h-[400px] sm:h-[280px]"></div>
 		</div>
-		<div class="chart-container">
-			<div bind:this={bondChart} class="chart"></div>
+		<div class="card preset-filled-surface-100-900 p-4">
+			<div bind:this={ikzeChart} class="w-full h-[400px] sm:h-[280px]"></div>
+		</div>
+		<div class="card preset-filled-surface-100-900 p-4">
+			<div bind:this={ppkChart} class="w-full h-[400px] sm:h-[280px]"></div>
 		</div>
 	</div>
 
-	<h2>Roczny ROI według klasy aktywów</h2>
+	<h2 class="h2">Wzrost według typu inwestycji</h2>
 
-	<div class="chart-container-wide">
-		<div bind:this={yearlyRoiChart} class="chart-wide"></div>
+	<div class="grid grid-cols-1 gap-4 mb-8">
+		<div class="card preset-filled-surface-100-900 p-4">
+			<div bind:this={stockChart} class="w-full h-[400px] sm:h-[280px]"></div>
+		</div>
+		<div class="card preset-filled-surface-100-900 p-4">
+			<div bind:this={bondChart} class="w-full h-[400px] sm:h-[280px]"></div>
+		</div>
+	</div>
+
+	<h2 class="h2">Roczny ROI według klasy aktywów</h2>
+
+	<div class="card preset-filled-surface-100-900 p-4 mb-8">
+		<div bind:this={yearlyRoiChart} class="w-full h-[500px] sm:h-[320px]"></div>
 	</div>
 </div>
-
-<style>
-	.container {
-		padding: var(--size-5);
-		max-width: 1400px;
-		margin: 0 auto;
-	}
-
-	h1 {
-		margin-bottom: var(--size-6);
-		color: var(--color-text);
-	}
-
-	h2 {
-		margin-top: var(--size-8);
-		margin-bottom: var(--size-4);
-		color: var(--color-text);
-		font-size: var(--font-size-4);
-	}
-
-	.metrics-grid {
-		display: grid;
-		grid-template-columns: repeat(3, 1fr);
-		gap: var(--size-4);
-	}
-
-	.charts-grid {
-		display: grid;
-		grid-template-columns: repeat(2, 1fr);
-		gap: var(--size-6);
-		margin-bottom: var(--size-8);
-	}
-
-	.wrapper-charts-grid {
-		display: grid;
-		grid-template-columns: 1fr;
-		gap: var(--size-4);
-		margin-bottom: var(--size-8);
-	}
-
-	.chart-container {
-		background: var(--surface-2);
-		border-radius: var(--radius-2);
-		padding: var(--size-4);
-		border: 1px solid var(--surface-3);
-	}
-
-	.chart {
-		width: 100%;
-		height: 400px;
-	}
-
-	.chart-container-wide {
-		background: var(--surface-2);
-		border-radius: var(--radius-2);
-		padding: var(--size-4);
-		border: 1px solid var(--surface-3);
-		margin-bottom: var(--size-8);
-	}
-
-	.chart-wide {
-		width: 100%;
-		height: 500px;
-	}
-
-	.rebalancing-container {
-		background: var(--surface-2);
-		border-radius: var(--radius-2);
-		padding: var(--size-5);
-		border: 1px solid var(--surface-3);
-	}
-
-	.rebalancing-intro {
-		margin-bottom: var(--size-4);
-		color: var(--text-2);
-	}
-
-	.rebalancing-list {
-		display: flex;
-		flex-direction: column;
-		gap: var(--size-3);
-		margin-bottom: var(--size-4);
-	}
-
-	.rebalancing-item {
-		display: flex;
-		align-items: center;
-		gap: var(--size-4);
-		padding: var(--size-3);
-		border-radius: var(--radius-2);
-		border: 1px solid;
-	}
-
-	.rebalancing-item.buy {
-		background: rgba(163, 190, 140, 0.1);
-		border-color: var(--green-6);
-	}
-
-	.action-label {
-		font-weight: var(--font-weight-7);
-		min-width: 120px;
-	}
-
-	.rebalancing-item.buy .action-label {
-		color: var(--green-6);
-	}
-
-	.category-name {
-		flex: 1;
-		color: var(--color-text);
-		text-transform: capitalize;
-	}
-
-	.amount {
-		font-weight: var(--font-weight-7);
-		color: var(--color-text);
-		font-size: var(--font-size-3);
-	}
-
-	.rebalancing-note {
-		color: var(--text-2);
-		font-style: italic;
-		margin-top: var(--size-4);
-	}
-
-	.no-rebalancing {
-		background: rgba(163, 190, 140, 0.15);
-		border: 1px solid var(--green-6);
-		border-radius: var(--radius-2);
-		padding: var(--size-4);
-		color: var(--green-6);
-		text-align: center;
-		font-weight: var(--font-weight-6);
-	}
-
-	.ppk-owner-title {
-		font-size: var(--font-size-3);
-		font-weight: var(--font-weight-6);
-		color: var(--color-text);
-		margin-top: var(--size-4);
-		margin-bottom: var(--size-3);
-	}
-
-	@media (max-width: 1024px) {
-		.metrics-grid {
-			grid-template-columns: repeat(2, 1fr);
-		}
-
-		.charts-grid {
-			grid-template-columns: 1fr;
-		}
-	}
-
-	@media (max-width: 640px) {
-		.container {
-			padding: var(--size-3);
-		}
-
-		.metrics-grid {
-			grid-template-columns: 1fr;
-		}
-
-		.chart {
-			height: 280px;
-		}
-
-		.chart-wide {
-			height: 320px;
-		}
-
-		.chart-container,
-		.chart-container-wide,
-		.rebalancing-container {
-			padding: var(--size-3);
-		}
-
-		h1 {
-			font-size: var(--font-size-5);
-		}
-
-		h2 {
-			font-size: var(--font-size-3);
-			margin-top: var(--size-6);
-		}
-
-		.rebalancing-item {
-			flex-direction: column;
-			align-items: flex-start;
-			gap: var(--size-2);
-		}
-
-		.action-label {
-			min-width: auto;
-		}
-	}
-</style>

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -87,6 +87,13 @@
 	let salaryError = $state('');
 	let savingSalary = $state(false);
 
+	function getPreviousCompany(owner: string, date: string): string | null {
+		return (
+			data.salaries.salary_records.find((r) => r.owner === owner && r.date === date)?.company ??
+			null
+		);
+	}
+
 	function applyFilters() {
 		const params = new URLSearchParams();
 		if (filterOwner) params.set('owner', filterOwner);
@@ -429,17 +436,13 @@
 		{:else}
 			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 				{#each inflationEntries as ctx (ctx.owner)}
-					{@const realPositive = (ctx.real_change_pln ?? 0) >= 0}
-					{@const previousRecord = data.salaries.salary_records.find(
-						(r) => r.owner === ctx.owner && r.date === ctx.previous_change_date
-					)}
 					<div class="card preset-tonal-surface p-4 space-y-2">
 						<div class="flex items-baseline justify-between flex-wrap gap-2">
 							<strong class="text-lg">{ctx.owner}</strong>
 							<span class="text-xs text-surface-700-300">
 								od {new Date(ctx.last_change_date).toLocaleDateString('pl-PL')}
-								{#if previousRecord?.company}
-									· {previousRecord.company}
+								{#if getPreviousCompany(ctx.owner, ctx.previous_change_date)}
+									· {getPreviousCompany(ctx.owner, ctx.previous_change_date)}
 								{/if}
 							</span>
 						</div>
@@ -458,8 +461,8 @@
 							<dt class="font-semibold pt-1">Realna podwyżka:</dt>
 							<dd
 								class="text-right font-bold pt-1"
-								class:text-success-500={realPositive}
-								class:text-error-500={!realPositive}
+								class:text-success-500={(ctx.real_change_pln ?? 0) >= 0}
+								class:text-error-500={(ctx.real_change_pln ?? 0) < 0}
 							>
 								{formatPlnSigned(ctx.real_change_pln)}
 								<span class="text-xs font-normal">

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -87,7 +87,8 @@
 	let salaryError = $state('');
 	let savingSalary = $state(false);
 
-	function getPreviousCompany(owner: string, date: string): string | null {
+	function getPreviousCompany(owner: string, date: string | null): string | null {
+		if (!date) return null;
 		return (
 			data.salaries.salary_records.find((r) => r.owner === owner && r.date === date)?.company ??
 			null

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -257,56 +257,73 @@
 	}
 </script>
 
-<div class="simulations-page">
-	<h1>Symulacje Emerytalne</h1>
+<div class="space-y-4">
+	<h1 class="h1">Symulacje Emerytalne</h1>
 
-	<div class="content">
-		<div class="form-section">
-			<h2>Parametry symulacji</h2>
+	<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
+		<div class="card preset-filled-surface-100-900 p-5 space-y-4">
+			<h2 class="h3">Parametry symulacji</h2>
 
-			<div class="form-group">
-				<label>
-					Obecny wiek
-					<input type="number" bind:value={currentAge} min="18" max="100" />
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+				<label class="label">
+					<span class="text-sm font-semibold">Obecny wiek</span>
+					<input type="number" bind:value={currentAge} min="18" max="100" class="input" />
 				</label>
-				<label>
-					Wiek emerytalny
-					<input type="number" bind:value={retirementAge} min="18" max="100" />
+				<label class="label">
+					<span class="text-sm font-semibold">Wiek emerytalny</span>
+					<input type="number" bind:value={retirementAge} min="18" max="100" class="input" />
 				</label>
 			</div>
 
-			<h3>Konta do symulacji</h3>
-			<div class="accounts-grid">
+			<h3 class="h4">Konta do symulacji</h3>
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
 				{#each ikeIkzeAccounts as account, i}
-					<div class="account-card">
-						<label class="checkbox-label">
-							<input type="checkbox" bind:checked={ikeIkzeAccounts[i].enabled} />
-							{account.wrapper} ({account.owner})
+					<div class="card preset-tonal-surface p-4 flex flex-col gap-2">
+						<label class="flex items-center gap-2 cursor-pointer">
+							<input type="checkbox" bind:checked={ikeIkzeAccounts[i].enabled} class="checkbox" />
+							<span class="text-sm font-semibold">{account.wrapper} ({account.owner})</span>
 						</label>
 						{#if account.enabled}
-							<label>
-								Saldo obecne (PLN)
-								<input type="number" bind:value={ikeIkzeAccounts[i].balance} min="0" step="100" />
+							<label class="label">
+								<span class="text-sm font-semibold">Saldo obecne (PLN)</span>
+								<input
+									type="number"
+									bind:value={ikeIkzeAccounts[i].balance}
+									min="0"
+									step="100"
+									class="input"
+								/>
 							</label>
-							<label class="checkbox-label">
-								<input type="checkbox" bind:checked={ikeIkzeAccounts[i].autoFill} />
-								Auto-wypełnienie limitu
+							<label class="flex items-center gap-2 cursor-pointer">
+								<input
+									type="checkbox"
+									bind:checked={ikeIkzeAccounts[i].autoFill}
+									class="checkbox"
+								/>
+								<span class="text-sm">Auto-wypełnienie limitu</span>
 							</label>
 							{#if !account.autoFill}
-								<label>
-									Wpłata miesięczna (PLN)
-									<input type="number" bind:value={ikeIkzeAccounts[i].monthly} min="0" step="100" />
+								<label class="label">
+									<span class="text-sm font-semibold">Wpłata miesięczna (PLN)</span>
+									<input
+										type="number"
+										bind:value={ikeIkzeAccounts[i].monthly}
+										min="0"
+										step="100"
+										class="input"
+									/>
 								</label>
 							{/if}
 							{#if account.wrapper === 'IKZE'}
-								<label>
-									Stawka podatkowa (%)
+								<label class="label">
+									<span class="text-sm font-semibold">Stawka podatkowa (%)</span>
 									<input
 										type="number"
 										bind:value={ikeIkzeAccounts[i].taxRate}
 										min="0"
 										max="50"
 										step="1"
+										class="input"
 									/>
 								</label>
 							{/if}
@@ -315,210 +332,275 @@
 				{/each}
 
 				{#each ppkAccounts as ppk, i}
-					<div class="account-card">
-						<label class="checkbox-label">
-							<input type="checkbox" bind:checked={ppkAccounts[i].enabled} />
-							PPK ({ppk.owner})
+					<div class="card preset-tonal-surface p-4 flex flex-col gap-2">
+						<label class="flex items-center gap-2 cursor-pointer">
+							<input type="checkbox" bind:checked={ppkAccounts[i].enabled} class="checkbox" />
+							<span class="text-sm font-semibold">PPK ({ppk.owner})</span>
 						</label>
 						{#if ppk.enabled}
-							<label>
-								Obecna wartość (PLN)
-								<input type="number" bind:value={ppkAccounts[i].balance} min="0" step="1000" />
+							<label class="label">
+								<span class="text-sm font-semibold">Obecna wartość (PLN)</span>
+								<input
+									type="number"
+									bind:value={ppkAccounts[i].balance}
+									min="0"
+									step="1000"
+									class="input"
+								/>
 							</label>
-							<label>
-								Miesięczne wynagrodzenie brutto (PLN)
-								<input type="number" bind:value={ppkAccounts[i].salary} min="1000" step="500" />
+							<label class="label">
+								<span class="text-sm font-semibold">Miesięczne wynagrodzenie brutto (PLN)</span>
+								<input
+									type="number"
+									bind:value={ppkAccounts[i].salary}
+									min="1000"
+									step="500"
+									class="input"
+								/>
 							</label>
-							<div class="contribution-rates">
-								<label>
-									Składka pracownika (%)
+							<div class="space-y-2">
+								<label class="label">
+									<span class="text-sm font-semibold">Składka pracownika (%)</span>
 									<input
 										type="number"
 										bind:value={ppkAccounts[i].employeeRate}
 										min="0.5"
 										max="4"
 										step="0.5"
+										class="input"
 									/>
-									<small>Zakres: 0.5-4% (podstawa: 2%)</small>
+									<span class="text-xs text-surface-600-400">Zakres: 0.5-4% (podstawa: 2%)</span>
 								</label>
-								<label>
-									Składka pracodawcy (%)
+								<label class="label">
+									<span class="text-sm font-semibold">Składka pracodawcy (%)</span>
 									<input
 										type="number"
 										bind:value={ppkAccounts[i].employerRate}
 										min="1.5"
 										max="4"
 										step="0.5"
+										class="input"
 									/>
-									<small>Zakres: 1.5-4% (podstawa: 1.5%)</small>
+									<span class="text-xs text-surface-600-400">Zakres: 1.5-4% (podstawa: 1.5%)</span>
 								</label>
 							</div>
-							<label class="checkbox-label">
-								<input type="checkbox" bind:checked={ppkAccounts[i].belowThreshold} />
-								Wynagrodzenie poniżej progu ({SALARY_THRESHOLD_2026} PLN)
-								<small>Dotyczy dopłaty rocznej 240 PLN</small>
+							<label class="flex items-start gap-2 cursor-pointer">
+								<input
+									type="checkbox"
+									bind:checked={ppkAccounts[i].belowThreshold}
+									class="checkbox mt-0.5"
+								/>
+								<span class="text-sm"
+									>Wynagrodzenie poniżej progu ({SALARY_THRESHOLD_2026} PLN)
+									<span class="block text-xs text-surface-600-400"
+										>Dotyczy dopłaty rocznej 240 PLN</span
+									>
+								</span>
 							</label>
-							<label class="checkbox-label">
-								<input type="checkbox" bind:checked={ppkAccounts[i].includeSubsidies} />
-								Uwzględnij dopłaty państwa (250 PLN + 240 PLN/rok)
+							<label class="flex items-center gap-2 cursor-pointer">
+								<input
+									type="checkbox"
+									bind:checked={ppkAccounts[i].includeSubsidies}
+									class="checkbox"
+								/>
+								<span class="text-sm">Uwzględnij dopłaty państwa (250 PLN + 240 PLN/rok)</span>
 							</label>
-							<div class="contribution-estimate">
-								<small>
-									Szacowana miesięczna składka:
-									{formatCurrency((ppk.salary * (ppk.employeeRate + ppk.employerRate)) / 100)}
-									PLN (pracownik: {formatCurrency((ppk.salary * ppk.employeeRate) / 100)} PLN, pracodawca:
-									{formatCurrency((ppk.salary * ppk.employerRate) / 100)} PLN)
-								</small>
-							</div>
+							<p class="text-xs text-surface-600-400">
+								Szacowana miesięczna składka:
+								{formatCurrency((ppk.salary * (ppk.employeeRate + ppk.employerRate)) / 100)}
+								PLN (pracownik: {formatCurrency((ppk.salary * ppk.employeeRate) / 100)} PLN, pracodawca:
+								{formatCurrency((ppk.salary * ppk.employerRate) / 100)} PLN)
+							</p>
 						{/if}
 					</div>
 				{/each}
 
 				{#each brokerageAccounts as brokerage, i}
-					<div class="account-card">
-						<label class="checkbox-label">
-							<input type="checkbox" bind:checked={brokerageAccounts[i].enabled} />
-							Rachunek maklerski ({brokerage.owner})
+					<div class="card preset-tonal-surface p-4 flex flex-col gap-2">
+						<label class="flex items-center gap-2 cursor-pointer">
+							<input type="checkbox" bind:checked={brokerageAccounts[i].enabled} class="checkbox" />
+							<span class="text-sm font-semibold">Rachunek maklerski ({brokerage.owner})</span>
 						</label>
 						{#if brokerage.enabled}
-							<label>
-								Obecna wartość (PLN)
+							<label class="label">
+								<span class="text-sm font-semibold">Obecna wartość (PLN)</span>
 								<input
 									type="number"
 									bind:value={brokerageAccounts[i].balance}
 									min="0"
 									step="1000"
+									class="input"
 								/>
 							</label>
-							<label>
-								Wpłata miesięczna (PLN)
-								<input type="number" bind:value={brokerageAccounts[i].monthly} min="0" step="100" />
+							<label class="label">
+								<span class="text-sm font-semibold">Wpłata miesięczna (PLN)</span>
+								<input
+									type="number"
+									bind:value={brokerageAccounts[i].monthly}
+									min="0"
+									step="100"
+									class="input"
+								/>
 							</label>
-							<div class="card-note">
-								<small
-									>Rachunki maklerskie są opodatkowane 19% podatkiem Belki od zysków kapitałowych</small
-								>
-							</div>
+							<p class="text-xs text-surface-600-400">
+								Rachunki maklerskie są opodatkowane 19% podatkiem Belki od zysków kapitałowych
+							</p>
 						{/if}
 					</div>
 				{/each}
 			</div>
 
-			<h3>Założenia</h3>
-			<div class="form-group">
-				<label>
-					Roczna stopa zwrotu (%)
-					<input type="number" bind:value={annualReturnRate} min="-50" max="50" step="0.1" />
+			<h3 class="h4">Założenia</h3>
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+				<label class="label">
+					<span class="text-sm font-semibold">Roczna stopa zwrotu (%)</span>
+					<input
+						type="number"
+						bind:value={annualReturnRate}
+						min="-50"
+						max="50"
+						step="0.1"
+						class="input"
+					/>
 				</label>
-				<label>
-					Wzrost limitów wpłat (%)
-					<input type="number" bind:value={limitGrowthRate} min="0" max="20" step="0.1" />
+				<label class="label">
+					<span class="text-sm font-semibold">Wzrost limitów wpłat (%)</span>
+					<input
+						type="number"
+						bind:value={limitGrowthRate}
+						min="0"
+						max="20"
+						step="0.1"
+						class="input"
+					/>
 				</label>
-				<label>
-					Przewidywany wzrost wynagrodzeń (%)
-					<input type="number" bind:value={expectedSalaryGrowth} min="0" max="10" step="0.5" />
-					<small>Roczny wzrost płacy brutto (typowo 3-5%)</small>
+				<label class="label">
+					<span class="text-sm font-semibold">Przewidywany wzrost wynagrodzeń (%)</span>
+					<input
+						type="number"
+						bind:value={expectedSalaryGrowth}
+						min="0"
+						max="10"
+						step="0.5"
+						class="input"
+					/>
+					<span class="text-xs text-surface-600-400">Roczny wzrost płacy brutto (typowo 3-5%)</span>
 				</label>
-				<label>
-					Inflacja (%)
-					<input type="number" bind:value={inflationRate} min="0" max="20" step="0.1" />
-					<small>Roczna inflacja do przeliczenia dochodu na dzisiejsze pieniądze</small>
+				<label class="label">
+					<span class="text-sm font-semibold">Inflacja (%)</span>
+					<input
+						type="number"
+						bind:value={inflationRate}
+						min="0"
+						max="20"
+						step="0.1"
+						class="input"
+					/>
+					<span class="text-xs text-surface-600-400"
+						>Roczna inflacja do przeliczenia dochodu na dzisiejsze pieniądze</span
+					>
 				</label>
 			</div>
 
-			<button class="primary-button" onclick={runSimulation} disabled={loading}>
+			<button
+				class="btn preset-filled-primary-500 w-full"
+				onclick={runSimulation}
+				disabled={loading}
+			>
 				{loading ? 'Obliczanie...' : 'Uruchom symulację'}
 			</button>
 
 			{#if error}
-				<div class="error-message">{error}</div>
+				<div class="card preset-filled-error-500 p-3 text-sm">{error}</div>
 			{/if}
 		</div>
 
 		{#if results}
-			<div class="results-section">
-				<h2>Wyniki symulacji</h2>
+			<div class="card preset-filled-surface-100-900 p-5 space-y-4">
+				<h2 class="h3">Wyniki symulacji</h2>
 
-				<div class="summary-cards">
-					<div class="summary-card">
-						<div class="card-label">Końcowy kapitał</div>
-						<div class="card-value">
+				<div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Końcowy kapitał</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.summary.total_final_balance)} PLN
 						</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Miesięczny dochód (4% rule)</div>
-						<div class="card-value">
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Miesięczny dochód (4% rule)</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.summary.estimated_monthly_income)} PLN
 						</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Miesięczny dochód (w dzisiejszych pieniądzach)</div>
-						<div class="card-value">
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">
+							Miesięczny dochód (w dzisiejszych pieniądzach)
+						</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.summary.estimated_monthly_income_today)} PLN
 						</div>
-						<div class="card-note">przy 3% inflacji rocznie</div>
+						<div class="text-xs text-surface-600-400 mt-1">przy 3% inflacji rocznie</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Suma wpłat</div>
-						<div class="card-value">
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Suma wpłat</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.summary.total_contributions)} PLN
 						</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Zyski z inwestycji</div>
-						<div class="card-value">
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Zyski z inwestycji</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.summary.total_returns)} PLN
 						</div>
 					</div>
 					{#if results.summary.total_tax_savings > 0}
-						<div class="summary-card">
-							<div class="card-label">Oszczędności podatkowe (IKZE)</div>
-							<div class="card-value">
+						<div class="card preset-tonal-surface p-4">
+							<div class="text-xs text-surface-600-400 mb-2">Oszczędności podatkowe (IKZE)</div>
+							<div class="text-xl font-bold">
 								{formatCurrency(results.summary.total_tax_savings)} PLN
 							</div>
 						</div>
 					{/if}
 					{#if results.summary.total_subsidies && results.summary.total_subsidies > 0}
-						<div class="summary-card">
-							<div class="card-label">Dopłaty państwa (PPK)</div>
-							<div class="card-value">
+						<div class="card preset-tonal-surface p-4">
+							<div class="text-xs text-surface-600-400 mb-2">Dopłaty państwa (PPK)</div>
+							<div class="text-xl font-bold">
 								{formatCurrency(results.summary.total_subsidies)} PLN
 							</div>
 						</div>
 					{/if}
 				</div>
 
-				<div class="chart-container" bind:this={chartContainer}></div>
+				<div bind:this={chartContainer} class="w-full h-[400px] sm:h-[280px]"></div>
 
-				<h3>Szczegóły projekcji</h3>
+				<h3 class="h4">Szczegóły projekcji</h3>
 				{#each results.simulations as simulation}
-					<details class="account-details">
-						<summary>
+					<details class="card preset-tonal-surface p-3 mb-3">
+						<summary class="cursor-pointer text-sm font-semibold">
 							<strong>{simulation.account_name}</strong> - Końcowa wartość: {formatCurrency(
 								simulation.final_balance
 							)} PLN
 						</summary>
-						<div class="projection-table">
-							<table>
+						<div class="table-wrap mt-3">
+							<table class="table table-hover text-xs">
 								<thead>
 									<tr>
 										<th>Rok</th>
-										<th>Wiek</th>
-										<th>Roczna wpłata</th>
+										<th class="text-right">Wiek</th>
+										<th class="text-right">Roczna wpłata</th>
 										{#if !simulation.account_name.startsWith('PPK')}
-											<th>Wykorzystanie limitu</th>
+											<th class="text-right">Wykorzystanie limitu</th>
 										{/if}
-										<th>Saldo</th>
-										<th>Suma wpłat</th>
-										<th>Zyski</th>
+										<th class="text-right">Saldo</th>
+										<th class="text-right">Suma wpłat</th>
+										<th class="text-right">Zyski</th>
 										{#if simulation.account_name.includes('IKZE')}
-											<th>Ulga podatkowa</th>
+											<th class="text-right">Ulga podatkowa</th>
 										{/if}
 										{#if simulation.account_name.startsWith('PPK')}
-											<th>Dopłaty państwa</th>
-											<th>Roczne wynagrodzenie</th>
-											<th>Stopa zwrotu</th>
+											<th class="text-right">Dopłaty państwa</th>
+											<th class="text-right">Roczne wynagrodzenie</th>
+											<th class="text-right">Stopa zwrotu</th>
 										{/if}
 									</tr>
 								</thead>
@@ -526,23 +608,27 @@
 									{#each simulation.yearly_projections as projection}
 										<tr>
 											<td>{projection.year}</td>
-											<td>{projection.age}</td>
-											<td>{formatCurrency(projection.annual_contribution)}</td>
+											<td class="text-right">{projection.age}</td>
+											<td class="text-right">{formatCurrency(projection.annual_contribution)}</td>
 											{#if !simulation.account_name.startsWith('PPK')}
-												<td>{projection.limit_utilized_pct.toFixed(1)}%</td>
+												<td class="text-right">{projection.limit_utilized_pct.toFixed(1)}%</td>
 											{/if}
-											<td>{formatCurrency(projection.balance_end_of_year)}</td>
-											<td>{formatCurrency(projection.cumulative_contributions)}</td>
-											<td>{formatCurrency(projection.cumulative_returns)}</td>
+											<td class="text-right">{formatCurrency(projection.balance_end_of_year)}</td>
+											<td class="text-right"
+												>{formatCurrency(projection.cumulative_contributions)}</td
+											>
+											<td class="text-right">{formatCurrency(projection.cumulative_returns)}</td>
 											{#if simulation.account_name.includes('IKZE')}
-												<td>{formatCurrency(projection.tax_savings)}</td>
+												<td class="text-right">{formatCurrency(projection.tax_savings)}</td>
 											{/if}
 											{#if simulation.account_name.startsWith('PPK')}
-												<td>{formatCurrency(projection.government_subsidies || 0)}</td>
-												<td>
+												<td class="text-right"
+													>{formatCurrency(projection.government_subsidies || 0)}</td
+												>
+												<td class="text-right">
 													{formatCurrency((projection.monthly_salary || 0) * 12)}
 												</td>
-												<td>{(projection.return_rate || 0).toFixed(1)}%</td>
+												<td class="text-right">{(projection.return_rate || 0).toFixed(1)}%</td>
 											{/if}
 										</tr>
 									{/each}
@@ -555,265 +641,3 @@
 		{/if}
 	</div>
 </div>
-
-<style>
-	.simulations-page {
-		padding: var(--size-4);
-		max-width: 1400px;
-		margin: 0 auto;
-	}
-
-	h1 {
-		margin-bottom: var(--size-6);
-		color: var(--color-text-1);
-	}
-
-	.content {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		gap: var(--size-6);
-	}
-
-	.form-section,
-	.results-section {
-		background: var(--surface-2);
-		padding: var(--size-5);
-		border-radius: var(--radius-2);
-	}
-
-	h2,
-	h3 {
-		margin-top: var(--size-5);
-		margin-bottom: var(--size-3);
-		color: var(--color-text-2);
-	}
-
-	h2 {
-		margin-top: 0;
-	}
-
-	.form-group {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		gap: var(--size-3);
-		margin-bottom: var(--size-4);
-	}
-
-	.accounts-grid {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		gap: var(--size-3);
-		margin-bottom: var(--size-4);
-	}
-
-	.account-card {
-		background: var(--surface-3);
-		padding: var(--size-4);
-		border-radius: var(--radius-2);
-		display: flex;
-		flex-direction: column;
-		gap: var(--size-2);
-	}
-
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: var(--size-1);
-		font-size: var(--font-size-1);
-		color: var(--color-text-2);
-	}
-
-	.checkbox-label {
-		flex-direction: row;
-		align-items: center;
-		font-weight: 600;
-	}
-
-	.checkbox-label input[type='checkbox'] {
-		margin-right: var(--size-2);
-	}
-
-	input[type='number'] {
-		padding: var(--size-2);
-		border: 1px solid var(--surface-4);
-		border-radius: var(--radius-2);
-		background: var(--surface-1);
-		color: var(--color-text-1);
-		font-size: var(--font-size-1);
-		min-height: var(--tap-target-min);
-	}
-
-	input[type='checkbox'] {
-		width: var(--size-4);
-		height: var(--size-4);
-		cursor: pointer;
-	}
-
-	.primary-button {
-		width: 100%;
-		padding: var(--size-3);
-		background: var(--color-primary);
-		color: white;
-		border: none;
-		border-radius: var(--radius-2);
-		font-size: var(--font-size-2);
-		font-weight: 600;
-		cursor: pointer;
-		margin-top: var(--size-4);
-	}
-
-	.primary-button:hover:not(:disabled) {
-		background: var(--color-primary-hover);
-	}
-
-	.primary-button:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	.error-message {
-		margin-top: var(--size-3);
-		padding: var(--size-3);
-		background: var(--color-error-bg);
-		color: var(--color-error);
-		border-radius: var(--radius-2);
-	}
-
-	.summary-cards {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-		gap: var(--size-3);
-		margin-bottom: var(--size-5);
-	}
-
-	.summary-card {
-		background: var(--surface-3);
-		padding: var(--size-4);
-		border-radius: var(--radius-2);
-	}
-
-	.card-label {
-		font-size: var(--font-size-0);
-		color: var(--color-text-3);
-		margin-bottom: var(--size-2);
-	}
-
-	.card-value {
-		font-size: var(--font-size-4);
-		font-weight: 700;
-		color: var(--color-text-1);
-	}
-
-	.card-note {
-		font-size: var(--font-size-0);
-		color: var(--color-text-3);
-		margin-top: var(--size-1);
-	}
-
-	.chart-container {
-		width: 100%;
-		height: 400px;
-		margin-bottom: var(--size-5);
-	}
-
-	.account-details {
-		background: var(--surface-3);
-		padding: var(--size-3);
-		border-radius: var(--radius-2);
-		margin-bottom: var(--size-3);
-	}
-
-	.account-details summary {
-		cursor: pointer;
-		padding: var(--size-2);
-		font-size: var(--font-size-2);
-	}
-
-	.projection-table {
-		margin-top: var(--size-3);
-		overflow-x: auto;
-	}
-
-	table {
-		width: 100%;
-		border-collapse: collapse;
-		font-size: var(--font-size-0);
-	}
-
-	th,
-	td {
-		padding: var(--size-2);
-		text-align: right;
-		border-bottom: 1px solid var(--surface-4);
-	}
-
-	th {
-		background: var(--surface-4);
-		font-weight: 600;
-		color: var(--color-text-2);
-	}
-
-	th:first-child,
-	td:first-child {
-		text-align: left;
-	}
-
-	@media (max-width: 1200px) {
-		.content {
-			grid-template-columns: 1fr;
-		}
-	}
-
-	@media (max-width: 768px) {
-		.accounts-grid {
-			grid-template-columns: 1fr;
-		}
-
-		.form-group {
-			grid-template-columns: 1fr;
-		}
-	}
-
-	@media (max-width: 640px) {
-		.simulations-page {
-			padding: var(--size-3);
-		}
-
-		.form-section,
-		.results-section {
-			padding: var(--size-4);
-		}
-
-		.chart-container {
-			height: 280px;
-		}
-
-		.summary-cards {
-			grid-template-columns: 1fr 1fr;
-			gap: var(--size-2);
-		}
-
-		.card-value {
-			font-size: var(--font-size-2);
-		}
-
-		.primary-button {
-			min-height: var(--tap-target-min);
-		}
-
-		table {
-			font-size: var(--font-size-0);
-		}
-
-		th,
-		td {
-			padding: var(--size-1);
-			white-space: normal;
-			word-break: break-word;
-		}
-
-		h1 {
-			font-size: var(--font-size-4);
-		}
-	}
-</style>

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -571,7 +571,7 @@
 					{/if}
 				</div>
 
-				<div bind:this={chartContainer} class="w-full h-[400px] sm:h-[280px]"></div>
+				<div bind:this={chartContainer} class="w-full h-[280px] sm:h-[400px]"></div>
 
 				<h3 class="h4">Szczegóły projekcji</h3>
 				{#each results.simulations as simulation}

--- a/src/routes/simulations/mortgage/+page.svelte
+++ b/src/routes/simulations/mortgage/+page.svelte
@@ -395,7 +395,7 @@
 					</div>
 				</div>
 
-				<div bind:this={chartContainer} class="w-full h-[380px] sm:h-[280px]"></div>
+				<div bind:this={chartContainer} class="w-full h-[280px] sm:h-[380px]"></div>
 
 				<details class="card preset-tonal-surface p-3">
 					<summary class="cursor-pointer text-sm font-semibold py-1">Projekcja roczna</summary>
@@ -403,7 +403,7 @@
 						<table class="table table-hover text-xs">
 							<thead>
 								<tr>
-									<th>Rok</th>
+									<th class="sticky left-0 z-10 bg-surface-100 dark:bg-surface-900">Rok</th>
 									<th class="text-right">Stopa %</th>
 									<th class="text-right">Saldo A</th>
 									<th class="text-right">Saldo A (realne)</th>
@@ -422,7 +422,7 @@
 							<tbody>
 								{#each results.yearly_projections as row}
 									<tr>
-										<td
+										<td class="sticky left-0 z-10 bg-surface-100 dark:bg-surface-900"
 											>{row.year}{#if row.scenario_a_paid_off}
 												✓{/if}</td
 										>

--- a/src/routes/simulations/mortgage/+page.svelte
+++ b/src/routes/simulations/mortgage/+page.svelte
@@ -205,179 +205,247 @@
 	}
 </script>
 
-<div class="mortgage-page">
-	<h1>Hipoteka vs Inwestycja</h1>
+<div class="space-y-4">
+	<h1 class="h1">Hipoteka vs Inwestycja</h1>
 
-	<div class="content">
-		<div class="form-section">
-			<h2>Parametry</h2>
+	<div class="grid grid-cols-1 lg:grid-cols-[400px_1fr] gap-6 items-start">
+		<div class="card preset-filled-surface-100-900 p-5 space-y-4">
+			<h2 class="h3">Parametry</h2>
 
-			<div class="form-group">
-				<label>
-					Kwota pozostała do spłaty (PLN)
-					<input type="number" bind:value={remainingPrincipal} min="1" step="10000" />
+			<div class="flex flex-col gap-3">
+				<label class="label">
+					<span class="text-sm font-semibold">Kwota pozostała do spłaty (PLN)</span>
+					<input type="number" bind:value={remainingPrincipal} min="1" step="10000" class="input" />
 				</label>
-				<label>
-					Oprocentowanie (% rocznie)
-					<input type="number" bind:value={annualInterestRate} min="0.1" max="30" step="0.1" />
+				<label class="label">
+					<span class="text-sm font-semibold">Oprocentowanie (% rocznie)</span>
+					<input
+						type="number"
+						bind:value={annualInterestRate}
+						min="0.1"
+						max="30"
+						step="0.1"
+						class="input"
+					/>
 				</label>
-				<label>
-					Pozostałe miesiące
-					<input type="number" bind:value={remainingMonths} min="1" max="600" step="1" />
-					<small>{Math.floor(remainingMonths / 12)} lat {remainingMonths % 12} mies.</small>
-				</label>
-				<label>
-					Miesięczny budżet (PLN)
-					<input type="number" bind:value={totalMonthlyBudget} min="0" step="100" />
-					<small
-						>Łączna kwota na ratę i inwestycje (A: wszystko na nadpłatę, B: reszta po racie
-						inwestowana)</small
+				<label class="label">
+					<span class="text-sm font-semibold">Pozostałe miesiące</span>
+					<input
+						type="number"
+						bind:value={remainingMonths}
+						min="1"
+						max="600"
+						step="1"
+						class="input"
+					/>
+					<span class="text-xs text-surface-600-400"
+						>{Math.floor(remainingMonths / 12)} lat {remainingMonths % 12} mies.</span
 					>
 				</label>
-				<label>
-					Oczekiwany zwrot z inwestycji (% rocznie)
-					<input type="number" bind:value={expectedAnnualReturn} min="0.1" max="50" step="0.1" />
+				<label class="label">
+					<span class="text-sm font-semibold">Miesięczny budżet (PLN)</span>
+					<input type="number" bind:value={totalMonthlyBudget} min="0" step="100" class="input" />
+					<span class="text-xs text-surface-600-400"
+						>Łączna kwota na ratę i inwestycje (A: wszystko na nadpłatę, B: reszta po racie
+						inwestowana)</span
+					>
 				</label>
-				<label>
-					Inflacja (% rocznie)
-					<input type="number" bind:value={inflationRate} min="0" max="20" step="0.1" />
-					<small>Do przeliczenia wartości realnej (siły nabywczej)</small>
+				<label class="label">
+					<span class="text-sm font-semibold">Oczekiwany zwrot z inwestycji (% rocznie)</span>
+					<input
+						type="number"
+						bind:value={expectedAnnualReturn}
+						min="0.1"
+						max="50"
+						step="0.1"
+						class="input"
+					/>
+				</label>
+				<label class="label">
+					<span class="text-sm font-semibold">Inflacja (% rocznie)</span>
+					<input
+						type="number"
+						bind:value={inflationRate}
+						min="0"
+						max="20"
+						step="0.1"
+						class="input"
+					/>
+					<span class="text-xs text-surface-600-400"
+						>Do przeliczenia wartości realnej (siły nabywczej)</span
+					>
 				</label>
 
-				<label class="checkbox-label">
-					<input type="checkbox" bind:checked={enableVariableRate} />
-					Zmienna stopa procentowa
-					<small>Cykle 10-letnie: spadek do ~1%, wzrost do ~8%, powtarza się</small>
-				</label>
+				<div class="space-y-1">
+					<label class="flex items-center gap-2 cursor-pointer">
+						<input type="checkbox" bind:checked={enableVariableRate} class="checkbox" />
+						<span class="text-sm font-semibold">Zmienna stopa procentowa</span>
+					</label>
+					<p class="text-xs text-surface-600-400 ml-6">
+						Cykle 10-letnie: spadek do ~1%, wzrost do ~8%, powtarza się
+					</p>
+				</div>
 			</div>
 
-			<button class="primary-button" onclick={runSimulation} disabled={loading}>
+			<button
+				class="btn preset-filled-primary-500 w-full"
+				onclick={runSimulation}
+				disabled={loading}
+			>
 				{loading ? 'Obliczanie...' : 'Oblicz'}
 			</button>
 
 			{#if error}
-				<div class="error-message">{error}</div>
+				<div class="card preset-filled-error-500 p-3 text-sm">{error}</div>
 			{/if}
 		</div>
 
 		{#if results}
-			<div class="results-section">
-				<h2>Wyniki</h2>
+			<div class="card preset-filled-surface-100-900 p-5 space-y-4">
+				<h2 class="h3">Wyniki</h2>
 
-				<div class="winner-banner" class:invest={results.summary.winning_strategy === 'inwestycja'}>
+				<div
+					class="flex justify-between items-center p-4 rounded-container font-bold text-lg {results
+						.summary.winning_strategy === 'inwestycja'
+						? 'bg-success-500/10'
+						: 'bg-surface-200-800'}"
+				>
 					{winnerLabel(results.summary.winning_strategy)}
-					<span class="net-advantage">
+					<span class="text-sm font-normal">
 						Przewaga: {formatCurrency(results.summary.net_advantage)} PLN
 					</span>
 				</div>
 
-				<div class="summary-cards">
-					<div class="summary-card">
-						<div class="card-label">Rata bazowa</div>
-						<div class="card-value">
+				<div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Rata bazowa</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.summary.regular_monthly_payment)} PLN
 						</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Zaoszczędzone odsetki (nadpłata)</div>
-						<div class="card-value">{formatCurrency(results.summary.interest_saved)} PLN</div>
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Zaoszczędzone odsetki (nadpłata)</div>
+						<div class="text-xl font-bold">
+							{formatCurrency(results.summary.interest_saved)} PLN
+						</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Portfel inwestycyjny B (brutto)</div>
-						<div class="card-value">
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Portfel inwestycyjny B (brutto)</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.summary.final_investment_portfolio)} PLN
 						</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Miesięcy wcześniej (A)</div>
-						<div class="card-value">{results.summary.months_saved}</div>
-						<div class="card-note">
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Miesięcy wcześniej (A)</div>
+						<div class="text-xl font-bold">{results.summary.months_saved}</div>
+						<div class="text-xs text-surface-600-400 mt-1">
 							{Math.floor(results.summary.months_saved / 12)} lat {results.summary.months_saved %
 								12} mies.
 						</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Odsetki razem (nadpłata A)</div>
-						<div class="card-value">{formatCurrency(results.summary.total_interest_a)} PLN</div>
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Odsetki razem (nadpłata A)</div>
+						<div class="text-xl font-bold">
+							{formatCurrency(results.summary.total_interest_a)} PLN
+						</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Odsetki razem (inwestycja B)</div>
-						<div class="card-value">{formatCurrency(results.summary.total_interest_b)} PLN</div>
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Odsetki razem (inwestycja B)</div>
+						<div class="text-xl font-bold">
+							{formatCurrency(results.summary.total_interest_b)} PLN
+						</div>
 					</div>
 					<div
-						class="summary-card belka"
-						class:above-breakeven={expectedAnnualReturn >= results.summary.break_even_gross_return}
-						class:below-breakeven={expectedAnnualReturn < results.summary.break_even_gross_return}
+						class="card preset-tonal-surface p-4 border-l-4 {expectedAnnualReturn >=
+						results.summary.break_even_gross_return
+							? 'border-l-success-500'
+							: 'border-l-error-500'}"
 					>
-						<div class="card-label">Próg rentowności (brutto)</div>
-						<div class="card-value">{results.summary.break_even_gross_return.toFixed(2)}%</div>
-						<div class="card-note">
+						<div class="text-xs text-surface-600-400 mb-2">Próg rentowności (brutto)</div>
+						<div class="text-xl font-bold">
+							{results.summary.break_even_gross_return.toFixed(2)}%
+						</div>
+						<div
+							class="text-xs mt-1 {expectedAnnualReturn >= results.summary.break_even_gross_return
+								? 'text-success-500'
+								: 'text-error-500'}"
+						>
 							min. stopa przed podatkiem Belki · twój cel: {expectedAnnualReturn.toFixed(1)}%
 							{expectedAnnualReturn >= results.summary.break_even_gross_return ? '✓' : '✗'}
 						</div>
 					</div>
-					<div class="summary-card belka">
-						<div class="card-label">Podatek Belki (19%)</div>
-						<div class="card-value">wbudowany</div>
-						<div class="card-note">odliczany co miesiąc od stopy zwrotu</div>
+					<div class="card preset-tonal-surface p-4 border-l-4 border-l-warning-500">
+						<div class="text-xs text-surface-600-400 mb-2">Podatek Belki (19%)</div>
+						<div class="text-xl font-bold">wbudowany</div>
+						<div class="text-xs text-surface-600-400 mt-1">
+							odliczany co miesiąc od stopy zwrotu
+						</div>
 					</div>
-					<div class="summary-card real">
-						<div class="card-label">Portfel A realny (dziś PLN)</div>
-						<div class="card-value">
+					<div class="card preset-tonal-surface p-4 border-l-4 border-l-primary-500">
+						<div class="text-xs text-surface-600-400 mb-2">Portfel A realny (dziś PLN)</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.summary.final_portfolio_a_real)} PLN
 						</div>
 					</div>
-					<div class="summary-card real">
-						<div class="card-label">Portfel B realny (dziś PLN)</div>
-						<div class="card-value">
+					<div class="card preset-tonal-surface p-4 border-l-4 border-l-primary-500">
+						<div class="text-xs text-surface-600-400 mb-2">Portfel B realny (dziś PLN)</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.summary.final_portfolio_b_real)} PLN
 						</div>
 					</div>
 				</div>
 
-				<div class="chart-container" bind:this={chartContainer}></div>
+				<div bind:this={chartContainer} class="w-full h-[380px] sm:h-[280px]"></div>
 
-				<details class="projection-details">
-					<summary>Projekcja roczna</summary>
-					<div class="projection-table">
-						<table>
+				<details class="card preset-tonal-surface p-3">
+					<summary class="cursor-pointer text-sm font-semibold py-1">Projekcja roczna</summary>
+					<div class="table-wrap mt-3">
+						<table class="table table-hover text-xs">
 							<thead>
 								<tr>
 									<th>Rok</th>
-									<th>Stopa %</th>
-									<th>Saldo A</th>
-									<th>Saldo A (realne)</th>
-									<th>Portfel A (brutto)</th>
-									<th>Portfel A (po Belce)</th>
-									<th>Portfel A (realny)</th>
-									<th>Spłacone A</th>
-									<th>Saldo B</th>
-									<th>Saldo B (realne)</th>
-									<th>Portfel B (brutto)</th>
-									<th>Portfel B (po Belce)</th>
-									<th>Portfel B (realny)</th>
-									<th>Przewaga B (realna)</th>
+									<th class="text-right">Stopa %</th>
+									<th class="text-right">Saldo A</th>
+									<th class="text-right">Saldo A (realne)</th>
+									<th class="text-right">Portfel A (brutto)</th>
+									<th class="text-right">Portfel A (po Belce)</th>
+									<th class="text-right">Portfel A (realny)</th>
+									<th class="text-right">Spłacone A</th>
+									<th class="text-right">Saldo B</th>
+									<th class="text-right">Saldo B (realne)</th>
+									<th class="text-right">Portfel B (brutto)</th>
+									<th class="text-right">Portfel B (po Belce)</th>
+									<th class="text-right">Portfel B (realny)</th>
+									<th class="text-right">Przewaga B (realna)</th>
 								</tr>
 							</thead>
 							<tbody>
 								{#each results.yearly_projections as row}
-									<tr class:paid-off={row.scenario_a_paid_off}>
-										<td>{row.year}</td>
-										<td>{row.annual_rate.toFixed(2)}%</td>
-										<td>{formatCurrency(row.scenario_a_mortgage_balance)}</td>
-										<td>{formatCurrency(row.scenario_a_real_mortgage_balance)}</td>
-										<td>{formatCurrency(row.scenario_a_investment_balance)}</td>
-										<td>{formatCurrency(row.scenario_a_after_tax_portfolio)}</td>
-										<td>{formatCurrency(row.scenario_a_real_portfolio)}</td>
-										<td>{row.scenario_a_paid_off ? '✓' : '—'}</td>
-										<td>{formatCurrency(row.scenario_b_mortgage_balance)}</td>
-										<td>{formatCurrency(row.scenario_b_real_mortgage_balance)}</td>
-										<td>{formatCurrency(row.scenario_b_investment_balance)}</td>
-										<td>{formatCurrency(row.scenario_b_after_tax_portfolio)}</td>
-										<td>{formatCurrency(row.scenario_b_real_portfolio)}</td>
+									<tr>
 										<td
-											class:positive={row.net_advantage_invest >= 0}
-											class:negative={row.net_advantage_invest < 0}
+											>{row.year}{#if row.scenario_a_paid_off}
+												✓{/if}</td
+										>
+										<td class="text-right">{row.annual_rate.toFixed(2)}%</td>
+										<td class="text-right">{formatCurrency(row.scenario_a_mortgage_balance)}</td>
+										<td class="text-right"
+											>{formatCurrency(row.scenario_a_real_mortgage_balance)}</td
+										>
+										<td class="text-right">{formatCurrency(row.scenario_a_investment_balance)}</td>
+										<td class="text-right">{formatCurrency(row.scenario_a_after_tax_portfolio)}</td>
+										<td class="text-right">{formatCurrency(row.scenario_a_real_portfolio)}</td>
+										<td class="text-right">{row.scenario_a_paid_off ? '✓' : '—'}</td>
+										<td class="text-right">{formatCurrency(row.scenario_b_mortgage_balance)}</td>
+										<td class="text-right"
+											>{formatCurrency(row.scenario_b_real_mortgage_balance)}</td
+										>
+										<td class="text-right">{formatCurrency(row.scenario_b_investment_balance)}</td>
+										<td class="text-right">{formatCurrency(row.scenario_b_after_tax_portfolio)}</td>
+										<td class="text-right">{formatCurrency(row.scenario_b_real_portfolio)}</td>
+										<td
+											class="text-right {row.net_advantage_invest >= 0
+												? 'text-success-500'
+												: 'text-error-500'}"
 										>
 											{formatCurrency(row.net_advantage_invest)}
 										</td>
@@ -391,317 +459,3 @@
 		{/if}
 	</div>
 </div>
-
-<style>
-	.mortgage-page {
-		padding: var(--size-4);
-		max-width: 1400px;
-		margin: 0 auto;
-	}
-
-	h1 {
-		margin-bottom: var(--size-6);
-		color: var(--color-text-1);
-	}
-
-	.content {
-		display: grid;
-		grid-template-columns: 400px 1fr;
-		gap: var(--size-6);
-		align-items: start;
-	}
-
-	.form-section,
-	.results-section {
-		background: var(--surface-2);
-		padding: var(--size-5);
-		border-radius: var(--radius-2);
-	}
-
-	h2 {
-		margin-top: 0;
-		margin-bottom: var(--size-4);
-		color: var(--color-text-2);
-	}
-
-	.form-group {
-		display: flex;
-		flex-direction: column;
-		gap: var(--size-3);
-		margin-bottom: var(--size-4);
-	}
-
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: var(--size-1);
-		font-size: var(--font-size-1);
-		color: var(--color-text-2);
-	}
-
-	input[type='number'] {
-		padding: var(--size-2);
-		border: 1px solid var(--surface-4);
-		border-radius: var(--radius-2);
-		background: var(--surface-1);
-		color: var(--color-text-1);
-		font-size: var(--font-size-1);
-		min-height: var(--tap-target-min);
-	}
-
-	small {
-		font-size: var(--font-size-0);
-		color: var(--color-text-3);
-	}
-
-	.checkbox-label {
-		flex-direction: row;
-		align-items: center;
-		gap: var(--size-2);
-		font-weight: 600;
-	}
-
-	.checkbox-label input[type='checkbox'] {
-		width: 1rem;
-		height: 1rem;
-		cursor: pointer;
-	}
-
-	.primary-button {
-		width: 100%;
-		padding: var(--size-3);
-		background: var(--color-primary);
-		color: white;
-		border: none;
-		border-radius: var(--radius-2);
-		font-size: var(--font-size-2);
-		font-weight: 600;
-		cursor: pointer;
-	}
-
-	.primary-button:hover:not(:disabled) {
-		background: var(--color-primary-hover);
-	}
-
-	.primary-button:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	.error-message {
-		margin-top: var(--size-3);
-		padding: var(--size-3);
-		background: var(--color-error-bg);
-		color: var(--color-error);
-		border-radius: var(--radius-2);
-	}
-
-	.winner-banner {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: var(--size-4);
-		border-radius: var(--radius-2);
-		margin-bottom: var(--size-4);
-		font-weight: 700;
-		font-size: var(--font-size-3);
-		background: hsl(210 14% 85%);
-		color: var(--color-text-1);
-	}
-
-	.winner-banner.invest {
-		background: hsl(92 30% 80%);
-	}
-
-	.net-advantage {
-		font-size: var(--font-size-1);
-		font-weight: 400;
-	}
-
-	.summary-cards {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-		gap: var(--size-3);
-		margin-bottom: var(--size-5);
-	}
-
-	.summary-card {
-		background: var(--surface-3);
-		padding: var(--size-4);
-		border-radius: var(--radius-2);
-	}
-
-	.card-label {
-		font-size: var(--font-size-0);
-		color: var(--color-text-3);
-		margin-bottom: var(--size-2);
-	}
-
-	.card-value {
-		font-size: var(--font-size-3);
-		font-weight: 700;
-		color: var(--color-text-1);
-	}
-
-	.card-note {
-		font-size: var(--font-size-0);
-		color: var(--color-text-3);
-		margin-top: var(--size-1);
-	}
-
-	.summary-card.belka {
-		border-left: 3px solid hsl(30 70% 55%);
-	}
-
-	.summary-card.above-breakeven {
-		border-left: 3px solid hsl(140 60% 45%);
-	}
-
-	.summary-card.above-breakeven .card-note {
-		color: hsl(140 60% 35%);
-	}
-
-	.summary-card.below-breakeven {
-		border-left: 3px solid hsl(0 65% 50%);
-	}
-
-	.summary-card.below-breakeven .card-note {
-		color: hsl(0 65% 40%);
-	}
-
-	.summary-card.real {
-		border-left: 3px solid hsl(200 60% 55%);
-	}
-
-	.chart-container {
-		width: 100%;
-		height: 380px;
-		margin-bottom: var(--size-5);
-	}
-
-	.projection-details {
-		background: var(--surface-3);
-		padding: var(--size-3);
-		border-radius: var(--radius-2);
-	}
-
-	.projection-details summary {
-		cursor: pointer;
-		padding: var(--size-2);
-		font-size: var(--font-size-2);
-		font-weight: 600;
-	}
-
-	.projection-table {
-		margin-top: var(--size-3);
-		overflow-x: auto;
-	}
-
-	table {
-		width: 100%;
-		border-collapse: collapse;
-		font-size: var(--font-size-0);
-	}
-
-	th,
-	td {
-		padding: var(--size-2);
-		text-align: right;
-		border-bottom: 1px solid var(--surface-4);
-		white-space: nowrap;
-	}
-
-	th {
-		background: var(--surface-4);
-		font-weight: 600;
-		color: var(--color-text-2);
-	}
-
-	th:first-child,
-	td:first-child {
-		text-align: left;
-	}
-
-	tr.paid-off td:first-child::after {
-		content: ' ✓';
-		color: green;
-	}
-
-	.positive {
-		color: hsl(130 50% 35%);
-	}
-
-	.negative {
-		color: hsl(0 60% 45%);
-	}
-
-	@media (max-width: 640px) {
-		table {
-			font-size: var(--font-size-0);
-		}
-
-		th,
-		td {
-			padding: var(--size-1);
-			white-space: normal;
-			word-break: break-word;
-		}
-
-		th:first-child,
-		td:first-child {
-			position: sticky;
-			left: 0;
-			background: var(--surface-2);
-			z-index: 1;
-		}
-
-		th:first-child {
-			background: var(--surface-4);
-		}
-	}
-
-	@media (max-width: 1024px) {
-		.content {
-			grid-template-columns: 1fr;
-		}
-	}
-
-	@media (max-width: 640px) {
-		.mortgage-page {
-			padding: var(--size-3);
-		}
-
-		.form-section,
-		.results-section {
-			padding: var(--size-4);
-		}
-
-		.chart-container {
-			height: 280px;
-		}
-
-		.summary-cards {
-			grid-template-columns: 1fr 1fr;
-			gap: var(--size-2);
-		}
-
-		.card-value {
-			font-size: var(--font-size-2);
-		}
-
-		.winner-banner {
-			flex-direction: column;
-			align-items: flex-start;
-			font-size: var(--font-size-2);
-			gap: var(--size-2);
-		}
-
-		.primary-button {
-			min-height: var(--tap-target-min);
-		}
-
-		h1 {
-			font-size: var(--font-size-4);
-		}
-	}
-</style>

--- a/src/routes/simulations/zus/+page.svelte
+++ b/src/routes/simulations/zus/+page.svelte
@@ -206,93 +206,141 @@
 	}
 </script>
 
-<div class="zus-page">
-	<h1>Kalkulator emerytury ZUS</h1>
+<div class="space-y-4">
+	<h1 class="h1">Kalkulator emerytury ZUS</h1>
 
-	<div class="content">
-		<div class="form-section">
-			<h2>Parametry</h2>
+	<div class="grid grid-cols-1 lg:grid-cols-[400px_1fr] gap-6 items-start">
+		<div class="card preset-filled-surface-100-900 p-5 space-y-4">
+			<h2 class="h3">Parametry</h2>
 
-			<div class="form-group">
-				<label>
-					Osoba
-					<select bind:value={owner}>
+			<div class="flex flex-col gap-3">
+				<label class="label">
+					<span class="text-sm font-semibold">Osoba</span>
+					<select bind:value={owner} class="select">
 						{#each data.personas as persona}
 							<option value={persona.name}>{persona.name}</option>
 						{/each}
 					</select>
 				</label>
 
-				<label>
-					Data urodzenia
-					<input type="date" bind:value={birthDate} />
+				<label class="label">
+					<span class="text-sm font-semibold">Data urodzenia</span>
+					<input type="date" bind:value={birthDate} class="input" />
 				</label>
 
-				<label>
-					Płeć
-					<select bind:value={gender}>
+				<label class="label">
+					<span class="text-sm font-semibold">Płeć</span>
+					<select bind:value={gender} class="select">
 						<option value="M">Mężczyzna</option>
 						<option value="F">Kobieta</option>
 					</select>
 				</label>
 
-				<label>
-					Wiek emerytalny
-					<input type="number" bind:value={retirementAge} min="55" max="70" step="1" />
+				<label class="label">
+					<span class="text-sm font-semibold">Wiek emerytalny</span>
+					<input
+						type="number"
+						bind:value={retirementAge}
+						min="55"
+						max="70"
+						step="1"
+						class="input"
+					/>
 				</label>
 
-				<label>
-					Aktualne wynagrodzenie brutto (PLN/mies.)
-					<input type="number" bind:value={currentGrossMonthly} min="0" step="500" />
+				<label class="label">
+					<span class="text-sm font-semibold">Aktualne wynagrodzenie brutto (PLN/mies.)</span>
+					<input type="number" bind:value={currentGrossMonthly} min="0" step="500" class="input" />
 				</label>
 
-				<label>
-					Rok rozpoczęcia pracy
-					<input type="number" bind:value={workStartYear} min="1970" max="2030" step="1" />
+				<label class="label">
+					<span class="text-sm font-semibold">Rok rozpoczęcia pracy</span>
+					<input
+						type="number"
+						bind:value={workStartYear}
+						min="1970"
+						max="2030"
+						step="1"
+						class="input"
+					/>
 				</label>
 
-				<label>
-					Kapitał początkowy (PLN)
-					<input type="number" bind:value={kapitalPoczatkowy} min="0" step="1000" />
-					<small>Dla pracy przed 1999 r.</small>
+				<label class="label">
+					<span class="text-sm font-semibold">Kapitał początkowy (PLN)</span>
+					<input type="number" bind:value={kapitalPoczatkowy} min="0" step="1000" class="input" />
+					<span class="text-xs text-surface-600-400">Dla pracy przed 1999 r.</span>
 				</label>
 			</div>
 
-			<h3>Założenia</h3>
-			<div class="form-group">
-				<label>
-					Wzrost wynagrodzeń (% rocznie)
-					<input type="number" bind:value={salaryGrowthRate} min="0" max="20" step="0.5" />
+			<h3 class="h4">Założenia</h3>
+			<div class="flex flex-col gap-3">
+				<label class="label">
+					<span class="text-sm font-semibold">Wzrost wynagrodzeń (% rocznie)</span>
+					<input
+						type="number"
+						bind:value={salaryGrowthRate}
+						min="0"
+						max="20"
+						step="0.5"
+						class="input"
+					/>
 				</label>
 
-				<label>
-					Waloryzacja konto (%)
-					<input type="number" bind:value={valorizationKonto} min="0" max="20" step="0.5" />
+				<label class="label">
+					<span class="text-sm font-semibold">Waloryzacja konto (%)</span>
+					<input
+						type="number"
+						bind:value={valorizationKonto}
+						min="0"
+						max="20"
+						step="0.5"
+						class="input"
+					/>
 				</label>
 
-				<label>
-					Waloryzacja subkonto (%)
-					<input type="number" bind:value={valorizationSubkonto} min="0" max="20" step="0.5" />
+				<label class="label">
+					<span class="text-sm font-semibold">Waloryzacja subkonto (%)</span>
+					<input
+						type="number"
+						bind:value={valorizationSubkonto}
+						min="0"
+						max="20"
+						step="0.5"
+						class="input"
+					/>
 				</label>
 
-				<label>
-					Inflacja (% rocznie)
-					<input type="number" bind:value={inflationRate} min="0" max="20" step="0.5" />
+				<label class="label">
+					<span class="text-sm font-semibold">Inflacja (% rocznie)</span>
+					<input
+						type="number"
+						bind:value={inflationRate}
+						min="0"
+						max="20"
+						step="0.5"
+						class="input"
+					/>
 				</label>
 
-				<label class="checkbox-label">
-					<input type="checkbox" bind:checked={hasOfe} />
-					Członek OFE
-					<small>Zmniejsza składkę na subkonto (4.38% zamiast 7.30%)</small>
-				</label>
+				<div class="space-y-1">
+					<label class="flex items-center gap-2 cursor-pointer">
+						<input type="checkbox" bind:checked={hasOfe} class="checkbox" />
+						<span class="text-sm font-semibold">Członek OFE</span>
+					</label>
+					<p class="text-xs text-surface-600-400 ml-6">
+						Zmniejsza składkę na subkonto (4.38% zamiast 7.30%)
+					</p>
+				</div>
 			</div>
 
 			{#if data.prefill.salary_history.length > 0}
-				<details class="salary-history">
-					<summary>Historia wynagrodzeń ({data.prefill.salary_history.length} lat)</summary>
-					<div class="history-list">
+				<details class="card preset-tonal-surface p-3">
+					<summary class="cursor-pointer text-sm font-semibold">
+						Historia wynagrodzeń ({data.prefill.salary_history.length} lat)
+					</summary>
+					<div class="mt-2 flex flex-col divide-y divide-surface-200-800">
 						{#each data.prefill.salary_history as entry}
-							<div class="history-entry">
+							<div class="flex justify-between py-1 text-xs">
 								<span>{entry.year}</span>
 								<span>{formatCurrency(entry.annual_gross)} PLN/rok</span>
 							</div>
@@ -301,131 +349,135 @@
 				</details>
 			{/if}
 
-			<button class="primary-button" onclick={runCalculation} disabled={loading}>
+			<button
+				class="btn preset-filled-primary-500 w-full"
+				onclick={runCalculation}
+				disabled={loading}
+			>
 				{loading ? 'Obliczanie...' : 'Oblicz emeryturę'}
 			</button>
 
 			{#if error}
-				<div class="error-message">{error}</div>
+				<div class="card preset-filled-error-500 p-3 text-sm">{error}</div>
 			{/if}
 		</div>
 
 		{#if results}
-			<div class="results-section">
-				<h2>Wyniki</h2>
+			<div class="card preset-filled-surface-100-900 p-5 space-y-4">
+				<h2 class="h3">Wyniki</h2>
 
-				<div class="summary-cards">
-					<div class="summary-card highlight">
-						<div class="card-label">Emerytura brutto</div>
-						<div class="card-value">
+				<div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+					<div class="card preset-tonal-surface p-4 border-l-4 border-l-success-500">
+						<div class="text-xs text-surface-600-400 mb-2">Emerytura brutto</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.monthly_pension_gross)} PLN
 						</div>
-						<div class="card-note">miesięcznie</div>
+						<div class="text-xs text-surface-600-400 mt-1">miesięcznie</div>
 					</div>
-					<div class="summary-card highlight">
-						<div class="card-label">Emerytura netto</div>
-						<div class="card-value">
+					<div class="card preset-tonal-surface p-4 border-l-4 border-l-success-500">
+						<div class="text-xs text-surface-600-400 mb-2">Emerytura netto</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.monthly_pension_net)} PLN
 						</div>
-						<div class="card-note">miesięcznie</div>
+						<div class="text-xs text-surface-600-400 mt-1">miesięcznie</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Stopa zastąpienia</div>
-						<div class="card-value">{results.replacement_rate.toFixed(1)}%</div>
-						<div class="card-note">
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Stopa zastąpienia</div>
+						<div class="text-xl font-bold">{results.replacement_rate.toFixed(1)}%</div>
+						<div class="text-xs text-surface-600-400 mt-1">
 							emerytura / ostatnia pensja ({formatCurrency(results.last_gross_salary)} PLN)
 						</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Kapitał łączny</div>
-						<div class="card-value">{formatCurrency(results.total_capital)} PLN</div>
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Kapitał łączny</div>
+						<div class="text-xl font-bold">{formatCurrency(results.total_capital)} PLN</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Konto indywidualne</div>
-						<div class="card-value">
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Konto indywidualne</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.konto_at_retirement)} PLN
 						</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Subkonto</div>
-						<div class="card-value">
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Subkonto</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.subkonto_at_retirement)} PLN
 						</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Kapitał początkowy (zwal.)</div>
-						<div class="card-value">
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Kapitał początkowy (zwal.)</div>
+						<div class="text-xl font-bold">
 							{formatCurrency(results.kapital_poczatkowy_valorized)} PLN
 						</div>
 					</div>
-					<div class="summary-card">
-						<div class="card-label">Dalsze trwanie życia</div>
-						<div class="card-value">{results.life_expectancy_months.toFixed(1)} mies.</div>
-						<div class="card-note">
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400 mb-2">Dalsze trwanie życia</div>
+						<div class="text-xl font-bold">{results.life_expectancy_months.toFixed(1)} mies.</div>
+						<div class="text-xs text-surface-600-400 mt-1">
 							{(results.life_expectancy_months / 12).toFixed(1)} lat
 						</div>
 					</div>
 				</div>
 
-				<div class="chart-container" bind:this={chartContainer}></div>
+				<div bind:this={chartContainer} class="w-full h-[380px] sm:h-[280px]"></div>
 
-				<h3>Analiza wrażliwości</h3>
-				<div class="sensitivity-table">
-					<table>
+				<h3 class="h4">Analiza wrażliwości</h3>
+				<div class="table-wrap">
+					<table class="table table-hover text-xs">
 						<thead>
 							<tr>
 								<th>Scenariusz</th>
-								<th>Wal. konto</th>
-								<th>Wal. subkonto</th>
-								<th>Emerytura brutto</th>
-								<th>Emerytura netto</th>
-								<th>Stopa zastąpienia</th>
+								<th class="text-right">Wal. konto</th>
+								<th class="text-right">Wal. subkonto</th>
+								<th class="text-right">Emerytura brutto</th>
+								<th class="text-right">Emerytura netto</th>
+								<th class="text-right">Stopa zastąpienia</th>
 							</tr>
 						</thead>
 						<tbody>
 							{#each results.sensitivity as scenario}
 								<tr>
 									<td>{scenario.label}</td>
-									<td>{scenario.valorization_konto.toFixed(1)}%</td>
-									<td>{scenario.valorization_subkonto.toFixed(1)}%</td>
-									<td>{formatCurrency(scenario.monthly_pension_gross)} PLN</td>
-									<td>{formatCurrency(scenario.monthly_pension_net)} PLN</td>
-									<td>{scenario.replacement_rate.toFixed(1)}%</td>
+									<td class="text-right">{scenario.valorization_konto.toFixed(1)}%</td>
+									<td class="text-right">{scenario.valorization_subkonto.toFixed(1)}%</td>
+									<td class="text-right">{formatCurrency(scenario.monthly_pension_gross)} PLN</td>
+									<td class="text-right">{formatCurrency(scenario.monthly_pension_net)} PLN</td>
+									<td class="text-right">{scenario.replacement_rate.toFixed(1)}%</td>
 								</tr>
 							{/each}
 						</tbody>
 					</table>
 				</div>
 
-				<details class="projection-details">
-					<summary>Projekcja roczna</summary>
-					<div class="projection-table">
-						<table>
+				<details class="card preset-tonal-surface p-3">
+					<summary class="cursor-pointer text-sm font-semibold py-1">Projekcja roczna</summary>
+					<div class="table-wrap mt-3">
+						<table class="table table-hover text-xs">
 							<thead>
 								<tr>
 									<th>Rok</th>
-									<th>Wiek</th>
-									<th>Wynagrodzenie</th>
-									<th>Limit</th>
-									<th>Składka konto</th>
-									<th>Składka subkonto</th>
-									<th>Saldo konto</th>
-									<th>Saldo subkonto</th>
-									<th>Razem</th>
+									<th class="text-right">Wiek</th>
+									<th class="text-right">Wynagrodzenie</th>
+									<th class="text-right">Limit</th>
+									<th class="text-right">Składka konto</th>
+									<th class="text-right">Składka subkonto</th>
+									<th class="text-right">Saldo konto</th>
+									<th class="text-right">Saldo subkonto</th>
+									<th class="text-right">Razem</th>
 								</tr>
 							</thead>
 							<tbody>
 								{#each results.yearly_projections as row}
-									<tr class:capped={row.salary_capped}>
+									<tr class={row.salary_capped ? 'bg-warning-500/10' : ''}>
 										<td>{row.year}</td>
-										<td>{row.age}</td>
-										<td>{formatCurrency(row.annual_gross_salary)}</td>
-										<td>{row.salary_capped ? '30x' : '—'}</td>
-										<td>{formatCurrency(row.contribution_konto)}</td>
-										<td>{formatCurrency(row.contribution_subkonto)}</td>
-										<td>{formatCurrency(row.konto_balance)}</td>
-										<td>{formatCurrency(row.subkonto_balance)}</td>
-										<td>{formatCurrency(row.total_balance)}</td>
+										<td class="text-right">{row.age}</td>
+										<td class="text-right">{formatCurrency(row.annual_gross_salary)}</td>
+										<td class="text-right">{row.salary_capped ? '30x' : '—'}</td>
+										<td class="text-right">{formatCurrency(row.contribution_konto)}</td>
+										<td class="text-right">{formatCurrency(row.contribution_subkonto)}</td>
+										<td class="text-right">{formatCurrency(row.konto_balance)}</td>
+										<td class="text-right">{formatCurrency(row.subkonto_balance)}</td>
+										<td class="text-right">{formatCurrency(row.total_balance)}</td>
 									</tr>
 								{/each}
 							</tbody>
@@ -436,293 +488,3 @@
 		{/if}
 	</div>
 </div>
-
-<style>
-	.zus-page {
-		padding: var(--size-4);
-		max-width: 1400px;
-		margin: 0 auto;
-	}
-
-	h1 {
-		margin-bottom: var(--size-6);
-		color: var(--color-text-1);
-	}
-
-	.content {
-		display: grid;
-		grid-template-columns: 400px 1fr;
-		gap: var(--size-6);
-		align-items: start;
-	}
-
-	.form-section,
-	.results-section {
-		background: var(--surface-2);
-		padding: var(--size-5);
-		border-radius: var(--radius-2);
-	}
-
-	h2 {
-		margin-top: 0;
-		margin-bottom: var(--size-4);
-		color: var(--color-text-2);
-	}
-
-	h3 {
-		margin-top: var(--size-4);
-		margin-bottom: var(--size-3);
-		color: var(--color-text-2);
-	}
-
-	.form-group {
-		display: flex;
-		flex-direction: column;
-		gap: var(--size-3);
-		margin-bottom: var(--size-4);
-	}
-
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: var(--size-1);
-		font-size: var(--font-size-1);
-		color: var(--color-text-2);
-	}
-
-	input[type='number'],
-	input[type='date'],
-	select {
-		padding: var(--size-2);
-		border: 1px solid var(--surface-4);
-		border-radius: var(--radius-2);
-		background: var(--surface-1);
-		color: var(--color-text-1);
-		font-size: var(--font-size-1);
-		min-height: var(--tap-target-min);
-	}
-
-	small {
-		font-size: var(--font-size-0);
-		color: var(--color-text-3);
-	}
-
-	.checkbox-label {
-		flex-direction: row;
-		align-items: center;
-		gap: var(--size-2);
-		font-weight: 600;
-	}
-
-	.checkbox-label input[type='checkbox'] {
-		width: 1rem;
-		height: 1rem;
-		cursor: pointer;
-	}
-
-	.salary-history {
-		margin-bottom: var(--size-4);
-		background: var(--surface-3);
-		padding: var(--size-3);
-		border-radius: var(--radius-2);
-	}
-
-	.salary-history summary {
-		cursor: pointer;
-		font-size: var(--font-size-1);
-		font-weight: 600;
-	}
-
-	.history-list {
-		margin-top: var(--size-2);
-	}
-
-	.history-entry {
-		display: flex;
-		justify-content: space-between;
-		padding: var(--size-1) 0;
-		font-size: var(--font-size-0);
-		border-bottom: 1px solid var(--surface-4);
-	}
-
-	.primary-button {
-		width: 100%;
-		padding: var(--size-3);
-		background: var(--color-primary);
-		color: white;
-		border: none;
-		border-radius: var(--radius-2);
-		font-size: var(--font-size-2);
-		font-weight: 600;
-		cursor: pointer;
-	}
-
-	.primary-button:hover:not(:disabled) {
-		background: var(--color-primary-hover);
-	}
-
-	.primary-button:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	.error-message {
-		margin-top: var(--size-3);
-		padding: var(--size-3);
-		background: var(--color-error-bg);
-		color: var(--color-error);
-		border-radius: var(--radius-2);
-	}
-
-	.summary-cards {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-		gap: var(--size-3);
-		margin-bottom: var(--size-5);
-	}
-
-	.summary-card {
-		background: var(--surface-3);
-		padding: var(--size-4);
-		border-radius: var(--radius-2);
-	}
-
-	.summary-card.highlight {
-		border-left: 3px solid hsl(140 60% 45%);
-	}
-
-	.card-label {
-		font-size: var(--font-size-0);
-		color: var(--color-text-3);
-		margin-bottom: var(--size-2);
-	}
-
-	.card-value {
-		font-size: var(--font-size-3);
-		font-weight: 700;
-		color: var(--color-text-1);
-	}
-
-	.card-note {
-		font-size: var(--font-size-0);
-		color: var(--color-text-3);
-		margin-top: var(--size-1);
-	}
-
-	.chart-container {
-		width: 100%;
-		height: 380px;
-		margin-bottom: var(--size-5);
-	}
-
-	.sensitivity-table,
-	.projection-table {
-		overflow-x: auto;
-		margin-bottom: var(--size-4);
-	}
-
-	.projection-details {
-		background: var(--surface-3);
-		padding: var(--size-3);
-		border-radius: var(--radius-2);
-	}
-
-	.projection-details summary {
-		cursor: pointer;
-		padding: var(--size-2);
-		font-size: var(--font-size-2);
-		font-weight: 600;
-	}
-
-	table {
-		width: 100%;
-		border-collapse: collapse;
-		font-size: var(--font-size-0);
-	}
-
-	th,
-	td {
-		padding: var(--size-2);
-		text-align: right;
-		border-bottom: 1px solid var(--surface-4);
-		white-space: nowrap;
-	}
-
-	th {
-		background: var(--surface-4);
-		font-weight: 600;
-		color: var(--color-text-2);
-	}
-
-	th:first-child,
-	td:first-child {
-		text-align: left;
-	}
-
-	tr.capped {
-		background: hsl(40 80% 95%);
-	}
-
-	@media (max-width: 640px) {
-		table {
-			font-size: var(--font-size-0);
-		}
-
-		th,
-		td {
-			padding: var(--size-1);
-			white-space: normal;
-			word-break: break-word;
-		}
-
-		th:first-child,
-		td:first-child {
-			position: sticky;
-			left: 0;
-			background: var(--surface-2);
-			z-index: 1;
-		}
-
-		th:first-child {
-			background: var(--surface-4);
-		}
-	}
-
-	@media (max-width: 1024px) {
-		.content {
-			grid-template-columns: 1fr;
-		}
-	}
-
-	@media (max-width: 640px) {
-		.zus-page {
-			padding: var(--size-3);
-		}
-
-		.form-section,
-		.results-section {
-			padding: var(--size-4);
-		}
-
-		.chart-container {
-			height: 280px;
-		}
-
-		.summary-cards {
-			grid-template-columns: 1fr 1fr;
-			gap: var(--size-2);
-		}
-
-		.card-value {
-			font-size: var(--font-size-2);
-		}
-
-		.primary-button {
-			min-height: var(--tap-target-min);
-		}
-
-		h1 {
-			font-size: var(--font-size-4);
-		}
-	}
-</style>

--- a/src/routes/simulations/zus/+page.svelte
+++ b/src/routes/simulations/zus/+page.svelte
@@ -419,7 +419,7 @@
 					</div>
 				</div>
 
-				<div bind:this={chartContainer} class="w-full h-[380px] sm:h-[280px]"></div>
+				<div bind:this={chartContainer} class="w-full h-[280px] sm:h-[380px]"></div>
 
 				<h3 class="h4">Analiza wrażliwości</h3>
 				<div class="table-wrap">
@@ -455,7 +455,7 @@
 						<table class="table table-hover text-xs">
 							<thead>
 								<tr>
-									<th>Rok</th>
+									<th class="sticky left-0 z-10 bg-surface-100 dark:bg-surface-900">Rok</th>
 									<th class="text-right">Wiek</th>
 									<th class="text-right">Wynagrodzenie</th>
 									<th class="text-right">Limit</th>
@@ -469,7 +469,8 @@
 							<tbody>
 								{#each results.yearly_projections as row}
 									<tr class={row.salary_capped ? 'bg-warning-500/10' : ''}>
-										<td>{row.year}</td>
+										<td class="sticky left-0 z-10 bg-surface-100 dark:bg-surface-900">{row.year}</td
+										>
 										<td class="text-right">{row.age}</td>
 										<td class="text-right">{formatCurrency(row.annual_gross_salary)}</td>
 										<td class="text-right">{row.salary_capped ? '30x' : '—'}</td>


### PR DESCRIPTION
## Motivation

Legacy custom CSS was scattered across multiple component files, duplicating styles that Tailwind/Skeleton already provide. This drift made the UI inconsistent and added maintenance overhead whenever Skeleton tokens changed.

## Implementation information

- Removed hand-rolled CSS rules that duplicated Tailwind utility classes or Skeleton component variants
- Replaced custom spacing/color/typography declarations with their Tailwind equivalents (`text-`, `bg-`, `p-`, `gap-` etc.)
- Fixed chart responsive breakpoints that broke after the CSS cleanup and made the accounts table header column sticky

Closes https://github.com/Automaat/finance-buddy/issues/398

> Changelog: refactor(ui): converge legacy CSS to Tailwind/Skeleton