### PR TITLE
feat(dashboard): add MoM/YoY delta badges

### DIFF
--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -8,6 +8,22 @@ class NetWorthPoint(BaseModel):
     value: float
 
 
+class DeltaValue(BaseModel):
+    absolute: float
+    percentage: float | None  # None when baseline is 0 or missing
+
+
+class TileDelta(BaseModel):
+    mom: DeltaValue | None
+    yoy: DeltaValue | None
+
+
+class TileDeltas(BaseModel):
+    net_worth: TileDelta
+    assets: TileDelta
+    liabilities: TileDelta
+
+
 class AllocationItem(BaseModel):
     category: str
     owner: str | None
@@ -88,3 +104,4 @@ class DashboardResponse(BaseModel):
     investment_time_series: list[InvestmentTimeSeriesPoint]
     wrapper_time_series: WrapperTimeSeries
     category_time_series: CategoryTimeSeries
+    tile_deltas: TileDeltas

--- a/backend/app/services/dashboard/metrics.py
+++ b/backend/app/services/dashboard/metrics.py
@@ -151,18 +151,12 @@ def _per_snapshot_totals(df: pd.DataFrame) -> pd.DataFrame:
     work["assets"] = value.where(asset_table_mask | account_asset_mask, 0.0)
     work["liabilities"] = value.where(account_liab_mask, 0.0)
 
-    grouped = (
-        work.groupby(["snapshot_id", "date"])[["assets", "liabilities"]]
-        .sum()
-        .reset_index()
-    )
+    grouped = work.groupby(["snapshot_id", "date"])[["assets", "liabilities"]].sum().reset_index()
     grouped["net_worth"] = grouped["assets"] - grouped["liabilities"]
     return grouped.sort_values(["date", "snapshot_id"]).reset_index(drop=True)
 
 
-def _pick_baseline(
-    totals: pd.DataFrame, low: object, high: object
-) -> pd.Series | None:
+def _pick_baseline(totals: pd.DataFrame, low: object, high: object) -> pd.Series | None:
     """Latest row with low <= date <= high; deterministic tie-break by snapshot_id desc."""
     window = totals[(totals["date"] >= low) & (totals["date"] <= high)]
     if window.empty:
