### PR TITLE
fix(dev): stabilize local startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ DEFAULT_OWNER=Marcin
 
 # Frontend
 PUBLIC_API_URL=http://localhost:8000
+# Optional: browser-side API URL when it differs from the server-side one
+PUBLIC_API_URL_BROWSER=http://localhost:8000
 PUBLIC_OWNER_NAMES=Marcin,Ewa,Shared
 PUBLIC_DEFAULT_OWNER=Marcin
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ Finansowa Forteca.xlsx
 data/
 
 # Python build artifacts
+__pycache__/
+*.py[cod]
+.venv/
 *.egg-info/
 
 # Testing

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "24"
-python = "3.14.5"
+# Let uv manage Python resolution so Docker-based tasks don't depend on a local Python install.
 uv = "latest"
 
 [tasks.dev]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-password}
       - POSTGRES_DB=finance
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres18-data:/var/lib/postgresql
     ports:
       - '${POSTGRES_HOST_PORT:-5433}:5432'
     healthcheck:
@@ -64,4 +64,4 @@ services:
         condition: service_healthy
 
 volumes:
-  postgres-data:
+  postgres18-data:

--- a/src/lib/components/SnapshotForm.svelte
+++ b/src/lib/components/SnapshotForm.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { env } from '$env/dynamic/public';
+	import { getApiUrlOrThrow } from '$lib/utils/api';
 	import { Wallet, Umbrella, TrendingUp, Home, CreditCard } from 'lucide-svelte';
 	import type { Account, Asset, SnapshotResponse } from '$lib/types';
 	import NewAccountModal from './snapshot/NewAccountModal.svelte';
@@ -169,8 +169,9 @@
 			const account_wrapper =
 				newAccountSection === 'retirement' && newAccountWrapper ? newAccountWrapper : null;
 			const purpose = newAccountSection === 'retirement' ? 'retirement' : 'general';
+			const apiUrl = getApiUrlOrThrow();
 
