### PR TITLE
perf(db): materialized monthly snapshot aggregates

### DIFF
--- a/backend/alembic/versions/0005_add_snapshot_aggregates.py
+++ b/backend/alembic/versions/0005_add_snapshot_aggregates.py
@@ -16,6 +16,7 @@ Create Date: 2026-05-21
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 from alembic import op
 
@@ -26,6 +27,10 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    # Baseline 0001 uses Base.metadata.create_all against current metadata,
+    # which already creates snapshot_aggregates on fresh databases. Skip when present.
+    if inspect(op.get_bind()).has_table("snapshot_aggregates"):
+        return
     op.create_table(
         "snapshot_aggregates",
         sa.Column("id", sa.Integer, primary_key=True),

--- a/backend/alembic/versions/0005_add_snapshot_aggregates.py
+++ b/backend/alembic/versions/0005_add_snapshot_aggregates.py
@@ -1,0 +1,52 @@
+"""Add snapshot_aggregates table for precomputed per-owner aggregates.
+
+Grain: (snapshot_id, owner). The 'Shared' owner holds Asset-table
+(non-account) contributions. See SnapshotAggregate model and
+aggregate_spec.compute_aggregates() for full field semantics.
+
+DB-level CASCADE on snapshot_id FK ensures aggregate rows are cleaned up
+automatically when a snapshot is deleted (verify with \\d snapshot_aggregates
+after upgrade).
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-05-21
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "snapshot_aggregates",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "snapshot_id",
+            sa.Integer,
+            sa.ForeignKey("snapshots.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("month", sa.Date, nullable=False),
+        sa.Column("owner", sa.String(100), nullable=False),
+        sa.Column("total_assets", sa.Numeric(15, 2), nullable=False),
+        sa.Column("total_liabilities", sa.Numeric(15, 2), nullable=False),
+        sa.Column("net_worth", sa.Numeric(15, 2), nullable=False),
+        sa.Column("allocation_json", sa.JSON, nullable=False),
+        sa.Column("computed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("snapshot_id", "owner", name="uix_snapshot_agg_snapshot_owner"),
+    )
+    op.create_index("ix_snapshot_aggregates_month", "snapshot_aggregates", ["month"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_snapshot_aggregates_month", table_name="snapshot_aggregates")
+    op.drop_table("snapshot_aggregates")

--- a/backend/alembic/versions/0006_backfill_snapshot_aggregates.py
+++ b/backend/alembic/versions/0006_backfill_snapshot_aggregates.py
@@ -1,0 +1,182 @@
+"""Backfill snapshot_aggregates for all existing snapshots.
+
+The aggregation logic is copied verbatim from services.aggregate_spec as the
+frozen local function _compute_aggregates_frozen(). This duplication is
+intentional: Alembic migrations must not import app code (which evolves),
+but the frozen copy preserves the logic that was correct as of this revision.
+
+If aggregate_spec.py changes after this migration is applied, write a new
+migration — do NOT update this file.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-21
+"""
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import text
+
+from alembic import op
+
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# ---------- Frozen copy of aggregate_spec.compute_aggregates ----------
+# Intentionally duplicated. Migrations must not import app code.
+# A parity test (test_aggregate_parity.py) asserts byte-equal output between
+# this function and the live aggregate_spec.compute_aggregates().
+
+
+@dataclass
+class _AggRow:
+    snapshot_id: int
+    month: date
+    owner: str
+    total_assets: Decimal
+    total_liabilities: Decimal
+    net_worth: Decimal
+    allocation: list[dict[str, Any]]
+
+
+def _first_of_month_frozen(d: date) -> date:
+    return d.replace(day=1)
+
+
+def _compute_aggregates_frozen(
+    snapshot_id: int,
+    snapshot_date: date,
+    sv_tuples: list[tuple[Any, Any, Any]],  # (asset_id, account_id, value)
+    account_map: dict[int, tuple[str, str, str]],  # id → (owner, type, category)
+    active_asset_ids: set[int],
+) -> list[_AggRow]:
+    """Frozen copy of aggregate_spec.compute_aggregates for migration use."""
+    totals: dict[str, dict[str, Any]] = {}
+
+    def _bucket(owner: str) -> dict[str, Any]:
+        if owner not in totals:
+            totals[owner] = {"assets": Decimal("0"), "liabilities": Decimal("0"), "alloc": {}}
+        return totals[owner]
+
+    for sv_asset_id, sv_account_id, sv_value in sv_tuples:
+        value = sv_value if isinstance(sv_value, Decimal) else Decimal(str(sv_value))
+        if sv_asset_id is not None:
+            if sv_asset_id in active_asset_ids:
+                _bucket("Shared")["assets"] += value
+        elif sv_account_id is not None:
+            acct = account_map.get(sv_account_id)
+            if acct is None:
+                continue
+            owner, acct_type, category = acct
+            bkt = _bucket(owner)
+            if acct_type == "asset":
+                bkt["assets"] += value
+                bkt["alloc"][category] = bkt["alloc"].get(category, Decimal("0")) + value
+            else:
+                bkt["liabilities"] += value
+
+    month = _first_of_month_frozen(snapshot_date)
+    if not totals:
+        return [_AggRow(snapshot_id, month, "Shared", Decimal("0"), Decimal("0"), Decimal("0"), [])]
+
+    result = []
+    for owner, data in totals.items():
+        alloc = [{"category": c, "value": v} for c, v in sorted(data["alloc"].items())]
+        result.append(
+            _AggRow(
+                snapshot_id,
+                month,
+                owner,
+                data["assets"],
+                data["liabilities"],
+                data["assets"] - data["liabilities"],
+                alloc,
+            )
+        )
+    return result
+
+
+# -----------------------------------------------------------------------
+
+
+def _parse_date(raw: Any) -> date:
+    """Parse a date from either a Python date object or an ISO string."""
+    if isinstance(raw, date):
+        return raw
+    return date.fromisoformat(str(raw))
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    now = datetime.now(UTC)
+
+    account_rows = bind.execute(
+        text("SELECT id, owner, type, category FROM accounts WHERE is_active = TRUE")
+    ).fetchall()
+    account_map: dict[int, tuple[str, str, str]] = {
+        r.id: (r.owner, r.type, r.category) for r in account_rows
+    }
+
+    active_asset_ids: set[int] = {
+        r.id for r in bind.execute(text("SELECT id FROM assets WHERE is_active = TRUE")).fetchall()
+    }
+
+    snapshots = bind.execute(text("SELECT id, date FROM snapshots ORDER BY date")).fetchall()
+
+    for snap in snapshots:
+        snap_id: int = snap.id
+        snap_date: date = _parse_date(snap.date)
+
+        sv_rows = bind.execute(
+            text(
+                "SELECT asset_id, account_id, value FROM snapshot_values WHERE snapshot_id = :sid"
+            ),
+            {"sid": snap_id},
+        ).fetchall()
+
+        agg_rows = _compute_aggregates_frozen(
+            snap_id,
+            snap_date,
+            [(r.asset_id, r.account_id, r.value) for r in sv_rows],
+            account_map,
+            active_asset_ids,
+        )
+
+        for row in agg_rows:
+            alloc_json = json.dumps(
+                [
+                    {"category": item["category"], "value": float(item["value"])}
+                    for item in row.allocation
+                ]
+            )
+            bind.execute(
+                text(
+                    "INSERT INTO snapshot_aggregates "
+                    "(snapshot_id, month, owner, total_assets, total_liabilities, "
+                    "net_worth, allocation_json, computed_at) "
+                    "VALUES (:snapshot_id, :month, :owner, :total_assets, "
+                    ":total_liabilities, :net_worth, :allocation_json, :computed_at)"
+                ),
+                {
+                    "snapshot_id": row.snapshot_id,
+                    "month": row.month.isoformat(),
+                    "owner": row.owner,
+                    "total_assets": str(row.total_assets),
+                    "total_liabilities": str(row.total_liabilities),
+                    "net_worth": str(row.net_worth),
+                    "allocation_json": alloc_json,
+                    "computed_at": now.isoformat(),
+                },
+            )
+
+
+def downgrade() -> None:
+    op.execute(text("DELETE FROM snapshot_aggregates"))

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.persona import Persona
 from app.models.retirement_limit import RetirementLimit
 from app.models.salary_record import SalaryRecord
 from app.models.snapshot import Snapshot, SnapshotValue
+from app.models.snapshot_aggregate import SnapshotAggregate
 from app.models.transaction import Transaction
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "RetirementLimit",
     "SalaryRecord",
     "Snapshot",
+    "SnapshotAggregate",
     "SnapshotValue",
     "Transaction",
 ]

--- a/backend/app/models/snapshot_aggregate.py
+++ b/backend/app/models/snapshot_aggregate.py
@@ -1,0 +1,47 @@
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import JSON, Date, DateTime, ForeignKey, Index, Numeric, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class SnapshotAggregate(Base):
+    """Precomputed aggregate per (snapshot_id, owner).
+
+    Grain: one row per distinct account-owner found in a snapshot's values,
+    plus 'Shared' for Asset-table (non-account) entries.
+
+    The 'month' column is denormalized (= snapshot.date with day=1) for fast
+    month-bucket grouping in the dashboard. It is NOT part of the uniqueness
+    constraint — the unique key is (snapshot_id, owner). Storing month here
+    avoids a JOIN to the snapshots table on hot reads.
+
+    Table name is 'snapshot_aggregates' (not 'monthly_aggregates') because the
+    grain is per-snapshot, not per-calendar-month. Two snapshots in the same
+    calendar month produce two distinct sets of rows.
+
+    Populated by services.snapshot_aggregates.recompute_for_snapshot(), which
+    uses the signed-value logic in services.aggregate_spec.compute_aggregates().
+    On snapshot delete the FK ondelete=CASCADE removes aggregate rows automatically.
+    """
+
+    __tablename__ = "snapshot_aggregates"
+    __table_args__ = (
+        UniqueConstraint("snapshot_id", "owner", name="uix_snapshot_agg_snapshot_owner"),
+        Index("ix_snapshot_aggregates_month", "month"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    snapshot_id: Mapped[int] = mapped_column(ForeignKey("snapshots.id", ondelete="CASCADE"))
+    month: Mapped[date] = mapped_column(Date)
+    owner: Mapped[str] = mapped_column(String(100))
+    total_assets: Mapped[Decimal] = mapped_column(Numeric(15, 2))
+    total_liabilities: Mapped[Decimal] = mapped_column(Numeric(15, 2))
+    net_worth: Mapped[Decimal] = mapped_column(Numeric(15, 2))
+    allocation_json: Mapped[Any] = mapped_column(JSON)
+    computed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )

--- a/backend/app/services/accounts.py
+++ b/backend/app/services/accounts.py
@@ -3,27 +3,37 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.models import Account
+from app.models import Account, SnapshotValue
 from app.schemas.accounts import AccountCreate, AccountResponse, AccountsListResponse, AccountUpdate
+from app.services.snapshot_aggregates import recompute_for_snapshots
 from app.utils.db_helpers import (
     check_duplicate_name,
     get_latest_snapshot_value,
     get_latest_snapshot_values_batch,
     get_or_404,
-    soft_delete,
 )
+
+
+def _affected_snapshot_ids(db: Session, account_id: int) -> list[int]:
+    """Return snapshot IDs that have a SnapshotValue for this account."""
+    return list(
+        db.execute(
+            select(SnapshotValue.snapshot_id)
+            .where(SnapshotValue.account_id == account_id)
+            .distinct()
+        )
+        .scalars()
+        .all()
+    )
 
 
 def get_all_accounts(db: Session) -> AccountsListResponse:
     """Get all active accounts with their latest snapshot values"""
-    # Get all active accounts
     accounts = db.execute(select(Account).where(Account.is_active.is_(True))).scalars().all()
 
-    # Batch fetch latest snapshot values for all accounts
     account_ids = [account.id for account in accounts]
     latest_values = get_latest_snapshot_values_batch(db, account_ids)
 
-    # Build response with accounts grouped by type
     assets = []
     liabilities = []
 
@@ -54,7 +64,6 @@ def get_all_accounts(db: Session) -> AccountsListResponse:
 
 def create_account(db: Session, data: AccountCreate) -> AccountResponse:
     """Create new account"""
-    # Check for duplicate active account name
     check_duplicate_name(db, Account, data.name)
 
     account = Account(
@@ -102,11 +111,12 @@ def update_account(db: Session, account_id: int, data: AccountUpdate) -> Account
     """Update existing account"""
     account = get_or_404(db, Account, account_id)
 
-    # Check for duplicate name if changing name
     if data.name and data.name != account.name:
         check_duplicate_name(db, Account, data.name, exclude_id=account_id)
 
-    # Update fields
+    old_owner = account.owner
+    old_category = account.category
+
     if data.name is not None:
         account.name = data.name
     if data.category is not None:
@@ -119,13 +129,22 @@ def update_account(db: Session, account_id: int, data: AccountUpdate) -> Account
         account.purpose = data.purpose
     if data.receives_contributions is not None:
         account.receives_contributions = data.receives_contributions
-    # For account_wrapper and square_meters, distinguish between
-    # "not provided" and "explicitly set to None"
     _field_set = getattr(data, "model_fields_set", set())
     if "account_wrapper" in _field_set:
         account.account_wrapper = data.account_wrapper
     if "square_meters" in _field_set:
         account.square_meters = data.square_meters
+
+    # Recompute aggregates when fields that affect totals/allocation change
+    needs_recompute = (data.owner is not None and data.owner != old_owner) or (
+        data.category is not None and data.category != old_category
+    )
+
+    if needs_recompute:
+        affected_ids = _affected_snapshot_ids(db, account_id)
+        if affected_ids:
+            db.flush()  # Persist new owner/category before recompute queries accounts
+            recompute_for_snapshots(db, affected_ids)
 
     try:
         db.commit()
@@ -137,7 +156,6 @@ def update_account(db: Session, account_id: int, data: AccountUpdate) -> Account
             detail="Failed to update account due to database integrity error",
         ) from e
 
-    # Get current value
     current_value = get_latest_snapshot_value(db, account.id)
 
     return AccountResponse(
@@ -158,5 +176,18 @@ def update_account(db: Session, account_id: int, data: AccountUpdate) -> Account
 
 
 def delete_account(db: Session, account_id: int) -> None:
-    """Soft delete account by setting is_active=False"""
-    soft_delete(db, Account, account_id)
+    """Soft delete account and recompute affected aggregates"""
+    account = get_or_404(db, Account, account_id)
+
+    if not account.is_active:
+        return
+
+    affected_ids = _affected_snapshot_ids(db, account_id)
+
+    account.is_active = False
+    db.flush()  # Persist is_active=False before recompute queries accounts
+
+    if affected_ids:
+        recompute_for_snapshots(db, affected_ids)
+
+    db.commit()

--- a/backend/app/services/aggregate_spec.py
+++ b/backend/app/services/aggregate_spec.py
@@ -1,0 +1,131 @@
+"""Pure aggregation spec for snapshot aggregates.
+
+No ORM or SQLAlchemy imports — safe to call from Alembic migrations
+without booting the application.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+
+@dataclass
+class AggregateRow:
+    """One precomputed row per (snapshot_id, owner).
+
+    'owner' is Account.owner for account-type rows, or the literal string
+    'Shared' for Asset-table (non-account) entries.
+    """
+
+    snapshot_id: int
+    month: date  # snapshot.date with day=1; denormalized for month-bucket grouping
+    owner: str
+    total_assets: Decimal
+    total_liabilities: Decimal
+    net_worth: Decimal
+    allocation: list[dict[str, Any]]  # [{"category": str, "value": Decimal}] sorted by category
+
+
+def compute_aggregates(
+    snapshot: Any,
+    snapshot_value_rows: Sequence[Any],
+    account_rows: Sequence[Any],
+    asset_rows: Sequence[Any],
+) -> list[AggregateRow]:
+    """Compute per-owner aggregate rows for one snapshot.
+
+    Parameters
+    ----------
+    snapshot:
+        Object with .id (int) and .date (date).
+    snapshot_value_rows:
+        Objects with .asset_id (int|None), .account_id (int|None),
+        .value (Decimal|str|float).
+    account_rows:
+        Active Account objects with .id, .owner, .type, .category.
+        Inactive accounts must be excluded by the caller.
+    asset_rows:
+        Active Asset objects with .id.
+        Inactive assets must be excluded by the caller.
+
+    Returns
+    -------
+    One AggregateRow per distinct owner. If no active rows exist, returns a
+    single zero row for owner='Shared' so the month is not a gap in the chart.
+
+    Signed-value logic mirrors dashboard/service.py:104-114:
+    - Asset-table entry (asset_id in active_asset_ids) → total_assets += value, owner='Shared'
+    - Account type='asset' → total_assets += value; allocation[category] += value
+    - Account type='liability' → total_liabilities += value
+    """
+    account_map: dict[int, Any] = {a.id: a for a in account_rows}
+    active_asset_ids: set[int] = {a.id for a in asset_rows}
+
+    totals: dict[str, dict[str, Any]] = {}
+
+    def _bucket(owner: str) -> dict[str, Any]:
+        if owner not in totals:
+            totals[owner] = {
+                "assets": Decimal("0"),
+                "liabilities": Decimal("0"),
+                "alloc": {},
+            }
+        return totals[owner]
+
+    for sv in snapshot_value_rows:
+        raw = sv.value
+        value = raw if isinstance(raw, Decimal) else Decimal(str(raw))
+
+        if sv.asset_id is not None:
+            if sv.asset_id in active_asset_ids:
+                _bucket("Shared")["assets"] += value
+        elif sv.account_id is not None:
+            account = account_map.get(sv.account_id)
+            if account is None:
+                continue
+            bkt = _bucket(account.owner)
+            if account.type == "asset":
+                bkt["assets"] += value
+                cat: str = account.category
+                bkt["alloc"][cat] = bkt["alloc"].get(cat, Decimal("0")) + value
+            else:
+                bkt["liabilities"] += value
+
+    if not totals:
+        return [
+            AggregateRow(
+                snapshot_id=snapshot.id,
+                month=_first_of_month(snapshot.date),
+                owner="Shared",
+                total_assets=Decimal("0"),
+                total_liabilities=Decimal("0"),
+                net_worth=Decimal("0"),
+                allocation=[],
+            )
+        ]
+
+    result: list[AggregateRow] = []
+    for owner, data in totals.items():
+        allocation_sorted = [
+            {"category": cat, "value": v} for cat, v in sorted(data["alloc"].items())
+        ]
+        result.append(
+            AggregateRow(
+                snapshot_id=snapshot.id,
+                month=_first_of_month(snapshot.date),
+                owner=owner,
+                total_assets=data["assets"],
+                total_liabilities=data["liabilities"],
+                net_worth=data["assets"] - data["liabilities"],
+                allocation=allocation_sorted,
+            )
+        )
+    return result
+
+
+def _first_of_month(d: date) -> date:
+    return d.replace(day=1)

--- a/backend/app/services/assets.py
+++ b/backend/app/services/assets.py
@@ -5,24 +5,32 @@ from sqlalchemy.orm import Session
 
 from app.models import Asset, Snapshot, SnapshotValue
 from app.schemas.assets import AssetCreate, AssetResponse, AssetsListResponse, AssetUpdate
+from app.services.snapshot_aggregates import recompute_for_snapshots
 from app.utils.db_helpers import (
     check_duplicate_name,
     get_latest_snapshot_values_batch_for_assets,
     get_or_404,
-    soft_delete,
 )
+
+
+def _affected_snapshot_ids_for_asset(db: Session, asset_id: int) -> list[int]:
+    """Return snapshot IDs that have a SnapshotValue for this asset."""
+    return list(
+        db.execute(
+            select(SnapshotValue.snapshot_id).where(SnapshotValue.asset_id == asset_id).distinct()
+        )
+        .scalars()
+        .all()
+    )
 
 
 def get_all_assets(db: Session) -> AssetsListResponse:
     """Get all active assets with their latest snapshot values"""
-    # Get all active assets
     assets = db.execute(select(Asset).where(Asset.is_active.is_(True))).scalars().all()
 
-    # Batch fetch latest snapshot values for all assets
     asset_ids = [asset.id for asset in assets]
     latest_values = get_latest_snapshot_values_batch_for_assets(db, asset_ids)
 
-    # Build response
     asset_responses = []
     for asset in assets:
         asset_response = AssetResponse(
@@ -39,7 +47,6 @@ def get_all_assets(db: Session) -> AssetsListResponse:
 
 def create_asset(db: Session, data: AssetCreate) -> AssetResponse:
     """Create new asset"""
-    # Check for duplicate active asset name
     check_duplicate_name(db, Asset, data.name)
 
     asset = Asset(
@@ -68,14 +75,12 @@ def create_asset(db: Session, data: AssetCreate) -> AssetResponse:
 
 
 def update_asset(db: Session, asset_id: int, data: AssetUpdate) -> AssetResponse:
-    """Update existing asset"""
+    """Update existing asset (name-only; no aggregate recompute needed)"""
     asset = get_or_404(db, Asset, asset_id)
 
-    # Check for duplicate name if changing name
     if data.name and data.name != asset.name:
         check_duplicate_name(db, Asset, data.name, exclude_id=asset_id)
 
-    # Update fields
     if data.name is not None:
         asset.name = data.name
 
@@ -89,7 +94,6 @@ def update_asset(db: Session, asset_id: int, data: AssetUpdate) -> AssetResponse
             detail="Failed to update asset due to database integrity error",
         ) from e
 
-    # Get current value
     latest_snapshot = db.execute(
         select(Snapshot).order_by(desc(Snapshot.date)).limit(1)
     ).scalar_one_or_none()
@@ -115,5 +119,18 @@ def update_asset(db: Session, asset_id: int, data: AssetUpdate) -> AssetResponse
 
 
 def delete_asset(db: Session, asset_id: int) -> None:
-    """Soft delete asset by setting is_active=False"""
-    soft_delete(db, Asset, asset_id)
+    """Soft delete asset and recompute affected aggregates"""
+    asset = get_or_404(db, Asset, asset_id)
+
+    if not asset.is_active:
+        return
+
+    affected_ids = _affected_snapshot_ids_for_asset(db, asset_id)
+
+    asset.is_active = False
+    db.flush()  # Persist is_active=False before recompute queries assets
+
+    if affected_ids:
+        recompute_for_snapshots(db, affected_ids)
+
+    db.commit()

--- a/backend/app/services/dashboard/service.py
+++ b/backend/app/services/dashboard/service.py
@@ -199,6 +199,9 @@ def _get_dashboard_data_from_aggregates(
         accounts_df["category"].isin(_INVESTMENT_CATEGORIES).any()
     )
 
+    df = pd.DataFrame()
+    snapshots_df = pd.DataFrame()
+
     if has_investment:
         assets_df = pd.read_sql(select(Asset).where(Asset.is_active.is_(True)), db.get_bind())
         snapshots_df = pd.read_sql(select(Snapshot).order_by(Snapshot.date), db.get_bind())
@@ -233,6 +236,28 @@ def _get_dashboard_data_from_aggregates(
         wrapper_time_series = WrapperTimeSeries(ike=[], ikze=[], ppk=[])
         category_time_series = CategoryTimeSeries(stock=[], bond=[])
 
+    if has_investment:
+        tile_deltas = compute_tile_deltas(df, snapshots_df)
+    else:
+        # Build synthetic df from agg_rows so compute_tile_deltas works without
+        # loading the full snapshot values table.
+        synth_rows: list[dict] = []
+        for sid in sorted_sids:
+            d = snap_date[sid]
+            sid_agg = [r for r in agg_rows if r.snapshot_id == sid]
+            ta = sum(float(r.total_assets) for r in sid_agg)
+            tl = sum(float(r.total_liabilities) for r in sid_agg)
+            synth_rows.append(
+                {"snapshot_id": sid, "date": d, "account_id": 1, "asset_id": None, "name": None, "type": "asset", "value": ta}
+            )
+            synth_rows.append(
+                {"snapshot_id": sid, "date": d, "account_id": 2, "asset_id": None, "name": None, "type": "liability", "value": tl}
+            )
+        tile_deltas = compute_tile_deltas(
+            pd.DataFrame(synth_rows) if synth_rows else pd.DataFrame(),
+            pd.DataFrame({"id": sorted_sids}) if sorted_sids else pd.DataFrame(),
+        )
+
     return DashboardResponse(
         net_worth_history=net_worth_history,
         current_net_worth=current_net_worth,
@@ -246,6 +271,7 @@ def _get_dashboard_data_from_aggregates(
         investment_time_series=investment_time_series,
         wrapper_time_series=wrapper_time_series,
         category_time_series=category_time_series,
+        tile_deltas=tile_deltas,
     )
 
 

--- a/backend/app/services/dashboard/service.py
+++ b/backend/app/services/dashboard/service.py
@@ -83,9 +83,9 @@ def _get_dashboard_data_from_aggregates(
     for row in agg_rows:
         snapshot_nw[row.snapshot_id] += float(row.net_worth)
 
-    snap_objs = db.execute(
-        select(Snapshot).where(Snapshot.id.in_(list(snapshot_nw)))
-    ).scalars().all()
+    snap_objs = (
+        db.execute(select(Snapshot).where(Snapshot.id.in_(list(snapshot_nw)))).scalars().all()
+    )
     snap_date: dict = {s.id: s.date for s in snap_objs}
 
     sorted_sids = sorted(snapshot_nw, key=lambda sid: snap_date[sid])

--- a/backend/app/services/dashboard/service.py
+++ b/backend/app/services/dashboard/service.py
@@ -78,13 +78,20 @@ def _load_aggregate_rows(db: Session) -> list[SnapshotAggregate]:
 def _get_dashboard_data_from_aggregates(
     db: Session, agg_rows: list[SnapshotAggregate]
 ) -> DashboardResponse:
-    # --- Net worth history (group by month across all owners) ---
-    month_nw: dict = defaultdict(float)
+    # --- Net worth history (one point per snapshot, sum across owners) ---
+    snapshot_nw: dict = defaultdict(float)
     for row in agg_rows:
-        month_nw[row.month] += float(row.net_worth)
+        snapshot_nw[row.snapshot_id] += float(row.net_worth)
 
-    sorted_months = sorted(month_nw)
-    net_worth_history = [NetWorthPoint(date=m, value=month_nw[m]) for m in sorted_months]
+    snap_objs = db.execute(
+        select(Snapshot).where(Snapshot.id.in_(list(snapshot_nw)))
+    ).scalars().all()
+    snap_date: dict = {s.id: s.date for s in snap_objs}
+
+    sorted_sids = sorted(snapshot_nw, key=lambda sid: snap_date[sid])
+    net_worth_history = [
+        NetWorthPoint(date=snap_date[sid], value=snapshot_nw[sid]) for sid in sorted_sids
+    ]
     current_net_worth = float(net_worth_history[-1].value)
     last_month_net_worth = float(net_worth_history[-2].value) if len(net_worth_history) > 1 else 0.0
 
@@ -286,9 +293,20 @@ def _compute_savings_rate_from_aggregates(
     """Savings rate from aggregate net_worth deltas — no SnapshotValue scan."""
     from app.models import SalaryRecord
 
-    month_nw: dict = defaultdict(float)
+    # Group by snapshot_id first to avoid summing across multiple same-month snapshots
+    snapshot_nw_sr: dict = defaultdict(float)
+    snapshot_month_sr: dict = {}
     for row in agg_rows:
-        month_nw[row.month] += float(row.net_worth)
+        snapshot_nw_sr[row.snapshot_id] += float(row.net_worth)
+        snapshot_month_sr[row.snapshot_id] = row.month
+
+    # Per month, take the latest snapshot (highest snapshot_id = most recent)
+    month_latest_sid: dict = {}
+    for sid, month in snapshot_month_sr.items():
+        if month not in month_latest_sid or sid > month_latest_sid[month]:
+            month_latest_sid[month] = sid
+
+    month_nw: dict = {month: snapshot_nw_sr[sid] for month, sid in month_latest_sid.items()}
 
     sorted_months = sorted(month_nw)
     if len(sorted_months) < 4:

--- a/backend/app/services/dashboard/service.py
+++ b/backend/app/services/dashboard/service.py
@@ -1,7 +1,15 @@
 """
-Dashboard service using pandas for financial calculations.
-Demonstrates: groupby, pivot, merge, aggregations, time series
+Dashboard service: aggregate-backed hot paths with raw fallback.
+
+Hot paths (net_worth_history, current totals, allocation) read from
+snapshot_aggregates — O(snapshots × owners) rows, no merge needed.
+
+Raw paths (time series, savings-rate sub-computation) still use the full
+merged DataFrame, but are only loaded when investment accounts are present
+or when no aggregates exist (migration period / tests using factories).
 """
+
+from collections import defaultdict
 
 import numpy as np
 import pandas as pd
@@ -9,6 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.models import Account, AppConfig, Asset, Snapshot, SnapshotValue, Transaction
+from app.models.snapshot_aggregate import SnapshotAggregate
 from app.schemas.dashboard import (
     AccountWrapperBreakdown,
     AllocationAnalysis,
@@ -27,7 +36,6 @@ from app.services.dashboard.metrics import (
     _calculate_debt_to_income,
     _calculate_hour_of_life_cost,
     _calculate_hour_of_work_cost,
-    _calculate_savings_rate,
     compute_tile_deltas,
 )
 from app.services.dashboard.time_series import (
@@ -36,10 +44,512 @@ from app.services.dashboard.time_series import (
     build_wrapper_time_series,
 )
 
+_INVESTMENT_CATEGORIES = {"stock", "bond", "fund", "etf", "gold", "ppk"}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
 
 def get_dashboard_data(db: Session) -> DashboardResponse:
+    """Return dashboard metrics.
+
+    Uses snapshot_aggregates for net_worth_history, current totals, and
+    allocation when aggregates exist. Falls back to the raw-path implementation
+    when the table is empty (migration period, or tests that create data via
+    factories without triggering the service layer).
     """
-    Calculate dashboard metrics using pandas.
+    agg_rows = _load_aggregate_rows(db)
+    if not agg_rows:
+        return _get_dashboard_data_raw(db)
+    return _get_dashboard_data_from_aggregates(db, agg_rows)
+
+
+# ---------------------------------------------------------------------------
+# Aggregate path
+# ---------------------------------------------------------------------------
+
+
+def _load_aggregate_rows(db: Session) -> list[SnapshotAggregate]:
+    return list(db.execute(select(SnapshotAggregate)).scalars().all())
+
+
+def _get_dashboard_data_from_aggregates(
+    db: Session, agg_rows: list[SnapshotAggregate]
+) -> DashboardResponse:
+    # --- Net worth history (group by month across all owners) ---
+    month_nw: dict = defaultdict(float)
+    for row in agg_rows:
+        month_nw[row.month] += float(row.net_worth)
+
+    sorted_months = sorted(month_nw)
+    net_worth_history = [NetWorthPoint(date=m, value=month_nw[m]) for m in sorted_months]
+    current_net_worth = float(net_worth_history[-1].value)
+    last_month_net_worth = float(net_worth_history[-2].value) if len(net_worth_history) > 1 else 0.0
+
+    # --- Latest snapshot (by highest snapshot_id) ---
+    latest_sid: int = max(row.snapshot_id for row in agg_rows)
+    latest_rows = [r for r in agg_rows if r.snapshot_id == latest_sid]
+
+    total_assets = sum(float(r.total_assets) for r in latest_rows)
+    total_liabilities = sum(float(r.total_liabilities) for r in latest_rows)
+
+    allocation = sorted(
+        [
+            AllocationItem(
+                category=item["category"],
+                owner=row.owner,
+                value=float(item["value"]),
+            )
+            for row in latest_rows
+            for item in (row.allocation_json or [])
+        ],
+        key=lambda x: (x.category, x.owner),
+    )
+
+    # --- Shared data (always loaded) ---
+    accounts_df = pd.read_sql(select(Account).where(Account.is_active.is_(True)), db.get_bind())
+    app_config = db.execute(select(AppConfig).where(AppConfig.id == 1)).scalar_one_or_none()
+
+    retirement_account_value = 0.0
+    metric_cards: MetricCards
+    allocation_analysis: AllocationAnalysis
+    transactions_with_accounts_df = pd.DataFrame()
+
+    if app_config:
+        # Narrow load: only the latest snapshot's values (not a full table scan)
+        latest_sv_df = _load_raw_for_metrics(db, latest_sid)
+
+        if not latest_sv_df.empty:
+            latest_df = latest_sv_df.merge(
+                accounts_df,
+                left_on="account_id",
+                right_on="id",
+                how="left",
+                suffixes=("", "_account"),
+            )
+        else:
+            latest_df = pd.DataFrame()
+
+        if not latest_df.empty and "type" in latest_df.columns:
+            retirement_df = latest_df[
+                pd.notna(latest_df["account_id"])
+                & (latest_df["type"] == "asset")
+                & (latest_df["purpose"] == "retirement")
+            ]
+            retirement_account_value = float(retirement_df["value"].sum())
+
+        # Transactions — shared between metric cards and time series
+        transactions_df = _load_raw_for_transactions(db)
+        if not transactions_df.empty:
+            transactions_with_accounts_df = transactions_df.merge(
+                accounts_df, left_on="account_id", right_on="id", how="left"
+            )
+            sign = np.where(
+                transactions_with_accounts_df["transaction_type"] == "withdrawal", -1.0, 1.0
+            )
+            transactions_with_accounts_df["signed_amount"] = (
+                transactions_with_accounts_df["amount"].astype(float) * sign
+            )
+
+        metric_cards = _build_metric_cards_aggregate(
+            agg_rows,
+            latest_df,
+            accounts_df,
+            transactions_with_accounts_df,
+            app_config,
+            retirement_account_value,
+            db,
+        )
+
+        allocation_analysis = _build_allocation_analysis(latest_df, app_config)
+    else:
+        metric_cards = MetricCards(
+            property_sqm=0,
+            emergency_fund_months=0,
+            retirement_income_monthly=0,
+            mortgage_remaining=0,
+            mortgage_months_left=0,
+            mortgage_years_left=0,
+            retirement_total=0,
+            investment_contributions=0,
+            investment_returns=0,
+            savings_rate=None,
+            debt_to_income_ratio=None,
+            hour_of_work_cost=None,
+            hour_of_life_cost=None,
+        )
+        allocation_analysis = AllocationAnalysis(
+            by_category=[],
+            by_wrapper=[],
+            rebalancing=[],
+            total_investment_value=0,
+        )
+
+    # --- Time series (only when investment accounts exist) ---
+    has_investment = not accounts_df.empty and bool(
+        accounts_df["category"].isin(_INVESTMENT_CATEGORIES).any()
+    )
+
+    if has_investment:
+        assets_df = pd.read_sql(select(Asset).where(Asset.is_active.is_(True)), db.get_bind())
+        snapshots_df = pd.read_sql(select(Snapshot).order_by(Snapshot.date), db.get_bind())
+        values_df = pd.read_sql(select(SnapshotValue), db.get_bind())
+        df = _build_merged_df(values_df, assets_df, accounts_df, snapshots_df)
+
+        if app_config is None:
+            # Transactions not yet loaded
+            transactions_df = _load_raw_for_transactions(db)
+            if not transactions_df.empty:
+                transactions_with_accounts_df = transactions_df.merge(
+                    accounts_df, left_on="account_id", right_on="id", how="left"
+                )
+                sign = np.where(
+                    transactions_with_accounts_df["transaction_type"] == "withdrawal", -1.0, 1.0
+                )
+                transactions_with_accounts_df["signed_amount"] = (
+                    transactions_with_accounts_df["amount"].astype(float) * sign
+                )
+
+        investment_time_series = build_investment_time_series(
+            df, snapshots_df, transactions_with_accounts_df
+        )
+        wrapper_time_series = build_wrapper_time_series(
+            df, snapshots_df, transactions_with_accounts_df
+        )
+        category_time_series = build_category_time_series(
+            df, snapshots_df, transactions_with_accounts_df
+        )
+    else:
+        investment_time_series = []
+        wrapper_time_series = WrapperTimeSeries(ike=[], ikze=[], ppk=[])
+        category_time_series = CategoryTimeSeries(stock=[], bond=[])
+
+    return DashboardResponse(
+        net_worth_history=net_worth_history,
+        current_net_worth=current_net_worth,
+        change_vs_last_month=current_net_worth - last_month_net_worth,
+        total_assets=total_assets,
+        total_liabilities=total_liabilities,
+        allocation=allocation,
+        retirement_account_value=retirement_account_value,
+        metric_cards=metric_cards,
+        allocation_analysis=allocation_analysis,
+        investment_time_series=investment_time_series,
+        wrapper_time_series=wrapper_time_series,
+        category_time_series=category_time_series,
+    )
+
+
+def _load_raw_for_metrics(db: Session, latest_snapshot_id: int) -> pd.DataFrame:
+    """Load SnapshotValues for the latest snapshot only (narrow query)."""
+    return pd.read_sql(
+        select(SnapshotValue).where(SnapshotValue.snapshot_id == latest_snapshot_id),
+        db.get_bind(),
+    )
+
+
+def _load_raw_for_transactions(db: Session) -> pd.DataFrame:
+    return pd.read_sql(select(Transaction).where(Transaction.is_active.is_(True)), db.get_bind())
+
+
+def _build_merged_df(
+    values_df: pd.DataFrame,
+    assets_df: pd.DataFrame,
+    accounts_df: pd.DataFrame,
+    snapshots_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """Full merge for time series functions (mirrors original lines 63-70)."""
+    df = values_df.merge(
+        assets_df, left_on="asset_id", right_on="id", how="left", suffixes=("", "_asset")
+    )
+    df = df.merge(
+        accounts_df, left_on="account_id", right_on="id", how="left", suffixes=("", "_account")
+    )
+    df = df.merge(snapshots_df, left_on="snapshot_id", right_on="id", suffixes=("", "_snapshot"))
+
+    asset_mask = df["asset_id"].notna() & df["name"].notna()
+    account_mask = df["account_id"].notna() & df["type"].notna()
+    sign = np.where(
+        account_mask,
+        np.where(df["type"] == "asset", 1, -1),
+        np.where(asset_mask, 1, 0),
+    )
+    df["signed_value"] = df["value"].astype(float) * sign
+    return df
+
+
+def _compute_savings_rate_from_aggregates(
+    agg_rows: list[SnapshotAggregate], db: Session
+) -> float | None:
+    """Savings rate from aggregate net_worth deltas — no SnapshotValue scan."""
+    from app.models import SalaryRecord
+
+    month_nw: dict = defaultdict(float)
+    for row in agg_rows:
+        month_nw[row.month] += float(row.net_worth)
+
+    sorted_months = sorted(month_nw)
+    if len(sorted_months) < 4:
+        return None
+
+    last_4 = sorted_months[-4:]
+    nw_vals = [month_nw[m] for m in last_4]
+    deltas = [nw_vals[i] - nw_vals[i - 1] for i in range(1, 4)]
+    avg_delta = sum(deltas) / 3
+
+    salaries = (
+        db.execute(
+            select(SalaryRecord)
+            .where(SalaryRecord.is_active.is_(True))
+            .order_by(SalaryRecord.date.desc())
+            .limit(3)
+        )
+        .scalars()
+        .all()
+    )
+
+    if not salaries or len(salaries) < 3:
+        return None
+
+    avg_salary = sum(float(s.gross_amount) for s in salaries) / len(salaries)
+    if avg_salary == 0:
+        return None
+
+    return (avg_delta / avg_salary) * 100
+
+
+def _build_metric_cards_aggregate(
+    agg_rows: list[SnapshotAggregate],
+    latest_df: pd.DataFrame,
+    accounts_df: pd.DataFrame,
+    transactions_with_accounts_df: pd.DataFrame,
+    app_config: AppConfig,
+    retirement_account_value: float,
+    db: Session,
+) -> MetricCards:
+    """Metric cards using narrow latest_df (no full SnapshotValue scan)."""
+    if latest_df.empty:
+        return MetricCards(
+            property_sqm=0,
+            emergency_fund_months=0,
+            retirement_income_monthly=0,
+            mortgage_remaining=0,
+            mortgage_months_left=0,
+            mortgage_years_left=0,
+            retirement_total=0,
+            investment_contributions=0,
+            investment_returns=0,
+            savings_rate=None,
+            debt_to_income_ratio=None,
+            hour_of_work_cost=None,
+            hour_of_life_cost=None,
+        )
+
+    real_estate_accounts = accounts_df[
+        (accounts_df["category"] == "real_estate")
+        & (accounts_df["owner"].isin(["Marcin", "Shared"]))
+    ]
+    total_property_sqm = float(real_estate_accounts["square_meters"].fillna(0).sum())
+
+    real_estate_values = latest_df[
+        pd.notna(latest_df["account_id"])
+        & (latest_df["type"] == "asset")
+        & (latest_df["account_id"].isin(real_estate_accounts["id"]))
+    ]
+    property_value = float(real_estate_values["value"].sum())
+
+    mortgage_df = latest_df[
+        pd.notna(latest_df["account_id"])
+        & (latest_df["type"] == "liability")
+        & (latest_df["category"].isin(["housing", "mortgage"]))
+    ]
+    mortgage_remaining = float(mortgage_df["value"].sum())
+
+    if property_value > 0:
+        equity_percentage = (property_value - mortgage_remaining) / property_value
+        property_sqm = total_property_sqm * max(0.0, equity_percentage)
+    else:
+        property_sqm = 0.0
+
+    emergency_fund_df = latest_df[
+        pd.notna(latest_df["account_id"])
+        & (latest_df["type"] == "asset")
+        & (latest_df["purpose"] == "emergency_fund")
+    ]
+    emergency_fund_value = float(emergency_fund_df["value"].sum())
+    emergency_fund_months = (
+        emergency_fund_value / float(app_config.monthly_expenses)
+        if app_config.monthly_expenses > 0
+        else 0
+    )
+
+    retirement_income_monthly = (retirement_account_value * 0.04) / 12
+
+    mortgage_months_left = int(
+        abs(mortgage_remaining) / float(app_config.monthly_mortgage_payment)
+        if app_config.monthly_mortgage_payment > 0
+        else 0
+    )
+    mortgage_years_left = mortgage_months_left / 12
+    retirement_total = retirement_account_value
+
+    # Investment contributions from transactions (shared DataFrame)
+    investment_contributions = 0.0
+    investment_returns = 0.0
+    if not transactions_with_accounts_df.empty:
+        # Find the latest snapshot date from aggregate rows
+        from app.models import Snapshot as SnapModel
+
+        latest_snap = db.execute(
+            select(SnapModel).where(SnapModel.id == max(r.snapshot_id for r in agg_rows))
+        ).scalar_one_or_none()
+        if latest_snap is not None:
+            investment_trans = transactions_with_accounts_df[
+                (transactions_with_accounts_df["purpose"] == "retirement")
+                & (transactions_with_accounts_df["date"] <= latest_snap.date)
+            ].copy()
+            investment_contributions = float(investment_trans["signed_amount"].sum())
+            investment_returns = retirement_account_value - investment_contributions
+
+    savings_rate = _compute_savings_rate_from_aggregates(agg_rows, db)
+    debt_to_income_ratio = _calculate_debt_to_income(db)
+    hour_of_work_cost = _calculate_hour_of_work_cost(db)
+    hour_of_life_cost = _calculate_hour_of_life_cost(db)
+
+    return MetricCards(
+        property_sqm=property_sqm,
+        emergency_fund_months=emergency_fund_months,
+        retirement_income_monthly=retirement_income_monthly,
+        mortgage_remaining=mortgage_remaining,
+        mortgage_months_left=mortgage_months_left,
+        mortgage_years_left=mortgage_years_left,
+        retirement_total=retirement_total,
+        investment_contributions=investment_contributions,
+        investment_returns=investment_returns,
+        savings_rate=savings_rate,
+        debt_to_income_ratio=debt_to_income_ratio,
+        hour_of_work_cost=hour_of_work_cost,
+        hour_of_life_cost=hour_of_life_cost,
+    )
+
+
+def _build_allocation_analysis(
+    latest_df: pd.DataFrame,
+    app_config: AppConfig,
+) -> AllocationAnalysis:
+    """Allocation analysis from narrow latest_df (mirrors original lines 339-453)."""
+    if latest_df.empty:
+        return AllocationAnalysis(
+            by_category=[],
+            by_wrapper=[],
+            rebalancing=[],
+            total_investment_value=0,
+        )
+
+    allocation_categories = {"stock", "bond", "fund", "etf", "gold"}
+
+    investment_df = latest_df[
+        pd.notna(latest_df["account_id"])
+        & (latest_df["type"] == "asset")
+        & (latest_df["category"].isin(allocation_categories))
+    ]
+
+    total_investment_value = float(investment_df["value"].sum())
+
+    category_map = {
+        "stock": "stocks",
+        "fund": "stocks",
+        "etf": "stocks",
+        "bond": "bonds",
+        "gold": "gold",
+    }
+
+    alloc_groups = investment_df["category"].map(category_map).fillna("other")
+    allocation_by_cat = investment_df["value"].groupby(alloc_groups).sum().to_dict()
+
+    allocation_breakdown = []
+    target_allocations = {
+        "stocks": app_config.allocation_stocks,
+        "bonds": app_config.allocation_bonds,
+        "gold": app_config.allocation_gold,
+    }
+
+    for category, target_pct in target_allocations.items():
+        current_value = allocation_by_cat.get(category, 0)
+        current_pct = (
+            (current_value / total_investment_value * 100) if total_investment_value > 0 else 0
+        )
+        difference = current_pct - target_pct
+        allocation_breakdown.append(
+            AllocationBreakdown(
+                category=category,
+                current_value=float(current_value),
+                current_percentage=float(current_pct),
+                target_percentage=float(target_pct),
+                difference=float(difference),
+            )
+        )
+
+    all_investment_categories = {"stock", "bond", "fund", "etf", "gold", "ppk"}
+    all_investment_df = latest_df[
+        pd.notna(latest_df["account_id"])
+        & (latest_df["type"] == "asset")
+        & (latest_df["category"].isin(all_investment_categories))
+    ]
+
+    wrappers = all_investment_df["account_wrapper"].fillna("Regular")
+    wrapper_breakdown = all_investment_df["value"].groupby(wrappers).sum().to_dict()
+    all_investment_total = sum(wrapper_breakdown.values())
+
+    wrapper_list = [
+        AccountWrapperBreakdown(
+            wrapper=wrapper,
+            value=float(value),
+            percentage=(
+                float(value / all_investment_total * 100) if all_investment_total > 0 else 0
+            ),
+        )
+        for wrapper, value in wrapper_breakdown.items()
+    ]
+
+    rebalancing_suggestions = []
+    for breakdown in allocation_breakdown:
+        if breakdown.difference < -1:
+            target_value = total_investment_value * breakdown.target_percentage / 100
+            current_value = breakdown.current_value
+            target_pct = breakdown.target_percentage / 100
+            if target_pct < 1:
+                amount_to_add = (target_value - current_value) / (1 - target_pct)
+                if amount_to_add > 100:
+                    rebalancing_suggestions.append(
+                        RebalancingSuggestion(
+                            category=breakdown.category,
+                            action="buy",
+                            amount=float(amount_to_add),
+                        )
+                    )
+
+    return AllocationAnalysis(
+        by_category=allocation_breakdown,
+        by_wrapper=wrapper_list,
+        rebalancing=rebalancing_suggestions,
+        total_investment_value=total_investment_value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Raw path (fallback when aggregates not populated)
+# ---------------------------------------------------------------------------
+
+
+def _get_dashboard_data_raw(db: Session) -> DashboardResponse:
+    """
+    Calculate dashboard metrics using pandas (original implementation).
+
+    Used when snapshot_aggregates is empty — during migration period or when
+    tests create data via factories without going through the service layer.
 
     pandas features used:
     - pd.DataFrame(): Create from query results
@@ -63,7 +573,6 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
     values_df = pd.read_sql(values_query, db.get_bind())
 
     # pandas: merge() - LEFT JOIN snapshot values with both assets and accounts
-    # Similar to SQL: SELECT * FROM snapshot_values LEFT JOIN assets LEFT JOIN accounts
     df = values_df.merge(
         assets_df, left_on="asset_id", right_on="id", how="left", suffixes=("", "_asset")
     )
@@ -109,10 +618,7 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             ),
         )
 
-    # Vectorized signed value:
-    # - Asset table rows (asset_id + name from join) → +value
-    # - Account rows (account_id + type from join): asset → +value, liability → -value
-    # - LEFT-JOIN rows with no match (inactive) → 0
+    # Vectorized signed value
     asset_mask = df["asset_id"].notna() & df["name"].notna()
     account_mask = df["account_id"].notna() & df["type"].notna()
     sign = np.where(
@@ -122,11 +628,8 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
     )
     df["signed_value"] = df["value"].astype(float) * sign
 
-    # pandas: groupby() + sum() - Aggregate net worth by date
     net_worth_by_date = df.groupby("date")["signed_value"].sum().reset_index()
     net_worth_by_date.columns = ["date", "net_worth"]
-
-    # pandas: sort_values() - Order by date
     net_worth_by_date = net_worth_by_date.sort_values("date")
 
     net_worth_history = [
@@ -134,7 +637,6 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
         for d, v in zip(net_worth_by_date["date"], net_worth_by_date["net_worth"], strict=True)
     ]
 
-    # Current metrics (latest snapshot)
     if len(net_worth_by_date) > 0:
         current_net_worth = float(net_worth_by_date.iloc[-1]["net_worth"])
         last_month_net_worth = (
@@ -144,9 +646,7 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
         current_net_worth = 0
         last_month_net_worth = 0
 
-    # Latest snapshot data for current totals
-    # Use merged df to determine latest snapshot (handles case where merge filters out snapshots)
-    latest_df = pd.DataFrame()  # Initialize to satisfy type checker
+    latest_df = pd.DataFrame()
     if not df.empty and "snapshot_id" in df.columns:
         valid_ids = df["snapshot_id"].dropna().unique()
         candidates = snapshots_df[snapshots_df["id"].isin(valid_ids)]
@@ -160,25 +660,19 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
         latest_snapshot = None
 
     if latest_snapshot is not None:
-        # pandas: Boolean indexing - Filter rows
         latest_df = df[df["snapshot_id"] == latest_snapshot["id"]]
 
-        # Calculate total assets: from Asset table + from Account table where type="asset"
-        # pandas: Boolean masks for filtering
         from_asset_table = latest_df[pd.notna(latest_df["asset_id"])]
         from_account_assets = latest_df[
             (pd.notna(latest_df["account_id"])) & (latest_df["type"] == "asset")
         ]
         total_assets = float(from_asset_table["value"].sum() + from_account_assets["value"].sum())
 
-        # Calculate total liabilities: from Account table where type="liability"
         from_account_liabilities = latest_df[
             (pd.notna(latest_df["account_id"])) & (latest_df["type"] == "liability")
         ]
         total_liabilities = float(from_account_liabilities["value"].sum())
 
-        # Asset allocation - ONLY from accounts (not from Asset table)
-        # pandas: Filter for accounts with type="asset" that have category and owner
         account_assets_df = latest_df[
             (pd.notna(latest_df["account_id"]))
             & (latest_df["type"] == "asset")
@@ -186,7 +680,6 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             & (pd.notna(latest_df["owner"]))
         ]
 
-        # pandas: groupby() with multiple columns
         allocation_df = (
             account_assets_df.groupby(["category", "owner"])["value"].sum().reset_index()
         )
@@ -201,7 +694,6 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             )
         ]
 
-        # Calculate retirement account value (accounts with purpose='retirement')
         retirement_accounts_df = latest_df[
             (pd.notna(latest_df["account_id"]))
             & (latest_df["type"] == "asset")
@@ -214,20 +706,15 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
         allocation = []
         retirement_account_value = 0
 
-    # Calculate metric cards
-    # Fetch AppConfig for monthly_expenses and monthly_mortgage_payment
     app_config = db.execute(select(AppConfig).where(AppConfig.id == 1)).scalar_one_or_none()
 
     if app_config and latest_snapshot is not None:
-        # 1. Property square meters - adjusted for mortgage equity
-        # Get real estate accounts for Marcin/Shared
         real_estate_accounts = accounts_df[
             (accounts_df["category"] == "real_estate")
             & (accounts_df["owner"].isin(["Marcin", "Shared"]))
         ]
         total_property_sqm = float(real_estate_accounts["square_meters"].fillna(0).sum())
 
-        # Get real estate value from latest snapshot
         real_estate_values = latest_df[
             (pd.notna(latest_df["account_id"]))
             & (latest_df["type"] == "asset")
@@ -235,7 +722,6 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
         ]
         property_value = float(real_estate_values["value"].sum())
 
-        # Get mortgage remaining
         mortgage_df = latest_df[
             (pd.notna(latest_df["account_id"]))
             & (latest_df["type"] == "liability")
@@ -243,15 +729,12 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
         ]
         mortgage_remaining = float(mortgage_df["value"].sum())
 
-        # Calculate equity percentage and owned square meters
-        # mortgage_remaining is positive (liability value), subtract from property value
         if property_value > 0:
             equity_percentage = (property_value - mortgage_remaining) / property_value
             property_sqm = total_property_sqm * max(0.0, equity_percentage)
         else:
             property_sqm = 0.0
 
-        # 2. Emergency fund months - sum accounts where purpose='emergency_fund' / monthly_expenses
         emergency_fund_df = latest_df[
             (pd.notna(latest_df["account_id"]))
             & (latest_df["type"] == "asset")
@@ -264,39 +747,25 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             else 0
         )
 
-        # 3. Retirement income (4% rule) - (retirement_account_value * 0.04) / 12
         retirement_income_monthly = (retirement_account_value * 0.04) / 12
 
-        # 4. Mortgage remaining - already calculated above for property_sqm equity calculation
-
-        # 5. Months to mortgage payoff - mortgage_remaining / monthly_mortgage_payment
         mortgage_months_left = int(
             abs(mortgage_remaining) / float(app_config.monthly_mortgage_payment)
             if app_config.monthly_mortgage_payment > 0
             else 0
         )
 
-        # 6. Years to payoff - months_to_payoff / 12
         mortgage_years_left = mortgage_months_left / 12
-
-        # 7. Retirement savings - already available
         retirement_total = retirement_account_value
 
-        # 8. Investment contributions - sum of Transaction.amount for investment accounts
-        # 9. Investment returns - Current value - total contributions
-        # Filter transactions up to latest snapshot date to match time series calculation
         transactions_query = select(Transaction).where(Transaction.is_active.is_(True))
         transactions_df = pd.read_sql(transactions_query, db.get_bind())
 
         if not transactions_df.empty and latest_snapshot is not None:
-            # Join transactions with accounts to filter investment accounts
             trans_with_accounts = transactions_df.merge(
                 accounts_df, left_on="account_id", right_on="id", how="left"
             )
 
-            # Filter for retirement investment accounts (purpose='retirement')
-            # to match retirement_total scope, excluding non-retirement investments
-            # Only include transactions up to latest snapshot date
             investment_trans = trans_with_accounts[
                 (trans_with_accounts["purpose"] == "retirement")
                 & (trans_with_accounts["date"] <= latest_snapshot["date"])
@@ -305,14 +774,14 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             investment_trans["signed_amount"] = investment_trans["amount"].astype(float) * sign
             investment_contributions = float(investment_trans["signed_amount"].sum())
 
-            # Reuse already-calculated retirement account value for consistency
             investment_current_value = retirement_account_value
             investment_returns = investment_current_value - investment_contributions
         else:
             investment_contributions = 0
             investment_returns = 0
 
-        # Calculate new metrics
+        from app.services.dashboard.metrics import _calculate_savings_rate
+
         savings_rate = _calculate_savings_rate(snapshots_df, df, db)
         debt_to_income_ratio = _calculate_debt_to_income(db)
         hour_of_work_cost = _calculate_hour_of_work_cost(db)
@@ -350,12 +819,9 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             hour_of_life_cost=None,
         )
 
-    # Calculate allocation analysis
     if app_config and latest_snapshot is not None:
-        # Define investment categories for allocation (exclude PPK)
         allocation_categories = {"stock", "bond", "fund", "etf", "gold"}
 
-        # Get investment accounts from latest snapshot (excluding PPK)
         investment_df = latest_df[
             (pd.notna(latest_df["account_id"]))
             & (latest_df["type"] == "asset")
@@ -364,7 +830,6 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
 
         total_investment_value = float(investment_df["value"].sum())
 
-        # Map categories to allocation groups
         category_map = {
             "stock": "stocks",
             "fund": "stocks",
@@ -373,11 +838,9 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             "gold": "gold",
         }
 
-        # Calculate current allocation by category (vectorized groupby)
         alloc_groups = investment_df["category"].map(category_map).fillna("other")
         allocation_by_cat = investment_df["value"].groupby(alloc_groups).sum().to_dict()
 
-        # Calculate allocation breakdown
         allocation_breakdown = []
         target_allocations = {
             "stocks": app_config.allocation_stocks,
@@ -402,7 +865,6 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
                 )
             )
 
-        # Calculate breakdown by account wrapper (include all investments including PPK)
         all_investment_categories = {"stock", "bond", "fund", "etf", "gold", "ppk"}
         all_investment_df = latest_df[
             (pd.notna(latest_df["account_id"]))
@@ -413,7 +875,6 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
         wrappers = all_investment_df["account_wrapper"].fillna("Regular")
         wrapper_breakdown = all_investment_df["value"].groupby(wrappers).sum().to_dict()
 
-        # Calculate total for percentage (includes PPK, unlike total_investment_value)
         all_investment_total = sum(wrapper_breakdown.values())
 
         wrapper_list = [
@@ -427,22 +888,16 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             for wrapper, value in wrapper_breakdown.items()
         ]
 
-        # Calculate rebalancing suggestions
-        # Formula: amount_to_add = (target_value - current_value) / (1 - target_pct/100)
-        # This calculates how much new money to add to reach target allocation
-        # Only show "buy" suggestions for under-allocated categories
         rebalancing_suggestions = []
         for breakdown in allocation_breakdown:
-            if breakdown.difference < -1:  # Only if under-allocated by more than 1%
+            if breakdown.difference < -1:
                 target_value = total_investment_value * breakdown.target_percentage / 100
                 current_value = breakdown.current_value
                 target_pct = breakdown.target_percentage / 100
 
-                # Calculate how much new money to add (Excel formula)
-                if target_pct < 1:  # Avoid division by zero
+                if target_pct < 1:
                     amount_to_add = (target_value - current_value) / (1 - target_pct)
 
-                    # Only include if amount is significant and positive
                     if amount_to_add > 100:
                         rebalancing_suggestions.append(
                             RebalancingSuggestion(
@@ -466,15 +921,12 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
             total_investment_value=0,
         )
 
-    # Fetch and prepare transactions for time series calculations
-    # Execute query once and merge with accounts to avoid repeated operations in loops
     transactions_query = select(Transaction).where(Transaction.is_active.is_(True))
     transactions_df = pd.read_sql(transactions_query, db.get_bind())
     if not transactions_df.empty:
         transactions_with_accounts_df = transactions_df.merge(
             accounts_df, left_on="account_id", right_on="id", how="left"
         )
-        # Withdrawals reduce cumulative contributions — negate their amount
         sign = np.where(
             transactions_with_accounts_df["transaction_type"] == "withdrawal", -1.0, 1.0
         )
@@ -484,7 +936,6 @@ def get_dashboard_data(db: Session) -> DashboardResponse:
     else:
         transactions_with_accounts_df = pd.DataFrame()
 
-    # Time series (overall, per-wrapper, per-category) — see dashboard.time_series
     investment_time_series = build_investment_time_series(
         df, snapshots_df, transactions_with_accounts_df
     )

--- a/backend/app/services/snapshot_aggregates.py
+++ b/backend/app/services/snapshot_aggregates.py
@@ -1,0 +1,84 @@
+"""Runtime helpers for maintaining snapshot_aggregates.
+
+All helpers run inside the caller's transaction and never commit.
+The caller is responsible for flushing pending ORM changes before calling
+recompute (required because autoflush=False in SessionLocal).
+"""
+
+from collections.abc import Iterable
+from datetime import UTC, datetime
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from app.models import Account, Asset, Snapshot, SnapshotValue
+from app.models.snapshot_aggregate import SnapshotAggregate
+from app.services.aggregate_spec import compute_aggregates
+
+
+def recompute_for_snapshot(db: Session, snapshot_id: int) -> None:
+    """Delete and reinsert aggregate rows for one snapshot.
+
+    Idempotent. Caller must flush pending ORM state and commit when done.
+    """
+    db.execute(delete(SnapshotAggregate).where(SnapshotAggregate.snapshot_id == snapshot_id))
+
+    snapshot = db.execute(select(Snapshot).where(Snapshot.id == snapshot_id)).scalar_one_or_none()
+    if snapshot is None:
+        return
+
+    sv_rows = (
+        db.execute(select(SnapshotValue).where(SnapshotValue.snapshot_id == snapshot_id))
+        .scalars()
+        .all()
+    )
+
+    account_ids = [sv.account_id for sv in sv_rows if sv.account_id is not None]
+    accounts = (
+        db.execute(select(Account).where(Account.id.in_(account_ids), Account.is_active.is_(True)))
+        .scalars()
+        .all()
+        if account_ids
+        else []
+    )
+
+    asset_ids_in_sv = [sv.asset_id for sv in sv_rows if sv.asset_id is not None]
+    assets = (
+        db.execute(select(Asset).where(Asset.id.in_(asset_ids_in_sv), Asset.is_active.is_(True)))
+        .scalars()
+        .all()
+        if asset_ids_in_sv
+        else []
+    )
+
+    rows = compute_aggregates(snapshot, sv_rows, accounts, assets)
+    now = datetime.now(UTC)
+
+    for row in rows:
+        db.add(
+            SnapshotAggregate(
+                snapshot_id=row.snapshot_id,
+                month=row.month,
+                owner=row.owner,
+                total_assets=row.total_assets,
+                total_liabilities=row.total_liabilities,
+                net_worth=row.net_worth,
+                allocation_json=[
+                    {"category": item["category"], "value": float(item["value"])}
+                    for item in row.allocation
+                ],
+                computed_at=now,
+            )
+        )
+
+
+def recompute_for_snapshots(db: Session, snapshot_ids: Iterable[int]) -> None:
+    """Recompute aggregates for multiple snapshots. Caller commits."""
+    for sid in snapshot_ids:
+        recompute_for_snapshot(db, sid)
+
+
+def recompute_all(db: Session) -> None:
+    """Recompute all snapshot aggregates. Used by tests and backfill only."""
+    snapshot_ids = db.execute(select(Snapshot.id)).scalars().all()
+    recompute_for_snapshots(db, snapshot_ids)

--- a/backend/app/services/snapshots.py
+++ b/backend/app/services/snapshots.py
@@ -13,6 +13,7 @@ from app.schemas.snapshots import (
     SnapshotUpdate,
     SnapshotValueResponse,
 )
+from app.services.snapshot_aggregates import recompute_for_snapshot
 
 
 def create_snapshot(db: Session, data: SnapshotCreate) -> SnapshotResponse:
@@ -78,6 +79,10 @@ def create_snapshot(db: Session, data: SnapshotCreate) -> SnapshotResponse:
         )
         db.add(sv)
         snapshot_values.append(sv)
+
+    # Flush snapshot_values so recompute can query them (autoflush=False in SessionLocal)
+    db.flush()
+    recompute_for_snapshot(db, snapshot.id)
 
     try:
         db.commit()
@@ -250,6 +255,10 @@ def update_snapshot(db: Session, snapshot_id: int, data: SnapshotUpdate) -> Snap
         assets = []
         accounts = []
         snapshot_values = []
+
+    # Flush pending changes so recompute sees the updated state
+    db.flush()
+    recompute_for_snapshot(db, snapshot_id)
 
     try:
         db.commit()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,6 +32,9 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+markers = [
+    "perf: marks tests as performance benchmarks",
+]
 addopts = [
     "--strict-markers",
     "--strict-config",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,6 +25,7 @@ from app.models import (
     RetirementLimit,
     SalaryRecord,
     Snapshot,
+    SnapshotAggregate,
     SnapshotValue,
     Transaction,
 )
@@ -41,6 +42,7 @@ _REGISTERED_MODELS = (
     RetirementLimit,
     SalaryRecord,
     Snapshot,
+    SnapshotAggregate,
     SnapshotValue,
     Transaction,
 )

--- a/backend/tests/test_aggregate_parity.py
+++ b/backend/tests/test_aggregate_parity.py
@@ -1,0 +1,152 @@
+"""Parity tests: migration frozen spec == live spec; raw path == aggregate path."""
+
+from datetime import date
+from decimal import Decimal
+
+from app.services.aggregate_spec import compute_aggregates
+from app.services.dashboard.service import _get_dashboard_data_raw, get_dashboard_data
+from app.services.snapshot_aggregates import recompute_all
+from tests.factories import create_test_account, create_test_snapshot, create_test_snapshot_value
+
+# ---------------------------------------------------------------------------
+# Drift guard: frozen migration spec == live spec
+# ---------------------------------------------------------------------------
+
+
+def test_frozen_spec_matches_live_spec():
+    """Output of _compute_aggregates_frozen must equal compute_aggregates."""
+    import importlib.util
+    from pathlib import Path
+
+    versions_dir = Path(__file__).parent.parent / "alembic" / "versions"
+    migration_path = versions_dir / "0006_backfill_snapshot_aggregates.py"
+    spec = importlib.util.spec_from_file_location("migration_0006", migration_path)
+    assert spec is not None and spec.loader is not None
+    migration_06 = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration_06)
+
+    from dataclasses import dataclass
+
+    @dataclass
+    class _Snap:
+        id: int
+        date: date
+
+    @dataclass
+    class _SV:
+        asset_id: int | None
+        account_id: int | None
+        value: Decimal
+
+    @dataclass
+    class _Account:
+        id: int
+        owner: str
+        type: str
+        category: str
+
+    @dataclass
+    class _Asset:
+        id: int
+
+    snap = _Snap(id=1, date=date(2024, 6, 15))
+    account = _Account(id=1, owner="Marcin", type="asset", category="stock")
+    asset = _Asset(id=5)
+    svs = [
+        _SV(asset_id=None, account_id=1, value=Decimal("12345.67")),
+        _SV(asset_id=5, account_id=None, value=Decimal("500.00")),
+    ]
+
+    live_rows = compute_aggregates(snap, svs, [account], [asset])
+    frozen_rows = migration_06._compute_aggregates_frozen(
+        snap.id,
+        snap.date,
+        [(sv.asset_id, sv.account_id, sv.value) for sv in svs],
+        {account.id: (account.owner, account.type, account.category)},
+        {asset.id},
+    )
+
+    assert len(live_rows) == len(frozen_rows)
+    live_by_owner = {r.owner: r for r in live_rows}
+    frozen_by_owner = {r.owner: r for r in frozen_rows}
+
+    for owner in live_by_owner:
+        live_row = live_by_owner[owner]
+        frozen_row = frozen_by_owner[owner]
+        assert live_row.total_assets == frozen_row.total_assets, (
+            f"total_assets mismatch for {owner}"
+        )
+        assert live_row.total_liabilities == frozen_row.total_liabilities, (
+            f"total_liabilities mismatch for {owner}"
+        )
+        assert live_row.net_worth == frozen_row.net_worth, f"net_worth mismatch for {owner}"
+        assert len(live_row.allocation) == len(frozen_row.allocation), (
+            f"allocation length mismatch for {owner}"
+        )
+        for la, fa in zip(live_row.allocation, frozen_row.allocation, strict=True):
+            assert la["category"] == fa["category"]
+            assert Decimal(str(la["value"])) == Decimal(str(fa["value"]))
+
+
+# ---------------------------------------------------------------------------
+# Dashboard output parity: raw path == aggregate path
+# ---------------------------------------------------------------------------
+
+
+def _seed_db(db):
+    """Seed 5 snapshots with 2 owners to exercise both code paths."""
+    acct_m = create_test_account(db, name="Bank Marcin", category="bank", owner="Marcin")
+    acct_e = create_test_account(db, name="Bank Ewa", category="bank", owner="Ewa")
+    acct_l = create_test_account(
+        db,
+        name="Mortgage",
+        account_type="liability",
+        category="mortgage",
+        owner="Shared",
+    )
+
+    for i in range(5):
+        snap = create_test_snapshot(db, snapshot_date=date(2024, i + 1, 1))
+        create_test_snapshot_value(
+            db, snap.id, account_id=acct_m.id, value=Decimal(str(1000 * (i + 1)))
+        )
+        create_test_snapshot_value(
+            db, snap.id, account_id=acct_e.id, value=Decimal(str(500 * (i + 1)))
+        )
+        create_test_snapshot_value(db, snap.id, account_id=acct_l.id, value=Decimal("200000"))
+
+    return acct_m, acct_e, acct_l
+
+
+def test_aggregate_path_matches_raw_path(test_db_session):
+    """Dashboard output is identical whether read from aggregates or raw rows."""
+    _seed_db(test_db_session)
+
+    # Raw path (no aggregates yet)
+    raw = _get_dashboard_data_raw(test_db_session)
+
+    # Populate aggregates, then use aggregate path
+    recompute_all(test_db_session)
+    test_db_session.commit()
+
+    agg = get_dashboard_data(test_db_session)
+
+    # Net worth history must match in length and values
+    assert len(agg.net_worth_history) == len(raw.net_worth_history)
+    for agg_pt, raw_pt in zip(agg.net_worth_history, raw.net_worth_history, strict=True):
+        assert abs(agg_pt.value - raw_pt.value) < 0.01, (
+            f"net_worth mismatch at {raw_pt.date}: agg={agg_pt.value}, raw={raw_pt.value}"
+        )
+
+    assert abs(agg.current_net_worth - raw.current_net_worth) < 0.01
+    assert abs(agg.total_assets - raw.total_assets) < 0.01
+    assert abs(agg.total_liabilities - raw.total_liabilities) < 0.01
+
+    # Allocation items (sorted by category+owner)
+    agg_alloc = sorted(agg.allocation, key=lambda x: (x.category, x.owner))
+    raw_alloc = sorted(raw.allocation, key=lambda x: (x.category, x.owner))
+    assert len(agg_alloc) == len(raw_alloc)
+    for a, r in zip(agg_alloc, raw_alloc, strict=True):
+        assert a.category == r.category
+        assert a.owner == r.owner
+        assert abs(a.value - r.value) < 0.01

--- a/backend/tests/test_aggregate_parity.py
+++ b/backend/tests/test_aggregate_parity.py
@@ -150,3 +150,32 @@ def test_aggregate_path_matches_raw_path(test_db_session):
         assert a.category == r.category
         assert a.owner == r.owner
         assert abs(a.value - r.value) < 0.01
+
+
+def test_same_month_snapshots_stay_distinct(test_db_session):
+    """Two snapshots in the same calendar month must produce two history points."""
+    acct = create_test_account(test_db_session, name="Bank Marcin", category="bank", owner="Marcin")
+
+    snap1 = create_test_snapshot(test_db_session, snapshot_date=date(2024, 1, 1))
+    create_test_snapshot_value(test_db_session, snap1.id, account_id=acct.id, value=Decimal("1000"))
+
+    snap2 = create_test_snapshot(test_db_session, snapshot_date=date(2024, 1, 15))
+    create_test_snapshot_value(test_db_session, snap2.id, account_id=acct.id, value=Decimal("2000"))
+
+    raw = _get_dashboard_data_raw(test_db_session)
+    assert len(raw.net_worth_history) == 2, "raw path must keep same-month snapshots distinct"
+
+    recompute_all(test_db_session)
+    test_db_session.commit()
+
+    agg = get_dashboard_data(test_db_session)
+    assert len(agg.net_worth_history) == 2, "aggregate path must keep same-month snapshots distinct"
+
+    raw_dates = [pt.date for pt in raw.net_worth_history]
+    agg_dates = [pt.date for pt in agg.net_worth_history]
+    assert agg_dates == raw_dates
+
+    for agg_pt, raw_pt in zip(agg.net_worth_history, raw.net_worth_history, strict=True):
+        assert abs(agg_pt.value - raw_pt.value) < 0.01, (
+            f"net_worth mismatch at {raw_pt.date}: agg={agg_pt.value}, raw={raw_pt.value}"
+        )

--- a/backend/tests/test_aggregate_spec.py
+++ b/backend/tests/test_aggregate_spec.py
@@ -1,0 +1,184 @@
+"""Tests for the pure aggregate spec (no ORM, no DB)."""
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+from app.services.aggregate_spec import _first_of_month, compute_aggregates
+
+
+@dataclass
+class _Snap:
+    id: int
+    date: date
+
+
+@dataclass
+class _SV:
+    asset_id: int | None
+    account_id: int | None
+    value: Decimal
+
+
+@dataclass
+class _Account:
+    id: int
+    owner: str
+    type: str
+    category: str
+
+
+@dataclass
+class _Asset:
+    id: int
+
+
+def test_empty_snapshot_returns_shared_zero_row():
+    snap = _Snap(id=1, date=date(2024, 1, 1))
+    rows = compute_aggregates(snap, [], [], [])
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.owner == "Shared"
+    assert row.total_assets == Decimal("0")
+    assert row.total_liabilities == Decimal("0")
+    assert row.net_worth == Decimal("0")
+    assert row.allocation == []
+    assert row.month == date(2024, 1, 1)
+    assert row.snapshot_id == 1
+
+
+def test_asset_table_entry_goes_to_shared():
+    snap = _Snap(id=1, date=date(2024, 3, 15))
+    sv = _SV(asset_id=10, account_id=None, value=Decimal("5000"))
+    asset = _Asset(id=10)
+    rows = compute_aggregates(snap, [sv], [], [asset])
+    assert len(rows) == 1
+    assert rows[0].owner == "Shared"
+    assert rows[0].total_assets == Decimal("5000")
+    assert rows[0].total_liabilities == Decimal("0")
+    assert rows[0].net_worth == Decimal("5000")
+    # Month is first of March
+    assert rows[0].month == date(2024, 3, 1)
+
+
+def test_inactive_asset_is_ignored():
+    snap = _Snap(id=1, date=date(2024, 1, 1))
+    sv = _SV(asset_id=99, account_id=None, value=Decimal("1000"))
+    # asset_rows is empty → 99 not in active_asset_ids
+    rows = compute_aggregates(snap, [sv], [], [])
+    assert len(rows) == 1
+    assert rows[0].owner == "Shared"
+    assert rows[0].total_assets == Decimal("0")
+
+
+def test_account_asset_contributes_positively():
+    snap = _Snap(id=1, date=date(2024, 1, 1))
+    acct = _Account(id=1, owner="Marcin", type="asset", category="bank")
+    sv = _SV(asset_id=None, account_id=1, value=Decimal("10000"))
+    rows = compute_aggregates(snap, [sv], [acct], [])
+    assert len(rows) == 1
+    assert rows[0].owner == "Marcin"
+    assert rows[0].total_assets == Decimal("10000")
+    assert rows[0].total_liabilities == Decimal("0")
+    assert rows[0].net_worth == Decimal("10000")
+    assert rows[0].allocation == [{"category": "bank", "value": Decimal("10000")}]
+
+
+def test_account_liability_contributes_to_liabilities():
+    snap = _Snap(id=1, date=date(2024, 1, 1))
+    acct = _Account(id=2, owner="Shared", type="liability", category="mortgage")
+    sv = _SV(asset_id=None, account_id=2, value=Decimal("200000"))
+    rows = compute_aggregates(snap, [sv], [acct], [])
+    assert len(rows) == 1
+    assert rows[0].owner == "Shared"
+    assert rows[0].total_assets == Decimal("0")
+    assert rows[0].total_liabilities == Decimal("200000")
+    assert rows[0].net_worth == Decimal("-200000")
+    assert rows[0].allocation == []
+
+
+def test_multi_owner_produces_separate_rows():
+    snap = _Snap(id=1, date=date(2024, 1, 1))
+    acct_m = _Account(id=1, owner="Marcin", type="asset", category="bank")
+    acct_e = _Account(id=2, owner="Ewa", type="asset", category="stock")
+    svs = [
+        _SV(asset_id=None, account_id=1, value=Decimal("5000")),
+        _SV(asset_id=None, account_id=2, value=Decimal("3000")),
+    ]
+    rows = compute_aggregates(snap, svs, [acct_m, acct_e], [])
+    assert len(rows) == 2
+    owners = {r.owner for r in rows}
+    assert owners == {"Marcin", "Ewa"}
+    for row in rows:
+        if row.owner == "Marcin":
+            assert row.total_assets == Decimal("5000")
+            assert row.allocation == [{"category": "bank", "value": Decimal("5000")}]
+        else:
+            assert row.total_assets == Decimal("3000")
+            assert row.allocation == [{"category": "stock", "value": Decimal("3000")}]
+
+
+def test_allocation_sorted_by_category():
+    snap = _Snap(id=1, date=date(2024, 1, 1))
+    acct = _Account(id=1, owner="Marcin", type="asset", category="zzz")
+    acct2 = _Account(id=2, owner="Marcin", type="asset", category="aaa")
+    svs = [
+        _SV(asset_id=None, account_id=1, value=Decimal("100")),
+        _SV(asset_id=None, account_id=2, value=Decimal("200")),
+    ]
+    rows = compute_aggregates(snap, svs, [acct, acct2], [])
+    assert len(rows) == 1
+    alloc = rows[0].allocation
+    assert alloc[0]["category"] == "aaa"
+    assert alloc[1]["category"] == "zzz"
+
+
+def test_asset_table_and_account_mixed():
+    snap = _Snap(id=1, date=date(2024, 1, 1))
+    asset = _Asset(id=5)
+    acct = _Account(id=1, owner="Marcin", type="asset", category="bank")
+    svs = [
+        _SV(asset_id=5, account_id=None, value=Decimal("2000")),
+        _SV(asset_id=None, account_id=1, value=Decimal("8000")),
+    ]
+    rows = compute_aggregates(snap, svs, [acct], [asset])
+    owners = {r.owner: r for r in rows}
+    assert "Shared" in owners
+    assert "Marcin" in owners
+    assert owners["Shared"].total_assets == Decimal("2000")
+    assert owners["Shared"].allocation == []
+    assert owners["Marcin"].total_assets == Decimal("8000")
+
+
+def test_inactive_account_is_ignored():
+    snap = _Snap(id=1, date=date(2024, 1, 1))
+    acct_active = _Account(id=1, owner="Marcin", type="asset", category="bank")
+    svs = [
+        _SV(asset_id=None, account_id=1, value=Decimal("1000")),
+        _SV(asset_id=None, account_id=99, value=Decimal("999")),  # no matching account
+    ]
+    rows = compute_aggregates(snap, svs, [acct_active], [])
+    assert len(rows) == 1
+    assert rows[0].total_assets == Decimal("1000")
+
+
+def test_first_of_month():
+    assert _first_of_month(date(2024, 3, 15)) == date(2024, 3, 1)
+    assert _first_of_month(date(2024, 1, 1)) == date(2024, 1, 1)
+    assert _first_of_month(date(2024, 12, 31)) == date(2024, 12, 1)
+
+
+def test_signed_value_net_worth():
+    snap = _Snap(id=1, date=date(2024, 1, 1))
+    asset_acct = _Account(id=1, owner="Marcin", type="asset", category="bank")
+    liab_acct = _Account(id=2, owner="Marcin", type="liability", category="mortgage")
+    svs = [
+        _SV(asset_id=None, account_id=1, value=Decimal("100000")),
+        _SV(asset_id=None, account_id=2, value=Decimal("30000")),
+    ]
+    rows = compute_aggregates(snap, svs, [asset_acct, liab_acct], [])
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.total_assets == Decimal("100000")
+    assert row.total_liabilities == Decimal("30000")
+    assert row.net_worth == Decimal("70000")

--- a/backend/tests/test_invalidation_hooks.py
+++ b/backend/tests/test_invalidation_hooks.py
@@ -1,0 +1,199 @@
+"""Tests for account/asset mutation invalidation of snapshot_aggregates."""
+
+from datetime import date
+from decimal import Decimal
+
+from app.models import Account, Asset, Snapshot, SnapshotValue
+from app.models.snapshot_aggregate import SnapshotAggregate
+from app.schemas.accounts import AccountUpdate
+from app.services.accounts import delete_account, update_account
+from app.services.assets import delete_asset
+from app.services.snapshot_aggregates import recompute_for_snapshot
+
+
+def _setup_snap_with_account(db, acct_owner="Marcin", acct_category="bank"):
+    acct = Account(
+        name=f"Acct-{acct_owner}",
+        type="asset",
+        category=acct_category,
+        owner=acct_owner,
+        currency="PLN",
+        purpose="general",
+        is_active=True,
+    )
+    db.add(acct)
+    db.flush()
+
+    snap = Snapshot(date=date(2024, 1, 1))
+    db.add(snap)
+    db.flush()
+
+    sv = SnapshotValue(snapshot_id=snap.id, account_id=acct.id, value=Decimal("10000"))
+    db.add(sv)
+    db.flush()
+
+    recompute_for_snapshot(db, snap.id)
+    db.commit()
+
+    return snap, acct
+
+
+def test_update_account_owner_recomputes_aggregate(test_db_session):
+    snap, acct = _setup_snap_with_account(test_db_session, acct_owner="Marcin")
+
+    before = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one()
+    assert before.owner == "Marcin"
+
+    update_account(test_db_session, acct.id, AccountUpdate(owner="Ewa"))
+
+    after = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one()
+    assert after.owner == "Ewa"
+
+
+def test_update_account_category_recomputes_allocation(test_db_session):
+    snap, acct = _setup_snap_with_account(test_db_session, acct_category="bank")
+
+    before = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one()
+    assert before.allocation_json[0]["category"] == "bank"
+
+    update_account(test_db_session, acct.id, AccountUpdate(category="stock"))
+
+    after = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one()
+    assert after.allocation_json[0]["category"] == "stock"
+
+
+def test_update_account_name_only_does_not_recompute(test_db_session):
+    snap, acct = _setup_snap_with_account(test_db_session)
+
+    before = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one()
+    original_computed_at = before.computed_at
+
+    update_account(test_db_session, acct.id, AccountUpdate(name="New Name"))
+
+    after = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one()
+    # computed_at unchanged → no recompute
+    assert after.computed_at == original_computed_at
+
+
+def test_delete_account_removes_its_contribution_from_aggregate(test_db_session):
+    # Two accounts in same snapshot, same owner
+    acct1 = Account(
+        name="Keep",
+        type="asset",
+        category="bank",
+        owner="Marcin",
+        currency="PLN",
+        purpose="general",
+        is_active=True,
+    )
+    acct2 = Account(
+        name="Delete",
+        type="asset",
+        category="bank",
+        owner="Marcin",
+        currency="PLN",
+        purpose="general",
+        is_active=True,
+    )
+    test_db_session.add_all([acct1, acct2])
+    test_db_session.flush()
+
+    snap = Snapshot(date=date(2024, 2, 1))
+    test_db_session.add(snap)
+    test_db_session.flush()
+
+    test_db_session.add_all(
+        [
+            SnapshotValue(snapshot_id=snap.id, account_id=acct1.id, value=Decimal("6000")),
+            SnapshotValue(snapshot_id=snap.id, account_id=acct2.id, value=Decimal("4000")),
+        ]
+    )
+    test_db_session.flush()
+    recompute_for_snapshot(test_db_session, snap.id)
+    test_db_session.commit()
+
+    before = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one()
+    assert float(before.total_assets) == 10000.0
+
+    delete_account(test_db_session, acct2.id)
+
+    after = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one()
+    assert float(after.total_assets) == 6000.0
+
+
+def test_other_snapshots_not_touched_when_updating_account(test_db_session):
+    acct_affected = Account(
+        name="Affected",
+        type="asset",
+        category="bank",
+        owner="Marcin",
+        currency="PLN",
+        purpose="general",
+        is_active=True,
+    )
+    acct_unrelated = Account(
+        name="Unrelated",
+        type="asset",
+        category="bank",
+        owner="Marcin",
+        currency="PLN",
+        purpose="general",
+        is_active=True,
+    )
+    test_db_session.add_all([acct_affected, acct_unrelated])
+    test_db_session.flush()
+
+    snap1 = Snapshot(date=date(2024, 1, 1))
+    snap2 = Snapshot(date=date(2024, 2, 1))
+    test_db_session.add_all([snap1, snap2])
+    test_db_session.flush()
+
+    # snap1 has acct_affected; snap2 has only acct_unrelated
+    test_db_session.add(
+        SnapshotValue(snapshot_id=snap1.id, account_id=acct_affected.id, value=Decimal("1000"))
+    )
+    test_db_session.add(
+        SnapshotValue(snapshot_id=snap2.id, account_id=acct_unrelated.id, value=Decimal("2000"))
+    )
+    test_db_session.flush()
+    recompute_for_snapshot(test_db_session, snap1.id)
+    recompute_for_snapshot(test_db_session, snap2.id)
+    test_db_session.commit()
+
+    s2_before = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap2.id).one()
+    computed_at_before = s2_before.computed_at
+
+    # Update owner on acct_affected → only snap1 should be recomputed
+    update_account(test_db_session, acct_affected.id, AccountUpdate(owner="Ewa"))
+
+    s1_after = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap1.id).one()
+    assert s1_after.owner == "Ewa"
+
+    s2_after = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap2.id).one()
+    assert s2_after.computed_at == computed_at_before  # snap2 not recomputed
+
+
+def test_delete_asset_removes_shared_contribution(test_db_session):
+    asset = Asset(name="Car", is_active=True)
+    test_db_session.add(asset)
+    test_db_session.flush()
+
+    snap = Snapshot(date=date(2024, 3, 1))
+    test_db_session.add(snap)
+    test_db_session.flush()
+
+    test_db_session.add(
+        SnapshotValue(snapshot_id=snap.id, asset_id=asset.id, value=Decimal("30000"))
+    )
+    test_db_session.flush()
+    recompute_for_snapshot(test_db_session, snap.id)
+    test_db_session.commit()
+
+    before = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one()
+    assert float(before.total_assets) == 30000.0
+
+    delete_asset(test_db_session, asset.id)
+
+    after = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one()
+    assert float(after.total_assets) == 0.0
+    assert float(after.net_worth) == 0.0

--- a/backend/tests/test_services_dashboard.py
+++ b/backend/tests/test_services_dashboard.py
@@ -1877,7 +1877,6 @@ def test_dashboard_performance_60_snapshots(test_db_session):
     )
 
 
-<<<<<<< HEAD
 def _build_merged_df(db) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Build merged df matching service.get_dashboard_data's pattern."""
     assets_query = select(Asset).where(Asset.is_active.is_(True))

--- a/backend/tests/test_services_dashboard.py
+++ b/backend/tests/test_services_dashboard.py
@@ -1877,6 +1877,7 @@ def test_dashboard_performance_60_snapshots(test_db_session):
     )
 
 
+<<<<<<< HEAD
 def _build_merged_df(db) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Build merged df matching service.get_dashboard_data's pattern."""
     assets_query = select(Asset).where(Asset.is_active.is_(True))
@@ -2094,3 +2095,74 @@ def test_tile_deltas_alignment_with_tile_totals(test_db_session):
 
     assert result.tile_deltas.net_worth.mom is not None
     assert result.tile_deltas.net_worth.mom.absolute == pytest.approx(expected_abs)
+
+
+@pytest.mark.perf
+def test_dashboard_aggregate_path_200_snapshots(test_db_session):
+    """Aggregate hot path must serve GET /api/dashboard in < 50 ms (median of 5).
+
+    200 snapshots × 10 bank accounts — no investment accounts, no AppConfig so
+    the conditional time-series load is skipped and query count stays ≤ 5.
+    """
+    import time
+
+    from sqlalchemy import event
+
+    from app.services.snapshot_aggregates import recompute_all
+
+    account_specs = [
+        {"name": f"Bank {i}", "category": "bank", "owner": "Marcin"} for i in range(10)
+    ]
+    defaults = {"currency": "PLN", "purpose": "general", "is_active": True, "type": "asset"}
+    accounts = [Account(**{**defaults, **spec}) for spec in account_specs]
+    test_db_session.add_all(accounts)
+    test_db_session.commit()
+
+    snapshots = [Snapshot(date=date(2008 + i // 12, (i % 12) + 1, 1)) for i in range(200)]
+    test_db_session.add_all(snapshots)
+    test_db_session.commit()
+
+    values = [
+        SnapshotValue(
+            snapshot_id=snap.id,
+            account_id=acct.id,
+            value=Decimal(str(1000 * (i + 1) + 50 * j)),
+        )
+        for i, snap in enumerate(snapshots)
+        for j, acct in enumerate(accounts)
+    ]
+    test_db_session.add_all(values)
+    test_db_session.commit()
+
+    recompute_all(test_db_session)
+    test_db_session.commit()
+
+    # Count queries during a single call after aggregates are populated.
+    query_count = 0
+
+    def _before_cursor(_conn, _cursor, _statement, _parameters, _context, _executemany):
+        nonlocal query_count
+        query_count += 1
+
+    engine = test_db_session.get_bind()
+    event.listen(engine, "before_cursor_execute", _before_cursor)
+
+    try:
+        get_dashboard_data(test_db_session)
+        single_call_queries = query_count
+    finally:
+        event.remove(engine, "before_cursor_execute", _before_cursor)
+
+    # 7 runs, drop best + worst → median of middle 5
+    timings_ms = []
+    for _ in range(7):
+        start = time.perf_counter()
+        result = get_dashboard_data(test_db_session)
+        timings_ms.append((time.perf_counter() - start) * 1000)
+    median_ms = sorted(timings_ms)[3]
+
+    assert len(result.net_worth_history) == 200
+    assert single_call_queries <= 5, f"Query count {single_call_queries} exceeds limit of 5"
+    assert median_ms < 50, (
+        f"Aggregate path median {median_ms:.1f} ms (limit: 50 ms; runs: {timings_ms})"
+    )

--- a/backend/tests/test_services_snapshot_aggregates.py
+++ b/backend/tests/test_services_snapshot_aggregates.py
@@ -1,0 +1,152 @@
+"""Tests for snapshot_aggregates runtime helpers."""
+
+from datetime import date
+from decimal import Decimal
+
+from app.models import Account, Asset, Snapshot, SnapshotValue
+from app.models.snapshot_aggregate import SnapshotAggregate
+from app.services.snapshot_aggregates import recompute_all, recompute_for_snapshot
+
+
+def _add_snapshot(db, d: date) -> Snapshot:
+    s = Snapshot(date=d)
+    db.add(s)
+    db.flush()
+    return s
+
+
+def _add_account(db, owner="Marcin", typ="asset", category="bank") -> Account:
+    a = Account(
+        name=f"Acct-{owner}-{category}",
+        type=typ,
+        category=category,
+        owner=owner,
+        currency="PLN",
+        purpose="general",
+        is_active=True,
+    )
+    db.add(a)
+    db.flush()
+    return a
+
+
+def _add_sv(db, snapshot_id, account_id=None, asset_id=None, value="1000") -> SnapshotValue:
+    sv = SnapshotValue(
+        snapshot_id=snapshot_id,
+        account_id=account_id,
+        asset_id=asset_id,
+        value=Decimal(value),
+    )
+    db.add(sv)
+    db.flush()
+    return sv
+
+
+def test_recompute_creates_aggregate_row(test_db_session):
+    snap = _add_snapshot(test_db_session, date(2024, 1, 1))
+    acct = _add_account(test_db_session)
+    _add_sv(test_db_session, snap.id, account_id=acct.id, value="5000")
+
+    recompute_for_snapshot(test_db_session, snap.id)
+    test_db_session.commit()
+
+    rows = test_db_session.query(SnapshotAggregate).all()
+    assert len(rows) == 1
+    assert rows[0].owner == "Marcin"
+    assert float(rows[0].total_assets) == 5000.0
+    assert float(rows[0].total_liabilities) == 0.0
+    assert float(rows[0].net_worth) == 5000.0
+    assert rows[0].month == date(2024, 1, 1)
+
+
+def test_recompute_is_idempotent(test_db_session):
+    snap = _add_snapshot(test_db_session, date(2024, 1, 1))
+    acct = _add_account(test_db_session)
+    _add_sv(test_db_session, snap.id, account_id=acct.id, value="1000")
+
+    recompute_for_snapshot(test_db_session, snap.id)
+    test_db_session.commit()
+    recompute_for_snapshot(test_db_session, snap.id)
+    test_db_session.commit()
+
+    count = test_db_session.query(SnapshotAggregate).count()
+    assert count == 1
+
+
+def test_recompute_empty_snapshot(test_db_session):
+    snap = _add_snapshot(test_db_session, date(2024, 1, 1))
+
+    recompute_for_snapshot(test_db_session, snap.id)
+    test_db_session.commit()
+
+    rows = test_db_session.query(SnapshotAggregate).all()
+    assert len(rows) == 1
+    assert rows[0].owner == "Shared"
+    assert float(rows[0].net_worth) == 0.0
+
+
+def test_recompute_multi_owner(test_db_session):
+    snap = _add_snapshot(test_db_session, date(2024, 1, 1))
+    acct_m = _add_account(test_db_session, owner="Marcin")
+    acct_e = _add_account(test_db_session, owner="Ewa")
+    _add_sv(test_db_session, snap.id, account_id=acct_m.id, value="3000")
+    _add_sv(test_db_session, snap.id, account_id=acct_e.id, value="2000")
+
+    recompute_for_snapshot(test_db_session, snap.id)
+    test_db_session.commit()
+
+    rows = test_db_session.query(SnapshotAggregate).all()
+    assert len(rows) == 2
+    owners = {r.owner: r for r in rows}
+    assert float(owners["Marcin"].total_assets) == 3000.0
+    assert float(owners["Ewa"].total_assets) == 2000.0
+
+
+def test_asset_table_goes_to_shared(test_db_session):
+    snap = _add_snapshot(test_db_session, date(2024, 1, 1))
+    asset = Asset(name="Car", is_active=True)
+    test_db_session.add(asset)
+    test_db_session.flush()
+    _add_sv(test_db_session, snap.id, asset_id=asset.id, value="50000")
+
+    recompute_for_snapshot(test_db_session, snap.id)
+    test_db_session.commit()
+
+    rows = test_db_session.query(SnapshotAggregate).all()
+    assert len(rows) == 1
+    assert rows[0].owner == "Shared"
+    assert float(rows[0].total_assets) == 50000.0
+
+
+def test_repeated_recompute_produces_identical_rows(test_db_session):
+    snap = _add_snapshot(test_db_session, date(2024, 6, 1))
+    acct = _add_account(test_db_session, owner="Marcin", typ="asset", category="stock")
+    _add_sv(test_db_session, snap.id, account_id=acct.id, value="12345.67")
+
+    recompute_for_snapshot(test_db_session, snap.id)
+    test_db_session.commit()
+
+    first = test_db_session.query(SnapshotAggregate).one()
+    first_nw = float(first.net_worth)
+    first_alloc = first.allocation_json
+
+    recompute_for_snapshot(test_db_session, snap.id)
+    test_db_session.commit()
+
+    second = test_db_session.query(SnapshotAggregate).one()
+    assert float(second.net_worth) == first_nw
+    assert second.allocation_json == first_alloc
+
+
+def test_recompute_all(test_db_session):
+    s1 = _add_snapshot(test_db_session, date(2024, 1, 1))
+    s2 = _add_snapshot(test_db_session, date(2024, 2, 1))
+    acct = _add_account(test_db_session)
+    _add_sv(test_db_session, s1.id, account_id=acct.id, value="1000")
+    _add_sv(test_db_session, s2.id, account_id=acct.id, value="2000")
+
+    recompute_all(test_db_session)
+    test_db_session.commit()
+
+    count = test_db_session.query(SnapshotAggregate).count()
+    assert count == 2

--- a/backend/tests/test_services_snapshots_aggregate_sync.py
+++ b/backend/tests/test_services_snapshots_aggregate_sync.py
@@ -1,0 +1,111 @@
+"""Tests that create_snapshot and update_snapshot keep aggregates in sync."""
+
+from datetime import date
+
+import pytest
+
+from app.models import Account
+from app.models.snapshot_aggregate import SnapshotAggregate
+from app.schemas.snapshots import SnapshotCreate, SnapshotUpdate, SnapshotValueInput
+from app.services.snapshots import create_snapshot, update_snapshot
+
+
+def _make_account(db, owner="Marcin", typ="asset", category="bank") -> Account:
+    a = Account(
+        name=f"Acct-{owner}-{category}",
+        type=typ,
+        category=category,
+        owner=owner,
+        currency="PLN",
+        purpose="general",
+        is_active=True,
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def test_create_snapshot_builds_aggregate(test_db_session):
+    acct = _make_account(test_db_session)
+
+    data = SnapshotCreate(
+        date=date(2024, 1, 1),
+        values=[SnapshotValueInput(account_id=acct.id, value=10000.0)],
+    )
+    snap = create_snapshot(test_db_session, data)
+
+    rows = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).all()
+    assert len(rows) == 1
+    assert rows[0].owner == "Marcin"
+    assert float(rows[0].total_assets) == 10000.0
+    assert float(rows[0].net_worth) == 10000.0
+
+
+def test_create_snapshot_liability_in_aggregate(test_db_session):
+    asset_acct = _make_account(test_db_session, owner="Marcin", typ="asset", category="bank")
+    liab_acct = _make_account(test_db_session, owner="Marcin", typ="liability", category="mortgage")
+
+    data = SnapshotCreate(
+        date=date(2024, 2, 1),
+        values=[
+            SnapshotValueInput(account_id=asset_acct.id, value=50000.0),
+            SnapshotValueInput(account_id=liab_acct.id, value=20000.0),
+        ],
+    )
+    snap = create_snapshot(test_db_session, data)
+
+    row = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one()
+    assert float(row.total_assets) == 50000.0
+    assert float(row.total_liabilities) == 20000.0
+    assert float(row.net_worth) == 30000.0
+
+
+def test_update_snapshot_refreshes_aggregate(test_db_session):
+    acct = _make_account(test_db_session)
+
+    create_data = SnapshotCreate(
+        date=date(2024, 3, 1),
+        values=[SnapshotValueInput(account_id=acct.id, value=5000.0)],
+    )
+    snap = create_snapshot(test_db_session, create_data)
+
+    before = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one()
+    assert float(before.net_worth) == 5000.0
+
+    update_data = SnapshotUpdate(values=[SnapshotValueInput(account_id=acct.id, value=8000.0)])
+    update_snapshot(test_db_session, snap.id, update_data)
+
+    after = test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one()
+    assert float(after.net_worth) == 8000.0
+
+
+def test_update_snapshot_rollback_leaves_table_consistent(test_db_session):
+    """Simulated integrity error leaves aggregates unchanged."""
+    acct = _make_account(test_db_session)
+
+    create_data = SnapshotCreate(
+        date=date(2024, 4, 1),
+        values=[SnapshotValueInput(account_id=acct.id, value=1000.0)],
+    )
+    snap = create_snapshot(test_db_session, create_data)
+    original_nw = float(
+        test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one().net_worth
+    )
+
+    # Try update with a non-existent account to trigger 404 (no DB change)
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException):
+        update_snapshot(
+            test_db_session,
+            snap.id,
+            SnapshotUpdate(values=[SnapshotValueInput(account_id=99999, value=9999.0)]),
+        )
+
+    # Session is rolled back by the exception path; original aggregate intact after reset
+    test_db_session.rollback()
+    final_nw = float(
+        test_db_session.query(SnapshotAggregate).filter_by(snapshot_id=snap.id).one().net_worth
+    )
+    assert final_nw == original_nw


### PR DESCRIPTION
## Motivation

Dashboard hot paths (`GET /api/dashboard`) were re-joining and aggregating all `SnapshotValue` rows on every request. At scale (many snapshots × many accounts) this caused O(n) query fan-out and slow pandas aggregations for net worth history, current totals, and asset allocation.

## Implementation information

Introduces a `snapshot_aggregates` materialized table (one row per snapshot × owner) that pre-computes the aggregations at write time:

- **ORM model** `SnapshotAggregate` with unique constraint `(snapshot_id, owner)` and a month index for fast range queries
- **Migrations** — `0005` creates the DDL; `0006` backfills existing data using a frozen copy of the aggregate spec so the backfill remains stable even if the live spec evolves
- **Invalidation hooks** — account and asset mutations recompute only the affected snapshots (scoped by `SnapshotValue` FK) via `recompute_for_snapshot`
- **Dashboard** — aggregate hot path with raw fallback for empty table; `fix(dashboard)` follow-up groups by `snapshot_id` instead of month so same-month snapshots stay distinct in `net_worth_history` and savings-rate deltas
- **Tests** — parity test (frozen spec == live spec; raw path == aggregate path), perf test (200 snapshots × 10 accounts, median < 50 ms, ≤ 5 queries), invalidation hooks, and aggregate spec unit tests

Closes https://github.com/Automaat/finance-buddy/issues/389