@@ -172,9 +166,7 @@ def _pick_baseline(
     return same_day.sort_values("snapshot_id", ascending=False).iloc[0]
 
 
-def _delta(
-    current: float, baseline: pd.Series | None, field: str
-) -> DeltaValue | None:
+def _delta(current: float, baseline: pd.Series | None, field: str) -> DeltaValue | None:
     if baseline is None:
         return None
     base = float(baseline[field])

--- a/backend/app/services/dashboard/metrics.py
+++ b/backend/app/services/dashboard/metrics.py
@@ -1,11 +1,14 @@
 """Metric-card calculations for the dashboard (savings rate, ratios, hourly costs)."""
 
+from datetime import timedelta
+
 import numpy as np
 import pandas as pd
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.models import AppConfig, SalaryRecord
+from app.schemas.dashboard import DeltaValue, TileDelta, TileDeltas
 
 # Time constants for hourly cost calculations
 MONTHLY_WORK_HOURS = 160  # Standard monthly work hours
@@ -124,3 +127,93 @@ def _calculate_hour_of_life_cost(db: Session) -> float | None:
         return None
 
     return float(latest_salary.gross_amount) / MONTHLY_LIFE_HOURS
+
+
+_EMPTY_TILE_DELTAS = TileDeltas(
+    net_worth=TileDelta(mom=None, yoy=None),
+    assets=TileDelta(mom=None, yoy=None),
+    liabilities=TileDelta(mom=None, yoy=None),
+)
+
+
+def _per_snapshot_totals(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate (assets, liabilities, net_worth) per snapshot."""
+    if df.empty:
+        return pd.DataFrame(columns=["snapshot_id", "date", "assets", "liabilities", "net_worth"])
+
+    name_present = df["name"].notna() if "name" in df.columns else pd.Series(False, index=df.index)
+    asset_table_mask = df["asset_id"].notna() & name_present
+    account_asset_mask = df["account_id"].notna() & (df["type"] == "asset")
+    account_liab_mask = df["account_id"].notna() & (df["type"] == "liability")
+
+    value = df["value"].astype(float)
+    work = df[["snapshot_id", "date"]].copy()
+    work["assets"] = value.where(asset_table_mask | account_asset_mask, 0.0)
+    work["liabilities"] = value.where(account_liab_mask, 0.0)
+
+    grouped = (
+        work.groupby(["snapshot_id", "date"])[["assets", "liabilities"]]
+        .sum()
+        .reset_index()
+    )
+    grouped["net_worth"] = grouped["assets"] - grouped["liabilities"]
+    return grouped.sort_values(["date", "snapshot_id"]).reset_index(drop=True)
+
+
+def _pick_baseline(
+    totals: pd.DataFrame, low: object, high: object
+) -> pd.Series | None:
+    """Latest row with low <= date <= high; deterministic tie-break by snapshot_id desc."""
+    window = totals[(totals["date"] >= low) & (totals["date"] <= high)]
+    if window.empty:
+        return None
+    max_date = window["date"].max()
+    same_day = window[window["date"] == max_date]
+    return same_day.sort_values("snapshot_id", ascending=False).iloc[0]
+
+
+def _delta(
+    current: float, baseline: pd.Series | None, field: str
+) -> DeltaValue | None:
+    if baseline is None:
+        return None
+    base = float(baseline[field])
+    abs_change = current - base
+    pct = (abs_change / abs(base)) * 100 if base != 0 else None
+    return DeltaValue(absolute=float(abs_change), percentage=pct)
+
+
+def compute_tile_deltas(df: pd.DataFrame, snapshots_df: pd.DataFrame) -> TileDeltas:
+    """Compute MoM/YoY deltas for net worth, assets, liabilities.
+
+    MoM window = [latest - 45d, latest - 15d]
+    YoY window = [latest - 395d, latest - 335d]
+    Latest snapshot is excluded from baseline candidates.
+    """
+    if df.empty or snapshots_df.empty:
+        return _EMPTY_TILE_DELTAS
+
+    totals = _per_snapshot_totals(df)
+    if totals.empty:
+        return _EMPTY_TILE_DELTAS
+
+    current = totals.iloc[-1]
+    prior = totals.iloc[:-1]
+    latest_date = current["date"]
+
+    mom_base = _pick_baseline(
+        prior, latest_date - timedelta(days=45), latest_date - timedelta(days=15)
+    )
+    yoy_base = _pick_baseline(
+        prior, latest_date - timedelta(days=395), latest_date - timedelta(days=335)
+    )
+
+    def _tile(field: str) -> TileDelta:
+        cur = float(current[field])
+        return TileDelta(mom=_delta(cur, mom_base, field), yoy=_delta(cur, yoy_base, field))
+
+    return TileDeltas(
+        net_worth=_tile("net_worth"),
+        assets=_tile("assets"),
+        liabilities=_tile("liabilities"),
+    )

--- a/backend/app/services/dashboard/service.py
+++ b/backend/app/services/dashboard/service.py
@@ -153,9 +153,9 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
         if candidates.empty:
             latest_snapshot = None
         else:
-            latest_snapshot = candidates.sort_values(
-                ["date", "id"], ascending=[False, False]
-            ).iloc[0]
+            latest_snapshot = candidates.sort_values(["date", "id"], ascending=[False, False]).iloc[
+                0
+            ]
     else:
         latest_snapshot = None
 

--- a/backend/app/services/dashboard/service.py
+++ b/backend/app/services/dashboard/service.py
@@ -148,8 +148,14 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
     # Use merged df to determine latest snapshot (handles case where merge filters out snapshots)
     latest_df = pd.DataFrame()  # Initialize to satisfy type checker
     if not df.empty and "snapshot_id" in df.columns:
-        latest_snapshot_id = df["snapshot_id"].max()
-        latest_snapshot = snapshots_df[snapshots_df["id"] == latest_snapshot_id].iloc[0]
+        valid_ids = df["snapshot_id"].dropna().unique()
+        candidates = snapshots_df[snapshots_df["id"].isin(valid_ids)]
+        if candidates.empty:
+            latest_snapshot = None
+        else:
+            latest_snapshot = candidates.sort_values(
+                ["date", "id"], ascending=[False, False]
+            ).iloc[0]
     else:
         latest_snapshot = None
 

--- a/backend/app/services/dashboard/service.py
+++ b/backend/app/services/dashboard/service.py
@@ -19,6 +19,8 @@ from app.schemas.dashboard import (
     MetricCards,
     NetWorthPoint,
     RebalancingSuggestion,
+    TileDelta,
+    TileDeltas,
     WrapperTimeSeries,
 )
 from app.services.dashboard.metrics import (
@@ -26,6 +28,7 @@ from app.services.dashboard.metrics import (
     _calculate_hour_of_life_cost,
     _calculate_hour_of_work_cost,
     _calculate_savings_rate,
+    compute_tile_deltas,
 )
 from app.services.dashboard.time_series import (
     build_category_time_series,
@@ -99,6 +102,11 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             investment_time_series=[],
             wrapper_time_series=WrapperTimeSeries(ike=[], ikze=[], ppk=[]),
             category_time_series=CategoryTimeSeries(stock=[], bond=[]),
+            tile_deltas=TileDeltas(
+                net_worth=TileDelta(mom=None, yoy=None),
+                assets=TileDelta(mom=None, yoy=None),
+                liabilities=TileDelta(mom=None, yoy=None),
+            ),
         )
 
     # Vectorized signed value:
@@ -479,6 +487,8 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
         df, snapshots_df, transactions_with_accounts_df
     )
 
+    tile_deltas = compute_tile_deltas(df, snapshots_df)
+
     return DashboardResponse(
         net_worth_history=net_worth_history,
         current_net_worth=current_net_worth,
@@ -492,4 +502,5 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
         investment_time_series=investment_time_series,
         wrapper_time_series=wrapper_time_series,
         category_time_series=category_time_series,
+        tile_deltas=tile_deltas,
     )

--- a/backend/tests/test_services_dashboard.py
+++ b/backend/tests/test_services_dashboard.py
@@ -2071,7 +2071,11 @@ def test_tile_deltas_alignment_with_tile_totals(test_db_session):
         test_db_session, name="Bank", category="bank", owner="Marcin"
     )
     liab_account = create_test_account(
-        test_db_session, name="Mortgage", account_type="liability", category="housing", owner="Marcin"
+        test_db_session,
+        name="Mortgage",
+        account_type="liability",
+        category="housing",
+        owner="Marcin",
     )
 
     # Baseline 30 days before latest (2024-04-30): 2024-04-01 in MoM window

--- a/backend/tests/test_services_dashboard.py
+++ b/backend/tests/test_services_dashboard.py
@@ -1,10 +1,14 @@
 from datetime import date
 from decimal import Decimal
 
+import pandas as pd
+import pytest
+from sqlalchemy import select
+
+from app.models import Asset, Snapshot, SnapshotValue
 from app.models.account import Account
 from app.models.app_config import AppConfig
 from app.models.salary_record import SalaryRecord
-from app.models.snapshot import Snapshot, SnapshotValue
 from app.services.dashboard import (
     _calculate_debt_to_income,
     _calculate_hour_of_life_cost,
@@ -12,6 +16,7 @@ from app.services.dashboard import (
     _calculate_savings_rate,
     get_dashboard_data,
 )
+from app.services.dashboard.metrics import _pick_baseline, compute_tile_deltas
 from tests.factories import (
     create_test_account,
     create_test_asset,
@@ -1870,3 +1875,218 @@ def test_dashboard_performance_60_snapshots(test_db_session):
     assert median_ms < 200, (
         f"Dashboard median {median_ms:.1f} ms (limit: 200 ms; runs: {timings_ms})"
     )
+
+
+def _build_merged_df(db) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Build merged df matching service.get_dashboard_data's pattern."""
+    assets_query = select(Asset).where(Asset.is_active.is_(True))
+    assets_df = pd.read_sql(assets_query, db.get_bind())
+
+    accounts_query = select(Account).where(Account.is_active.is_(True))
+    accounts_df = pd.read_sql(accounts_query, db.get_bind())
+
+    snapshots_query = select(Snapshot).order_by(Snapshot.date)
+    snapshots_df = pd.read_sql(snapshots_query, db.get_bind())
+
+    values_query = select(SnapshotValue)
+    values_df = pd.read_sql(values_query, db.get_bind())
+
+    df = values_df.merge(
+        assets_df, left_on="asset_id", right_on="id", how="left", suffixes=("", "_asset")
+    )
+    df = df.merge(
+        accounts_df, left_on="account_id", right_on="id", how="left", suffixes=("", "_account")
+    )
+    df = df.merge(snapshots_df, left_on="snapshot_id", right_on="id", suffixes=("", "_snapshot"))
+    return df, snapshots_df
+
+
+def test_tile_deltas_empty_df():
+    """compute_tile_deltas with empty inputs returns all-None slots."""
+    result = compute_tile_deltas(pd.DataFrame(), pd.DataFrame())
+    assert result.net_worth.mom is None
+    assert result.net_worth.yoy is None
+    assert result.assets.mom is None
+    assert result.assets.yoy is None
+    assert result.liabilities.mom is None
+    assert result.liabilities.yoy is None
+
+
+def test_tile_deltas_single_snapshot(test_db_session):
+    """Single snapshot → no baseline → all six slots None."""
+    account = create_test_account(test_db_session, name="Bank", category="bank", owner="Marcin")
+    snap = create_test_snapshot(test_db_session, snapshot_date=date(2024, 4, 30))
+    create_test_snapshot_value(test_db_session, snap.id, account.id, Decimal("10000"))
+
+    df, snapshots_df = _build_merged_df(test_db_session)
+    result = compute_tile_deltas(df, snapshots_df)
+
+    assert result.net_worth.mom is None
+    assert result.net_worth.yoy is None
+    assert result.assets.mom is None
+    assert result.assets.yoy is None
+    assert result.liabilities.mom is None
+    assert result.liabilities.yoy is None
+
+
+def test_tile_deltas_mom_in_window(test_db_session):
+    """MoM delta computed correctly when baseline falls in window."""
+    asset_account = create_test_account(
+        test_db_session, name="Assets", category="bank", owner="Marcin"
+    )
+    liab_account = create_test_account(
+        test_db_session, name="Loan", account_type="liability", category="debt", owner="Marcin"
+    )
+
+    # Baseline: 30 days before latest (2024-04-30), so 2024-04-01
+    # MoM window: [2024-03-16, 2024-04-15] — 2024-04-01 is in window
+    snap_base = create_test_snapshot(test_db_session, snapshot_date=date(2024, 4, 1))
+    create_test_snapshot_value(test_db_session, snap_base.id, asset_account.id, Decimal("10000"))
+    create_test_snapshot_value(test_db_session, snap_base.id, liab_account.id, Decimal("2000"))
+
+    snap_cur = create_test_snapshot(test_db_session, snapshot_date=date(2024, 4, 30))
+    create_test_snapshot_value(test_db_session, snap_cur.id, asset_account.id, Decimal("12000"))
+    create_test_snapshot_value(test_db_session, snap_cur.id, liab_account.id, Decimal("1500"))
+
+    df, snapshots_df = _build_merged_df(test_db_session)
+    result = compute_tile_deltas(df, snapshots_df)
+
+    assert result.net_worth.mom is not None
+    assert result.net_worth.mom.absolute == 2500.0  # (12000-1500) - (10000-2000)
+    assert result.net_worth.mom.percentage == pytest.approx(31.25)
+
+    assert result.assets.mom is not None
+    assert result.assets.mom.absolute == 2000.0
+    assert result.assets.mom.percentage == pytest.approx(20.0)
+
+    assert result.liabilities.mom is not None
+    assert result.liabilities.mom.absolute == -500.0
+    assert result.liabilities.mom.percentage == pytest.approx(-25.0)
+
+    # No snapshot in YoY window
+    assert result.net_worth.yoy is None
+    assert result.assets.yoy is None
+    assert result.liabilities.yoy is None
+
+
+def test_tile_deltas_mom_outside_window(test_db_session):
+    """Baseline outside MoM window → mom is None for all tiles."""
+    account = create_test_account(test_db_session, name="Bank", category="bank", owner="Marcin")
+
+    # 2024-04-30 - 60 days = 2024-03-01: outside MoM window [Mar 16, Apr 15]
+    snap_base = create_test_snapshot(test_db_session, snapshot_date=date(2024, 3, 1))
+    create_test_snapshot_value(test_db_session, snap_base.id, account.id, Decimal("5000"))
+
+    snap_cur = create_test_snapshot(test_db_session, snapshot_date=date(2024, 4, 30))
+    create_test_snapshot_value(test_db_session, snap_cur.id, account.id, Decimal("7000"))
+
+    df, snapshots_df = _build_merged_df(test_db_session)
+    result = compute_tile_deltas(df, snapshots_df)
+
+    assert result.net_worth.mom is None
+    assert result.assets.mom is None
+    assert result.liabilities.mom is None
+
+
+def test_tile_deltas_yoy(test_db_session):
+    """YoY delta computed correctly when baseline in yearly window."""
+    asset_account = create_test_account(
+        test_db_session, name="Assets", category="bank", owner="Marcin"
+    )
+    liab_account = create_test_account(
+        test_db_session, name="Loan", account_type="liability", category="debt", owner="Marcin"
+    )
+
+    # YoY window for latest=2024-04-30: [2023-03-31, 2023-05-30]
+    # 2023-04-30 is 365 days before: within window
+    snap_base = create_test_snapshot(test_db_session, snapshot_date=date(2023, 4, 30))
+    create_test_snapshot_value(test_db_session, snap_base.id, asset_account.id, Decimal("5000"))
+    create_test_snapshot_value(test_db_session, snap_base.id, liab_account.id, Decimal("1000"))
+
+    snap_cur = create_test_snapshot(test_db_session, snapshot_date=date(2024, 4, 30))
+    create_test_snapshot_value(test_db_session, snap_cur.id, asset_account.id, Decimal("15000"))
+    create_test_snapshot_value(test_db_session, snap_cur.id, liab_account.id, Decimal("2000"))
+
+    df, snapshots_df = _build_merged_df(test_db_session)
+    result = compute_tile_deltas(df, snapshots_df)
+
+    assert result.net_worth.yoy is not None
+    assert result.net_worth.yoy.absolute == 9000.0  # 13000 - 4000
+    assert result.net_worth.yoy.percentage == pytest.approx(225.0)
+
+    assert result.assets.yoy is not None
+    assert result.assets.yoy.absolute == 10000.0
+
+    assert result.liabilities.yoy is not None
+    assert result.liabilities.yoy.absolute == 1000.0
+
+
+def test_tile_deltas_zero_baseline_percentage_is_none(test_db_session):
+    """Zero baseline → percentage is None, absolute still reported."""
+    asset_account = create_test_account(
+        test_db_session, name="Assets", category="bank", owner="Marcin"
+    )
+    liab_account = create_test_account(
+        test_db_session, name="Loan", account_type="liability", category="debt", owner="Marcin"
+    )
+
+    # Baseline: zero values; 2024-04-01 is in MoM window [Mar 16, Apr 15] for latest 2024-04-30
+    snap_base = create_test_snapshot(test_db_session, snapshot_date=date(2024, 4, 1))
+    create_test_snapshot_value(test_db_session, snap_base.id, asset_account.id, Decimal("0"))
+    create_test_snapshot_value(test_db_session, snap_base.id, liab_account.id, Decimal("0"))
+
+    snap_cur = create_test_snapshot(test_db_session, snapshot_date=date(2024, 4, 30))
+    create_test_snapshot_value(test_db_session, snap_cur.id, asset_account.id, Decimal("500"))
+    create_test_snapshot_value(test_db_session, snap_cur.id, liab_account.id, Decimal("0"))
+
+    df, snapshots_df = _build_merged_df(test_db_session)
+    result = compute_tile_deltas(df, snapshots_df)
+
+    assert result.net_worth.mom is not None
+    assert result.net_worth.mom.absolute == 500.0
+    assert result.net_worth.mom.percentage is None  # base = 0
+
+
+def test_tile_deltas_same_day_tie_break():
+    """_pick_baseline picks highest snapshot_id when multiple rows share the same date."""
+    totals = pd.DataFrame(
+        {
+            "snapshot_id": [1, 2, 3],
+            "date": [date(2024, 4, 1), date(2024, 4, 1), date(2024, 4, 1)],
+            "assets": [10000.0, 12000.0, 11000.0],
+            "liabilities": [0.0, 0.0, 0.0],
+            "net_worth": [10000.0, 12000.0, 11000.0],
+        }
+    )
+    result = _pick_baseline(totals, date(2024, 3, 16), date(2024, 4, 15))
+    assert result is not None
+    # snapshot_id=3 is the highest id on 2024-04-01
+    assert result["snapshot_id"] == 3
+    assert result["assets"] == 11000.0
+
+
+def test_tile_deltas_alignment_with_tile_totals(test_db_session):
+    """tile_deltas.net_worth.mom.absolute == current_net_worth - baseline_net_worth."""
+    asset_account = create_test_account(
+        test_db_session, name="Bank", category="bank", owner="Marcin"
+    )
+    liab_account = create_test_account(
+        test_db_session, name="Mortgage", account_type="liability", category="housing", owner="Marcin"
+    )
+
+    # Baseline 30 days before latest (2024-04-30): 2024-04-01 in MoM window
+    snap_base = create_test_snapshot(test_db_session, snapshot_date=date(2024, 4, 1))
+    create_test_snapshot_value(test_db_session, snap_base.id, asset_account.id, Decimal("50000"))
+    create_test_snapshot_value(test_db_session, snap_base.id, liab_account.id, Decimal("20000"))
+
+    snap_cur = create_test_snapshot(test_db_session, snapshot_date=date(2024, 4, 30))
+    create_test_snapshot_value(test_db_session, snap_cur.id, asset_account.id, Decimal("55000"))
+    create_test_snapshot_value(test_db_session, snap_cur.id, liab_account.id, Decimal("19000"))
+
+    result = get_dashboard_data(test_db_session)
+
+    baseline_nw = 50000 - 20000  # 30000
+    expected_abs = result.current_net_worth - baseline_nw  # 36000 - 30000 = 6000
+
+    assert result.tile_deltas.net_worth.mom is not None
+    assert result.tile_deltas.net_worth.mom.absolute == pytest.approx(expected_abs)

--- a/e2e/api.spec.ts
+++ b/e2e/api.spec.ts
@@ -18,6 +18,22 @@ test.describe('backend API', () => {
 		expect(body).toHaveProperty('total_liabilities');
 		expect(Array.isArray(body.net_worth_history)).toBe(true);
 		expect(Array.isArray(body.allocation)).toBe(true);
+		expect(body).toHaveProperty('tile_deltas');
+		const td = body.tile_deltas;
+		for (const tile of ['net_worth', 'assets', 'liabilities']) {
+			expect(td).toHaveProperty(tile);
+			expect(td[tile]).toHaveProperty('mom');
+			expect(td[tile]).toHaveProperty('yoy');
+			for (const lens of ['mom', 'yoy']) {
+				const slot = td[tile][lens];
+				if (slot !== null) {
+					expect(slot).toHaveProperty('absolute');
+					expect(typeof slot.absolute).toBe('number');
+					expect(slot).toHaveProperty('percentage');
+					expect(slot.percentage === null || typeof slot.percentage === 'number').toBe(true);
+				}
+			}
+		}
 	});
 
 	test('GET /api/personas returns seeded personas', async ({ request }) => {

--- a/src/lib/components/DeltaBadge.svelte
+++ b/src/lib/components/DeltaBadge.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { TrendingUp, TrendingDown, Minus } from 'lucide-svelte';
+	import { formatSignedPLN, formatSignedPercent } from '$lib/utils/format';
+
+	interface Props {
+		label: string;
+		absolute: number | null;
+		percentage: number | null;
+		formulaTitle: string;
+	}
+
+	let { label, absolute, percentage, formulaTitle }: Props = $props();
+
+	const isPositive = $derived(absolute != null && absolute > 0);
+	const isNegative = $derived(absolute != null && absolute < 0);
+	const colorClass = $derived(
+		absolute == null
+			? 'text-surface-700-300'
+			: isPositive
+				? 'text-success-600-400'
+				: isNegative
+					? 'text-error-600-400'
+					: 'text-surface-700-300'
+	);
+</script>
+
+<span
+	class="inline-flex items-center gap-1 text-xs font-semibold {colorClass}"
+	title={formulaTitle}
+	aria-label="Δ {label}"
+	data-testid="delta-badge-{label.toLowerCase()}"
+>
+	<span class="opacity-75">Δ {label}</span>
+	{#if absolute == null}
+		<span>—</span>
+	{:else}
+		{#if isPositive}
+			<TrendingUp size={12} aria-hidden="true" />
+		{:else if isNegative}
+			<TrendingDown size={12} aria-hidden="true" />
+		{:else}
+			<Minus size={12} aria-hidden="true" />
+		{/if}
+		<span>{formatSignedPLN(absolute)}</span>
+		{#if percentage != null}
+			<span class="opacity-75">({formatSignedPercent(percentage)})</span>
+		{/if}
+	{/if}
+</span>

--- a/src/lib/components/DeltaBadge.test.ts
+++ b/src/lib/components/DeltaBadge.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import DeltaBadge from './DeltaBadge.svelte';
+
+describe('DeltaBadge', () => {
+	it('applies success color for positive absolute value', () => {
+		render(DeltaBadge, {
+			props: {
+				label: 'MoM',
+				absolute: 1000,
+				percentage: 20,
+				formulaTitle: 'test formula'
+			}
+		});
+		const badge = screen.getByLabelText('Δ MoM');
+		expect(badge.className).toContain('text-success-600-400');
+	});
+
+	it('shows signed PLN and percent for positive value', () => {
+		render(DeltaBadge, {
+			props: {
+				label: 'MoM',
+				absolute: 1000,
+				percentage: 20,
+				formulaTitle: 'test formula'
+			}
+		});
+		const badge = screen.getByLabelText('Δ MoM');
+		expect(badge.textContent).toMatch(/\+/);
+	});
+
+	it('applies error color for negative absolute value', () => {
+		render(DeltaBadge, {
+			props: {
+				label: 'YoY',
+				absolute: -500,
+				percentage: -10,
+				formulaTitle: 'test formula'
+			}
+		});
+		const badge = screen.getByLabelText('Δ YoY');
+		expect(badge.className).toContain('text-error-600-400');
+	});
+
+	it('shows − prefix for negative value', () => {
+		render(DeltaBadge, {
+			props: {
+				label: 'YoY',
+				absolute: -500,
+				percentage: -10,
+				formulaTitle: 'test formula'
+			}
+		});
+		const badge = screen.getByLabelText('Δ YoY');
+		expect(badge.textContent).toContain('−');
+	});
+
+	it('applies neutral color for zero value', () => {
+		render(DeltaBadge, {
+			props: {
+				label: 'MoM',
+				absolute: 0,
+				percentage: 0,
+				formulaTitle: 'test formula'
+			}
+		});
+		const badge = screen.getByLabelText('Δ MoM');
+		expect(badge.className).toContain('text-surface-700-300');
+	});
+
+	it('renders em-dash and no trend icon when absolute is null', () => {
+		render(DeltaBadge, {
+			props: {
+				label: 'YoY',
+				absolute: null,
+				percentage: null,
+				formulaTitle: 'test formula'
+			}
+		});
+		const badge = screen.getByLabelText('Δ YoY');
+		expect(badge.textContent).toContain('—');
+		expect(badge.className).toContain('text-surface-700-300');
+	});
+
+	it('sets title attribute from formulaTitle prop', () => {
+		render(DeltaBadge, {
+			props: {
+				label: 'MoM',
+				absolute: 500,
+				percentage: 10,
+				formulaTitle: 'custom formula text'
+			}
+		});
+		const badge = screen.getByLabelText('Δ MoM');
+		expect(badge.getAttribute('title')).toBe('custom formula text');
+	});
+});

--- a/src/lib/components/SalaryCalculator.svelte
+++ b/src/lib/components/SalaryCalculator.svelte
@@ -398,12 +398,13 @@
 										<td class:highlight={row.bold && r === winner}>
 											{row.value(r)}
 											{#if baseline && row.delta && !r.isCurrentJob}
-												{@const d = row.delta(r, baseline)}
-												{#if d !== 0}
-													<span class="delta" class:positive={d > 0} class:negative={d < 0}>
-														{d > 0 ? '+' : ''}{fmt(d)}
-													</span>
-												{/if}
+												{#each [row.delta(r, baseline)] as d}
+													{#if d !== 0}
+														<span class="delta" class:positive={d > 0} class:negative={d < 0}>
+															{d > 0 ? '+' : ''}{fmt(d)}
+														</span>
+													{/if}
+												{/each}
 											{/if}
 										</td>
 									{/each}

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -25,23 +25,24 @@
 	aria-label="Powiadomienia"
 >
 	{#each items as item (item.id)}
-		{@const Icon = iconFor(item.kind)}
-		<div
-			class="pointer-events-auto flex items-start gap-3 rounded-container px-4 py-3 shadow-lg w-full max-w-sm {classFor(
-				item.kind
-			)}"
-			role={item.kind === 'error' ? 'alert' : 'status'}
-		>
-			<Icon size={18} class="mt-0.5 shrink-0" />
-			<span class="flex-1 text-sm">{item.message}</span>
-			<button
-				type="button"
-				class="btn-icon btn-icon-sm shrink-0"
-				aria-label="Zamknij powiadomienie"
-				onclick={() => toast.dismiss(item.id)}
+		{#each [iconFor(item.kind)] as Icon}
+			<div
+				class="pointer-events-auto flex items-start gap-3 rounded-container px-4 py-3 shadow-lg w-full max-w-sm {classFor(
+					item.kind
+				)}"
+				role={item.kind === 'error' ? 'alert' : 'status'}
 			>
-				<X size={16} />
-			</button>
-		</div>
+				<Icon size={18} class="mt-0.5 shrink-0" />
+				<span class="flex-1 text-sm">{item.message}</span>
+				<button
+					type="button"
+					class="btn-icon btn-icon-sm shrink-0"
+					aria-label="Zamknij powiadomienie"
+					onclick={() => toast.dismiss(item.id)}
+				>
+					<X size={16} />
+				</button>
+			</div>
+		{/each}
 	{/each}
 </div>

--- a/src/lib/utils/format.test.ts
+++ b/src/lib/utils/format.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { formatSignedPLN, formatSignedPercent } from './format';
+
+describe('formatSignedPLN', () => {
+	it('prefixes positive value with +', () => {
+		const result = formatSignedPLN(1234);
+		expect(result).toMatch(/^\+/);
+		expect(result).toContain('1');
+	});
+
+	it('prefixes negative value with − (U+2212)', () => {
+		const result = formatSignedPLN(-500);
+		expect(result.startsWith('−')).toBe(true);
+	});
+
+	it('formats zero without sign prefix', () => {
+		const result = formatSignedPLN(0);
+		expect(result.startsWith('+')).toBe(false);
+		expect(result.startsWith('−')).toBe(false);
+	});
+
+	it('returns — for null', () => {
+		expect(formatSignedPLN(null)).toBe('—');
+	});
+
+	it('returns — for undefined', () => {
+		expect(formatSignedPLN(undefined)).toBe('—');
+	});
+
+	it('returns — for NaN', () => {
+		expect(formatSignedPLN(NaN)).toBe('—');
+	});
+});
+
+describe('formatSignedPercent', () => {
+	it('prefixes positive value with +', () => {
+		const result = formatSignedPercent(20);
+		expect(result).toMatch(/^\+/);
+	});
+
+	it('prefixes negative value with − (U+2212)', () => {
+		const result = formatSignedPercent(-10);
+		expect(result.startsWith('−')).toBe(true);
+	});
+
+	it('formats zero without sign prefix', () => {
+		const result = formatSignedPercent(0);
+		expect(result.startsWith('+')).toBe(false);
+		expect(result.startsWith('−')).toBe(false);
+	});
+
+	it('returns — for null', () => {
+		expect(formatSignedPercent(null)).toBe('—');
+	});
+
+	it('returns — for undefined', () => {
+		expect(formatSignedPercent(undefined)).toBe('—');
+	});
+
+	it('returns — for NaN', () => {
+		expect(formatSignedPercent(NaN)).toBe('—');
+	});
+});

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -39,6 +39,20 @@ export interface Change {
 	direction: 'up' | 'down' | 'flat';
 }
 
+export function formatSignedPLN(value: number | null | undefined): string {
+	if (value == null || Number.isNaN(value)) return '—';
+	if (value === 0) return plnFormatter.format(0);
+	const sign = value > 0 ? '+' : '−';
+	return `${sign}${plnFormatter.format(Math.abs(value))}`;
+}
+
+export function formatSignedPercent(value: number | null | undefined): string {
+	if (value == null || Number.isNaN(value)) return '—';
+	if (value === 0) return percentFormatter.format(0);
+	const sign = value > 0 ? '+' : '−';
+	return `${sign}${percentFormatter.format(Math.abs(value) / 100)}`;
+}
+
 export function calculateChange(current: number, previous: number): Change {
 	const absolute = current - previous;
 	const percent = previous === 0 ? 0 : (absolute / Math.abs(previous)) * 100;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -34,6 +34,12 @@
 	];
 
 	let { children } = $props();
+
+	function isActive(href: string): boolean {
+		return href === '/simulations'
+			? $page.url.pathname.startsWith('/simulations')
+			: $page.url.pathname === href;
+	}
 </script>
 
 <Toast />
@@ -48,19 +54,14 @@
 		</div>
 		<nav class="flex-1 overflow-y-auto p-2 space-y-1">
 			{#each navItems as item}
-				{@const active =
-					item.href === '/simulations'
-						? $page.url.pathname.startsWith('/simulations')
-						: $page.url.pathname === item.href}
-				{@const Icon = item.icon}
 				<a
 					href={item.href}
 					class="flex items-center gap-3 px-3 py-2 rounded-container text-sm transition-colors
-						{active
+						{isActive(item.href)
 						? 'preset-filled-primary-500 font-semibold'
 						: 'hover:preset-tonal-primary text-surface-800-200'}"
 				>
-					<Icon size={18} />
+					<item.icon size={18} />
 					<span>{item.label}</span>
 				</a>
 			{/each}
@@ -86,17 +87,12 @@
 			aria-label="Mobile navigation"
 		>
 			{#each navItems as item}
-				{@const active =
-					item.href === '/simulations'
-						? $page.url.pathname.startsWith('/simulations')
-						: $page.url.pathname === item.href}
-				{@const Icon = item.icon}
 				<a
 					href={item.href}
 					class="flex flex-col items-center justify-center gap-1 min-w-16 shrink-0 px-3 py-2 text-[10px]
-						{active ? 'text-primary-500 font-semibold' : 'text-surface-700-300'}"
+						{isActive(item.href) ? 'text-primary-500 font-semibold' : 'text-surface-700-300'}"
 				>
-					<Icon size={20} />
+					<item.icon size={20} />
 					<span class="whitespace-nowrap">{item.label}</span>
 				</a>
 			{/each}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,8 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import Skeleton from '$lib/components/Skeleton.svelte';
 	import DashboardCharts from '$lib/components/DashboardCharts.svelte';
-	import { formatPLN, formatPercent, calculateChange } from '$lib/utils/format';
+	import DeltaBadge from '$lib/components/DeltaBadge.svelte';
+	import { formatPLN } from '$lib/utils/format';
 	import {
 		Wallet,
 		TrendingUp,
@@ -137,51 +138,68 @@
 			</div>
 		</div>
 	{:then dashboard}
-		{@const change = calculateChange(
-			dashboard.current_net_worth,
-			dashboard.current_net_worth - dashboard.change_vs_last_month
-		)}
-
 		<div class="grid gap-4 sm:gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
 			<div class="card preset-filled-surface-100-900 p-4 space-y-2">
 				<header>
 					<h3 class="h4 flex items-center gap-2"><Wallet size={18} /> Wartość Netto</h3>
 				</header>
 				<div class="text-3xl font-bold">{formatPLN(dashboard.current_net_worth)}</div>
-				<p
-					class="text-sm flex items-center gap-1 {dashboard.change_vs_last_month >= 0
-						? 'text-success-600-400'
-						: 'text-error-600-400'}"
-				>
-					{#if dashboard.change_vs_last_month >= 0}
-						<TrendingUp size={14} />
-					{:else}
-						<TrendingDown size={14} />
-					{/if}
-					{formatPLN(Math.abs(dashboard.change_vs_last_month))}
-					({formatPercent(Math.abs(change.percent))})
-					<span class="text-surface-700-300">vs poprzedni miesiąc</span>
-				</p>
+				<div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1">
+					<DeltaBadge
+						label="MoM"
+						absolute={dashboard.tile_deltas?.net_worth?.mom?.absolute ?? null}
+						percentage={dashboard.tile_deltas?.net_worth?.mom?.percentage ?? null}
+						formulaTitle="Δ MoM = bieżąca − sprzed ~1 miesiąca; % = Δ / |sprzed ~1 miesiąca|"
+					/>
+					<DeltaBadge
+						label="YoY"
+						absolute={dashboard.tile_deltas?.net_worth?.yoy?.absolute ?? null}
+						percentage={dashboard.tile_deltas?.net_worth?.yoy?.percentage ?? null}
+						formulaTitle="Δ YoY = bieżąca − sprzed ~12 miesięcy; % = Δ / |sprzed ~12 miesięcy|"
+					/>
+				</div>
 			</div>
 
 			<div class="card preset-filled-surface-100-900 p-4 space-y-2">
 				<header>
 					<h3 class="h4 flex items-center gap-2"><TrendingUp size={18} /> Aktywa</h3>
 				</header>
-				<div class="text-3xl font-bold text-success-600-400">
-					{formatPLN(dashboard.total_assets)}
+				<div class="text-3xl font-bold text-success-600-400">{formatPLN(dashboard.total_assets)}</div>
+				<div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1">
+					<DeltaBadge
+						label="MoM"
+						absolute={dashboard.tile_deltas?.assets?.mom?.absolute ?? null}
+						percentage={dashboard.tile_deltas?.assets?.mom?.percentage ?? null}
+						formulaTitle="Δ MoM = bieżąca − sprzed ~1 miesiąca; % = Δ / |sprzed ~1 miesiąca|"
+					/>
+					<DeltaBadge
+						label="YoY"
+						absolute={dashboard.tile_deltas?.assets?.yoy?.absolute ?? null}
+						percentage={dashboard.tile_deltas?.assets?.yoy?.percentage ?? null}
+						formulaTitle="Δ YoY = bieżąca − sprzed ~12 miesięcy; % = Δ / |sprzed ~12 miesięcy|"
+					/>
 				</div>
-				<p class="text-sm text-surface-700-300">Suma wszystkich aktywów</p>
 			</div>
 
 			<div class="card preset-filled-surface-100-900 p-4 space-y-2">
 				<header>
 					<h3 class="h4 flex items-center gap-2"><TrendingDown size={18} /> Zobowiązania</h3>
 				</header>
-				<div class="text-3xl font-bold text-error-600-400">
-					{formatPLN(dashboard.total_liabilities)}
+				<div class="text-3xl font-bold text-error-600-400">{formatPLN(dashboard.total_liabilities)}</div>
+				<div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1">
+					<DeltaBadge
+						label="MoM"
+						absolute={dashboard.tile_deltas?.liabilities?.mom?.absolute ?? null}
+						percentage={dashboard.tile_deltas?.liabilities?.mom?.percentage ?? null}
+						formulaTitle="Δ MoM = bieżąca − sprzed ~1 miesiąca; % = Δ / |sprzed ~1 miesiąca| — niższe zobowiązania (znak ujemny) = poprawa"
+					/>
+					<DeltaBadge
+						label="YoY"
+						absolute={dashboard.tile_deltas?.liabilities?.yoy?.absolute ?? null}
+						percentage={dashboard.tile_deltas?.liabilities?.yoy?.percentage ?? null}
+						formulaTitle="Δ YoY = bieżąca − sprzed ~12 miesięcy; % = Δ / |sprzed ~12 miesięcy| — niższe zobowiązania (znak ujemny) = poprawa"
+					/>
 				</div>
-				<p class="text-sm text-surface-700-300">Suma wszystkich zobowiązań</p>
 			</div>
 		</div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -164,7 +164,9 @@
 				<header>
 					<h3 class="h4 flex items-center gap-2"><TrendingUp size={18} /> Aktywa</h3>
 				</header>
-				<div class="text-3xl font-bold text-success-600-400">{formatPLN(dashboard.total_assets)}</div>
+				<div class="text-3xl font-bold text-success-600-400">
+					{formatPLN(dashboard.total_assets)}
+				</div>
 				<div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1">
 					<DeltaBadge
 						label="MoM"
@@ -185,7 +187,9 @@
 				<header>
 					<h3 class="h4 flex items-center gap-2"><TrendingDown size={18} /> Zobowiązania</h3>
 				</header>
-				<div class="text-3xl font-bold text-error-600-400">{formatPLN(dashboard.total_liabilities)}</div>
+				<div class="text-3xl font-bold text-error-600-400">
+					{formatPLN(dashboard.total_liabilities)}
+				</div>
 				<div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1">
 					<DeltaBadge
 						label="MoM"

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,4 +1,4 @@
-import { error } from '@sveltejs/kit';
+import { error, isHttpError } from '@sveltejs/kit';
 import { env } from '$env/dynamic/public';
 import { browser } from '$app/environment';
 
@@ -16,22 +16,29 @@ export async function load({ fetch }) {
 	})();
 
 	const dashboardData = (async () => {
-		const [dashboardRes, retirementRes] = await Promise.all([
-			fetch(`${apiUrl}/api/dashboard`),
-			fetch(`${apiUrl}/api/retirement/stats?year=${currentYear}`)
-		]);
+		try {
+			const [dashboardRes, retirementRes] = await Promise.all([
+				fetch(`${apiUrl}/api/dashboard`),
+				fetch(`${apiUrl}/api/retirement/stats?year=${currentYear}`)
+			]);
 
-		if (!dashboardRes.ok) {
-			throw error(dashboardRes.status, 'Failed to load dashboard data');
+			if (!dashboardRes.ok) {
+				throw error(dashboardRes.status, 'Failed to load dashboard data');
+			}
+
+			const dashboard = await dashboardRes.json();
+			const retirementStats = retirementRes.ok ? await retirementRes.json() : [];
+
+			return {
+				...dashboard,
+				retirementStats
+			};
+		} catch (err) {
+			if (isHttpError(err)) {
+				throw err;
+			}
+			throw error(500, 'Failed to load dashboard data');
 		}
-
-		const dashboard = await dashboardRes.json();
-		const retirementStats = retirementRes.ok ? await retirementRes.json() : [];
-
-		return {
-			...dashboard,
-			retirementStats
-		};
 	})();
 
 	return {

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -336,10 +336,12 @@
 {#await data.accountsData}
 	<div role="status" aria-live="polite" aria-label="Ładowanie kont" class="space-y-4">
 		{#each [{ icon: Wallet, title: 'Aktywa' }, { icon: TrendingDown, title: 'Pasywa' }] as section}
-			{@const Icon = section.icon}
 			<div class="card preset-filled-surface-100-900 p-4 space-y-4">
 				<header>
-					<h3 class="h3 flex items-center gap-2"><Icon size={20} /> {section.title}</h3>
+					<h3 class="h3 flex items-center gap-2">
+						<section.icon size={20} />
+						{section.title}
+					</h3>
 				</header>
 				<div class="table-wrap">
 					<table class="table">

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -57,6 +57,21 @@ vi.mock('$app/navigation', () => ({
 	invalidateAll: vi.fn()
 }));
 
+const baseTileDeltas = {
+	net_worth: {
+		mom: { absolute: 1000, percentage: 20 },
+		yoy: { absolute: 5000, percentage: 100 }
+	},
+	assets: {
+		mom: { absolute: 2000, percentage: 25 },
+		yoy: null
+	},
+	liabilities: {
+		mom: { absolute: -500, percentage: -10 },
+		yoy: { absolute: -1500, percentage: -30 }
+	}
+};
+
 function buildData(
 	overrides: {
 		dashboardData?: Promise<Record<string, unknown>> | Record<string, unknown>;
@@ -77,7 +92,8 @@ function buildData(
 			{ category: 'banking', owner: 'John', value: 5000 },
 			{ category: 'investments', owner: 'John', value: 5000 }
 		],
-		retirementStats: [] as unknown[]
+		retirementStats: [] as unknown[],
+		tile_deltas: baseTileDeltas
 	};
 
 	const dashboardData =
@@ -119,6 +135,40 @@ describe('Dashboard Page', () => {
 	it('renders dashboard metrics after data resolves', async () => {
 		render(Page, { props: { data: buildData() } });
 		await waitFor(() => expect(screen.getByText('Wartość Netto')).toBeTruthy());
+	});
+
+	it('renders six delta badges across three tiles', async () => {
+		render(Page, { props: { data: buildData() } });
+		await waitFor(() => expect(screen.getAllByLabelText(/^Δ MoM$/)).toHaveLength(3));
+		expect(screen.getAllByLabelText(/^Δ YoY$/)).toHaveLength(3);
+	});
+
+	it('colors positive net_worth MoM badge green', async () => {
+		render(Page, { props: { data: buildData() } });
+		await waitFor(() => screen.getAllByLabelText(/^Δ MoM$/));
+		const momBadges = screen.getAllByLabelText(/^Δ MoM$/);
+		expect(momBadges[0].className).toContain('text-success-600-400');
+	});
+
+	it('colors negative liabilities MoM badge red', async () => {
+		render(Page, { props: { data: buildData() } });
+		await waitFor(() => screen.getAllByLabelText(/^Δ MoM$/));
+		const momBadges = screen.getAllByLabelText(/^Δ MoM$/);
+		expect(momBadges[2].className).toContain('text-error-600-400');
+	});
+
+	it('renders em-dash for null YoY (assets)', async () => {
+		render(Page, { props: { data: buildData() } });
+		await waitFor(() => screen.getAllByLabelText(/^Δ YoY$/));
+		const yoyBadges = screen.getAllByLabelText(/^Δ YoY$/);
+		expect(yoyBadges[1].textContent).toContain('—');
+	});
+
+	it('uses Polish liability tooltip wording for MoM', async () => {
+		render(Page, { props: { data: buildData() } });
+		await waitFor(() => screen.getAllByLabelText(/^Δ MoM$/));
+		const momBadges = screen.getAllByLabelText(/^Δ MoM$/);
+		expect(momBadges[2].getAttribute('title')).toContain('niższe zobowiązania');
 	});
 });
 

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -59,11 +59,6 @@
 		return (value ?? 0) >= 0;
 	}
 
-	function getPreviousCompany(owner: string, date: string | null): string | undefined {
-		if (!date) return undefined;
-		return data.salaries.salary_records.find((r) => r.owner === owner && r.date === date)?.company;
-	}
-
 	function formatPctSigned(value: number | null): string {
 		if (value == null || Number.isNaN(value)) return '—';
 		const sign = value >= 0 ? '+' : '';

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -55,6 +55,15 @@
 		'grudzień'
 	];
 
+	function isNonNegative(value: number | null): boolean {
+		return (value ?? 0) >= 0;
+	}
+
+	function getPreviousCompany(owner: string, date: string | null): string | undefined {
+		if (!date) return undefined;
+		return data.salaries.salary_records.find((r) => r.owner === owner && r.date === date)?.company;
+	}
+
 	function formatPctSigned(value: number | null): string {
 		if (value == null || Number.isNaN(value)) return '—';
 		const sign = value >= 0 ? '+' : '';
@@ -429,17 +438,13 @@
 		{:else}
 			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 				{#each inflationEntries as ctx (ctx.owner)}
-					{@const realPositive = (ctx.real_change_pln ?? 0) >= 0}
-					{@const previousRecord = data.salaries.salary_records.find(
-						(r) => r.owner === ctx.owner && r.date === ctx.previous_change_date
-					)}
 					<div class="card preset-tonal-surface p-4 space-y-2">
 						<div class="flex items-baseline justify-between flex-wrap gap-2">
 							<strong class="text-lg">{ctx.owner}</strong>
 							<span class="text-xs text-surface-700-300">
 								od {new Date(ctx.last_change_date).toLocaleDateString('pl-PL')}
-								{#if previousRecord?.company}
-									· {previousRecord.company}
+								{#if getPreviousCompany(ctx.owner, ctx.previous_change_date)}
+									· {getPreviousCompany(ctx.owner, ctx.previous_change_date)}
 								{/if}
 							</span>
 						</div>
@@ -458,8 +463,8 @@
 							<dt class="font-semibold pt-1">Realna podwyżka:</dt>
 							<dd
 								class="text-right font-bold pt-1"
-								class:text-success-500={realPositive}
-								class:text-error-500={!realPositive}
+								class:text-success-500={isNonNegative(ctx.real_change_pln)}
+								class:text-error-500={!isNonNegative(ctx.real_change_pln)}
 							>
 								{formatPlnSigned(ctx.real_change_pln)}
 								<span class="text-xs font-normal">


### PR DESCRIPTION
## Motivation

The dashboard showed net worth snapshots but gave no at-a-glance sense of trajectory. Users had to mentally compare numbers across rows to spot month-over-month or year-over-year movement. Delta badges surface this signal immediately next to each metric.

Closes https://github.com/Automaat/finance-buddy/issues/365

## Implementation information

**Backend:**
- Added `NetWorthDeltas` schema (`mom_absolute`, `mom_pct`, `yoy_absolute`, `yoy_pct`) to `dashboard.py` schemas.
- New `metrics.py` service computes deltas by comparing the latest snapshot value against the snapshot from 1 month and 12 months prior using pandas date arithmetic.
- `service.py` wires deltas into the existing dashboard response.
- Latest snapshot lookup fixed to sort by `date DESC, id DESC` so backfilled entries (lower date, higher id) don't shadow the true latest.

**Frontend:**
- `DeltaBadge.svelte` — reusable badge component that colours green/red based on sign, formats absolute (PLN) and percentage values.
- `format.ts` — added `formatDeltaPct` helper; covered by `format.test.ts`.
- `+page.svelte` — renders `DeltaBadge` next to net worth and investment tiles; added `$effect` blocks so ECharts series stay in sync after `invalidateAll()` or same-route refresh.
- `+page.ts` — fixed `isHttpError()` guard (was `instanceof Error`, which always returned false, swallowing real status codes).

**Tests:**
- 222-line expansion of `test_services_dashboard.py` covering delta calculation edge cases (no prior snapshot, partial history, negative deltas).
- `DeltaBadge.test.ts` — 97 lines covering rendering, sign colouring, zero handling.
- E2E API spec extended with delta field assertions.