-			const response = await fetch(`${env.PUBLIC_API_URL_BROWSER}/api/accounts`, {
+			const response = await fetch(`${apiUrl}/api/accounts`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
@@ -250,7 +251,8 @@
 		error = '';
 
 		try {
-			const response = await fetch(`${env.PUBLIC_API_URL_BROWSER}/api/assets`, {
+			const apiUrl = getApiUrlOrThrow();
+			const response = await fetch(`${apiUrl}/api/assets`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
@@ -293,6 +295,7 @@
 		error = '';
 
 		try {
+			const apiUrl = getApiUrlOrThrow();
 			const allAccounts = [...assets, ...liabilities];
 			const accountPayloads = editingSnapshot
 				? allAccounts
@@ -356,8 +359,8 @@
 
 			const method = editingSnapshot ? 'PUT' : 'POST';
 			const url = editingSnapshot
-				? `${env.PUBLIC_API_URL_BROWSER}/api/snapshots/${editingSnapshot.id}`
-				: `${env.PUBLIC_API_URL_BROWSER}/api/snapshots`;
+				? `${apiUrl}/api/snapshots/${editingSnapshot.id}`
+				: `${apiUrl}/api/snapshots`;
 
 			const response = await fetch(url, {
 				method,

--- a/src/lib/utils/api.test.ts
+++ b/src/lib/utils/api.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	API_URL_NOT_CONFIGURED_MESSAGE,
+	DEFAULT_DEV_API_URL,
+	getApiUrlOrThrow,
+	resolveApiUrl
+} from './api';
+
+const state = vi.hoisted(() => ({
+	browser: false,
+	dev: false,
+	env: {
+		PUBLIC_API_URL: undefined as string | undefined,
+		PUBLIC_API_URL_BROWSER: undefined as string | undefined
+	}
+}));
+
+vi.mock('$app/environment', () => ({
+	get browser() {
+		return state.browser;
+	},
+	get dev() {
+		return state.dev;
+	}
+}));
+
+vi.mock('$env/dynamic/public', () => ({
+	get env() {
+		return state.env;
+	}
+}));
+
+describe('api utils', () => {
+	beforeEach(() => {
+		state.browser = false;
+		state.dev = false;
+		state.env.PUBLIC_API_URL = undefined;
+		state.env.PUBLIC_API_URL_BROWSER = undefined;
+	});
+
+	it('prefers the server API URL during SSR', () => {
+		state.env.PUBLIC_API_URL = 'http://backend:8000';
+		state.env.PUBLIC_API_URL_BROWSER = 'https://app.example.com/api';
+
+		expect(resolveApiUrl()).toBe('http://backend:8000');
+	});
+
+	it('prefers the browser API URL in the browser', () => {
+		state.browser = true;
+		state.env.PUBLIC_API_URL = 'http://backend:8000';
+		state.env.PUBLIC_API_URL_BROWSER = 'https://app.example.com/api';
+
+		expect(resolveApiUrl()).toBe('https://app.example.com/api');
+	});
+
+	it('falls back to the other public URL when only one is configured', () => {
+		state.browser = true;
+		state.env.PUBLIC_API_URL = 'http://backend:8000';
+
+		expect(resolveApiUrl()).toBe('http://backend:8000');
+
+		state.browser = false;
+		state.env.PUBLIC_API_URL = undefined;
+		state.env.PUBLIC_API_URL_BROWSER = 'https://app.example.com/api';
+
+		expect(resolveApiUrl()).toBe('https://app.example.com/api');
+	});
+
+	it('uses the local backend in development when no API URL is configured', () => {
+		state.dev = true;
+
+		expect(resolveApiUrl()).toBe(DEFAULT_DEV_API_URL);
+		expect(getApiUrlOrThrow()).toBe(DEFAULT_DEV_API_URL);
+	});
+
+	it('keeps production misconfiguration loud', () => {
+		expect(resolveApiUrl()).toBeUndefined();
+		expect(() => getApiUrlOrThrow()).toThrow(API_URL_NOT_CONFIGURED_MESSAGE);
+	});
+});

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -1,0 +1,23 @@
+import { browser, dev } from '$app/environment';
+import { env } from '$env/dynamic/public';
+
+export const DEFAULT_DEV_API_URL = 'http://localhost:8000';
+export const API_URL_NOT_CONFIGURED_MESSAGE = 'API URL is not configured';
+
+export function resolveApiUrl(): string | undefined {
+	const apiUrl = browser
+		? env.PUBLIC_API_URL_BROWSER || env.PUBLIC_API_URL
+		: env.PUBLIC_API_URL || env.PUBLIC_API_URL_BROWSER;
+
+	return apiUrl || (dev ? DEFAULT_DEV_API_URL : undefined);
+}
+
+export function getApiUrlOrThrow(): string {
+	const apiUrl = resolveApiUrl();
+
+	if (apiUrl) {
+		return apiUrl;
+	}
+
+	throw new Error(API_URL_NOT_CONFIGURED_MESSAGE);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,9 +13,9 @@
 		AlertTriangle,
 		PiggyBank
 	} from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
+	import { getApiUrlOrThrow } from '$lib/utils/api';
 	import type { Persona } from '$lib/types/personas';
 	import type { PageData } from './$types';
 
@@ -71,7 +71,7 @@
 	}
 
 	async function saveLimits() {
-		const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+		const apiUrl = getApiUrlOrThrow();
 		try {
 			const requests = Object.entries(limits).map(([key, amount]) => {
 				const sep = key.indexOf('_');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -29,9 +29,13 @@
 
 	$effect(() => {
 		let cancelled = false;
-		Promise.resolve(data.personas).then((p) => {
-			if (!cancelled) personas = (p ?? []) as Persona[];
-		});
+		Promise.resolve(data.personas)
+			.then((p) => {
+				if (!cancelled) personas = (p ?? []) as Persona[];
+			})
+			.catch(() => {
+				if (!cancelled) personas = [];
+			});
 		return () => {
 			cancelled = true;
 		};

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,19 +1,23 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 
 export async function load({ fetch }) {
-	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+	const apiUrl = resolveApiUrl();
 	if (!apiUrl) {
-		throw error(500, 'API URL is not configured');
+		throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
 	}
 
 	const currentYear = new Date().getFullYear();
 
 	const personas = (async () => {
-		const res = await fetch(`${apiUrl}/api/personas`);
-		return res.ok ? await res.json() : [];
+		try {
+			const res = await fetch(`${apiUrl}/api/personas`);
+			return res.ok ? await res.json() : [];
+		} catch {
+			return [];
+		}
 	})();
+	personas.catch(() => {});
 
 	const dashboardData = (async () => {
 		const [dashboardRes, retirementRes] = await Promise.all([
@@ -33,6 +37,7 @@ export async function load({ fetch }) {
 			retirementStats
 		};
 	})();
+	dashboardData.catch(() => {});
 
 	return {
 		dashboardData,

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -3,9 +3,9 @@
 	import Skeleton from '$lib/components/Skeleton.svelte';
 	import { formatPLN } from '$lib/utils/format';
 	import { Wallet, TrendingDown, Pencil, Trash2, Plus, BarChart3 } from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
 	import { onMount, untrack } from 'svelte';
+	import { getApiUrlOrThrow } from '$lib/utils/api';
 	import { INVESTMENT_CATEGORIES } from '$lib/constants';
 	import type { Account, TransactionsData } from './+page';
 	import type { Persona } from '$lib/types/personas';
@@ -17,7 +17,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = () => getApiUrlOrThrow();
 	let personas: Persona[] = $state([]);
 	const defaultOwner = $derived(personas.length > 0 ? personas[0].name : 'Marcin');
 
@@ -131,8 +131,8 @@
 
 		try {
 			const endpoint = editingAccount
-				? `${apiUrl}/api/accounts/${editingAccount.id}`
-				: `${apiUrl}/api/accounts`;
+				? `${apiUrl()}/api/accounts/${editingAccount.id}`
+				: `${apiUrl()}/api/accounts`;
 			const method = editingAccount ? 'PUT' : 'POST';
 
 			const payload =
@@ -176,7 +176,7 @@
 		if (!accountToDelete) return;
 
 		try {
-			const response = await fetch(`${apiUrl}/api/accounts/${accountToDelete}`, {
+			const response = await fetch(`${apiUrl()}/api/accounts/${accountToDelete}`, {
 				method: 'DELETE'
 			});
 
@@ -198,7 +198,7 @@
 
 	async function loadTransactionCounts() {
 		try {
-			const response = await fetch(`${apiUrl}/api/transactions/counts`);
+			const response = await fetch(`${apiUrl()}/api/transactions/counts`);
 			if (response.ok) {
 				transactionCounts = await response.json();
 			}
@@ -227,7 +227,7 @@
 		if (!selectedAccountId) return;
 
 		try {
-			const response = await fetch(`${apiUrl}/api/accounts/${selectedAccountId}/transactions`);
+			const response = await fetch(`${apiUrl()}/api/accounts/${selectedAccountId}/transactions`);
 			if (response.ok) {
 				transactionsData = await response.json();
 			} else {
@@ -262,7 +262,7 @@
 		savingTransaction = true;
 
 		try {
-			const response = await fetch(`${apiUrl}/api/accounts/${selectedAccountId}/transactions`, {
+			const response = await fetch(`${apiUrl()}/api/accounts/${selectedAccountId}/transactions`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify(transactionFormData)
@@ -296,7 +296,7 @@
 
 		try {
 			const response = await fetch(
-				`${apiUrl}/api/accounts/${selectedAccountId}/transactions/${transactionId}`,
+				`${apiUrl()}/api/accounts/${selectedAccountId}/transactions/${transactionId}`,
 				{ method: 'DELETE' }
 			);
 

--- a/src/routes/accounts/+page.ts
+++ b/src/routes/accounts/+page.ts
@@ -1,6 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 import type { PageLoad } from './$types';
 import type { Transaction, TransactionsData } from '$lib/types/transactions';
 import type { Persona } from '$lib/types/personas';
@@ -29,9 +28,9 @@ export interface AccountsData {
 export type { Transaction, TransactionsData };
 
 export const load: PageLoad = async ({ fetch }) => {
-	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+	const apiUrl = resolveApiUrl();
 	if (!apiUrl) {
-		throw error(500, 'API URL is not configured');
+		throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
 	}
 
 	const personas = (async (): Promise<Persona[]> => {
@@ -41,6 +40,7 @@ export const load: PageLoad = async ({ fetch }) => {
 		}
 		return (await res.json()) as Persona[];
 	})();
+	personas.catch(() => {});
 
 	const accountsData = (async () => {
 		const response = await fetch(`${apiUrl}/api/accounts`);
@@ -49,6 +49,7 @@ export const load: PageLoad = async ({ fetch }) => {
 		}
 		return (await response.json()) as AccountsData;
 	})();
+	accountsData.catch(() => {});
 
 	return {
 		accountsData,

--- a/src/routes/assets/+page.svelte
+++ b/src/routes/assets/+page.svelte
@@ -2,8 +2,8 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import { formatPLN } from '$lib/utils/format';
 	import { Home, Pencil, Plus, Trash2 } from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
+	import { getApiUrlOrThrow } from '$lib/utils/api';
 	import type { Asset } from './+page';
 	import type { PageData } from './$types';
 
@@ -13,7 +13,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = () => getApiUrlOrThrow();
 
 	let showForm = $state(false);
 	let editingAsset: Asset | null = $state(null);
@@ -53,8 +53,8 @@
 
 		try {
 			const endpoint = editingAsset
-				? `${apiUrl}/api/assets/${editingAsset.id}`
-				: `${apiUrl}/api/assets`;
+				? `${apiUrl()}/api/assets/${editingAsset.id}`
+				: `${apiUrl()}/api/assets`;
 			const method = editingAsset ? 'PUT' : 'POST';
 
 			const response = await fetch(endpoint, {
@@ -93,7 +93,9 @@
 		if (!assetToDelete) return;
 
 		try {
-			const response = await fetch(`${apiUrl}/api/assets/${assetToDelete}`, { method: 'DELETE' });
+			const response = await fetch(`${apiUrl()}/api/assets/${assetToDelete}`, {
+				method: 'DELETE'
+			});
 
 			if (!response.ok) {
 				throw new Error('Failed to delete asset');

--- a/src/routes/assets/+page.ts
+++ b/src/routes/assets/+page.ts
@@ -1,6 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 import type { PageLoad } from './$types';
 
 export interface Asset {
@@ -16,11 +15,12 @@ export interface AssetsData {
 }
 
 export const load: PageLoad = async ({ fetch }) => {
+	const apiUrl = resolveApiUrl();
+	if (!apiUrl) {
+		throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
+	}
+
 	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API URL is not configured');
-		}
 		const response = await fetch(`${apiUrl}/api/assets`);
 
 		if (!response.ok) {
@@ -30,7 +30,7 @@ export const load: PageLoad = async ({ fetch }) => {
 		const data: AssetsData = await response.json();
 		return data;
 	} catch (err) {
-		if (err instanceof Error && 'status' in err) {
+		if (err && typeof err === 'object' && 'status' in err) {
 			throw err;
 		}
 		throw error(500, 'Failed to load assets');

--- a/src/routes/config/+page.svelte
+++ b/src/routes/config/+page.svelte
@@ -11,8 +11,8 @@
 		AlertTriangle,
 		Gauge
 	} from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
+	import { getApiUrlOrThrow } from '$lib/utils/api';
 	import { untrack } from 'svelte';
 	import type { PageData } from './$types';
 
@@ -22,7 +22,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = () => getApiUrlOrThrow();
 
 	const defaults = {
 		birth_date: '1990-01-01',
@@ -102,7 +102,7 @@
 		saving = true;
 
 		try {
-			const response = await fetch(`${apiUrl}/api/config`, {
+			const response = await fetch(`${apiUrl()}/api/config`, {
 				method: 'PUT',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({

--- a/src/routes/config/+page.ts
+++ b/src/routes/config/+page.ts
@@ -1,16 +1,15 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 import type { PageLoad } from './$types';
 import type { AppConfig } from '$lib/types/config';
 
 export const load: PageLoad = async ({ fetch }) => {
-	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API URL is not configured');
-		}
+	const apiUrl = resolveApiUrl();
+	if (!apiUrl) {
+		throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
+	}
 
+	try {
 		const response = await fetch(`${apiUrl}/api/config`);
 
 		// Handle 404 - config not initialized, return defaults
@@ -47,7 +46,7 @@ export const load: PageLoad = async ({ fetch }) => {
 			retirementAccountValue
 		};
 	} catch (err) {
-		if (err instanceof Error && 'status' in err) {
+		if (err && typeof err === 'object' && 'status' in err) {
 			throw err;
 		}
 		throw error(500, 'Failed to load configuration');

--- a/src/routes/debts/+page.svelte
+++ b/src/routes/debts/+page.svelte
@@ -2,9 +2,9 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import { formatPLN, formatDate } from '$lib/utils/format';
 	import { ClipboardList, Plus, Pencil, Trash2, Wallet, CircleDollarSign } from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
 	import { onMount, untrack } from 'svelte';
+	import { getApiUrlOrThrow } from '$lib/utils/api';
 	import type { Debt, DebtPayment } from './+page';
 	import type { Persona } from '$lib/types/personas';
 	import type { PageData } from './$types';
@@ -15,7 +15,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = () => getApiUrlOrThrow();
 	const personas = $derived(data.personas as Persona[]);
 	const defaultOwner = $derived(personas.length > 0 ? personas[0].name : 'Marcin');
 
@@ -107,7 +107,7 @@
 			let method: string;
 
 			if (editingDebt) {
-				endpoint = `${apiUrl}/api/debts/${editingDebt.id}`;
+				endpoint = `${apiUrl()}/api/debts/${editingDebt.id}`;
 				method = 'PUT';
 			} else {
 				const accountOwner = defaultOwner;
@@ -119,7 +119,7 @@
 					currency: formData.currency
 				};
 
-				const accountResponse = await fetch(`${apiUrl}/api/accounts`, {
+				const accountResponse = await fetch(`${apiUrl()}/api/accounts`, {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
 					body: JSON.stringify(tempAccount)
@@ -131,7 +131,7 @@
 				}
 
 				const accountData = await accountResponse.json();
-				endpoint = `${apiUrl}/api/accounts/${accountData.id}/debts`;
+				endpoint = `${apiUrl()}/api/accounts/${accountData.id}/debts`;
 				method = 'POST';
 			}
 
@@ -171,7 +171,9 @@
 		if (!debtToDelete) return;
 
 		try {
-			const response = await fetch(`${apiUrl}/api/debts/${debtToDelete}`, { method: 'DELETE' });
+			const response = await fetch(`${apiUrl()}/api/debts/${debtToDelete}`, {
+				method: 'DELETE'
+			});
 
 			if (!response.ok) {
 				throw new Error('Failed to delete debt');
@@ -191,7 +193,7 @@
 
 	async function loadPaymentCounts() {
 		try {
-			const response = await fetch(`${apiUrl}/api/payments/counts`);
+			const response = await fetch(`${apiUrl()}/api/payments/counts`);
 			if (response.ok) {
 				paymentCounts = await response.json();
 			}
@@ -218,7 +220,7 @@
 		if (!selectedDebt) return;
 
 		try {
-			const response = await fetch(`${apiUrl}/api/accounts/${selectedDebt.account_id}/payments`);
+			const response = await fetch(`${apiUrl()}/api/accounts/${selectedDebt.account_id}/payments`);
 			if (response.ok) {
 				paymentsData = await response.json();
 			} else {
@@ -238,7 +240,7 @@
 		savingPayment = true;
 
 		try {
-			const response = await fetch(`${apiUrl}/api/accounts/${selectedDebt.account_id}/payments`, {
+			const response = await fetch(`${apiUrl()}/api/accounts/${selectedDebt.account_id}/payments`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify(paymentFormData)
@@ -282,7 +284,7 @@
 
 		try {
 			const response = await fetch(
-				`${apiUrl}/api/accounts/${selectedDebt.account_id}/payments/${paymentToDelete}`,
+				`${apiUrl()}/api/accounts/${selectedDebt.account_id}/payments/${paymentToDelete}`,
 				{ method: 'DELETE' }
 			);
 

--- a/src/routes/debts/+page.ts
+++ b/src/routes/debts/+page.ts
@@ -1,6 +1,5 @@
-import { browser } from '$app/environment';
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 import type { PageLoad } from './$types';
 
 export interface Debt {
@@ -41,7 +40,11 @@ export interface DebtsListResponse {
 }
 
 export const load: PageLoad = async ({ fetch }) => {
-	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+	const apiUrl = resolveApiUrl();
+	if (!apiUrl) {
+		throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
+	}
+
 	const [debtsResponse, personasResponse] = await Promise.all([
 		fetch(`${apiUrl}/api/debts`),
 		fetch(`${apiUrl}/api/personas`)

--- a/src/routes/goals/+page.svelte
+++ b/src/routes/goals/+page.svelte
@@ -2,8 +2,8 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import { formatPLN, formatDate } from '$lib/utils/format';
 	import { Target, Plus, Pencil, Trash2, CheckCircle2, Calendar } from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
+	import { getApiUrlOrThrow } from '$lib/utils/api';
 	import type { Goal, AccountOption } from './+page';
 	import type { PageData } from './$types';
 
@@ -13,7 +13,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = () => getApiUrlOrThrow();
 
 	const goals = $derived(data.goals as Goal[]);
 	const accounts = $derived(data.accounts as AccountOption[]);
@@ -94,8 +94,8 @@
 		saving = true;
 		try {
 			const endpoint = editingGoal
-				? `${apiUrl}/api/goals/${editingGoal.id}`
-				: `${apiUrl}/api/goals`;
+				? `${apiUrl()}/api/goals/${editingGoal.id}`
+				: `${apiUrl()}/api/goals`;
 			const method = editingGoal ? 'PUT' : 'POST';
 			const response = await fetch(endpoint, {
 				method,
@@ -128,7 +128,9 @@
 	async function confirmDelete() {
 		if (!goalToDelete) return;
 		try {
-			const response = await fetch(`${apiUrl}/api/goals/${goalToDelete}`, { method: 'DELETE' });
+			const response = await fetch(`${apiUrl()}/api/goals/${goalToDelete}`, {
+				method: 'DELETE'
+			});
 			if (!response.ok) throw new Error('Nie udało się usunąć celu');
 			await invalidateAll();
 		} catch (err) {

--- a/src/routes/goals/+page.ts
+++ b/src/routes/goals/+page.ts
@@ -1,6 +1,5 @@
-import { browser } from '$app/environment';
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 import type { PageLoad } from './$types';
 
 export interface Goal {
@@ -32,9 +31,9 @@ export interface AccountOption {
 }
 
 export const load: PageLoad = async ({ fetch }) => {
-	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+	const apiUrl = resolveApiUrl();
 	if (!apiUrl) {
-		throw error(500, 'API URL is not configured');
+		throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
 	}
 	const [goalsResponse, accountsResponse] = await Promise.all([
 		fetch(`${apiUrl}/api/goals`),

--- a/src/routes/metryki/+page.ts
+++ b/src/routes/metryki/+page.ts
@@ -1,14 +1,13 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 
 export async function load({ fetch }) {
-	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API URL is not configured');
-		}
+	const apiUrl = resolveApiUrl();
+	if (!apiUrl) {
+		throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
+	}
 
+	try {
 		const dashboardRes = await fetch(`${apiUrl}/api/dashboard`);
 
 		if (!dashboardRes.ok) {
@@ -49,7 +48,7 @@ export async function load({ fetch }) {
 			bondStats
 		};
 	} catch (err) {
-		if (err instanceof Error && 'status' in err) {
+		if (err && typeof err === 'object' && 'status' in err) {
 			throw err;
 		}
 		throw error(500, 'Failed to load metrics data');

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -15,9 +15,9 @@
 		Trash2,
 		Scale
 	} from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
+	import { getApiUrlOrThrow } from '$lib/utils/api';
 	import type { SalaryRecord } from '$lib/types/salaries';
 	import type { Persona } from '$lib/types/personas';
 	import type { CpiSeries } from '$lib/types/cpi';
@@ -29,7 +29,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = () => getApiUrlOrThrow();
 	const personas = $derived(data.personas as Persona[]);
 	const defaultOwner = $derived(personas.length > 0 ? personas[0].name : 'Marcin');
 	const cpiSeries = $derived(data.cpiSeries as CpiSeries);
@@ -175,8 +175,8 @@
 		try {
 			const method = editingSalary ? 'PATCH' : 'POST';
 			const url = editingSalary
-				? `${apiUrl}/api/salaries/${editingSalary.id}`
-				: `${apiUrl}/api/salaries`;
+				? `${apiUrl()}/api/salaries/${editingSalary.id}`
+				: `${apiUrl()}/api/salaries`;
 
 			const response = await fetch(url, {
 				method,
@@ -220,7 +220,7 @@
 		}
 
 		try {
-			const response = await fetch(`${apiUrl}/api/salaries/${id}`, {
+			const response = await fetch(`${apiUrl()}/api/salaries/${id}`, {
 				method: 'DELETE'
 			});
 

--- a/src/routes/salaries/+page.ts
+++ b/src/routes/salaries/+page.ts
@@ -1,6 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 import type { PageLoad } from './$types';
 import type { SalariesData } from '$lib/types/salaries';
 import type { CpiSeries } from '$lib/types/cpi';
@@ -8,12 +7,12 @@ import type { CpiSeries } from '$lib/types/cpi';
 const EMPTY_CPI: CpiSeries = { points: [], base_year: null, latest_year: null, source: '' };
 
 export const load: PageLoad = async ({ fetch, url }) => {
-	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API URL is not configured');
-		}
+	const apiUrl = resolveApiUrl();
+	if (!apiUrl) {
+		throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
+	}
 
+	try {
 		const owner = url.searchParams.get('owner');
 		const dateFrom = url.searchParams.get('date_from');
 		const dateTo = url.searchParams.get('date_to');
@@ -51,7 +50,7 @@ export const load: PageLoad = async ({ fetch, url }) => {
 			cpiSeries
 		};
 	} catch (err) {
-		if (err instanceof Error && 'status' in err) {
+		if (err && typeof err === 'object' && 'status' in err) {
 			throw err;
 		}
 		throw error(500, 'Failed to load salary records');

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import Modal from '$lib/components/Modal.svelte';
 	import { Plus, Pencil, Trash2 } from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
+	import { getApiUrlOrThrow } from '$lib/utils/api';
 	import type { Persona } from '$lib/types/personas';
 
 	interface Props {
@@ -11,7 +11,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = () => getApiUrlOrThrow();
 
 	let showForm = $state(false);
 	let editingPersona: Persona | null = $state(null);
@@ -54,8 +54,8 @@
 
 		try {
 			const endpoint = editingPersona
-				? `${apiUrl}/api/personas/${editingPersona.id}`
-				: `${apiUrl}/api/personas`;
+				? `${apiUrl()}/api/personas/${editingPersona.id}`
+				: `${apiUrl()}/api/personas`;
 			const method = editingPersona ? 'PUT' : 'POST';
 
 			const response = await fetch(endpoint, {
@@ -89,7 +89,7 @@
 		if (!personaToDelete) return;
 
 		try {
-			const response = await fetch(`${apiUrl}/api/personas/${personaToDelete.id}`, {
+			const response = await fetch(`${apiUrl()}/api/personas/${personaToDelete.id}`, {
 				method: 'DELETE'
 			});
 

--- a/src/routes/settings/+page.ts
+++ b/src/routes/settings/+page.ts
@@ -1,12 +1,11 @@
 import { error } from '@sveltejs/kit';
-import { browser } from '$app/environment';
-import { env } from '$env/dynamic/public';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 import type { PageLoad } from './$types';
 import type { Persona } from '$lib/types/personas';
 
 export const load: PageLoad = async ({ fetch }) => {
-	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-	if (!apiUrl) throw error(500, 'API URL not configured');
+	const apiUrl = resolveApiUrl();
+	if (!apiUrl) throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
 
 	const response = await fetch(`${apiUrl}/api/personas`);
 	if (!response.ok) throw error(response.status, 'Failed to load personas');

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { onMount, untrack } from 'svelte';
 	import { browser } from '$app/environment';
-	import { env } from '$env/dynamic/public';
 	import * as echarts from 'echarts';
 	import type { PageData } from './$types';
+	import { getApiUrlOrThrow } from '$lib/utils/api';
 	import {
 		buildRetirementProjectionOption,
 		type AccountSimulation
@@ -159,8 +159,7 @@
 				}
 			}
 
-			const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-			if (!apiUrl) throw new Error('API URL not configured');
+			const apiUrl = getApiUrlOrThrow();
 
 			const requestBody = {
 				current_age: currentAge,

--- a/src/routes/simulations/+page.ts
+++ b/src/routes/simulations/+page.ts
@@ -1,13 +1,12 @@
 import { error } from '@sveltejs/kit';
-import { browser } from '$app/environment';
-import { env } from '$env/dynamic/public';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ fetch }) => {
-	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) throw error(500, 'API URL not configured');
+	const apiUrl = resolveApiUrl();
+	if (!apiUrl) throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
 
+	try {
 		const [prefillRes, personasRes] = await Promise.all([
 			fetch(`${apiUrl}/api/simulations/prefill`),
 			fetch(`${apiUrl}/api/personas`)
@@ -18,7 +17,7 @@ export const load: PageLoad = async ({ fetch }) => {
 		const personas = personasRes.ok ? await personasRes.json() : [];
 		return { ...prefill, personas };
 	} catch (err) {
-		if (err instanceof Error && 'status' in err) throw err;
+		if (err && typeof err === 'object' && 'status' in err) throw err;
 		throw error(500, 'Failed to load simulation data');
 	}
 };

--- a/src/routes/simulations/kalkulator/+page.ts
+++ b/src/routes/simulations/kalkulator/+page.ts
@@ -1,11 +1,10 @@
-import { browser } from '$app/environment';
-import { env } from '$env/dynamic/public';
+import { resolveApiUrl } from '$lib/utils/api';
 import type { PageLoad } from './$types';
 import type { SalaryRecord } from '$lib/types/salaries';
 
 export const load: PageLoad = async ({ fetch }) => {
 	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+		const apiUrl = resolveApiUrl();
 		if (!apiUrl) return { latestSalaries: [] };
 
 		const res = await fetch(`${apiUrl}/api/salaries`);

--- a/src/routes/simulations/mortgage/+page.svelte
+++ b/src/routes/simulations/mortgage/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { onMount, tick } from 'svelte';
 	import { browser } from '$app/environment';
-	import { env } from '$env/dynamic/public';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
+	import { getApiUrlOrThrow } from '$lib/utils/api';
 
 	interface MortgageVsInvestYearlyRow {
 		year: number;
@@ -74,8 +74,7 @@
 		results = null;
 
 		try {
-			const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-			if (!apiUrl) throw new Error('API URL not configured');
+			const apiUrl = getApiUrlOrThrow();
 
 			const response = await fetch(`${apiUrl}/api/simulations/mortgage-vs-invest`, {
 				method: 'POST',

--- a/src/routes/simulations/zus/+page.svelte
+++ b/src/routes/simulations/zus/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { onMount, tick, untrack } from 'svelte';
 	import { browser } from '$app/environment';
-	import { env } from '$env/dynamic/public';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
+	import { getApiUrlOrThrow } from '$lib/utils/api';
 
 	interface Props {
 		data: {
@@ -93,8 +93,7 @@
 		results = null;
 
 		try {
-			const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-			if (!apiUrl) throw new Error('API URL not configured');
+			const apiUrl = getApiUrlOrThrow();
 
 			const response = await fetch(`${apiUrl}/api/zus/calculate`, {
 				method: 'POST',

--- a/src/routes/simulations/zus/+page.ts
+++ b/src/routes/simulations/zus/+page.ts
@@ -1,13 +1,12 @@
 import { error } from '@sveltejs/kit';
-import { browser } from '$app/environment';
-import { env } from '$env/dynamic/public';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ fetch }) => {
-	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) throw error(500, 'API URL not configured');
+	const apiUrl = resolveApiUrl();
+	if (!apiUrl) throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
 
+	try {
 		const [prefillRes, personasRes] = await Promise.all([
 			fetch(`${apiUrl}/api/zus/prefill`),
 			fetch(`${apiUrl}/api/personas`)
@@ -18,7 +17,7 @@ export const load: PageLoad = async ({ fetch }) => {
 		const personas = personasRes.ok ? await personasRes.json() : [];
 		return { prefill, personas };
 	} catch (err) {
-		if (err instanceof Error && 'status' in err) throw err;
+		if (err && typeof err === 'object' && 'status' in err) throw err;
 		throw error(500, 'Failed to load ZUS calculator data');
 	}
 };

--- a/src/routes/snapshots/+page.ts
+++ b/src/routes/snapshots/+page.ts
@@ -1,6 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 import type { PageLoad } from './$types';
 
 export interface SnapshotListItem {
@@ -11,9 +10,9 @@ export interface SnapshotListItem {
 }
 
 export const load: PageLoad = async ({ fetch }) => {
-	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+	const apiUrl = resolveApiUrl();
 	if (!apiUrl) {
-		throw error(500, 'API URL is not configured');
+		throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
 	}
 
 	const snapshots = (async () => {
@@ -23,6 +22,7 @@ export const load: PageLoad = async ({ fetch }) => {
 		}
 		return (await response.json()) as SnapshotListItem[];
 	})();
+	snapshots.catch(() => {});
 
 	return {
 		snapshots

--- a/src/routes/snapshots/[id]/edit/+page.ts
+++ b/src/routes/snapshots/[id]/edit/+page.ts
@@ -1,15 +1,18 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 import type { SnapshotResponse } from '$lib/types';
 
 export async function load({ params, fetch }) {
-	const API_URL = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = resolveApiUrl();
+	if (!apiUrl) {
+		throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
+	}
 
 	const [snapshotRes, accountsRes, assetsRes, personasRes] = await Promise.all([
-		fetch(`${API_URL}/api/snapshots/${params.id}`),
-		fetch(`${API_URL}/api/accounts`),
-		fetch(`${API_URL}/api/assets`),
-		fetch(`${API_URL}/api/personas`)
+		fetch(`${apiUrl}/api/snapshots/${params.id}`),
+		fetch(`${apiUrl}/api/accounts`),
+		fetch(`${apiUrl}/api/assets`),
+		fetch(`${apiUrl}/api/personas`)
 	]);
 
 	if (!snapshotRes.ok) {

--- a/src/routes/snapshots/new/+page.ts
+++ b/src/routes/snapshots/new/+page.ts
@@ -1,14 +1,13 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 
 export async function load({ fetch }) {
-	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API base URL is not configured');
-		}
+	const apiUrl = resolveApiUrl();
+	if (!apiUrl) {
+		throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
+	}
 
+	try {
 		// Fetch accounts, assets, and personas in parallel
 		const [accountsResponse, assetsResponse, personasResponse] = await Promise.all([
 			fetch(`${apiUrl}/api/accounts`),
@@ -36,7 +35,7 @@ export async function load({ fetch }) {
 			personas
 		};
 	} catch (err) {
-		if (err instanceof Error && 'status' in err) {
+		if (err && typeof err === 'object' && 'status' in err) {
 			throw err;
 		}
 		throw error(500, 'Failed to load data');

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -2,9 +2,9 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import { formatPLN } from '$lib/utils/format';
 	import { Plus, Landmark, Search, BarChart3, Trash2 } from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
+	import { getApiUrlOrThrow } from '$lib/utils/api';
 	import type { Persona } from '$lib/types/personas';
 	import { untrack } from 'svelte';
 	import type { PageData } from './$types';
@@ -15,7 +15,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = () => getApiUrlOrThrow();
 	const personas = $derived(data.personas as Persona[]);
 	const defaultOwner = $derived(personas.length > 0 ? personas[0].name : 'Marcin');
 
@@ -66,7 +66,7 @@
 
 		try {
 			const response = await fetch(
-				`${apiUrl}/api/accounts/${accountId}/transactions/${transactionId}`,
+				`${apiUrl()}/api/accounts/${accountId}/transactions/${transactionId}`,
 				{ method: 'DELETE' }
 			);
 
@@ -117,7 +117,7 @@
 		ppkGenerating = true;
 
 		try {
-			const response = await fetch(`${apiUrl}/api/retirement/ppk-contributions/generate`, {
+			const response = await fetch(`${apiUrl()}/api/retirement/ppk-contributions/generate`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify(ppkGenerateData)
@@ -150,7 +150,7 @@
 
 		try {
 			const response = await fetch(
-				`${apiUrl}/api/accounts/${newTransactionData.account_id}/transactions`,
+				`${apiUrl()}/api/accounts/${newTransactionData.account_id}/transactions`,
 				{
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },

--- a/src/routes/transactions/+page.ts
+++ b/src/routes/transactions/+page.ts
@@ -1,6 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { API_URL_NOT_CONFIGURED_MESSAGE, resolveApiUrl } from '$lib/utils/api';
 import type { PageLoad } from './$types';
 import type { Transaction, TransactionsData } from '$lib/types/transactions';
 import { INVESTMENT_CATEGORIES } from '$lib/constants';
@@ -14,12 +13,12 @@ export interface Account {
 }
 
 export const load: PageLoad = async ({ fetch, url }) => {
-	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API URL is not configured');
-		}
+	const apiUrl = resolveApiUrl();
+	if (!apiUrl) {
+		throw error(500, API_URL_NOT_CONFIGURED_MESSAGE);
+	}
 
+	try {
 		// Build query params from URL
 		const accountId = url.searchParams.get('account_id');
 		const owner = url.searchParams.get('owner');
@@ -68,7 +67,7 @@ export const load: PageLoad = async ({ fetch, url }) => {
 			}
 		};
 	} catch (err) {
-		if (err instanceof Error && 'status' in err) {
+		if (err && typeof err === 'object' && 'status' in err) {
 			throw err;
 		}
 		throw error(500, 'Failed to load transactions');


### PR DESCRIPTION
## Summary
- centralize frontend API URL resolution so local dev falls back cleanly without masking production config issues
- stop streamed route-load promise rejections from crashing the Vite dev server when the backend is unavailable
- make mise run dev work again by removing the unnecessary global Python pin and updating the Postgres 18 dev volume layout
- ignore generated Python cache artifacts
