### PR TITLE
docs(migration): phase 0 backend audit

### DIFF
--- a/migration/coupling.md
+++ b/migration/coupling.md
@@ -7,19 +7,19 @@ Goal: identify endpoints whose DB writes/reads cross domain boundaries, so we kn
 
 Service modules imported by more than one router. Anything in this table is a shared dependency that must be available (in Python or Go) to every router that uses it.
 
-| Service module | Used by routers | Why it matters |
-|---|---|---|
-| `services/snapshot_aggregates` | snapshots (writes), accounts (writes), assets (writes) | Account/Asset mutations recompute `snapshot_aggregates` rows owned by the snapshot domain. Splitting writer without splitting recomputer breaks dashboard. |
-| `services/fx` (`get_fx_rate_to_pln`, `to_pln`) | bonus_events, equity_grants | Read-through cache that writes to `fx_rates` on cache miss. Any handler calling these is a stealth writer to a shared table. |
-| `services/company_valuations` (`get_latest_valuation`) | company_valuations, equity_grants (via service import) | equity_grants serialization depends on company_valuations rows. |
-| `services/vesting` | equity_grants only (currently) | Pure functions, no DB. Safe shared lib. |
-| `services/pl_tax` | none (no router) | Pure functions; only used by tests. Safe shared lib. |
-| `services/inflation` | cpi, salary_records (via `_build_inflation_context`) | salary_records GET reads cpi_index. cpi POST `/refresh` writes cpi_index. Reader/writer split across routers. |
-| `services/salary_records` (`_get_current_salary`) | salary_records, retirement (via service import) | retirement.generate_ppk_contributions depends on salary lookup. |
-| `services/dashboard` | dashboard only | Self-contained read service, but pulls from ~7 tables. |
-| `services/simulations` (sub-package) | simulations only | Internal read-only DB use (Snapshot, SnapshotValue, Account, AppConfig, Persona, RetirementLimit). |
-| `services/zus_calculator` | zus only | Reads Persona, SalaryRecord, AppConfig. |
-| `services/scheduler` | none (in-process job) | Writes `cpi_index` independently of any router. Cutover plan must account for the cron writer. |
+| Service module                                         | Used by routers                                        | Why it matters                                                                                                                                             |
+| ------------------------------------------------------ | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `services/snapshot_aggregates`                         | snapshots (writes), accounts (writes), assets (writes) | Account/Asset mutations recompute `snapshot_aggregates` rows owned by the snapshot domain. Splitting writer without splitting recomputer breaks dashboard. |
+| `services/fx` (`get_fx_rate_to_pln`, `to_pln`)         | bonus_events, equity_grants                            | Read-through cache that writes to `fx_rates` on cache miss. Any handler calling these is a stealth writer to a shared table.                               |
+| `services/company_valuations` (`get_latest_valuation`) | company_valuations, equity_grants (via service import) | equity_grants serialization depends on company_valuations rows.                                                                                            |
+| `services/vesting`                                     | equity_grants only (currently)                         | Pure functions, no DB. Safe shared lib.                                                                                                                    |
+| `services/pl_tax`                                      | none (no router)                                       | Pure functions; only used by tests. Safe shared lib.                                                                                                       |
+| `services/inflation`                                   | cpi, salary_records (via `_build_inflation_context`)   | salary_records GET reads cpi_index. cpi POST `/refresh` writes cpi_index. Reader/writer split across routers.                                              |
+| `services/salary_records` (`_get_current_salary`)      | salary_records, retirement (via service import)        | retirement.generate_ppk_contributions depends on salary lookup.                                                                                            |
+| `services/dashboard`                                   | dashboard only                                         | Self-contained read service, but pulls from ~7 tables.                                                                                                     |
+| `services/simulations` (sub-package)                   | simulations only                                       | Internal read-only DB use (Snapshot, SnapshotValue, Account, AppConfig, Persona, RetirementLimit).                                                         |
+| `services/zus_calculator`                              | zus only                                               | Reads Persona, SalaryRecord, AppConfig.                                                                                                                    |
+| `services/scheduler`                                   | none (in-process job)                                  | Writes `cpi_index` independently of any router. Cutover plan must account for the cron writer.                                                             |
 
 Non-shared services (1:1 with a router and isolated): `accounts`, `assets`, `bonus_events`, `company_valuations`, `config`, `debt_payments`, `debts`, `equity_grants`, `goals`, `investment`, `retirement`, `salary_records`, `snapshots`, `transactions`.
 
@@ -27,124 +27,137 @@ Non-shared services (1:1 with a router and isolated): `accounts`, `assets`, `bon
 
 Handlers that write tables owned by other domains, or read+write multiple domains in one transaction. "Domain" = the natural table family a router primarily owns.
 
-| Handler | Tables written | Tables read | Notes |
-|---|---|---|---|
-| `POST /api/snapshots` (snapshots.create_snapshot) | snapshots, snapshot_values, snapshot_aggregates | accounts (active), assets (active) | Single tx writes 3 tables. snapshot_aggregates is the cross-domain coupling — owned by dashboard reads. |
-| `PUT /api/snapshots/{id}` (snapshots.update_snapshot) | snapshots, snapshot_values (delete+insert), snapshot_aggregates | accounts, assets | Same as above; replaces values atomically and recomputes aggregates. |
-| `PUT /api/accounts/{id}` (accounts.update_account) | accounts, snapshot_aggregates (on owner/category change) | snapshot_values, snapshots, accounts | Recomputes aggregates for every snapshot containing the account. Writer to snapshots' aggregate table. |
-| `DELETE /api/accounts/{id}` (accounts.delete_account) | accounts (soft), snapshot_aggregates | snapshot_values, snapshots, accounts, assets | Soft-delete cascades into aggregate recompute. |
-| `DELETE /api/assets/{id}` (assets.delete_asset) | assets (soft), snapshot_aggregates | snapshot_values, snapshots, accounts | Same coupling as account delete. |
-| `PUT /api/personas/{id}` (personas.update_persona) | personas, accounts, transactions, salary_records, debt_payments, retirement_limits | personas | Renaming a persona cascades `owner` string updates across 5 tables in one tx. Highest fan-out write in the codebase. |
-| `POST /api/retirement/ppk-contributions/generate` (retirement.generate_ppk_contributions) | transactions (2 rows) | personas, salary_records, accounts, transactions | Writes to transactions table owned by a different router (transactions). Reads salary + persona + account. |
-| `POST /api/cpi/refresh` (cpi.refresh_cpi) | cpi_index | cpi_index | Single-domain, but same table is also written by the in-process scheduler — concurrency contract must hold across cutover. |
-| `POST /api/cpi/adjust` (cpi.adjust_amount) | none | cpi_index | Read-only but consumes data the `/refresh` endpoint produces. |
-| `POST /api/bonuses`, `PATCH /api/bonuses/{id}` (bonus_events.*) | bonus_events, fx_rates (cache-miss side effect) | bonus_events, fx_rates | Every write call goes through `_to_response` → `get_fx_rate_to_pln` which can INSERT into fx_rates. Same for GET handlers. |
-| `GET /api/equity-grants`, `POST`, `PATCH /equity-grants/{id}` | equity_grants, fx_rates (cache-miss side effect) | equity_grants, company_valuations, fx_rates | Same fx_rates side-effect plus reads from company_valuations on every response build. |
-| `POST /api/accounts/{id}/debts` (debts.create_debt) | debts | accounts | Validates account is liability before inserting debt. Single-tx, but writes to debts only — cross-domain read of accounts. |
-| `POST /api/accounts/{id}/payments` (debt_payments.create_payment) | debt_payments | accounts, debt_payments | Validates account is liability before insert. |
-| `POST /api/accounts/{id}/transactions` (transactions.create_transaction) | transactions | accounts, transactions | Validates account is investment-capable. |
-| `PUT /api/retirement/limits/...` (retirement.upsert_limit) | retirement_limits | retirement_limits | Single-table write. |
+| Handler                                                                                   | Tables written                                                                     | Tables read                                      | Notes                                                                                                                      |
+| ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `POST /api/snapshots` (snapshots.create_snapshot)                                         | snapshots, snapshot_values, snapshot_aggregates                                    | accounts (active), assets (active)               | Single tx writes 3 tables. snapshot_aggregates is the cross-domain coupling — owned by dashboard reads.                    |
+| `PUT /api/snapshots/{id}` (snapshots.update_snapshot)                                     | snapshots, snapshot_values (delete+insert), snapshot_aggregates                    | accounts, assets                                 | Same as above; replaces values atomically and recomputes aggregates.                                                       |
+| `PUT /api/accounts/{id}` (accounts.update_account)                                        | accounts, snapshot_aggregates (on owner/category change)                           | snapshot_values, snapshots, accounts             | Recomputes aggregates for every snapshot containing the account. Writer to snapshots' aggregate table.                     |
+| `DELETE /api/accounts/{id}` (accounts.delete_account)                                     | accounts (soft), snapshot_aggregates                                               | snapshot_values, snapshots, accounts, assets     | Soft-delete cascades into aggregate recompute.                                                                             |
+| `DELETE /api/assets/{id}` (assets.delete_asset)                                           | assets (soft), snapshot_aggregates                                                 | snapshot_values, snapshots, accounts             | Same coupling as account delete.                                                                                           |
+| `PUT /api/personas/{id}` (personas.update_persona)                                        | personas, accounts, transactions, salary_records, debt_payments, retirement_limits | personas                                         | Renaming a persona cascades `owner` string updates across 5 tables in one tx. Highest fan-out write in the codebase.       |
+| `POST /api/retirement/ppk-contributions/generate` (retirement.generate_ppk_contributions) | transactions (2 rows)                                                              | personas, salary_records, accounts, transactions | Writes to transactions table owned by a different router (transactions). Reads salary + persona + account.                 |
+| `POST /api/cpi/refresh` (cpi.refresh_cpi)                                                 | cpi_index                                                                          | cpi_index                                        | Single-domain, but same table is also written by the in-process scheduler — concurrency contract must hold across cutover. |
+| `POST /api/cpi/adjust` (cpi.adjust_amount)                                                | none                                                                               | cpi_index                                        | Read-only but consumes data the `/refresh` endpoint produces.                                                              |
+| `POST /api/bonuses`, `PATCH /api/bonuses/{id}` (bonus_events.\*)                          | bonus_events, fx_rates (cache-miss side effect)                                    | bonus_events, fx_rates                           | Every write call goes through `_to_response` → `get_fx_rate_to_pln` which can INSERT into fx_rates. Same for GET handlers. |
+| `GET /api/equity-grants`, `POST`, `PATCH /equity-grants/{id}`                             | equity_grants, fx_rates (cache-miss side effect)                                   | equity_grants, company_valuations, fx_rates      | Same fx_rates side-effect plus reads from company_valuations on every response build.                                      |
+| `POST /api/accounts/{id}/debts` (debts.create_debt)                                       | debts                                                                              | accounts                                         | Validates account is liability before inserting debt. Single-tx, but writes to debts only — cross-domain read of accounts. |
+| `POST /api/accounts/{id}/payments` (debt_payments.create_payment)                         | debt_payments                                                                      | accounts, debt_payments                          | Validates account is liability before insert.                                                                              |
+| `POST /api/accounts/{id}/transactions` (transactions.create_transaction)                  | transactions                                                                       | accounts, transactions                           | Validates account is investment-capable.                                                                                   |
+| `PUT /api/retirement/limits/...` (retirement.upsert_limit)                                | retirement_limits                                                                  | retirement_limits                                | Single-table write.                                                                                                        |
 
 ## Read endpoints that depend on writes from another endpoint
 
-| Read endpoint | Depends on (writer endpoint or job) | Coupling severity |
-|---|---|---|
-| `GET /api/dashboard` | snapshots.create_snapshot, snapshots.update_snapshot, accounts.update/delete, assets.delete (all populate `snapshot_aggregates`); also AppConfig PUT, transactions POST, salary POST | Critical. Reads ~7 tables and falls back to raw SnapshotValue scan if `snapshot_aggregates` empty. Both the aggregate writer and raw-fallback must agree byte-for-byte across cutover. |
-| `GET /api/dashboard` (savings_rate, hour_of_work, debt_to_income, hour_of_life) | salary_records POST, config PUT | Medium. Returns null if salaries/config missing — graceful but UX-breaking. |
-| `GET /api/accounts` | snapshots POST | High. Each account's `current_value` is the latest SnapshotValue. Cutover writer without reader leaves stale values. |
-| `GET /api/assets` | snapshots POST | High. Same as accounts. |
-| `GET /api/debts` | snapshots POST, debt_payments POST | High. `latest_balance` and `interest_paid` read from SnapshotValue + DebtPayment. |
-| `GET /api/accounts/{id}/payments`, `GET /api/payments` | debt_payments POST, accounts (active flag) | Medium. Returns 404 if account is inactive. |
-| `GET /api/accounts/{id}/transactions`, `GET /api/transactions` | transactions POST, accounts | Medium. Same as payments. |
-| `GET /api/investment/stock-stats`, `/bond-stats` | snapshots POST, transactions POST, accounts | High. Joins Snapshot + SnapshotValue + Transaction + Account. ROI silently wrong if any writer lags. |
-| `GET /api/retirement/stats` | snapshots POST, transactions POST, accounts, retirement.upsert_limit | High. IKE/IKZE % used derived from Transaction × RetirementLimit. |
-| `GET /api/retirement/ppk-stats` | snapshots POST, transactions POST, accounts (PPK), retirement.generate_ppk_contributions | High. PPK ROI depends on snapshot value AND PPK-generated transactions. |
-| `GET /api/salaries` | salary_records POST, cpi `/refresh` (or scheduler) | Medium. `inflation_context` returns empty if cpi_index empty — degrades gracefully. |
-| `GET /api/cpi/series`, `POST /api/cpi/adjust` | cpi `/refresh`, scheduler `_refresh_job` | Medium. Returns 503 if cpi_index empty. |
-| `GET /api/bonuses` | bonus_events POST, NBP via fx (side effect on fx_rates) | Low. fx fallback returns null PLN values gracefully. |
-| `GET /api/equity-grants` | equity_grants POST, company_valuations POST, NBP via fx | Medium. Paper-value PLN drops to null without valuation + fx rate. |
-| `GET /api/goals` | goals POST, accounts (for account_name) | Low. Account FK is nullable; name resolves separately. |
-| `GET /api/simulations/prefill` | snapshots POST, accounts, personas, salary_records POST, config PUT | High. Aggregates from 5 tables; missing any one degrades the simulation. |
-| `GET /api/zus/prefill` | salary_records POST, personas, config PUT | Medium. Returns mostly-empty response if data missing. |
-| `POST /api/simulations/retirement` | retirement.upsert_limit, config PUT | High. Limit lookup falls back to hardcoded 2026 defaults if RetirementLimit empty. |
+| Read endpoint                                                                   | Depends on (writer endpoint or job)                                                                                                                                                  | Coupling severity                                                                                                                                                                      |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/dashboard`                                                            | snapshots.create_snapshot, snapshots.update_snapshot, accounts.update/delete, assets.delete (all populate `snapshot_aggregates`); also AppConfig PUT, transactions POST, salary POST | Critical. Reads ~7 tables and falls back to raw SnapshotValue scan if `snapshot_aggregates` empty. Both the aggregate writer and raw-fallback must agree byte-for-byte across cutover. |
+| `GET /api/dashboard` (savings_rate, hour_of_work, debt_to_income, hour_of_life) | salary_records POST, config PUT                                                                                                                                                      | Medium. Returns null if salaries/config missing — graceful but UX-breaking.                                                                                                            |
+| `GET /api/accounts`                                                             | snapshots POST                                                                                                                                                                       | High. Each account's `current_value` is the latest SnapshotValue. Cutover writer without reader leaves stale values.                                                                   |
+| `GET /api/assets`                                                               | snapshots POST                                                                                                                                                                       | High. Same as accounts.                                                                                                                                                                |
+| `GET /api/debts`                                                                | snapshots POST, debt_payments POST                                                                                                                                                   | High. `latest_balance` and `interest_paid` read from SnapshotValue + DebtPayment.                                                                                                      |
+| `GET /api/accounts/{id}/payments`, `GET /api/payments`                          | debt_payments POST, accounts (active flag)                                                                                                                                           | Medium. Returns 404 if account is inactive.                                                                                                                                            |
+| `GET /api/accounts/{id}/transactions`, `GET /api/transactions`                  | transactions POST, accounts                                                                                                                                                          | Medium. Same as payments.                                                                                                                                                              |
+| `GET /api/investment/stock-stats`, `/bond-stats`                                | snapshots POST, transactions POST, accounts                                                                                                                                          | High. Joins Snapshot + SnapshotValue + Transaction + Account. ROI silently wrong if any writer lags.                                                                                   |
+| `GET /api/retirement/stats`                                                     | snapshots POST, transactions POST, accounts, retirement.upsert_limit                                                                                                                 | High. IKE/IKZE % used derived from Transaction × RetirementLimit.                                                                                                                      |
+| `GET /api/retirement/ppk-stats`                                                 | snapshots POST, transactions POST, accounts (PPK), retirement.generate_ppk_contributions                                                                                             | High. PPK ROI depends on snapshot value AND PPK-generated transactions.                                                                                                                |
+| `GET /api/salaries`                                                             | salary_records POST, cpi `/refresh` (or scheduler)                                                                                                                                   | Medium. `inflation_context` returns empty if cpi_index empty — degrades gracefully.                                                                                                    |
+| `GET /api/cpi/series`, `POST /api/cpi/adjust`                                   | cpi `/refresh`, scheduler `_refresh_job`                                                                                                                                             | Medium. Returns 503 if cpi_index empty.                                                                                                                                                |
+| `GET /api/bonuses`                                                              | bonus_events POST, NBP via fx (side effect on fx_rates)                                                                                                                              | Low. fx fallback returns null PLN values gracefully.                                                                                                                                   |
+| `GET /api/equity-grants`                                                        | equity_grants POST, company_valuations POST, NBP via fx                                                                                                                              | Medium. Paper-value PLN drops to null without valuation + fx rate.                                                                                                                     |
+| `GET /api/goals`                                                                | goals POST, accounts (for account_name)                                                                                                                                              | Low. Account FK is nullable; name resolves separately.                                                                                                                                 |
+| `GET /api/simulations/prefill`                                                  | snapshots POST, accounts, personas, salary_records POST, config PUT                                                                                                                  | High. Aggregates from 5 tables; missing any one degrades the simulation.                                                                                                               |
+| `GET /api/zus/prefill`                                                          | salary_records POST, personas, config PUT                                                                                                                                            | Medium. Returns mostly-empty response if data missing.                                                                                                                                 |
+| `POST /api/simulations/retirement`                                              | retirement.upsert_limit, config PUT                                                                                                                                                  | High. Limit lookup falls back to hardcoded 2026 defaults if RetirementLimit empty.                                                                                                     |
 
 ## Cutover groups
 
 Ranked lowest-risk first. "Risk" reflects join fan-out, write side-effects, pandas usage, and number of dependent readers.
 
 ### Group 1: Config singleton
+
 - **Endpoints:** `GET /api/config`, `PUT /api/config`
 - **Why grouped:** Single-row singleton table; no FKs out, no shared service.
 - **Risk:** S
 - **Suggested order in migration:** 1
 
 ### Group 2: Personas CRUD + cascade
+
 - **Endpoints:** `GET/POST/PUT/DELETE /api/personas`
 - **Why grouped:** PUT cascades `owner` rename to 5 other tables in one tx — must move atomically with all five. If group 7/8/9/10 ship before this, persona rename risks partial updates across language boundaries.
 - **Risk:** L
 - **Suggested order in migration:** 8 (after all owner-referencing tables — bumped from earlier slot because of the 5-table cascade)
 
 ### Group 3: Goals CRUD
+
 - **Endpoints:** `GET/POST/PUT/DELETE /api/goals`, `GET /api/goals/{id}`
 - **Why grouped:** Single table; only soft FK to accounts (read-only lookup for `account_name`). No aggregate recompute, no shared writes.
 - **Risk:** S
 - **Suggested order in migration:** 2
 
 ### Group 4: Equity domain (bonuses + valuations + grants + fx)
+
 - **Endpoints:** all `/api/bonuses/*`, `/api/company-valuations/*`, `/api/equity-grants/*`
 - **Why grouped:** equity_grants service imports company_valuations and fx. All three write to fx_rates as a side effect of read/write through `get_fx_rate_to_pln`. Splitting any one strands the others or duplicates the NBP fetcher in two languages.
 - **Risk:** M
 - **Suggested order in migration:** 5
 
 ### Group 5: CPI + inflation scheduler
+
 - **Endpoints:** `GET /api/cpi/series`, `POST /api/cpi/adjust`, `POST /api/cpi/refresh`
 - **Why grouped:** All three operate on `cpi_index`. The in-process APScheduler also writes to the same table — the cron job must move with the endpoints or be relocated to an external scheduler.
 - **Risk:** M
 - **Suggested order in migration:** 4
 
 ### Group 6: Salaries + inflation context
+
 - **Endpoints:** all `/api/salaries/*`
 - **Why grouped:** GET handler reads cpi_index via `inflation.load_index`. Can ship after group 5 since contract is just "if cpi_index has rows, decorate response".
 - **Risk:** M
 - **Suggested order in migration:** 6
 
 ### Group 7: ZUS calculator + prefill
+
 - **Endpoints:** `POST /api/zus/calculate`, `GET /api/zus/prefill`
 - **Why grouped:** Pure calculator + read-only prefill from Persona/SalaryRecord/AppConfig. No writes, no shared services except read access to salary table.
 - **Risk:** S
 - **Suggested order in migration:** 3
 
 ### Group 8: Transactions + DebtPayments + Debts (account-scoped writes)
+
 - **Endpoints:** all `/api/transactions/*`, `/api/payments/*`, `/api/debts/*`, `/api/accounts/{id}/debts`, `/api/accounts/{id}/payments`, `/api/accounts/{id}/transactions`
 - **Why grouped:** All validate `accounts.type` (liability vs investment) before insert. debts.get_all_debts reads SnapshotValue + DebtPayment for derived balances. Splitting transactions from debt_payments leaves accounts.update reachable from both languages.
 - **Risk:** M
 - **Suggested order in migration:** 7
 
 ### Group 9: Accounts + Assets + Snapshots + snapshot_aggregates
+
 - **Endpoints:** all `/api/accounts/*`, `/api/assets/*`, `/api/snapshots/*`
 - **Why grouped:** Tightest coupling in the codebase. Snapshot create/update writes snapshot + snapshot_values + snapshot_aggregates. Account update/delete and Asset delete trigger `recompute_for_snapshots`. Three routers, three services, one shared aggregate table. Cannot split any one without dual-writing the aggregate maintenance code.
 - **Risk:** L
 - **Suggested order in migration:** 9
 
 ### Group 10: Retirement (limits + stats + PPK generation)
+
 - **Endpoints:** all `/api/retirement/*`
 - **Why grouped:** Reads from Account, Transaction, RetirementLimit, Persona, SalaryRecord. `generate_ppk_contributions` writes to transactions (owned by group 8). Depends on group 8 already moved or remaining stable.
 - **Risk:** L
 - **Suggested order in migration:** 10
 
 ### Group 11: Investment stats (ROI)
+
 - **Endpoints:** `GET /api/investment/stock-stats`, `/bond-stats`
 - **Why grouped:** Read-only aggregation across Account + Snapshot + SnapshotValue + Transaction. Must follow whatever language owns those writers (group 8 + group 9).
 - **Risk:** M
 - **Suggested order in migration:** 11
 
 ### Group 12: Simulations (mortgage + retirement + prefill)
+
 - **Endpoints:** all `/api/simulations/*`
 - **Why grouped:** Mortgage simulator is pure (no DB). Retirement simulator reads RetirementLimit. Prefill reads AppConfig + Persona + SalaryRecord + Snapshot/SnapshotValue/Account. Mostly read-only but spans everything.
 - **Risk:** M
 - **Suggested order in migration:** 12
 
 ### Group 13: Dashboard
+
 - **Endpoints:** `GET /api/dashboard`
 - **Why grouped:** Reads 7 tables; uses pandas + numpy for time series, allocation analysis, tile deltas, savings-rate, hour-of-work/life costs; falls back to a raw path when `snapshot_aggregates` is empty. Highest blast radius. Cut over last when everything it consumes is stable in either language.
 - **Risk:** L

--- a/migration/coupling.md
+++ b/migration/coupling.md
@@ -1,0 +1,155 @@
+# Backend coupling audit (per-endpoint Go cutover)
+
+Scope: every router in `backend/app/api/` and every service in `backend/app/services/`.
+Goal: identify endpoints whose DB writes/reads cross domain boundaries, so we know what must cut over together.
+
+## Shared service modules
+
+Service modules imported by more than one router. Anything in this table is a shared dependency that must be available (in Python or Go) to every router that uses it.
+
+| Service module | Used by routers | Why it matters |
+|---|---|---|
+| `services/snapshot_aggregates` | snapshots (writes), accounts (writes), assets (writes) | Account/Asset mutations recompute `snapshot_aggregates` rows owned by the snapshot domain. Splitting writer without splitting recomputer breaks dashboard. |
+| `services/fx` (`get_fx_rate_to_pln`, `to_pln`) | bonus_events, equity_grants | Read-through cache that writes to `fx_rates` on cache miss. Any handler calling these is a stealth writer to a shared table. |
+| `services/company_valuations` (`get_latest_valuation`) | company_valuations, equity_grants (via service import) | equity_grants serialization depends on company_valuations rows. |
+| `services/vesting` | equity_grants only (currently) | Pure functions, no DB. Safe shared lib. |
+| `services/pl_tax` | none (no router) | Pure functions; only used by tests. Safe shared lib. |
+| `services/inflation` | cpi, salary_records (via `_build_inflation_context`) | salary_records GET reads cpi_index. cpi POST `/refresh` writes cpi_index. Reader/writer split across routers. |
+| `services/salary_records` (`_get_current_salary`) | salary_records, retirement (via service import) | retirement.generate_ppk_contributions depends on salary lookup. |
+| `services/dashboard` | dashboard only | Self-contained read service, but pulls from ~7 tables. |
+| `services/simulations` (sub-package) | simulations only | Internal read-only DB use (Snapshot, SnapshotValue, Account, AppConfig, Persona, RetirementLimit). |
+| `services/zus_calculator` | zus only | Reads Persona, SalaryRecord, AppConfig. |
+| `services/scheduler` | none (in-process job) | Writes `cpi_index` independently of any router. Cutover plan must account for the cron writer. |
+
+Non-shared services (1:1 with a router and isolated): `accounts`, `assets`, `bonus_events`, `company_valuations`, `config`, `debt_payments`, `debts`, `equity_grants`, `goals`, `investment`, `retirement`, `salary_records`, `snapshots`, `transactions`.
+
+## Cross-router DB transactions
+
+Handlers that write tables owned by other domains, or read+write multiple domains in one transaction. "Domain" = the natural table family a router primarily owns.
+
+| Handler | Tables written | Tables read | Notes |
+|---|---|---|---|
+| `POST /api/snapshots` (snapshots.create_snapshot) | snapshots, snapshot_values, snapshot_aggregates | accounts (active), assets (active) | Single tx writes 3 tables. snapshot_aggregates is the cross-domain coupling — owned by dashboard reads. |
+| `PUT /api/snapshots/{id}` (snapshots.update_snapshot) | snapshots, snapshot_values (delete+insert), snapshot_aggregates | accounts, assets | Same as above; replaces values atomically and recomputes aggregates. |
+| `PUT /api/accounts/{id}` (accounts.update_account) | accounts, snapshot_aggregates (on owner/category change) | snapshot_values, snapshots, accounts | Recomputes aggregates for every snapshot containing the account. Writer to snapshots' aggregate table. |
+| `DELETE /api/accounts/{id}` (accounts.delete_account) | accounts (soft), snapshot_aggregates | snapshot_values, snapshots, accounts, assets | Soft-delete cascades into aggregate recompute. |
+| `DELETE /api/assets/{id}` (assets.delete_asset) | assets (soft), snapshot_aggregates | snapshot_values, snapshots, accounts | Same coupling as account delete. |
+| `PUT /api/personas/{id}` (personas.update_persona) | personas, accounts, transactions, salary_records, debt_payments, retirement_limits | personas | Renaming a persona cascades `owner` string updates across 5 tables in one tx. Highest fan-out write in the codebase. |
+| `POST /api/retirement/ppk-contributions/generate` (retirement.generate_ppk_contributions) | transactions (2 rows) | personas, salary_records, accounts, transactions | Writes to transactions table owned by a different router (transactions). Reads salary + persona + account. |
+| `POST /api/cpi/refresh` (cpi.refresh_cpi) | cpi_index | cpi_index | Single-domain, but same table is also written by the in-process scheduler — concurrency contract must hold across cutover. |
+| `POST /api/cpi/adjust` (cpi.adjust_amount) | none | cpi_index | Read-only but consumes data the `/refresh` endpoint produces. |
+| `POST /api/bonuses`, `PATCH /api/bonuses/{id}` (bonus_events.*) | bonus_events, fx_rates (cache-miss side effect) | bonus_events, fx_rates | Every write call goes through `_to_response` → `get_fx_rate_to_pln` which can INSERT into fx_rates. Same for GET handlers. |
+| `GET /api/equity-grants`, `POST`, `PATCH /equity-grants/{id}` | equity_grants, fx_rates (cache-miss side effect) | equity_grants, company_valuations, fx_rates | Same fx_rates side-effect plus reads from company_valuations on every response build. |
+| `POST /api/accounts/{id}/debts` (debts.create_debt) | debts | accounts | Validates account is liability before inserting debt. Single-tx, but writes to debts only — cross-domain read of accounts. |
+| `POST /api/accounts/{id}/payments` (debt_payments.create_payment) | debt_payments | accounts, debt_payments | Validates account is liability before insert. |
+| `POST /api/accounts/{id}/transactions` (transactions.create_transaction) | transactions | accounts, transactions | Validates account is investment-capable. |
+| `PUT /api/retirement/limits/...` (retirement.upsert_limit) | retirement_limits | retirement_limits | Single-table write. |
+
+## Read endpoints that depend on writes from another endpoint
+
+| Read endpoint | Depends on (writer endpoint or job) | Coupling severity |
+|---|---|---|
+| `GET /api/dashboard` | snapshots.create_snapshot, snapshots.update_snapshot, accounts.update/delete, assets.delete (all populate `snapshot_aggregates`); also AppConfig PUT, transactions POST, salary POST | Critical. Reads ~7 tables and falls back to raw SnapshotValue scan if `snapshot_aggregates` empty. Both the aggregate writer and raw-fallback must agree byte-for-byte across cutover. |
+| `GET /api/dashboard` (savings_rate, hour_of_work, debt_to_income, hour_of_life) | salary_records POST, config PUT | Medium. Returns null if salaries/config missing — graceful but UX-breaking. |
+| `GET /api/accounts` | snapshots POST | High. Each account's `current_value` is the latest SnapshotValue. Cutover writer without reader leaves stale values. |
+| `GET /api/assets` | snapshots POST | High. Same as accounts. |
+| `GET /api/debts` | snapshots POST, debt_payments POST | High. `latest_balance` and `interest_paid` read from SnapshotValue + DebtPayment. |
+| `GET /api/accounts/{id}/payments`, `GET /api/payments` | debt_payments POST, accounts (active flag) | Medium. Returns 404 if account is inactive. |
+| `GET /api/accounts/{id}/transactions`, `GET /api/transactions` | transactions POST, accounts | Medium. Same as payments. |
+| `GET /api/investment/stock-stats`, `/bond-stats` | snapshots POST, transactions POST, accounts | High. Joins Snapshot + SnapshotValue + Transaction + Account. ROI silently wrong if any writer lags. |
+| `GET /api/retirement/stats` | snapshots POST, transactions POST, accounts, retirement.upsert_limit | High. IKE/IKZE % used derived from Transaction × RetirementLimit. |
+| `GET /api/retirement/ppk-stats` | snapshots POST, transactions POST, accounts (PPK), retirement.generate_ppk_contributions | High. PPK ROI depends on snapshot value AND PPK-generated transactions. |
+| `GET /api/salaries` | salary_records POST, cpi `/refresh` (or scheduler) | Medium. `inflation_context` returns empty if cpi_index empty — degrades gracefully. |
+| `GET /api/cpi/series`, `POST /api/cpi/adjust` | cpi `/refresh`, scheduler `_refresh_job` | Medium. Returns 503 if cpi_index empty. |
+| `GET /api/bonuses` | bonus_events POST, NBP via fx (side effect on fx_rates) | Low. fx fallback returns null PLN values gracefully. |
+| `GET /api/equity-grants` | equity_grants POST, company_valuations POST, NBP via fx | Medium. Paper-value PLN drops to null without valuation + fx rate. |
+| `GET /api/goals` | goals POST, accounts (for account_name) | Low. Account FK is nullable; name resolves separately. |
+| `GET /api/simulations/prefill` | snapshots POST, accounts, personas, salary_records POST, config PUT | High. Aggregates from 5 tables; missing any one degrades the simulation. |
+| `GET /api/zus/prefill` | salary_records POST, personas, config PUT | Medium. Returns mostly-empty response if data missing. |
+| `POST /api/simulations/retirement` | retirement.upsert_limit, config PUT | High. Limit lookup falls back to hardcoded 2026 defaults if RetirementLimit empty. |
+
+## Cutover groups
+
+Ranked lowest-risk first. "Risk" reflects join fan-out, write side-effects, pandas usage, and number of dependent readers.
+
+### Group 1: Config singleton
+- **Endpoints:** `GET /api/config`, `PUT /api/config`
+- **Why grouped:** Single-row singleton table; no FKs out, no shared service.
+- **Risk:** S
+- **Suggested order in migration:** 1
+
+### Group 2: Personas CRUD + cascade
+- **Endpoints:** `GET/POST/PUT/DELETE /api/personas`
+- **Why grouped:** PUT cascades `owner` rename to 5 other tables in one tx — must move atomically with all five. If group 7/8/9/10 ship before this, persona rename risks partial updates across language boundaries.
+- **Risk:** L
+- **Suggested order in migration:** 8 (after all owner-referencing tables — bumped from earlier slot because of the 5-table cascade)
+
+### Group 3: Goals CRUD
+- **Endpoints:** `GET/POST/PUT/DELETE /api/goals`, `GET /api/goals/{id}`
+- **Why grouped:** Single table; only soft FK to accounts (read-only lookup for `account_name`). No aggregate recompute, no shared writes.
+- **Risk:** S
+- **Suggested order in migration:** 2
+
+### Group 4: Equity domain (bonuses + valuations + grants + fx)
+- **Endpoints:** all `/api/bonuses/*`, `/api/company-valuations/*`, `/api/equity-grants/*`
+- **Why grouped:** equity_grants service imports company_valuations and fx. All three write to fx_rates as a side effect of read/write through `get_fx_rate_to_pln`. Splitting any one strands the others or duplicates the NBP fetcher in two languages.
+- **Risk:** M
+- **Suggested order in migration:** 5
+
+### Group 5: CPI + inflation scheduler
+- **Endpoints:** `GET /api/cpi/series`, `POST /api/cpi/adjust`, `POST /api/cpi/refresh`
+- **Why grouped:** All three operate on `cpi_index`. The in-process APScheduler also writes to the same table — the cron job must move with the endpoints or be relocated to an external scheduler.
+- **Risk:** M
+- **Suggested order in migration:** 4
+
+### Group 6: Salaries + inflation context
+- **Endpoints:** all `/api/salaries/*`
+- **Why grouped:** GET handler reads cpi_index via `inflation.load_index`. Can ship after group 5 since contract is just "if cpi_index has rows, decorate response".
+- **Risk:** M
+- **Suggested order in migration:** 6
+
+### Group 7: ZUS calculator + prefill
+- **Endpoints:** `POST /api/zus/calculate`, `GET /api/zus/prefill`
+- **Why grouped:** Pure calculator + read-only prefill from Persona/SalaryRecord/AppConfig. No writes, no shared services except read access to salary table.
+- **Risk:** S
+- **Suggested order in migration:** 3
+
+### Group 8: Transactions + DebtPayments + Debts (account-scoped writes)
+- **Endpoints:** all `/api/transactions/*`, `/api/payments/*`, `/api/debts/*`, `/api/accounts/{id}/debts`, `/api/accounts/{id}/payments`, `/api/accounts/{id}/transactions`
+- **Why grouped:** All validate `accounts.type` (liability vs investment) before insert. debts.get_all_debts reads SnapshotValue + DebtPayment for derived balances. Splitting transactions from debt_payments leaves accounts.update reachable from both languages.
+- **Risk:** M
+- **Suggested order in migration:** 7
+
+### Group 9: Accounts + Assets + Snapshots + snapshot_aggregates
+- **Endpoints:** all `/api/accounts/*`, `/api/assets/*`, `/api/snapshots/*`
+- **Why grouped:** Tightest coupling in the codebase. Snapshot create/update writes snapshot + snapshot_values + snapshot_aggregates. Account update/delete and Asset delete trigger `recompute_for_snapshots`. Three routers, three services, one shared aggregate table. Cannot split any one without dual-writing the aggregate maintenance code.
+- **Risk:** L
+- **Suggested order in migration:** 9
+
+### Group 10: Retirement (limits + stats + PPK generation)
+- **Endpoints:** all `/api/retirement/*`
+- **Why grouped:** Reads from Account, Transaction, RetirementLimit, Persona, SalaryRecord. `generate_ppk_contributions` writes to transactions (owned by group 8). Depends on group 8 already moved or remaining stable.
+- **Risk:** L
+- **Suggested order in migration:** 10
+
+### Group 11: Investment stats (ROI)
+- **Endpoints:** `GET /api/investment/stock-stats`, `/bond-stats`
+- **Why grouped:** Read-only aggregation across Account + Snapshot + SnapshotValue + Transaction. Must follow whatever language owns those writers (group 8 + group 9).
+- **Risk:** M
+- **Suggested order in migration:** 11
+
+### Group 12: Simulations (mortgage + retirement + prefill)
+- **Endpoints:** all `/api/simulations/*`
+- **Why grouped:** Mortgage simulator is pure (no DB). Retirement simulator reads RetirementLimit. Prefill reads AppConfig + Persona + SalaryRecord + Snapshot/SnapshotValue/Account. Mostly read-only but spans everything.
+- **Risk:** M
+- **Suggested order in migration:** 12
+
+### Group 13: Dashboard
+- **Endpoints:** `GET /api/dashboard`
+- **Why grouped:** Reads 7 tables; uses pandas + numpy for time series, allocation analysis, tile deltas, savings-rate, hour-of-work/life costs; falls back to a raw path when `snapshot_aggregates` is empty. Highest blast radius. Cut over last when everything it consumes is stable in either language.
+- **Risk:** L
+- **Suggested order in migration:** 13
+
+---
+
+**Recommendation:** Start with **Group 1 (Config)**. Single-row singleton, no FKs, no shared services, no readers outside the dashboard fallback path which gracefully tolerates a missing AppConfig. Ship it as a thin Go handler against the same Postgres instance, validate request/response parity in CI, and use the experience to harden the dual-process deployment (connection pooling, migration ownership, logging, error semantics) before touching any table with cross-domain readers. Once Config is stable, Goals (Group 3) and ZUS (Group 7) are the next safest standalones; defer Snapshots/Accounts/Assets (Group 9), Retirement (Group 10), and Dashboard (Group 13) until last because their coupling to `snapshot_aggregates` and pandas time-series math are the highest-risk surfaces.

--- a/migration/inventory.md
+++ b/migration/inventory.md
@@ -82,13 +82,13 @@
 
 ## Summary
 
-**Total endpoints:** 73
+**Total endpoints:** 75
 
 **By risk:**
 
-- S (trivial CRUD): 47
+- S (trivial CRUD): 50
 - M (multi-table/logic): 17
-- L (pandas/sim/scheduler/aggregation): 9
+- L (pandas/sim/scheduler/aggregation): 8
 
 **Endpoints touching pandas (parity hotspots):**
 

--- a/migration/inventory.md
+++ b/migration/inventory.md
@@ -1,0 +1,114 @@
+# FastAPI Backend Inventory — Pre-Go-Rewrite Audit
+
+| Method | Path | Router file | Request body schema | Response schema | DB writes? | Calls scheduler? | External calls? | Uses pandas? | Money fields? | Date/datetime fields? | Risk (S/M/L) | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| GET | /health | main.py | — | dict[str,str] | N | N | N | N | N | N | S | liveness probe |
+| GET | /api/dashboard | dashboard.py | — | DashboardResponse | N | N | N | Y | Y | Y | L | aggregates + raw fallback, many merges |
+| GET | /api/accounts | accounts.py | — | AccountsListResponse | N | N | N | N | Y | Y | S | reads latest snapshot |
+| POST | /api/accounts | accounts.py | AccountCreate | AccountResponse | Y | N | N | N | Y | Y | S | simple insert |
+| PUT | /api/accounts/{account_id} | accounts.py | AccountUpdate | AccountResponse | Y | N | N | N | Y | Y | S | simple update |
+| DELETE | /api/accounts/{account_id} | accounts.py | — | — | Y | N | N | N | N | N | S | soft-delete |
+| GET | /api/assets | assets.py | — | AssetsListResponse | N | N | N | N | Y | Y | S | reads latest snapshot |
+| POST | /api/assets | assets.py | AssetCreate | AssetResponse | Y | N | N | N | Y | Y | S | simple insert |
+| PUT | /api/assets/{asset_id} | assets.py | AssetUpdate | AssetResponse | Y | N | N | N | Y | Y | S | simple update |
+| DELETE | /api/assets/{asset_id} | assets.py | — | — | Y | N | N | N | N | N | S | soft-delete |
+| GET | /api/bonuses | bonus_events.py | — | BonusEventsListResponse | N | N | N | N | Y | Y | S | filters: owner/date/company |
+| GET | /api/bonuses/{bonus_id} | bonus_events.py | — | BonusEventResponse | N | N | N | N | Y | Y | S | single fetch |
+| POST | /api/bonuses | bonus_events.py | BonusEventCreate | BonusEventResponse | Y | N | N | N | Y | Y | S | simple insert |
+| PATCH | /api/bonuses/{bonus_id} | bonus_events.py | BonusEventUpdate | BonusEventResponse | Y | N | N | N | Y | Y | S | partial update |
+| DELETE | /api/bonuses/{bonus_id} | bonus_events.py | — | — | Y | N | N | N | N | N | S | soft-delete |
+| GET | /api/company-valuations | company_valuations.py | — | CompanyValuationsListResponse | N | N | N | N | Y | Y | S | optional company filter |
+| GET | /api/company-valuations/{valuation_id} | company_valuations.py | — | CompanyValuationResponse | N | N | N | N | Y | Y | S | single fetch |
+| POST | /api/company-valuations | company_valuations.py | CompanyValuationCreate | CompanyValuationResponse | Y | N | N | N | Y | Y | S | simple insert |
+| PATCH | /api/company-valuations/{valuation_id} | company_valuations.py | CompanyValuationUpdate | CompanyValuationResponse | Y | N | N | N | Y | Y | S | partial update |
+| DELETE | /api/company-valuations/{valuation_id} | company_valuations.py | — | — | Y | N | N | N | N | N | S | soft-delete |
+| GET | /api/config | config.py | — | ConfigResponse | N | N | N | N | Y | Y | S | 404 if missing |
+| PUT | /api/config | config.py | ConfigCreate | ConfigResponse | Y | N | N | N | Y | Y | S | upsert single row |
+| GET | /api/cpi/series | cpi.py | — | CpiSeriesResponse | N | N | N | N | N | N | M | builds cumulative index |
+| POST | /api/cpi/adjust | cpi.py | AdjustRequest | AdjustResponse | N | N | N | N | Y | Y | M | inflation factor calc |
+| POST | /api/cpi/refresh | cpi.py | — | RefreshResponse | Y | N | Y | N | N | Y | L | GUS BDL httpx + upsert |
+| GET | /api/accounts/{account_id}/payments | debt_payments.py | — | DebtPaymentsListResponse | N | N | N | N | Y | Y | S | per-account list |
+| POST | /api/accounts/{account_id}/payments | debt_payments.py | DebtPaymentCreate | DebtPaymentResponse | Y | N | N | N | Y | Y | S | simple insert |
+| DELETE | /api/accounts/{account_id}/payments/{payment_id} | debt_payments.py | — | — | Y | N | N | N | N | N | S | soft-delete |
+| GET | /api/payments | debt_payments.py | — | DebtPaymentsListResponse | N | N | N | N | Y | Y | S | filters |
+| GET | /api/payments/counts | debt_payments.py | — | dict[int,int] | N | N | N | N | N | N | S | per-account count |
+| GET | /api/debts | debts.py | — | DebtsListResponse | N | N | N | N | Y | Y | S | filters |
+| POST | /api/accounts/{account_id}/debts | debts.py | DebtCreate | DebtResponse | Y | N | N | N | Y | Y | M | validates liability acct |
+| GET | /api/debts/{debt_id} | debts.py | — | DebtResponse | N | N | N | N | Y | Y | S | single fetch |
+| PUT | /api/debts/{debt_id} | debts.py | DebtUpdate | DebtResponse | Y | N | N | N | Y | Y | S | simple update |
+| DELETE | /api/debts/{debt_id} | debts.py | — | — | Y | N | N | N | N | N | S | soft-delete |
+| GET | /api/equity-grants | equity_grants.py | — | EquityGrantsListResponse | N | N | N | N | Y | Y | M | vesting calc + FX |
+| GET | /api/equity-grants/{grant_id} | equity_grants.py | — | EquityGrantResponse | N | N | N | N | Y | Y | M | vesting + FMV |
+| POST | /api/equity-grants | equity_grants.py | EquityGrantCreate | EquityGrantResponse | Y | N | N | N | Y | Y | M | validates schedule |
+| PATCH | /api/equity-grants/{grant_id} | equity_grants.py | EquityGrantUpdate | EquityGrantResponse | Y | N | N | N | Y | Y | M | partial update |
+| DELETE | /api/equity-grants/{grant_id} | equity_grants.py | — | — | Y | N | N | N | N | N | S | soft-delete |
+| GET | /api/goals | goals.py | — | GoalsListResponse | N | N | N | N | Y | Y | M | projects hit date |
+| POST | /api/goals | goals.py | GoalCreate | GoalResponse | Y | N | N | N | Y | Y | S | simple insert |
+| GET | /api/goals/{goal_id} | goals.py | — | GoalResponse | N | N | N | N | Y | Y | S | single fetch |
+| PUT | /api/goals/{goal_id} | goals.py | GoalUpdate | GoalResponse | Y | N | N | N | Y | Y | S | simple update |
+| DELETE | /api/goals/{goal_id} | goals.py | — | — | Y | N | N | N | N | N | S | hard delete |
+| GET | /api/investment/stock-stats | investment.py | — | CategoryStatsResponse | N | N | N | N | Y | Y | M | ROI across snapshots |
+| GET | /api/investment/bond-stats | investment.py | — | CategoryStatsResponse | N | N | N | N | Y | Y | M | ROI across snapshots |
+| GET | /api/personas | personas.py | — | list[PersonaResponse] | N | N | N | N | N | Y | S | list |
+| POST | /api/personas | personas.py | PersonaCreate | PersonaResponse | Y | N | N | N | N | Y | S | unique-name check |
+| PUT | /api/personas/{persona_id} | personas.py | PersonaUpdate | PersonaResponse | Y | N | N | N | N | Y | M | cascades owner rename 5 tables |
+| DELETE | /api/personas/{persona_id} | personas.py | — | — | Y | N | N | N | N | N | M | conflict check 5 tables |
+| GET | /api/retirement/stats | retirement.py | — | list[YearlyStatsResponse] | N | N | N | N | Y | Y | M | IKE/IKZE per owner |
+| GET | /api/retirement/ppk-stats | retirement.py | — | list[PPKStatsResponse] | N | N | N | N | Y | Y | M | PPK ROI per owner |
+| POST | /api/retirement/ppk-contributions/generate | retirement.py | PPKContributionGenerateRequest | PPKContributionGenerateResponse | Y | N | N | N | Y | Y | L | creates 2 txns, multi-table |
+| GET | /api/retirement/limits/{year} | retirement.py | — | list[RetirementLimitResponse] | N | N | N | N | Y | N | S | limits list |
+| PUT | /api/retirement/limits/{year}/{wrapper}/{owner} | retirement.py | RetirementLimitCreate | RetirementLimitResponse | Y | N | N | N | Y | N | S | upsert limit |
+| GET | /api/salaries | salary_records.py | — | SalaryRecordsListResponse | N | N | N | N | Y | Y | S | filters |
+| GET | /api/salaries/{salary_id} | salary_records.py | — | SalaryRecordResponse | N | N | N | N | Y | Y | S | single fetch |
+| POST | /api/salaries | salary_records.py | SalaryRecordCreate | SalaryRecordResponse | Y | N | N | N | Y | Y | S | simple insert |
+| PATCH | /api/salaries/{salary_id} | salary_records.py | SalaryRecordUpdate | SalaryRecordResponse | Y | N | N | N | Y | Y | S | partial update |
+| DELETE | /api/salaries/{salary_id} | salary_records.py | — | — | Y | N | N | N | N | N | S | soft-delete |
+| POST | /api/simulations/mortgage-vs-invest | simulations.py | MortgageVsInvestInputs | MortgageVsInvestResponse | N | N | N | N | Y | N | L | amortization loop, Belka tax |
+| POST | /api/simulations/retirement | simulations.py | SimulationInputs | SimulationResponse | N | N | N | N | Y | Y | L | multi-account projection |
+| GET | /api/simulations/prefill | simulations.py | — | PrefillResponse | N | N | N | N | Y | Y | M | aggregates balances 4 tables |
+| POST | /api/snapshots | snapshots.py | SnapshotCreate | SnapshotResponse | Y | N | N | N | Y | Y | L | atomic multi-row + recompute aggregates |
+| GET | /api/snapshots | snapshots.py | — | list[SnapshotListItem] | N | N | N | N | Y | Y | M | net worth per row, soft-delete filter |
+| GET | /api/snapshots/{snapshot_id} | snapshots.py | — | SnapshotResponse | N | N | N | N | Y | Y | S | single fetch |
+| PUT | /api/snapshots/{snapshot_id} | snapshots.py | SnapshotUpdate | SnapshotResponse | Y | N | N | N | Y | Y | L | replaces values + recompute aggregates |
+| GET | /api/accounts/{account_id}/transactions | transactions.py | — | TransactionsListResponse | N | N | N | N | Y | Y | S | per-account list |
+| POST | /api/accounts/{account_id}/transactions | transactions.py | TransactionCreate | TransactionResponse | Y | N | N | N | Y | Y | S | simple insert |
+| DELETE | /api/accounts/{account_id}/transactions/{transaction_id} | transactions.py | — | — | Y | N | N | N | N | N | S | soft-delete |
+| GET | /api/transactions | transactions.py | — | TransactionsListResponse | N | N | N | N | Y | Y | S | filters |
+| GET | /api/transactions/counts | transactions.py | — | dict[int,int] | N | N | N | N | N | N | S | per-account count |
+| POST | /api/zus/calculate | zus.py | ZusCalculatorInputs | ZusCalculatorResponse | N | N | N | N | Y | Y | L | pension projection + sensitivity |
+| GET | /api/zus/prefill | zus.py | — | ZusPrefillResponse | N | N | N | N | Y | Y | M | salary history aggregation |
+
+---
+
+## Summary
+
+**Total endpoints:** 73
+
+**By risk:**
+- S (trivial CRUD): 47
+- M (multi-table/logic): 17
+- L (pandas/sim/scheduler/aggregation): 9
+
+**Endpoints touching pandas (parity hotspots):**
+- GET /api/dashboard
+
+**Endpoints related to scheduler/external calls:**
+- POST /api/cpi/refresh — httpx → GUS BDL, also invoked by APScheduler `scheduler.py` monthly + on-startup-if-stale
+- (FX service `fx.py` uses httpx → NBP but lazy-loaded inside equity-grants/PL-tax flow, not directly via endpoints)
+
+**Endpoints that mutate state (POST/PUT/DELETE/PATCH):**
+- POST /api/accounts, PUT /api/accounts/{id}, DELETE /api/accounts/{id}
+- POST /api/assets, PUT /api/assets/{id}, DELETE /api/assets/{id}
+- POST /api/bonuses, PATCH /api/bonuses/{id}, DELETE /api/bonuses/{id}
+- POST /api/company-valuations, PATCH /api/company-valuations/{id}, DELETE /api/company-valuations/{id}
+- PUT /api/config
+- POST /api/cpi/refresh
+- POST /api/accounts/{id}/payments, DELETE /api/accounts/{id}/payments/{id}
+- POST /api/accounts/{id}/debts, PUT /api/debts/{id}, DELETE /api/debts/{id}
+- POST /api/equity-grants, PATCH /api/equity-grants/{id}, DELETE /api/equity-grants/{id}
+- POST /api/goals, PUT /api/goals/{id}, DELETE /api/goals/{id}
+- POST /api/personas, PUT /api/personas/{id}, DELETE /api/personas/{id}
+- POST /api/retirement/ppk-contributions/generate, PUT /api/retirement/limits/{year}/{wrapper}/{owner}
+- POST /api/salaries, PATCH /api/salaries/{id}, DELETE /api/salaries/{id}
+- POST /api/snapshots, PUT /api/snapshots/{id}
+- POST /api/accounts/{id}/transactions, DELETE /api/accounts/{id}/transactions/{id}

--- a/migration/inventory.md
+++ b/migration/inventory.md
@@ -1,82 +1,82 @@
 # FastAPI Backend Inventory — Pre-Go-Rewrite Audit
 
-| Method | Path | Router file | Request body schema | Response schema | DB writes? | Calls scheduler? | External calls? | Uses pandas? | Money fields? | Date/datetime fields? | Risk (S/M/L) | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| GET | /health | main.py | — | dict[str,str] | N | N | N | N | N | N | S | liveness probe |
-| GET | /api/dashboard | dashboard.py | — | DashboardResponse | N | N | N | Y | Y | Y | L | aggregates + raw fallback, many merges |
-| GET | /api/accounts | accounts.py | — | AccountsListResponse | N | N | N | N | Y | Y | S | reads latest snapshot |
-| POST | /api/accounts | accounts.py | AccountCreate | AccountResponse | Y | N | N | N | Y | Y | S | simple insert |
-| PUT | /api/accounts/{account_id} | accounts.py | AccountUpdate | AccountResponse | Y | N | N | N | Y | Y | S | simple update |
-| DELETE | /api/accounts/{account_id} | accounts.py | — | — | Y | N | N | N | N | N | S | soft-delete |
-| GET | /api/assets | assets.py | — | AssetsListResponse | N | N | N | N | Y | Y | S | reads latest snapshot |
-| POST | /api/assets | assets.py | AssetCreate | AssetResponse | Y | N | N | N | Y | Y | S | simple insert |
-| PUT | /api/assets/{asset_id} | assets.py | AssetUpdate | AssetResponse | Y | N | N | N | Y | Y | S | simple update |
-| DELETE | /api/assets/{asset_id} | assets.py | — | — | Y | N | N | N | N | N | S | soft-delete |
-| GET | /api/bonuses | bonus_events.py | — | BonusEventsListResponse | N | N | N | N | Y | Y | S | filters: owner/date/company |
-| GET | /api/bonuses/{bonus_id} | bonus_events.py | — | BonusEventResponse | N | N | N | N | Y | Y | S | single fetch |
-| POST | /api/bonuses | bonus_events.py | BonusEventCreate | BonusEventResponse | Y | N | N | N | Y | Y | S | simple insert |
-| PATCH | /api/bonuses/{bonus_id} | bonus_events.py | BonusEventUpdate | BonusEventResponse | Y | N | N | N | Y | Y | S | partial update |
-| DELETE | /api/bonuses/{bonus_id} | bonus_events.py | — | — | Y | N | N | N | N | N | S | soft-delete |
-| GET | /api/company-valuations | company_valuations.py | — | CompanyValuationsListResponse | N | N | N | N | Y | Y | S | optional company filter |
-| GET | /api/company-valuations/{valuation_id} | company_valuations.py | — | CompanyValuationResponse | N | N | N | N | Y | Y | S | single fetch |
-| POST | /api/company-valuations | company_valuations.py | CompanyValuationCreate | CompanyValuationResponse | Y | N | N | N | Y | Y | S | simple insert |
-| PATCH | /api/company-valuations/{valuation_id} | company_valuations.py | CompanyValuationUpdate | CompanyValuationResponse | Y | N | N | N | Y | Y | S | partial update |
-| DELETE | /api/company-valuations/{valuation_id} | company_valuations.py | — | — | Y | N | N | N | N | N | S | soft-delete |
-| GET | /api/config | config.py | — | ConfigResponse | N | N | N | N | Y | Y | S | 404 if missing |
-| PUT | /api/config | config.py | ConfigCreate | ConfigResponse | Y | N | N | N | Y | Y | S | upsert single row |
-| GET | /api/cpi/series | cpi.py | — | CpiSeriesResponse | N | N | N | N | N | N | M | builds cumulative index |
-| POST | /api/cpi/adjust | cpi.py | AdjustRequest | AdjustResponse | N | N | N | N | Y | Y | M | inflation factor calc |
-| POST | /api/cpi/refresh | cpi.py | — | RefreshResponse | Y | N | Y | N | N | Y | L | GUS BDL httpx + upsert |
-| GET | /api/accounts/{account_id}/payments | debt_payments.py | — | DebtPaymentsListResponse | N | N | N | N | Y | Y | S | per-account list |
-| POST | /api/accounts/{account_id}/payments | debt_payments.py | DebtPaymentCreate | DebtPaymentResponse | Y | N | N | N | Y | Y | S | simple insert |
-| DELETE | /api/accounts/{account_id}/payments/{payment_id} | debt_payments.py | — | — | Y | N | N | N | N | N | S | soft-delete |
-| GET | /api/payments | debt_payments.py | — | DebtPaymentsListResponse | N | N | N | N | Y | Y | S | filters |
-| GET | /api/payments/counts | debt_payments.py | — | dict[int,int] | N | N | N | N | N | N | S | per-account count |
-| GET | /api/debts | debts.py | — | DebtsListResponse | N | N | N | N | Y | Y | S | filters |
-| POST | /api/accounts/{account_id}/debts | debts.py | DebtCreate | DebtResponse | Y | N | N | N | Y | Y | M | validates liability acct |
-| GET | /api/debts/{debt_id} | debts.py | — | DebtResponse | N | N | N | N | Y | Y | S | single fetch |
-| PUT | /api/debts/{debt_id} | debts.py | DebtUpdate | DebtResponse | Y | N | N | N | Y | Y | S | simple update |
-| DELETE | /api/debts/{debt_id} | debts.py | — | — | Y | N | N | N | N | N | S | soft-delete |
-| GET | /api/equity-grants | equity_grants.py | — | EquityGrantsListResponse | N | N | N | N | Y | Y | M | vesting calc + FX |
-| GET | /api/equity-grants/{grant_id} | equity_grants.py | — | EquityGrantResponse | N | N | N | N | Y | Y | M | vesting + FMV |
-| POST | /api/equity-grants | equity_grants.py | EquityGrantCreate | EquityGrantResponse | Y | N | N | N | Y | Y | M | validates schedule |
-| PATCH | /api/equity-grants/{grant_id} | equity_grants.py | EquityGrantUpdate | EquityGrantResponse | Y | N | N | N | Y | Y | M | partial update |
-| DELETE | /api/equity-grants/{grant_id} | equity_grants.py | — | — | Y | N | N | N | N | N | S | soft-delete |
-| GET | /api/goals | goals.py | — | GoalsListResponse | N | N | N | N | Y | Y | M | projects hit date |
-| POST | /api/goals | goals.py | GoalCreate | GoalResponse | Y | N | N | N | Y | Y | S | simple insert |
-| GET | /api/goals/{goal_id} | goals.py | — | GoalResponse | N | N | N | N | Y | Y | S | single fetch |
-| PUT | /api/goals/{goal_id} | goals.py | GoalUpdate | GoalResponse | Y | N | N | N | Y | Y | S | simple update |
-| DELETE | /api/goals/{goal_id} | goals.py | — | — | Y | N | N | N | N | N | S | hard delete |
-| GET | /api/investment/stock-stats | investment.py | — | CategoryStatsResponse | N | N | N | N | Y | Y | M | ROI across snapshots |
-| GET | /api/investment/bond-stats | investment.py | — | CategoryStatsResponse | N | N | N | N | Y | Y | M | ROI across snapshots |
-| GET | /api/personas | personas.py | — | list[PersonaResponse] | N | N | N | N | N | Y | S | list |
-| POST | /api/personas | personas.py | PersonaCreate | PersonaResponse | Y | N | N | N | N | Y | S | unique-name check |
-| PUT | /api/personas/{persona_id} | personas.py | PersonaUpdate | PersonaResponse | Y | N | N | N | N | Y | M | cascades owner rename 5 tables |
-| DELETE | /api/personas/{persona_id} | personas.py | — | — | Y | N | N | N | N | N | M | conflict check 5 tables |
-| GET | /api/retirement/stats | retirement.py | — | list[YearlyStatsResponse] | N | N | N | N | Y | Y | M | IKE/IKZE per owner |
-| GET | /api/retirement/ppk-stats | retirement.py | — | list[PPKStatsResponse] | N | N | N | N | Y | Y | M | PPK ROI per owner |
-| POST | /api/retirement/ppk-contributions/generate | retirement.py | PPKContributionGenerateRequest | PPKContributionGenerateResponse | Y | N | N | N | Y | Y | L | creates 2 txns, multi-table |
-| GET | /api/retirement/limits/{year} | retirement.py | — | list[RetirementLimitResponse] | N | N | N | N | Y | N | S | limits list |
-| PUT | /api/retirement/limits/{year}/{wrapper}/{owner} | retirement.py | RetirementLimitCreate | RetirementLimitResponse | Y | N | N | N | Y | N | S | upsert limit |
-| GET | /api/salaries | salary_records.py | — | SalaryRecordsListResponse | N | N | N | N | Y | Y | S | filters |
-| GET | /api/salaries/{salary_id} | salary_records.py | — | SalaryRecordResponse | N | N | N | N | Y | Y | S | single fetch |
-| POST | /api/salaries | salary_records.py | SalaryRecordCreate | SalaryRecordResponse | Y | N | N | N | Y | Y | S | simple insert |
-| PATCH | /api/salaries/{salary_id} | salary_records.py | SalaryRecordUpdate | SalaryRecordResponse | Y | N | N | N | Y | Y | S | partial update |
-| DELETE | /api/salaries/{salary_id} | salary_records.py | — | — | Y | N | N | N | N | N | S | soft-delete |
-| POST | /api/simulations/mortgage-vs-invest | simulations.py | MortgageVsInvestInputs | MortgageVsInvestResponse | N | N | N | N | Y | N | L | amortization loop, Belka tax |
-| POST | /api/simulations/retirement | simulations.py | SimulationInputs | SimulationResponse | N | N | N | N | Y | Y | L | multi-account projection |
-| GET | /api/simulations/prefill | simulations.py | — | PrefillResponse | N | N | N | N | Y | Y | M | aggregates balances 4 tables |
-| POST | /api/snapshots | snapshots.py | SnapshotCreate | SnapshotResponse | Y | N | N | N | Y | Y | L | atomic multi-row + recompute aggregates |
-| GET | /api/snapshots | snapshots.py | — | list[SnapshotListItem] | N | N | N | N | Y | Y | M | net worth per row, soft-delete filter |
-| GET | /api/snapshots/{snapshot_id} | snapshots.py | — | SnapshotResponse | N | N | N | N | Y | Y | S | single fetch |
-| PUT | /api/snapshots/{snapshot_id} | snapshots.py | SnapshotUpdate | SnapshotResponse | Y | N | N | N | Y | Y | L | replaces values + recompute aggregates |
-| GET | /api/accounts/{account_id}/transactions | transactions.py | — | TransactionsListResponse | N | N | N | N | Y | Y | S | per-account list |
-| POST | /api/accounts/{account_id}/transactions | transactions.py | TransactionCreate | TransactionResponse | Y | N | N | N | Y | Y | S | simple insert |
-| DELETE | /api/accounts/{account_id}/transactions/{transaction_id} | transactions.py | — | — | Y | N | N | N | N | N | S | soft-delete |
-| GET | /api/transactions | transactions.py | — | TransactionsListResponse | N | N | N | N | Y | Y | S | filters |
-| GET | /api/transactions/counts | transactions.py | — | dict[int,int] | N | N | N | N | N | N | S | per-account count |
-| POST | /api/zus/calculate | zus.py | ZusCalculatorInputs | ZusCalculatorResponse | N | N | N | N | Y | Y | L | pension projection + sensitivity |
-| GET | /api/zus/prefill | zus.py | — | ZusPrefillResponse | N | N | N | N | Y | Y | M | salary history aggregation |
+| Method | Path                                                     | Router file           | Request body schema            | Response schema                 | DB writes? | Calls scheduler? | External calls? | Uses pandas? | Money fields? | Date/datetime fields? | Risk (S/M/L) | Notes                                   |
+| ------ | -------------------------------------------------------- | --------------------- | ------------------------------ | ------------------------------- | ---------- | ---------------- | --------------- | ------------ | ------------- | --------------------- | ------------ | --------------------------------------- |
+| GET    | /health                                                  | main.py               | —                              | dict[str,str]                   | N          | N                | N               | N            | N             | N                     | S            | liveness probe                          |
+| GET    | /api/dashboard                                           | dashboard.py          | —                              | DashboardResponse               | N          | N                | N               | Y            | Y             | Y                     | L            | aggregates + raw fallback, many merges  |
+| GET    | /api/accounts                                            | accounts.py           | —                              | AccountsListResponse            | N          | N                | N               | N            | Y             | Y                     | S            | reads latest snapshot                   |
+| POST   | /api/accounts                                            | accounts.py           | AccountCreate                  | AccountResponse                 | Y          | N                | N               | N            | Y             | Y                     | S            | simple insert                           |
+| PUT    | /api/accounts/{account_id}                               | accounts.py           | AccountUpdate                  | AccountResponse                 | Y          | N                | N               | N            | Y             | Y                     | S            | simple update                           |
+| DELETE | /api/accounts/{account_id}                               | accounts.py           | —                              | —                               | Y          | N                | N               | N            | N             | N                     | S            | soft-delete                             |
+| GET    | /api/assets                                              | assets.py             | —                              | AssetsListResponse              | N          | N                | N               | N            | Y             | Y                     | S            | reads latest snapshot                   |
+| POST   | /api/assets                                              | assets.py             | AssetCreate                    | AssetResponse                   | Y          | N                | N               | N            | Y             | Y                     | S            | simple insert                           |
+| PUT    | /api/assets/{asset_id}                                   | assets.py             | AssetUpdate                    | AssetResponse                   | Y          | N                | N               | N            | Y             | Y                     | S            | simple update                           |
+| DELETE | /api/assets/{asset_id}                                   | assets.py             | —                              | —                               | Y          | N                | N               | N            | N             | N                     | S            | soft-delete                             |
+| GET    | /api/bonuses                                             | bonus_events.py       | —                              | BonusEventsListResponse         | N          | N                | N               | N            | Y             | Y                     | S            | filters: owner/date/company             |
+| GET    | /api/bonuses/{bonus_id}                                  | bonus_events.py       | —                              | BonusEventResponse              | N          | N                | N               | N            | Y             | Y                     | S            | single fetch                            |
+| POST   | /api/bonuses                                             | bonus_events.py       | BonusEventCreate               | BonusEventResponse              | Y          | N                | N               | N            | Y             | Y                     | S            | simple insert                           |
+| PATCH  | /api/bonuses/{bonus_id}                                  | bonus_events.py       | BonusEventUpdate               | BonusEventResponse              | Y          | N                | N               | N            | Y             | Y                     | S            | partial update                          |
+| DELETE | /api/bonuses/{bonus_id}                                  | bonus_events.py       | —                              | —                               | Y          | N                | N               | N            | N             | N                     | S            | soft-delete                             |
+| GET    | /api/company-valuations                                  | company_valuations.py | —                              | CompanyValuationsListResponse   | N          | N                | N               | N            | Y             | Y                     | S            | optional company filter                 |
+| GET    | /api/company-valuations/{valuation_id}                   | company_valuations.py | —                              | CompanyValuationResponse        | N          | N                | N               | N            | Y             | Y                     | S            | single fetch                            |
+| POST   | /api/company-valuations                                  | company_valuations.py | CompanyValuationCreate         | CompanyValuationResponse        | Y          | N                | N               | N            | Y             | Y                     | S            | simple insert                           |
+| PATCH  | /api/company-valuations/{valuation_id}                   | company_valuations.py | CompanyValuationUpdate         | CompanyValuationResponse        | Y          | N                | N               | N            | Y             | Y                     | S            | partial update                          |
+| DELETE | /api/company-valuations/{valuation_id}                   | company_valuations.py | —                              | —                               | Y          | N                | N               | N            | N             | N                     | S            | soft-delete                             |
+| GET    | /api/config                                              | config.py             | —                              | ConfigResponse                  | N          | N                | N               | N            | Y             | Y                     | S            | 404 if missing                          |
+| PUT    | /api/config                                              | config.py             | ConfigCreate                   | ConfigResponse                  | Y          | N                | N               | N            | Y             | Y                     | S            | upsert single row                       |
+| GET    | /api/cpi/series                                          | cpi.py                | —                              | CpiSeriesResponse               | N          | N                | N               | N            | N             | N                     | M            | builds cumulative index                 |
+| POST   | /api/cpi/adjust                                          | cpi.py                | AdjustRequest                  | AdjustResponse                  | N          | N                | N               | N            | Y             | Y                     | M            | inflation factor calc                   |
+| POST   | /api/cpi/refresh                                         | cpi.py                | —                              | RefreshResponse                 | Y          | N                | Y               | N            | N             | Y                     | L            | GUS BDL httpx + upsert                  |
+| GET    | /api/accounts/{account_id}/payments                      | debt_payments.py      | —                              | DebtPaymentsListResponse        | N          | N                | N               | N            | Y             | Y                     | S            | per-account list                        |
+| POST   | /api/accounts/{account_id}/payments                      | debt_payments.py      | DebtPaymentCreate              | DebtPaymentResponse             | Y          | N                | N               | N            | Y             | Y                     | S            | simple insert                           |
+| DELETE | /api/accounts/{account_id}/payments/{payment_id}         | debt_payments.py      | —                              | —                               | Y          | N                | N               | N            | N             | N                     | S            | soft-delete                             |
+| GET    | /api/payments                                            | debt_payments.py      | —                              | DebtPaymentsListResponse        | N          | N                | N               | N            | Y             | Y                     | S            | filters                                 |
+| GET    | /api/payments/counts                                     | debt_payments.py      | —                              | dict[int,int]                   | N          | N                | N               | N            | N             | N                     | S            | per-account count                       |
+| GET    | /api/debts                                               | debts.py              | —                              | DebtsListResponse               | N          | N                | N               | N            | Y             | Y                     | S            | filters                                 |
+| POST   | /api/accounts/{account_id}/debts                         | debts.py              | DebtCreate                     | DebtResponse                    | Y          | N                | N               | N            | Y             | Y                     | M            | validates liability acct                |
+| GET    | /api/debts/{debt_id}                                     | debts.py              | —                              | DebtResponse                    | N          | N                | N               | N            | Y             | Y                     | S            | single fetch                            |
+| PUT    | /api/debts/{debt_id}                                     | debts.py              | DebtUpdate                     | DebtResponse                    | Y          | N                | N               | N            | Y             | Y                     | S            | simple update                           |
+| DELETE | /api/debts/{debt_id}                                     | debts.py              | —                              | —                               | Y          | N                | N               | N            | N             | N                     | S            | soft-delete                             |
+| GET    | /api/equity-grants                                       | equity_grants.py      | —                              | EquityGrantsListResponse        | N          | N                | N               | N            | Y             | Y                     | M            | vesting calc + FX                       |
+| GET    | /api/equity-grants/{grant_id}                            | equity_grants.py      | —                              | EquityGrantResponse             | N          | N                | N               | N            | Y             | Y                     | M            | vesting + FMV                           |
+| POST   | /api/equity-grants                                       | equity_grants.py      | EquityGrantCreate              | EquityGrantResponse             | Y          | N                | N               | N            | Y             | Y                     | M            | validates schedule                      |
+| PATCH  | /api/equity-grants/{grant_id}                            | equity_grants.py      | EquityGrantUpdate              | EquityGrantResponse             | Y          | N                | N               | N            | Y             | Y                     | M            | partial update                          |
+| DELETE | /api/equity-grants/{grant_id}                            | equity_grants.py      | —                              | —                               | Y          | N                | N               | N            | N             | N                     | S            | soft-delete                             |
+| GET    | /api/goals                                               | goals.py              | —                              | GoalsListResponse               | N          | N                | N               | N            | Y             | Y                     | M            | projects hit date                       |
+| POST   | /api/goals                                               | goals.py              | GoalCreate                     | GoalResponse                    | Y          | N                | N               | N            | Y             | Y                     | S            | simple insert                           |
+| GET    | /api/goals/{goal_id}                                     | goals.py              | —                              | GoalResponse                    | N          | N                | N               | N            | Y             | Y                     | S            | single fetch                            |
+| PUT    | /api/goals/{goal_id}                                     | goals.py              | GoalUpdate                     | GoalResponse                    | Y          | N                | N               | N            | Y             | Y                     | S            | simple update                           |
+| DELETE | /api/goals/{goal_id}                                     | goals.py              | —                              | —                               | Y          | N                | N               | N            | N             | N                     | S            | hard delete                             |
+| GET    | /api/investment/stock-stats                              | investment.py         | —                              | CategoryStatsResponse           | N          | N                | N               | N            | Y             | Y                     | M            | ROI across snapshots                    |
+| GET    | /api/investment/bond-stats                               | investment.py         | —                              | CategoryStatsResponse           | N          | N                | N               | N            | Y             | Y                     | M            | ROI across snapshots                    |
+| GET    | /api/personas                                            | personas.py           | —                              | list[PersonaResponse]           | N          | N                | N               | N            | N             | Y                     | S            | list                                    |
+| POST   | /api/personas                                            | personas.py           | PersonaCreate                  | PersonaResponse                 | Y          | N                | N               | N            | N             | Y                     | S            | unique-name check                       |
+| PUT    | /api/personas/{persona_id}                               | personas.py           | PersonaUpdate                  | PersonaResponse                 | Y          | N                | N               | N            | N             | Y                     | M            | cascades owner rename 5 tables          |
+| DELETE | /api/personas/{persona_id}                               | personas.py           | —                              | —                               | Y          | N                | N               | N            | N             | N                     | M            | conflict check 5 tables                 |
+| GET    | /api/retirement/stats                                    | retirement.py         | —                              | list[YearlyStatsResponse]       | N          | N                | N               | N            | Y             | Y                     | M            | IKE/IKZE per owner                      |
+| GET    | /api/retirement/ppk-stats                                | retirement.py         | —                              | list[PPKStatsResponse]          | N          | N                | N               | N            | Y             | Y                     | M            | PPK ROI per owner                       |
+| POST   | /api/retirement/ppk-contributions/generate               | retirement.py         | PPKContributionGenerateRequest | PPKContributionGenerateResponse | Y          | N                | N               | N            | Y             | Y                     | L            | creates 2 txns, multi-table             |
+| GET    | /api/retirement/limits/{year}                            | retirement.py         | —                              | list[RetirementLimitResponse]   | N          | N                | N               | N            | Y             | N                     | S            | limits list                             |
+| PUT    | /api/retirement/limits/{year}/{wrapper}/{owner}          | retirement.py         | RetirementLimitCreate          | RetirementLimitResponse         | Y          | N                | N               | N            | Y             | N                     | S            | upsert limit                            |
+| GET    | /api/salaries                                            | salary_records.py     | —                              | SalaryRecordsListResponse       | N          | N                | N               | N            | Y             | Y                     | S            | filters                                 |
+| GET    | /api/salaries/{salary_id}                                | salary_records.py     | —                              | SalaryRecordResponse            | N          | N                | N               | N            | Y             | Y                     | S            | single fetch                            |
+| POST   | /api/salaries                                            | salary_records.py     | SalaryRecordCreate             | SalaryRecordResponse            | Y          | N                | N               | N            | Y             | Y                     | S            | simple insert                           |
+| PATCH  | /api/salaries/{salary_id}                                | salary_records.py     | SalaryRecordUpdate             | SalaryRecordResponse            | Y          | N                | N               | N            | Y             | Y                     | S            | partial update                          |
+| DELETE | /api/salaries/{salary_id}                                | salary_records.py     | —                              | —                               | Y          | N                | N               | N            | N             | N                     | S            | soft-delete                             |
+| POST   | /api/simulations/mortgage-vs-invest                      | simulations.py        | MortgageVsInvestInputs         | MortgageVsInvestResponse        | N          | N                | N               | N            | Y             | N                     | L            | amortization loop, Belka tax            |
+| POST   | /api/simulations/retirement                              | simulations.py        | SimulationInputs               | SimulationResponse              | N          | N                | N               | N            | Y             | Y                     | L            | multi-account projection                |
+| GET    | /api/simulations/prefill                                 | simulations.py        | —                              | PrefillResponse                 | N          | N                | N               | N            | Y             | Y                     | M            | aggregates balances 4 tables            |
+| POST   | /api/snapshots                                           | snapshots.py          | SnapshotCreate                 | SnapshotResponse                | Y          | N                | N               | N            | Y             | Y                     | L            | atomic multi-row + recompute aggregates |
+| GET    | /api/snapshots                                           | snapshots.py          | —                              | list[SnapshotListItem]          | N          | N                | N               | N            | Y             | Y                     | M            | net worth per row, soft-delete filter   |
+| GET    | /api/snapshots/{snapshot_id}                             | snapshots.py          | —                              | SnapshotResponse                | N          | N                | N               | N            | Y             | Y                     | S            | single fetch                            |
+| PUT    | /api/snapshots/{snapshot_id}                             | snapshots.py          | SnapshotUpdate                 | SnapshotResponse                | Y          | N                | N               | N            | Y             | Y                     | L            | replaces values + recompute aggregates  |
+| GET    | /api/accounts/{account_id}/transactions                  | transactions.py       | —                              | TransactionsListResponse        | N          | N                | N               | N            | Y             | Y                     | S            | per-account list                        |
+| POST   | /api/accounts/{account_id}/transactions                  | transactions.py       | TransactionCreate              | TransactionResponse             | Y          | N                | N               | N            | Y             | Y                     | S            | simple insert                           |
+| DELETE | /api/accounts/{account_id}/transactions/{transaction_id} | transactions.py       | —                              | —                               | Y          | N                | N               | N            | N             | N                     | S            | soft-delete                             |
+| GET    | /api/transactions                                        | transactions.py       | —                              | TransactionsListResponse        | N          | N                | N               | N            | Y             | Y                     | S            | filters                                 |
+| GET    | /api/transactions/counts                                 | transactions.py       | —                              | dict[int,int]                   | N          | N                | N               | N            | N             | N                     | S            | per-account count                       |
+| POST   | /api/zus/calculate                                       | zus.py                | ZusCalculatorInputs            | ZusCalculatorResponse           | N          | N                | N               | N            | Y             | Y                     | L            | pension projection + sensitivity        |
+| GET    | /api/zus/prefill                                         | zus.py                | —                              | ZusPrefillResponse              | N          | N                | N               | N            | Y             | Y                     | M            | salary history aggregation              |
 
 ---
 
@@ -85,18 +85,22 @@
 **Total endpoints:** 73
 
 **By risk:**
+
 - S (trivial CRUD): 47
 - M (multi-table/logic): 17
 - L (pandas/sim/scheduler/aggregation): 9
 
 **Endpoints touching pandas (parity hotspots):**
+
 - GET /api/dashboard
 
 **Endpoints related to scheduler/external calls:**
+
 - POST /api/cpi/refresh — httpx → GUS BDL, also invoked by APScheduler `scheduler.py` monthly + on-startup-if-stale
 - (FX service `fx.py` uses httpx → NBP but lazy-loaded inside equity-grants/PL-tax flow, not directly via endpoints)
 
 **Endpoints that mutate state (POST/PUT/DELETE/PATCH):**
+
 - POST /api/accounts, PUT /api/accounts/{id}, DELETE /api/accounts/{id}
 - POST /api/assets, PUT /api/assets/{id}, DELETE /api/assets/{id}
 - POST /api/bonuses, PATCH /api/bonuses/{id}, DELETE /api/bonuses/{id}

--- a/migration/scheduler.md
+++ b/migration/scheduler.md
@@ -1,0 +1,50 @@
+# Scheduler Migration Audit
+
+## Overview
+
+- **Library:** APScheduler `3.11.2` (pyproject: `apscheduler>=3.11.0`, locked in `uv.lock`)
+- **Scheduler class:** `AsyncIOScheduler` (timezone `Europe/Warsaw`)
+- **Wiring:**
+  - Defined in `backend/app/services/scheduler.py` as `scheduler_lifespan()` (`@asynccontextmanager`)
+  - Wrapped by `backend/app/main.py::lifespan()` after `init_db()`; passed to `FastAPI(..., lifespan=lifespan)`
+  - Module-level singleton `_scheduler: AsyncIOScheduler | None`
+- **Start/stop:**
+  - Startup: runs `_startup_refresh_if_stale()`, then `_scheduler.start()`
+  - Shutdown: `_scheduler.shutdown(wait=False)` in the `finally` block
+- **Job store:** Default in-memory (`MemoryJobStore`) — not persistent; jobs re-registered on every process start (with `replace_existing=True`)
+- **Concurrency model:** Async — single asyncio event loop shared with FastAPI; job is `async def`
+- **Deployment assumption (per module docstring):** single-instance only; no leader election or DB advisory lock. Horizontal scaling would duplicate refreshes.
+
+## Jobs
+
+Total jobs registered: **1** (plus 1 one-shot startup task that uses the same function but is not a registered APScheduler job).
+
+### `cpi_monthly_refresh`
+
+- **Trigger:** `CronTrigger(day=16, hour=4, minute=0, timezone="Europe/Warsaw")` — once a month, 16th at 04:00 Warsaw time
+- **Function called:** `app.services.scheduler:_refresh_job` → delegates to `app.services.inflation:refresh_cpi`
+- **What it does:** Fetches annual y/y CPI for Poland from GUS BDL API (variable `217230`), upserts rows into `cpi_index` table.
+- **DB writes:** Y — table `cpi_index` (model `CpiIndex`): inserts new years or updates `yoy_rate`, `source`, `fetched_at` when changed
+- **External calls:** Y — `GET https://bdl.stat.gov.pl/api/v1/data/by-variable/217230` (httpx, 15s read / 5s connect timeout)
+- **Idempotent if re-run:** Y — upsert keyed on `year`; updates only if `yoy_rate` differs. Safe to run multiple times.
+- **Coupling to API endpoints:**
+  - `app.api.cpi` router and any code reading `CpiIndex` depends on data freshness
+  - Inflation adjustments via `inflation.adjust` / `load_index` / `cpi_series` (consumed across services/routes) require CPI rows
+  - `app.services.inflation.needs_refresh` (7-day staleness threshold) is consulted at startup
+
+### Startup hook (not a registered job)
+
+- `_startup_refresh_if_stale()` runs once before scheduler starts. Calls `_refresh_job()` if `inflation.needs_refresh(db)` is true (no rows or freshest `fetched_at` older than 7 days). Logs and skips on failure.
+
+## Go migration options
+
+1. **Port to Go with `robfig/cron` or `go-co-op/gocron`**
+   Pros: single binary, no extra runtime, fits a Go rewrite cleanly; cron syntax maps 1:1 to current trigger; trivial to add a startup-staleness check; in-process means same DB connection pool. Cons: still single-instance only (same leader-election gap as today); needs reimplementation of httpx GUS client and upsert logic in Go; loses APScheduler ergonomics (job stores, listeners) — fine here because none are used.
+
+2. **Keep Python sidecar service running only the scheduler**
+   Pros: zero rewrite risk for the CPI logic; reuses tested `inflation.refresh_cpi`; isolates external API quirks (GUS payload parsing, Decimal handling) in Python where they live. Cons: two languages and two deploys for one job; shared DB schema coupling; extra container/process for ~1 cron tick per month; cross-language ops burden.
+
+3. **OS cron + small Go CLI subcommands**
+   Pros: dead-simple, no in-process scheduler, decouples scheduling from app lifecycle; OS cron handles restarts/timezones; easy to run ad-hoc (`finance-buddy cpi refresh`). Cons: requires host-level cron (Docker needs a cron sidecar or supervisor); startup-staleness check must move into app boot anyway; logs scattered between cron and app; harder to ship as a single artifact.
+
+**Recommendation:** Option 1 — port to Go with `go-co-op/gocron` (or `robfig/cron`). Single binary preserves current single-instance model, the job is tiny (one HTTP call + upsert) and a clean Go port is cheaper than maintaining a Python sidecar or external cron plumbing.

--- a/migration/types.md
+++ b/migration/types.md
@@ -1,0 +1,277 @@
+# Backend type audit for Go rewrite
+
+Source of truth: SQLAlchemy models (`backend/app/models/`) for DB types, Pydantic schemas (`backend/app/schemas/`) for wire format, `backend/app/core/enums.py` for enums.
+
+---
+
+## Money fields
+
+| Model.field | SQL column type | Pydantic type | Currency | Stored unit | Nullable | Notes |
+|---|---|---|---|---|---|---|
+| Account.square_meters | Numeric(10,2) | Decimal in Create/Update; **float** in AccountResponse | n/a (m²) | not money — square meters | yes | Not money but uses Numeric. AccountResponse coerces to float. |
+| AppConfig.retirement_monthly_salary | Numeric(15,2) | Decimal | PLN | PLN | no | Decimal end-to-end. |
+| AppConfig.monthly_expenses | Numeric(15,2) | Decimal | PLN | PLN | no, default 0 | Decimal end-to-end. |
+| AppConfig.monthly_mortgage_payment | Numeric(15,2) | Decimal | PLN | PLN | no, default 0 | Decimal end-to-end. |
+| BonusEvent.amount | Numeric(15,2) | **float** | per BonusEvent.currency | original currency | no | Float on wire — red flag. |
+| CompanyValuation.fmv_per_share | Numeric(15,4) | **float** | per CompanyValuation.currency (default USD) | per-share, original currency | no | Note 4 decimal scale (per-share price). |
+| CompanyValuation.fmv_low | Numeric(15,4) | **float** | same as fmv_per_share | per-share | yes | |
+| CompanyValuation.fmv_high | Numeric(15,4) | **float** | same as fmv_per_share | per-share | yes | |
+| CompanyValuation.common_stock_discount_pct | Numeric(5,2) | **float** | n/a (%) | percent 0–100 | yes | Not money — percent. Float on wire. |
+| CpiIndex.yoy_rate | Numeric(8,4) | **float** (CpiPoint.yoy_rate) | n/a (rate) | year-over-year rate, GUS-published scale (e.g. 114.4 = +14.4%) | no | Not money. Float on wire. |
+| Debt.initial_amount | Numeric(15,2) | **float** | per Debt.currency (validator forces "PLN") | PLN | no | Schema enforces currency == "PLN". Float on wire. |
+| Debt.interest_rate | Numeric(5,2) | **float** | n/a (%) | percent | no | Not money. Float on wire. |
+| DebtPayment.amount | Numeric(15,2) | **float** | PLN (parent Debt is PLN-only) | PLN | no | Float on wire. |
+| EquityGrant.strike_price | Numeric(15,4) | **float** | per EquityGrant.currency (default USD) | per-share, original currency | yes | Required when type=OPTION (model_validator). |
+| FxRate.rate_pln | Numeric(15,6) | n/a (not exposed via Pydantic) | rate PLN per 1 unit of currency | PLN per foreign-currency unit | no | 6 decimal scale. Internal-only. |
+| Goal.target_amount | Numeric(15,2) | **float** | PLN (implicit, no currency col) | PLN | no | Float on wire. |
+| Goal.current_amount | Numeric(15,2) | **float** | PLN | PLN | no, default 0 | Float on wire. |
+| Goal.monthly_contribution | Numeric(15,2) | **float** | PLN | PLN | no, default 0 | Float on wire. |
+| Persona.ppk_employee_rate | Numeric(5,2) | Decimal | n/a (%) | percent 0.5–4.0 | no, default 2.0 | Not money. Decimal end-to-end. |
+| Persona.ppk_employer_rate | Numeric(5,2) | Decimal | n/a (%) | percent 1.5–4.0 | no, default 1.5 | Not money. Decimal end-to-end. |
+| RetirementLimit.limit_amount | Numeric(15,2) | **float** | PLN (implicit) | PLN | no | Float on wire. |
+| SalaryRecord.gross_amount | Numeric(15,2) | **float** | PLN (implicit, no currency col) | PLN | no | Float on wire. |
+| Snapshot.notes | n/a | n/a | n/a | — | — | (not money — listed only because Snapshot has no money fields itself) |
+| SnapshotValue.value | Numeric(15,2) | **float** | PLN (implicit) | PLN | no | Float on wire. Signed semantics: see services/aggregate_spec. |
+| SnapshotAggregate.total_assets | Numeric(15,2) | n/a (not exposed) | PLN | PLN | no | Internal precomputed. |
+| SnapshotAggregate.total_liabilities | Numeric(15,2) | n/a (not exposed) | PLN | PLN | no | Internal precomputed. |
+| SnapshotAggregate.net_worth | Numeric(15,2) | n/a (not exposed) | PLN | PLN | no | Internal precomputed. |
+| Transaction.amount | Numeric(15,2) | **float** | PLN (implicit) | PLN | no | Float on wire. |
+
+Response-side dashboard fields (computed, no DB column) — all float, all PLN unless noted:
+
+| Field | Pydantic type | Currency | Notes |
+|---|---|---|---|
+| NetWorthPoint.value | float | PLN | |
+| DeltaValue.absolute | float | PLN | |
+| DeltaValue.percentage | float | none (%) | nullable |
+| AllocationItem.value | float | PLN | |
+| MetricCards.property_sqm | float | none (m²) | |
+| MetricCards.emergency_fund_months | float | none (months) | |
+| MetricCards.retirement_income_monthly | float | PLN | |
+| MetricCards.mortgage_remaining | float | PLN | |
+| MetricCards.mortgage_years_left | float | none (years) | |
+| MetricCards.retirement_total | float | PLN | |
+| MetricCards.investment_contributions | float | PLN | |
+| MetricCards.investment_returns | float | PLN | |
+| MetricCards.savings_rate | float\|None | none (%) | |
+| MetricCards.debt_to_income_ratio | float\|None | none (ratio) | |
+| MetricCards.hour_of_work_cost | float\|None | PLN/hr | |
+| MetricCards.hour_of_life_cost | float\|None | PLN/hr | |
+| AllocationBreakdown.{current_value,current_percentage,target_percentage,difference} | float | PLN / % | |
+| AccountWrapperBreakdown.{value,percentage} | float | PLN / % | |
+| RebalancingSuggestion.amount | float | PLN | |
+| AllocationAnalysis.total_investment_value | float | PLN | |
+| InvestmentTimeSeriesPoint.{value,contributions,returns} | float | PLN | |
+| DashboardResponse.{current_net_worth,change_vs_last_month,total_assets,total_liabilities,retirement_account_value} | float | PLN | |
+| AccountResponse.current_value | float | PLN | computed |
+| AssetResponse.current_value | float | PLN | computed |
+| BonusEventResponse.amount_pln | float\|None | PLN | converted via FxRate |
+| BonusEventResponse.fx_rate | float\|None | rate | |
+| DebtResponse.{latest_balance,total_paid,interest_paid} | float | PLN | computed |
+| DebtPaymentsListResponse.total_paid | float | PLN | |
+| DebtsListResponse.total_initial_amount | float | PLN | |
+| EquityGrantResponse.vesting_progress_pct | float | none (%) | |
+| EquityGrantResponse.paper_value_{base,low,high} | float\|None | original currency | |
+| EquityGrantResponse.paper_value_{base,low,high}_pln | float\|None | PLN | |
+| EquityGrantResponse.fx_rate | float\|None | rate | |
+| GoalResponse.{progress_percent,remaining_amount} | float | % / PLN | |
+| RetirementLimitResponse (inherits Create) | float | PLN | |
+| YearlyStatsResponse.{limit_amount,total_contributed,employee_contributed,employer_contributed,remaining,percentage_used} | float\|None | PLN/% | |
+| PPKStatsResponse.{total_value,employee_contributed,employer_contributed,government_contributed,total_contributed,returns,roi_percentage} | float | PLN/% | |
+| PPKContributionGenerateResponse.{gross_salary,employee_amount,employer_amount,total_amount} | float | PLN | |
+| CategoryStatsResponse.{total_value,total_contributed,returns,roi_percentage} | float | PLN/% | |
+| SnapshotValueResponse.value | float | PLN | |
+| SnapshotListItem.total_net_worth | float | PLN | |
+| TransactionsListResponse.total_invested | float | PLN | |
+| All Simulations.*, ZUS.*, MortgageVsInvest.* numeric fields | float | PLN / % | every monetary or rate field in `simulations.py` and `zus.py` is float. |
+| CpiPoint.cumulative_index, AdjustRequest/AdjustResponse.{amount,original_amount,adjusted_amount,factor} | float | PLN (amounts) / unitless (factor) | |
+
+### Float-money fields
+
+DB columns Numeric, wire (Pydantic) float — values silently round-trip through float and lose Decimal precision at the API boundary:
+
+- BonusEvent.amount
+- CompanyValuation.fmv_per_share, fmv_low, fmv_high
+- Debt.initial_amount
+- DebtPayment.amount
+- EquityGrant.strike_price
+- Goal.target_amount, current_amount, monthly_contribution
+- RetirementLimit.limit_amount
+- SalaryRecord.gross_amount
+- SnapshotValue.value
+- Transaction.amount
+- Account.square_meters (in AccountResponse only; Create/Update use Decimal)
+- All dashboard/computed response fields (NetWorthPoint.value, DeltaValue.absolute, AllocationItem.value, MetricCards.*, AllocationBreakdown.*, AccountWrapperBreakdown.*, RebalancingSuggestion.amount, AllocationAnalysis.total_investment_value, InvestmentTimeSeriesPoint.*, DashboardResponse.*, *Response.current_value, BonusEventResponse.amount_pln, DebtResponse.latest_balance/total_paid/interest_paid, EquityGrantResponse.paper_value_*, GoalResponse.{progress_percent,remaining_amount}, YearlyStatsResponse.*, PPKStatsResponse.*, PPKContributionGenerateResponse.*, CategoryStatsResponse.*, SnapshotValueResponse.value, SnapshotListItem.total_net_worth, TransactionsListResponse.total_invested, all Simulations/ZUS/MortgageVsInvest numerics, CpiPoint.yoy_rate/cumulative_index, AdjustRequest/AdjustResponse.*)
+
+Non-money float fields (also wire-float): Debt.interest_rate, CompanyValuation.common_stock_discount_pct, CpiIndex.yoy_rate, BonusEventResponse.fx_rate, EquityGrantResponse.fx_rate.
+
+### Decimal-money fields (Decimal end-to-end, both DB and wire)
+
+- AppConfig.retirement_monthly_salary — Numeric(15,2), PLN
+- AppConfig.monthly_expenses — Numeric(15,2), PLN
+- AppConfig.monthly_mortgage_payment — Numeric(15,2), PLN
+- Persona.ppk_employee_rate — Numeric(5,2), % (rate, not money)
+- Persona.ppk_employer_rate — Numeric(5,2), % (rate, not money)
+- Account.square_meters — Numeric(10,2) in Create/Update only; response demotes to float
+
+FxRate.rate_pln — Numeric(15,6) — never exposed via Pydantic; service-internal Decimal.
+
+### Recommended Go type per field
+
+All PLN amounts → `decimal.Decimal` (shopspring). Per-share USD/foreign-currency amounts → `decimal.Decimal`. Percentages/rates stored as Numeric → `decimal.Decimal`. m² → `decimal.Decimal`.
+
+Rounding policy observable in code: **none explicit**. No `Decimal.quantize(...)` calls, no `ROUND_HALF_*` constants, no `round()` calls on money in models/schemas/services money-paths. Numeric(15,2) at the DB layer is the only precision enforcement. pandas aggregations on dashboard rely on Python float semantics (see `backend/app/services/dashboard/`). Go side should emit Numeric(15,2)-scaled decimals to match.
+
+Wire-format parity caveat: any field currently typed `float` on the response model is serialized as a JSON number. To preserve byte-for-byte parity during cutover, the Go responses must emit the same numeric representation (i.e. JSON number, not string). `decimal.Decimal` with `MarshalJSON` returning string would *break* the frontend. Use `decimal.Decimal` internally; convert to `float64` only at the JSON boundary for fields currently typed `float` in Pydantic. Convert to string only for fields currently `Decimal` in Pydantic (AppConfig, Persona).
+
+---
+
+## Date/datetime fields
+
+| Model.field | SQL column (TZ aware?) | Pydantic type | Default | Nullable | Semantic | Notes |
+|---|---|---|---|---|---|---|
+| Account.created_at | DateTime (default, **naive** at DB; value passed is aware UTC) | datetime (AccountResponse) | `datetime.now(UTC)` | no | creation timestamp | SQLAlchemy default lambda is aware UTC; column is plain DateTime — Postgres stores `timestamp without time zone` unless overridden. Mismatch: aware Python → naive DB. |
+| Asset.created_at | DateTime (naive at DB; value aware UTC) | datetime (AssetResponse) | `datetime.now(UTC)` | no | creation timestamp | Same naive-column / aware-default pattern. |
+| AppConfig.birth_date | Date | date | — | no | event date (person's DOB) | Validator: must be in past, age 18–100. |
+| BonusEvent.date | Date | date_type | — | no | event date (bonus payout) | Validator: not future. |
+| BonusEvent.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
+| CompanyValuation.date | Date | date_type | — | no | event date (valuation as-of) | |
+| CompanyValuation.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
+| CpiIndex.fetched_at | **DateTime(timezone=True)** | n/a (not exposed) | `datetime.now(UTC)` | no | data-pull timestamp | Aware. Only fully-aware column in models. |
+| Debt.start_date | Date | date | — | no | event date (debt origination) | Validator: not future. |
+| Debt.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
+| DebtPayment.date | Date | date | — | no | event date (payment) | Validator: not future. |
+| DebtPayment.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
+| EquityGrant.grant_date | Date | date_type | — | no | event date (grant signing) | |
+| EquityGrant.vest_start_date | Date | date_type | — | no | event date (vesting clock start) | |
+| EquityGrant.liquidity_event_date | Date | date_type \| None | — | yes | event date (expected liquidity) | |
+| EquityGrant.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
+| FxRate.date | Date | n/a (not exposed) | — | no | event date (rate as-of) | Unique on (date, currency). |
+| FxRate.created_at | DateTime (naive at DB; value aware UTC) | n/a | `datetime.now(UTC)` | no | creation timestamp | |
+| Goal.target_date | Date | date | — | no | target date (future) | |
+| Goal.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
+| Persona.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
+| SalaryRecord.date | Date | date_type | — | no | event date (salary effective) | Validator: not future. |
+| SalaryRecord.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
+| Snapshot.date | **Date** unique | date_type | — | no | **end-of-month** snapshot date (by convention) | Unique constraint enforces one snapshot per calendar date. |
+| Snapshot.created_at | DateTime (naive at DB; value aware UTC) | n/a in response | `datetime.now(UTC)` | no | creation timestamp | Not in SnapshotResponse. |
+| SnapshotAggregate.month | **Date** (denormalized = snapshot.date with day=1) | n/a | — | no | **month-bucket** key for dashboard grouping | NOT part of uniqueness; index `ix_snapshot_aggregates_month`. |
+| SnapshotAggregate.computed_at | **DateTime(timezone=True)** | n/a | `datetime.now(UTC)` | no | computation timestamp | Aware. |
+| Transaction.date | Date | date | — | no | event date (transaction) | Validator: not future. |
+| Transaction.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
+
+Schema-only date fields (request bodies, no DB column):
+
+| Schema.field | Pydantic type | Notes |
+|---|---|---|
+| AdjustRequest.from_date, AdjustRequest.to_date | date | CPI inflation adjust window. |
+| AdjustResponse.from_date, AdjustResponse.to_date | date | Echoed. |
+| ZusCalculatorInputs.birth_date | date | Used for age calc. |
+| ZusPrefillResponse.birth_date | date \| None | |
+| DebtPaymentResponse.date | date | Mirrors DebtPayment.date. |
+| DebtResponse.latest_balance_date | date \| None | Computed. |
+| EquityGrantResponse.valuation_date | date_type \| None | Computed (from CompanyValuation). |
+| GoalResponse.projected_hit_date | date \| None | Computed projection. |
+| NetWorthPoint.date | date | Dashboard time-series. |
+| InvestmentTimeSeriesPoint.date | date | Dashboard time-series. |
+
+### Naive vs aware
+
+- **Aware (TZ-aware DB column):** `CpiIndex.fetched_at`, `SnapshotAggregate.computed_at`. Both use `DateTime(timezone=True)`.
+- **Naive at DB, aware in Python:** every other `created_at` (Account, Asset, BonusEvent, CompanyValuation, Debt, DebtPayment, EquityGrant, FxRate, Goal, Persona, SalaryRecord, Snapshot, Transaction). The SQLAlchemy `default=lambda: datetime.now(UTC)` produces an aware datetime; the column type defaults to plain `DateTime` (= `timestamp without time zone` in Postgres). Postgres strips the offset on insert. Round-trips lose the explicit UTC marker.
+- **Date columns:** all naive `date` (no tz semantics by definition).
+- **Pydantic `datetime` on response:** untagged. Whatever Postgres returns (naive) is what the API emits.
+
+### Assumed timezone
+
+**UTC for created_at / event timestamps.** The codebase consistently uses `datetime.now(UTC)`. No Europe/Warsaw conversion anywhere in models/schemas. The two TZ-aware columns are also UTC.
+
+`date` semantics (event dates, snapshot dates, etc.) are **timezone-naive calendar dates** — interpreted in whatever local zone the caller cares about (effectively Europe/Warsaw for Polish personal-finance usage, but never explicitly).
+
+Validators using `datetime.now(UTC).date()` (config.py, bonus_events.py via `validate_not_future_date`, etc.) compare against UTC "today". This can reject a salary record dated *today* in Warsaw if the UTC clock has rolled to tomorrow — minor edge case.
+
+### End-of-month / month-boundary fields
+
+- `Snapshot.date` — by domain convention monthly net-worth snapshot; uniqueness is per-day (not per-month), but operational pattern is one snapshot per month-end.
+- `SnapshotAggregate.month` — explicitly normalized to `snapshot.date` with `day=1` (month-bucket key). Indexed for fast month grouping.
+
+Go port: both fit `time.Time` truncated to UTC midnight; `SnapshotAggregate.month` invariant (day == 1) should be enforced on write.
+
+---
+
+## Enums
+
+All enums in `app/core/enums.py` derive from `(str, Enum)` — stored as string values via SQLAlchemy `String(N)` columns (no native PG enum). Pydantic accepts the enum class; serializes as the string value.
+
+| Enum | Values | DB storage | Used by |
+|---|---|---|---|
+| AccountType | `asset`, `liability` | `String(50)` (Account.type) | Account; schemas/accounts.py |
+| Category | `bank`, `saving_account`, `stock`, `bond`, `gold`, `real_estate`, `ppk`, `fund`, `etf`, `vehicle`, `mortgage`, `installment`, `other` | `String(100)` (Account.category), `String(100)` (Goal.category nullable) | Account, Goal; schemas/accounts.py, goals.py, investment.py |
+| Wrapper | `IKE`, `IKZE`, `PPK` | `String(50)` (Account.account_wrapper nullable), `String(10)` (RetirementLimit.account_wrapper) | Account, RetirementLimit; schemas/accounts.py, retirement.py |
+| Purpose | `retirement`, `emergency_fund`, `general` | `String(50)` (Account.purpose) | Account; schemas/accounts.py |
+| DebtType | `mortgage`, `installment_0percent` | `String(50)` (Debt.debt_type) | Debt; schemas/debts.py |
+| TransactionType | `employee`, `employer`, `withdrawal`, `government` | `String(20)` nullable (Transaction.transaction_type) | Transaction; schemas/transactions.py |
+| ContractType | `UOP`, `UZ`, `UoD`, `B2B` | `String(50)` (SalaryRecord.contract_type, BonusEvent.contract_type) | SalaryRecord, BonusEvent; schemas/salary_records.py, bonus_events.py |
+| BonusType | `annual`, `signon`, `spot`, `retention` | `String(20)` (BonusEvent.type) | BonusEvent; schemas/bonus_events.py |
+| EquityGrantType | `option`, `rsu` | `String(20)` (EquityGrant.type) | EquityGrant; schemas/equity_grants.py |
+| VestingFrequency | `monthly`, `quarterly`, `yearly` | `String(20)` (EquityGrant.vest_frequency) | EquityGrant; schemas/equity_grants.py |
+| EquityTaxTreatment | `capital_gains_19`, `employment_income` | `String(30)` (EquityGrant.tax_treatment, default `capital_gains_19`) | EquityGrant; schemas/equity_grants.py |
+| ValuationSource | `409a`, `preferred_round`, `tender`, `estimate` | `String(30)` (CompanyValuation.source) | CompanyValuation; schemas/company_valuations.py |
+
+Inline enum-like fields without `Enum` class (string with ad-hoc validation):
+
+- `ZusCalculatorInputs.gender` — `"M"` / `"F"`. No model column.
+- `RebalancingSuggestion.action` — `"buy"` / `"sell"`. Response-only.
+- `MortgageVsInvestSummary.winning_strategy` — `"nadpłata"` / `"inwestycja"`. Response-only.
+- Currency strings (`PLN`, `USD`, `EUR`, `GBP`, `CHF`) — validated by `_validate_currency` in bonus_events / company_valuations / equity_grants schemas. Debt schema restricts to `PLN` only. Stored as `String(3)` (BonusEvent, CompanyValuation, EquityGrant, FxRate) or `String(10)` (Account, Debt).
+
+---
+
+## Foreign keys & cascade behavior
+
+| From | To | ON DELETE | ON UPDATE | Soft-delete on parent? |
+|---|---|---|---|---|
+| Debt.account_id | accounts.id | CASCADE | (default NO ACTION) | yes (Account.is_active) |
+| DebtPayment.account_id | accounts.id | CASCADE | (default NO ACTION) | yes (Account.is_active) |
+| Goal.account_id (nullable) | accounts.id | (default NO ACTION) | (default NO ACTION) | yes (Account.is_active) |
+| SnapshotValue.snapshot_id | snapshots.id | CASCADE | (default NO ACTION) | no (Snapshot has no is_active) |
+| SnapshotValue.asset_id (nullable) | assets.id | CASCADE | (default NO ACTION) | yes (Asset.is_active) |
+| SnapshotValue.account_id (nullable) | accounts.id | CASCADE | (default NO ACTION) | yes (Account.is_active) |
+| SnapshotAggregate.snapshot_id | snapshots.id | CASCADE | (default NO ACTION) | no |
+| Transaction.account_id | accounts.id | CASCADE | (default NO ACTION) | yes (Account.is_active) |
+
+Notes:
+- Soft delete is the standard delete path through the API. Hard delete (cascade) only fires if a row is removed via direct SQL/admin — application code never calls `db.delete(account)`.
+- Goal → accounts.id has **no** ON DELETE — orphans Goal.account_id if Account row is hard-deleted (but soft-delete is the contract).
+- Indexes hot-path: `ix_accounts_owner`, `ix_transactions_account_id_date`, `ix_snapshot_values_asset_id`, `ix_snapshot_aggregates_month`.
+
+---
+
+## Soft-delete columns
+
+Every model with `is_active: bool` (default `True`). No `deleted_at` columns anywhere. No `deleted_by`.
+
+| Model | Filter applied by | API endpoints that filter |
+|---|---|---|
+| Account | services/accounts.py, services/snapshots.py, services/snapshot_aggregates.py, services/transactions.py, services/debt_payments.py, services/debts.py, services/investment.py, services/retirement.py | GET /accounts (list), all account-scoped reads, dashboard, retirement |
+| Asset | services/assets.py, services/snapshots.py, services/snapshot_aggregates.py | GET /assets, snapshot reads, aggregates |
+| BonusEvent | services/bonus_events.py | GET /bonus-events (all reads) |
+| CompanyValuation | services/company_valuations.py | GET /company-valuations (all reads) |
+| Debt | services/debts.py | GET /debts (all reads) |
+| DebtPayment | services/debt_payments.py | GET /debt-payments (all reads) |
+| EquityGrant | services/equity_grants.py | GET /equity-grants (all reads) |
+| SalaryRecord | services/salary_records.py, services/zus_calculator.py, api/simulations.py | GET /salary-records, ZUS prefill, simulations prefill |
+| Transaction | services/transactions.py, services/retirement.py, services/investment.py | GET /transactions, retirement stats, investment stats |
+
+Models WITHOUT soft-delete (hard delete or single-row config):
+- AppConfig — single-row table (CheckConstraint `id = 1`).
+- CpiIndex — reference data, PK on year, re-fetched idempotently.
+- FxRate — reference data, unique on (date, currency).
+- Goal — no `is_active`; uses `is_completed` boolean (different semantic — goal achieved, not deleted).
+- Persona — no soft-delete.
+- RetirementLimit — reference data.
+- Snapshot — no soft-delete (hard delete cascades to SnapshotValue/SnapshotAggregate).
+- SnapshotValue — child of Snapshot, no own soft-delete.
+- SnapshotAggregate — derived, recomputed.
+
+Aggregates filter (commit fd6f7fa): `services/snapshot_aggregates.py` filters out `Account.is_active = False` and `Asset.is_active = False` when computing per-snapshot aggregates. `services/dashboard/*` and `services/snapshots.py` outer-join with the same `is_active.is_(True)` predicate so reads of historical snapshots respect current soft-delete state. Go port must replicate this — historical snapshot rows are not rewritten on soft-delete; the read path filters them.

--- a/migration/types.md
+++ b/migration/types.md
@@ -6,85 +6,85 @@ Source of truth: SQLAlchemy models (`backend/app/models/`) for DB types, Pydanti
 
 ## Money fields
 
-| Model.field | SQL column type | Pydantic type | Currency | Stored unit | Nullable | Notes |
-|---|---|---|---|---|---|---|
-| Account.square_meters | Numeric(10,2) | Decimal in Create/Update; **float** in AccountResponse | n/a (m²) | not money — square meters | yes | Not money but uses Numeric. AccountResponse coerces to float. |
-| AppConfig.retirement_monthly_salary | Numeric(15,2) | Decimal | PLN | PLN | no | Decimal end-to-end. |
-| AppConfig.monthly_expenses | Numeric(15,2) | Decimal | PLN | PLN | no, default 0 | Decimal end-to-end. |
-| AppConfig.monthly_mortgage_payment | Numeric(15,2) | Decimal | PLN | PLN | no, default 0 | Decimal end-to-end. |
-| BonusEvent.amount | Numeric(15,2) | **float** | per BonusEvent.currency | original currency | no | Float on wire — red flag. |
-| CompanyValuation.fmv_per_share | Numeric(15,4) | **float** | per CompanyValuation.currency (default USD) | per-share, original currency | no | Note 4 decimal scale (per-share price). |
-| CompanyValuation.fmv_low | Numeric(15,4) | **float** | same as fmv_per_share | per-share | yes | |
-| CompanyValuation.fmv_high | Numeric(15,4) | **float** | same as fmv_per_share | per-share | yes | |
-| CompanyValuation.common_stock_discount_pct | Numeric(5,2) | **float** | n/a (%) | percent 0–100 | yes | Not money — percent. Float on wire. |
-| CpiIndex.yoy_rate | Numeric(8,4) | **float** (CpiPoint.yoy_rate) | n/a (rate) | year-over-year rate, GUS-published scale (e.g. 114.4 = +14.4%) | no | Not money. Float on wire. |
-| Debt.initial_amount | Numeric(15,2) | **float** | per Debt.currency (validator forces "PLN") | PLN | no | Schema enforces currency == "PLN". Float on wire. |
-| Debt.interest_rate | Numeric(5,2) | **float** | n/a (%) | percent | no | Not money. Float on wire. |
-| DebtPayment.amount | Numeric(15,2) | **float** | PLN (parent Debt is PLN-only) | PLN | no | Float on wire. |
-| EquityGrant.strike_price | Numeric(15,4) | **float** | per EquityGrant.currency (default USD) | per-share, original currency | yes | Required when type=OPTION (model_validator). |
-| FxRate.rate_pln | Numeric(15,6) | n/a (not exposed via Pydantic) | rate PLN per 1 unit of currency | PLN per foreign-currency unit | no | 6 decimal scale. Internal-only. |
-| Goal.target_amount | Numeric(15,2) | **float** | PLN (implicit, no currency col) | PLN | no | Float on wire. |
-| Goal.current_amount | Numeric(15,2) | **float** | PLN | PLN | no, default 0 | Float on wire. |
-| Goal.monthly_contribution | Numeric(15,2) | **float** | PLN | PLN | no, default 0 | Float on wire. |
-| Persona.ppk_employee_rate | Numeric(5,2) | Decimal | n/a (%) | percent 0.5–4.0 | no, default 2.0 | Not money. Decimal end-to-end. |
-| Persona.ppk_employer_rate | Numeric(5,2) | Decimal | n/a (%) | percent 1.5–4.0 | no, default 1.5 | Not money. Decimal end-to-end. |
-| RetirementLimit.limit_amount | Numeric(15,2) | **float** | PLN (implicit) | PLN | no | Float on wire. |
-| SalaryRecord.gross_amount | Numeric(15,2) | **float** | PLN (implicit, no currency col) | PLN | no | Float on wire. |
-| Snapshot.notes | n/a | n/a | n/a | — | — | (not money — listed only because Snapshot has no money fields itself) |
-| SnapshotValue.value | Numeric(15,2) | **float** | PLN (implicit) | PLN | no | Float on wire. Signed semantics: see services/aggregate_spec. |
-| SnapshotAggregate.total_assets | Numeric(15,2) | n/a (not exposed) | PLN | PLN | no | Internal precomputed. |
-| SnapshotAggregate.total_liabilities | Numeric(15,2) | n/a (not exposed) | PLN | PLN | no | Internal precomputed. |
-| SnapshotAggregate.net_worth | Numeric(15,2) | n/a (not exposed) | PLN | PLN | no | Internal precomputed. |
-| Transaction.amount | Numeric(15,2) | **float** | PLN (implicit) | PLN | no | Float on wire. |
+| Model.field                                | SQL column type | Pydantic type                                          | Currency                                    | Stored unit                                                    | Nullable        | Notes                                                                 |
+| ------------------------------------------ | --------------- | ------------------------------------------------------ | ------------------------------------------- | -------------------------------------------------------------- | --------------- | --------------------------------------------------------------------- |
+| Account.square_meters                      | Numeric(10,2)   | Decimal in Create/Update; **float** in AccountResponse | n/a (m²)                                    | not money — square meters                                      | yes             | Not money but uses Numeric. AccountResponse coerces to float.         |
+| AppConfig.retirement_monthly_salary        | Numeric(15,2)   | Decimal                                                | PLN                                         | PLN                                                            | no              | Decimal end-to-end.                                                   |
+| AppConfig.monthly_expenses                 | Numeric(15,2)   | Decimal                                                | PLN                                         | PLN                                                            | no, default 0   | Decimal end-to-end.                                                   |
+| AppConfig.monthly_mortgage_payment         | Numeric(15,2)   | Decimal                                                | PLN                                         | PLN                                                            | no, default 0   | Decimal end-to-end.                                                   |
+| BonusEvent.amount                          | Numeric(15,2)   | **float**                                              | per BonusEvent.currency                     | original currency                                              | no              | Float on wire — red flag.                                             |
+| CompanyValuation.fmv_per_share             | Numeric(15,4)   | **float**                                              | per CompanyValuation.currency (default USD) | per-share, original currency                                   | no              | Note 4 decimal scale (per-share price).                               |
+| CompanyValuation.fmv_low                   | Numeric(15,4)   | **float**                                              | same as fmv_per_share                       | per-share                                                      | yes             |                                                                       |
+| CompanyValuation.fmv_high                  | Numeric(15,4)   | **float**                                              | same as fmv_per_share                       | per-share                                                      | yes             |                                                                       |
+| CompanyValuation.common_stock_discount_pct | Numeric(5,2)    | **float**                                              | n/a (%)                                     | percent 0–100                                                  | yes             | Not money — percent. Float on wire.                                   |
+| CpiIndex.yoy_rate                          | Numeric(8,4)    | **float** (CpiPoint.yoy_rate)                          | n/a (rate)                                  | year-over-year rate, GUS-published scale (e.g. 114.4 = +14.4%) | no              | Not money. Float on wire.                                             |
+| Debt.initial_amount                        | Numeric(15,2)   | **float**                                              | per Debt.currency (validator forces "PLN")  | PLN                                                            | no              | Schema enforces currency == "PLN". Float on wire.                     |
+| Debt.interest_rate                         | Numeric(5,2)    | **float**                                              | n/a (%)                                     | percent                                                        | no              | Not money. Float on wire.                                             |
+| DebtPayment.amount                         | Numeric(15,2)   | **float**                                              | PLN (parent Debt is PLN-only)               | PLN                                                            | no              | Float on wire.                                                        |
+| EquityGrant.strike_price                   | Numeric(15,4)   | **float**                                              | per EquityGrant.currency (default USD)      | per-share, original currency                                   | yes             | Required when type=OPTION (model_validator).                          |
+| FxRate.rate_pln                            | Numeric(15,6)   | n/a (not exposed via Pydantic)                         | rate PLN per 1 unit of currency             | PLN per foreign-currency unit                                  | no              | 6 decimal scale. Internal-only.                                       |
+| Goal.target_amount                         | Numeric(15,2)   | **float**                                              | PLN (implicit, no currency col)             | PLN                                                            | no              | Float on wire.                                                        |
+| Goal.current_amount                        | Numeric(15,2)   | **float**                                              | PLN                                         | PLN                                                            | no, default 0   | Float on wire.                                                        |
+| Goal.monthly_contribution                  | Numeric(15,2)   | **float**                                              | PLN                                         | PLN                                                            | no, default 0   | Float on wire.                                                        |
+| Persona.ppk_employee_rate                  | Numeric(5,2)    | Decimal                                                | n/a (%)                                     | percent 0.5–4.0                                                | no, default 2.0 | Not money. Decimal end-to-end.                                        |
+| Persona.ppk_employer_rate                  | Numeric(5,2)    | Decimal                                                | n/a (%)                                     | percent 1.5–4.0                                                | no, default 1.5 | Not money. Decimal end-to-end.                                        |
+| RetirementLimit.limit_amount               | Numeric(15,2)   | **float**                                              | PLN (implicit)                              | PLN                                                            | no              | Float on wire.                                                        |
+| SalaryRecord.gross_amount                  | Numeric(15,2)   | **float**                                              | PLN (implicit, no currency col)             | PLN                                                            | no              | Float on wire.                                                        |
+| Snapshot.notes                             | n/a             | n/a                                                    | n/a                                         | —                                                              | —               | (not money — listed only because Snapshot has no money fields itself) |
+| SnapshotValue.value                        | Numeric(15,2)   | **float**                                              | PLN (implicit)                              | PLN                                                            | no              | Float on wire. Signed semantics: see services/aggregate_spec.         |
+| SnapshotAggregate.total_assets             | Numeric(15,2)   | n/a (not exposed)                                      | PLN                                         | PLN                                                            | no              | Internal precomputed.                                                 |
+| SnapshotAggregate.total_liabilities        | Numeric(15,2)   | n/a (not exposed)                                      | PLN                                         | PLN                                                            | no              | Internal precomputed.                                                 |
+| SnapshotAggregate.net_worth                | Numeric(15,2)   | n/a (not exposed)                                      | PLN                                         | PLN                                                            | no              | Internal precomputed.                                                 |
+| Transaction.amount                         | Numeric(15,2)   | **float**                                              | PLN (implicit)                              | PLN                                                            | no              | Float on wire.                                                        |
 
 Response-side dashboard fields (computed, no DB column) — all float, all PLN unless noted:
 
-| Field | Pydantic type | Currency | Notes |
-|---|---|---|---|
-| NetWorthPoint.value | float | PLN | |
-| DeltaValue.absolute | float | PLN | |
-| DeltaValue.percentage | float | none (%) | nullable |
-| AllocationItem.value | float | PLN | |
-| MetricCards.property_sqm | float | none (m²) | |
-| MetricCards.emergency_fund_months | float | none (months) | |
-| MetricCards.retirement_income_monthly | float | PLN | |
-| MetricCards.mortgage_remaining | float | PLN | |
-| MetricCards.mortgage_years_left | float | none (years) | |
-| MetricCards.retirement_total | float | PLN | |
-| MetricCards.investment_contributions | float | PLN | |
-| MetricCards.investment_returns | float | PLN | |
-| MetricCards.savings_rate | float\|None | none (%) | |
-| MetricCards.debt_to_income_ratio | float\|None | none (ratio) | |
-| MetricCards.hour_of_work_cost | float\|None | PLN/hr | |
-| MetricCards.hour_of_life_cost | float\|None | PLN/hr | |
-| AllocationBreakdown.{current_value,current_percentage,target_percentage,difference} | float | PLN / % | |
-| AccountWrapperBreakdown.{value,percentage} | float | PLN / % | |
-| RebalancingSuggestion.amount | float | PLN | |
-| AllocationAnalysis.total_investment_value | float | PLN | |
-| InvestmentTimeSeriesPoint.{value,contributions,returns} | float | PLN | |
-| DashboardResponse.{current_net_worth,change_vs_last_month,total_assets,total_liabilities,retirement_account_value} | float | PLN | |
-| AccountResponse.current_value | float | PLN | computed |
-| AssetResponse.current_value | float | PLN | computed |
-| BonusEventResponse.amount_pln | float\|None | PLN | converted via FxRate |
-| BonusEventResponse.fx_rate | float\|None | rate | |
-| DebtResponse.{latest_balance,total_paid,interest_paid} | float | PLN | computed |
-| DebtPaymentsListResponse.total_paid | float | PLN | |
-| DebtsListResponse.total_initial_amount | float | PLN | |
-| EquityGrantResponse.vesting_progress_pct | float | none (%) | |
-| EquityGrantResponse.paper_value_{base,low,high} | float\|None | original currency | |
-| EquityGrantResponse.paper_value_{base,low,high}_pln | float\|None | PLN | |
-| EquityGrantResponse.fx_rate | float\|None | rate | |
-| GoalResponse.{progress_percent,remaining_amount} | float | % / PLN | |
-| RetirementLimitResponse (inherits Create) | float | PLN | |
-| YearlyStatsResponse.{limit_amount,total_contributed,employee_contributed,employer_contributed,remaining,percentage_used} | float\|None | PLN/% | |
-| PPKStatsResponse.{total_value,employee_contributed,employer_contributed,government_contributed,total_contributed,returns,roi_percentage} | float | PLN/% | |
-| PPKContributionGenerateResponse.{gross_salary,employee_amount,employer_amount,total_amount} | float | PLN | |
-| CategoryStatsResponse.{total_value,total_contributed,returns,roi_percentage} | float | PLN/% | |
-| SnapshotValueResponse.value | float | PLN | |
-| SnapshotListItem.total_net_worth | float | PLN | |
-| TransactionsListResponse.total_invested | float | PLN | |
-| All Simulations.*, ZUS.*, MortgageVsInvest.* numeric fields | float | PLN / % | every monetary or rate field in `simulations.py` and `zus.py` is float. |
-| CpiPoint.cumulative_index, AdjustRequest/AdjustResponse.{amount,original_amount,adjusted_amount,factor} | float | PLN (amounts) / unitless (factor) | |
+| Field                                                                                                                                    | Pydantic type | Currency                          | Notes                                                                   |
+| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------- | --------------------------------- | ----------------------------------------------------------------------- |
+| NetWorthPoint.value                                                                                                                      | float         | PLN                               |                                                                         |
+| DeltaValue.absolute                                                                                                                      | float         | PLN                               |                                                                         |
+| DeltaValue.percentage                                                                                                                    | float         | none (%)                          | nullable                                                                |
+| AllocationItem.value                                                                                                                     | float         | PLN                               |                                                                         |
+| MetricCards.property_sqm                                                                                                                 | float         | none (m²)                         |                                                                         |
+| MetricCards.emergency_fund_months                                                                                                        | float         | none (months)                     |                                                                         |
+| MetricCards.retirement_income_monthly                                                                                                    | float         | PLN                               |                                                                         |
+| MetricCards.mortgage_remaining                                                                                                           | float         | PLN                               |                                                                         |
+| MetricCards.mortgage_years_left                                                                                                          | float         | none (years)                      |                                                                         |
+| MetricCards.retirement_total                                                                                                             | float         | PLN                               |                                                                         |
+| MetricCards.investment_contributions                                                                                                     | float         | PLN                               |                                                                         |
+| MetricCards.investment_returns                                                                                                           | float         | PLN                               |                                                                         |
+| MetricCards.savings_rate                                                                                                                 | float\|None   | none (%)                          |                                                                         |
+| MetricCards.debt_to_income_ratio                                                                                                         | float\|None   | none (ratio)                      |                                                                         |
+| MetricCards.hour_of_work_cost                                                                                                            | float\|None   | PLN/hr                            |                                                                         |
+| MetricCards.hour_of_life_cost                                                                                                            | float\|None   | PLN/hr                            |                                                                         |
+| AllocationBreakdown.{current_value,current_percentage,target_percentage,difference}                                                      | float         | PLN / %                           |                                                                         |
+| AccountWrapperBreakdown.{value,percentage}                                                                                               | float         | PLN / %                           |                                                                         |
+| RebalancingSuggestion.amount                                                                                                             | float         | PLN                               |                                                                         |
+| AllocationAnalysis.total_investment_value                                                                                                | float         | PLN                               |                                                                         |
+| InvestmentTimeSeriesPoint.{value,contributions,returns}                                                                                  | float         | PLN                               |                                                                         |
+| DashboardResponse.{current_net_worth,change_vs_last_month,total_assets,total_liabilities,retirement_account_value}                       | float         | PLN                               |                                                                         |
+| AccountResponse.current_value                                                                                                            | float         | PLN                               | computed                                                                |
+| AssetResponse.current_value                                                                                                              | float         | PLN                               | computed                                                                |
+| BonusEventResponse.amount_pln                                                                                                            | float\|None   | PLN                               | converted via FxRate                                                    |
+| BonusEventResponse.fx_rate                                                                                                               | float\|None   | rate                              |                                                                         |
+| DebtResponse.{latest_balance,total_paid,interest_paid}                                                                                   | float         | PLN                               | computed                                                                |
+| DebtPaymentsListResponse.total_paid                                                                                                      | float         | PLN                               |                                                                         |
+| DebtsListResponse.total_initial_amount                                                                                                   | float         | PLN                               |                                                                         |
+| EquityGrantResponse.vesting_progress_pct                                                                                                 | float         | none (%)                          |                                                                         |
+| EquityGrantResponse.paper*value*{base,low,high}                                                                                          | float\|None   | original currency                 |                                                                         |
+| EquityGrantResponse.paper*value*{base,low,high}\_pln                                                                                     | float\|None   | PLN                               |                                                                         |
+| EquityGrantResponse.fx_rate                                                                                                              | float\|None   | rate                              |                                                                         |
+| GoalResponse.{progress_percent,remaining_amount}                                                                                         | float         | % / PLN                           |                                                                         |
+| RetirementLimitResponse (inherits Create)                                                                                                | float         | PLN                               |                                                                         |
+| YearlyStatsResponse.{limit_amount,total_contributed,employee_contributed,employer_contributed,remaining,percentage_used}                 | float\|None   | PLN/%                             |                                                                         |
+| PPKStatsResponse.{total_value,employee_contributed,employer_contributed,government_contributed,total_contributed,returns,roi_percentage} | float         | PLN/%                             |                                                                         |
+| PPKContributionGenerateResponse.{gross_salary,employee_amount,employer_amount,total_amount}                                              | float         | PLN                               |                                                                         |
+| CategoryStatsResponse.{total_value,total_contributed,returns,roi_percentage}                                                             | float         | PLN/%                             |                                                                         |
+| SnapshotValueResponse.value                                                                                                              | float         | PLN                               |                                                                         |
+| SnapshotListItem.total_net_worth                                                                                                         | float         | PLN                               |                                                                         |
+| TransactionsListResponse.total_invested                                                                                                  | float         | PLN                               |                                                                         |
+| All Simulations._, ZUS._, MortgageVsInvest.\* numeric fields                                                                             | float         | PLN / %                           | every monetary or rate field in `simulations.py` and `zus.py` is float. |
+| CpiPoint.cumulative_index, AdjustRequest/AdjustResponse.{amount,original_amount,adjusted_amount,factor}                                  | float         | PLN (amounts) / unitless (factor) |                                                                         |
 
 ### Float-money fields
 
@@ -101,7 +101,7 @@ DB columns Numeric, wire (Pydantic) float — values silently round-trip through
 - SnapshotValue.value
 - Transaction.amount
 - Account.square_meters (in AccountResponse only; Create/Update use Decimal)
-- All dashboard/computed response fields (NetWorthPoint.value, DeltaValue.absolute, AllocationItem.value, MetricCards.*, AllocationBreakdown.*, AccountWrapperBreakdown.*, RebalancingSuggestion.amount, AllocationAnalysis.total_investment_value, InvestmentTimeSeriesPoint.*, DashboardResponse.*, *Response.current_value, BonusEventResponse.amount_pln, DebtResponse.latest_balance/total_paid/interest_paid, EquityGrantResponse.paper_value_*, GoalResponse.{progress_percent,remaining_amount}, YearlyStatsResponse.*, PPKStatsResponse.*, PPKContributionGenerateResponse.*, CategoryStatsResponse.*, SnapshotValueResponse.value, SnapshotListItem.total_net_worth, TransactionsListResponse.total_invested, all Simulations/ZUS/MortgageVsInvest numerics, CpiPoint.yoy_rate/cumulative_index, AdjustRequest/AdjustResponse.*)
+- All dashboard/computed response fields (NetWorthPoint.value, DeltaValue.absolute, AllocationItem.value, MetricCards._, AllocationBreakdown._, AccountWrapperBreakdown._, RebalancingSuggestion.amount, AllocationAnalysis.total_investment_value, InvestmentTimeSeriesPoint._, DashboardResponse.*, *Response.current*value, BonusEventResponse.amount_pln, DebtResponse.latest_balance/total_paid/interest_paid, EquityGrantResponse.paper_value*_, GoalResponse.{progress_percent,remaining_amount}, YearlyStatsResponse._, PPKStatsResponse._, PPKContributionGenerateResponse._, CategoryStatsResponse._, SnapshotValueResponse.value, SnapshotListItem.total_net_worth, TransactionsListResponse.total_invested, all Simulations/ZUS/MortgageVsInvest numerics, CpiPoint.yoy_rate/cumulative_index, AdjustRequest/AdjustResponse._)
 
 Non-money float fields (also wire-float): Debt.interest_rate, CompanyValuation.common_stock_discount_pct, CpiIndex.yoy_rate, BonusEventResponse.fx_rate, EquityGrantResponse.fx_rate.
 
@@ -122,58 +122,58 @@ All PLN amounts → `decimal.Decimal` (shopspring). Per-share USD/foreign-curren
 
 Rounding policy observable in code: **none explicit**. No `Decimal.quantize(...)` calls, no `ROUND_HALF_*` constants, no `round()` calls on money in models/schemas/services money-paths. Numeric(15,2) at the DB layer is the only precision enforcement. pandas aggregations on dashboard rely on Python float semantics (see `backend/app/services/dashboard/`). Go side should emit Numeric(15,2)-scaled decimals to match.
 
-Wire-format parity caveat: any field currently typed `float` on the response model is serialized as a JSON number. To preserve byte-for-byte parity during cutover, the Go responses must emit the same numeric representation (i.e. JSON number, not string). `decimal.Decimal` with `MarshalJSON` returning string would *break* the frontend. Use `decimal.Decimal` internally; convert to `float64` only at the JSON boundary for fields currently typed `float` in Pydantic. Convert to string only for fields currently `Decimal` in Pydantic (AppConfig, Persona).
+Wire-format parity caveat: any field currently typed `float` on the response model is serialized as a JSON number. To preserve byte-for-byte parity during cutover, the Go responses must emit the same numeric representation (i.e. JSON number, not string). `decimal.Decimal` with `MarshalJSON` returning string would _break_ the frontend. Use `decimal.Decimal` internally; convert to `float64` only at the JSON boundary for fields currently typed `float` in Pydantic. Convert to string only for fields currently `Decimal` in Pydantic (AppConfig, Persona).
 
 ---
 
 ## Date/datetime fields
 
-| Model.field | SQL column (TZ aware?) | Pydantic type | Default | Nullable | Semantic | Notes |
-|---|---|---|---|---|---|---|
-| Account.created_at | DateTime (default, **naive** at DB; value passed is aware UTC) | datetime (AccountResponse) | `datetime.now(UTC)` | no | creation timestamp | SQLAlchemy default lambda is aware UTC; column is plain DateTime — Postgres stores `timestamp without time zone` unless overridden. Mismatch: aware Python → naive DB. |
-| Asset.created_at | DateTime (naive at DB; value aware UTC) | datetime (AssetResponse) | `datetime.now(UTC)` | no | creation timestamp | Same naive-column / aware-default pattern. |
-| AppConfig.birth_date | Date | date | — | no | event date (person's DOB) | Validator: must be in past, age 18–100. |
-| BonusEvent.date | Date | date_type | — | no | event date (bonus payout) | Validator: not future. |
-| BonusEvent.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
-| CompanyValuation.date | Date | date_type | — | no | event date (valuation as-of) | |
-| CompanyValuation.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
-| CpiIndex.fetched_at | **DateTime(timezone=True)** | n/a (not exposed) | `datetime.now(UTC)` | no | data-pull timestamp | Aware. Only fully-aware column in models. |
-| Debt.start_date | Date | date | — | no | event date (debt origination) | Validator: not future. |
-| Debt.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
-| DebtPayment.date | Date | date | — | no | event date (payment) | Validator: not future. |
-| DebtPayment.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
-| EquityGrant.grant_date | Date | date_type | — | no | event date (grant signing) | |
-| EquityGrant.vest_start_date | Date | date_type | — | no | event date (vesting clock start) | |
-| EquityGrant.liquidity_event_date | Date | date_type \| None | — | yes | event date (expected liquidity) | |
-| EquityGrant.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
-| FxRate.date | Date | n/a (not exposed) | — | no | event date (rate as-of) | Unique on (date, currency). |
-| FxRate.created_at | DateTime (naive at DB; value aware UTC) | n/a | `datetime.now(UTC)` | no | creation timestamp | |
-| Goal.target_date | Date | date | — | no | target date (future) | |
-| Goal.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
-| Persona.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
-| SalaryRecord.date | Date | date_type | — | no | event date (salary effective) | Validator: not future. |
-| SalaryRecord.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
-| Snapshot.date | **Date** unique | date_type | — | no | **end-of-month** snapshot date (by convention) | Unique constraint enforces one snapshot per calendar date. |
-| Snapshot.created_at | DateTime (naive at DB; value aware UTC) | n/a in response | `datetime.now(UTC)` | no | creation timestamp | Not in SnapshotResponse. |
-| SnapshotAggregate.month | **Date** (denormalized = snapshot.date with day=1) | n/a | — | no | **month-bucket** key for dashboard grouping | NOT part of uniqueness; index `ix_snapshot_aggregates_month`. |
-| SnapshotAggregate.computed_at | **DateTime(timezone=True)** | n/a | `datetime.now(UTC)` | no | computation timestamp | Aware. |
-| Transaction.date | Date | date | — | no | event date (transaction) | Validator: not future. |
-| Transaction.created_at | DateTime (naive at DB; value aware UTC) | datetime | `datetime.now(UTC)` | no | creation timestamp | |
+| Model.field                      | SQL column (TZ aware?)                                         | Pydantic type              | Default             | Nullable | Semantic                                       | Notes                                                                                                                                                                  |
+| -------------------------------- | -------------------------------------------------------------- | -------------------------- | ------------------- | -------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Account.created_at               | DateTime (default, **naive** at DB; value passed is aware UTC) | datetime (AccountResponse) | `datetime.now(UTC)` | no       | creation timestamp                             | SQLAlchemy default lambda is aware UTC; column is plain DateTime — Postgres stores `timestamp without time zone` unless overridden. Mismatch: aware Python → naive DB. |
+| Asset.created_at                 | DateTime (naive at DB; value aware UTC)                        | datetime (AssetResponse)   | `datetime.now(UTC)` | no       | creation timestamp                             | Same naive-column / aware-default pattern.                                                                                                                             |
+| AppConfig.birth_date             | Date                                                           | date                       | —                   | no       | event date (person's DOB)                      | Validator: must be in past, age 18–100.                                                                                                                                |
+| BonusEvent.date                  | Date                                                           | date_type                  | —                   | no       | event date (bonus payout)                      | Validator: not future.                                                                                                                                                 |
+| BonusEvent.created_at            | DateTime (naive at DB; value aware UTC)                        | datetime                   | `datetime.now(UTC)` | no       | creation timestamp                             |                                                                                                                                                                        |
+| CompanyValuation.date            | Date                                                           | date_type                  | —                   | no       | event date (valuation as-of)                   |                                                                                                                                                                        |
+| CompanyValuation.created_at      | DateTime (naive at DB; value aware UTC)                        | datetime                   | `datetime.now(UTC)` | no       | creation timestamp                             |                                                                                                                                                                        |
+| CpiIndex.fetched_at              | **DateTime(timezone=True)**                                    | n/a (not exposed)          | `datetime.now(UTC)` | no       | data-pull timestamp                            | Aware. Only fully-aware column in models.                                                                                                                              |
+| Debt.start_date                  | Date                                                           | date                       | —                   | no       | event date (debt origination)                  | Validator: not future.                                                                                                                                                 |
+| Debt.created_at                  | DateTime (naive at DB; value aware UTC)                        | datetime                   | `datetime.now(UTC)` | no       | creation timestamp                             |                                                                                                                                                                        |
+| DebtPayment.date                 | Date                                                           | date                       | —                   | no       | event date (payment)                           | Validator: not future.                                                                                                                                                 |
+| DebtPayment.created_at           | DateTime (naive at DB; value aware UTC)                        | datetime                   | `datetime.now(UTC)` | no       | creation timestamp                             |                                                                                                                                                                        |
+| EquityGrant.grant_date           | Date                                                           | date_type                  | —                   | no       | event date (grant signing)                     |                                                                                                                                                                        |
+| EquityGrant.vest_start_date      | Date                                                           | date_type                  | —                   | no       | event date (vesting clock start)               |                                                                                                                                                                        |
+| EquityGrant.liquidity_event_date | Date                                                           | date_type \| None          | —                   | yes      | event date (expected liquidity)                |                                                                                                                                                                        |
+| EquityGrant.created_at           | DateTime (naive at DB; value aware UTC)                        | datetime                   | `datetime.now(UTC)` | no       | creation timestamp                             |                                                                                                                                                                        |
+| FxRate.date                      | Date                                                           | n/a (not exposed)          | —                   | no       | event date (rate as-of)                        | Unique on (date, currency).                                                                                                                                            |
+| FxRate.created_at                | DateTime (naive at DB; value aware UTC)                        | n/a                        | `datetime.now(UTC)` | no       | creation timestamp                             |                                                                                                                                                                        |
+| Goal.target_date                 | Date                                                           | date                       | —                   | no       | target date (future)                           |                                                                                                                                                                        |
+| Goal.created_at                  | DateTime (naive at DB; value aware UTC)                        | datetime                   | `datetime.now(UTC)` | no       | creation timestamp                             |                                                                                                                                                                        |
+| Persona.created_at               | DateTime (naive at DB; value aware UTC)                        | datetime                   | `datetime.now(UTC)` | no       | creation timestamp                             |                                                                                                                                                                        |
+| SalaryRecord.date                | Date                                                           | date_type                  | —                   | no       | event date (salary effective)                  | Validator: not future.                                                                                                                                                 |
+| SalaryRecord.created_at          | DateTime (naive at DB; value aware UTC)                        | datetime                   | `datetime.now(UTC)` | no       | creation timestamp                             |                                                                                                                                                                        |
+| Snapshot.date                    | **Date** unique                                                | date_type                  | —                   | no       | **end-of-month** snapshot date (by convention) | Unique constraint enforces one snapshot per calendar date.                                                                                                             |
+| Snapshot.created_at              | DateTime (naive at DB; value aware UTC)                        | n/a in response            | `datetime.now(UTC)` | no       | creation timestamp                             | Not in SnapshotResponse.                                                                                                                                               |
+| SnapshotAggregate.month          | **Date** (denormalized = snapshot.date with day=1)             | n/a                        | —                   | no       | **month-bucket** key for dashboard grouping    | NOT part of uniqueness; index `ix_snapshot_aggregates_month`.                                                                                                          |
+| SnapshotAggregate.computed_at    | **DateTime(timezone=True)**                                    | n/a                        | `datetime.now(UTC)` | no       | computation timestamp                          | Aware.                                                                                                                                                                 |
+| Transaction.date                 | Date                                                           | date                       | —                   | no       | event date (transaction)                       | Validator: not future.                                                                                                                                                 |
+| Transaction.created_at           | DateTime (naive at DB; value aware UTC)                        | datetime                   | `datetime.now(UTC)` | no       | creation timestamp                             |                                                                                                                                                                        |
 
 Schema-only date fields (request bodies, no DB column):
 
-| Schema.field | Pydantic type | Notes |
-|---|---|---|
-| AdjustRequest.from_date, AdjustRequest.to_date | date | CPI inflation adjust window. |
-| AdjustResponse.from_date, AdjustResponse.to_date | date | Echoed. |
-| ZusCalculatorInputs.birth_date | date | Used for age calc. |
-| ZusPrefillResponse.birth_date | date \| None | |
-| DebtPaymentResponse.date | date | Mirrors DebtPayment.date. |
-| DebtResponse.latest_balance_date | date \| None | Computed. |
-| EquityGrantResponse.valuation_date | date_type \| None | Computed (from CompanyValuation). |
-| GoalResponse.projected_hit_date | date \| None | Computed projection. |
-| NetWorthPoint.date | date | Dashboard time-series. |
-| InvestmentTimeSeriesPoint.date | date | Dashboard time-series. |
+| Schema.field                                     | Pydantic type     | Notes                             |
+| ------------------------------------------------ | ----------------- | --------------------------------- |
+| AdjustRequest.from_date, AdjustRequest.to_date   | date              | CPI inflation adjust window.      |
+| AdjustResponse.from_date, AdjustResponse.to_date | date              | Echoed.                           |
+| ZusCalculatorInputs.birth_date                   | date              | Used for age calc.                |
+| ZusPrefillResponse.birth_date                    | date \| None      |                                   |
+| DebtPaymentResponse.date                         | date              | Mirrors DebtPayment.date.         |
+| DebtResponse.latest_balance_date                 | date \| None      | Computed.                         |
+| EquityGrantResponse.valuation_date               | date_type \| None | Computed (from CompanyValuation). |
+| GoalResponse.projected_hit_date                  | date \| None      | Computed projection.              |
+| NetWorthPoint.date                               | date              | Dashboard time-series.            |
+| InvestmentTimeSeriesPoint.date                   | date              | Dashboard time-series.            |
 
 ### Naive vs aware
 
@@ -188,7 +188,7 @@ Schema-only date fields (request bodies, no DB column):
 
 `date` semantics (event dates, snapshot dates, etc.) are **timezone-naive calendar dates** — interpreted in whatever local zone the caller cares about (effectively Europe/Warsaw for Polish personal-finance usage, but never explicitly).
 
-Validators using `datetime.now(UTC).date()` (config.py, bonus_events.py via `validate_not_future_date`, etc.) compare against UTC "today". This can reject a salary record dated *today* in Warsaw if the UTC clock has rolled to tomorrow — minor edge case.
+Validators using `datetime.now(UTC).date()` (config.py, bonus*events.py via `validate_not_future_date`, etc.) compare against UTC "today". This can reject a salary record dated \_today* in Warsaw if the UTC clock has rolled to tomorrow — minor edge case.
 
 ### End-of-month / month-boundary fields
 
@@ -203,20 +203,20 @@ Go port: both fit `time.Time` truncated to UTC midnight; `SnapshotAggregate.mont
 
 All enums in `app/core/enums.py` derive from `(str, Enum)` — stored as string values via SQLAlchemy `String(N)` columns (no native PG enum). Pydantic accepts the enum class; serializes as the string value.
 
-| Enum | Values | DB storage | Used by |
-|---|---|---|---|
-| AccountType | `asset`, `liability` | `String(50)` (Account.type) | Account; schemas/accounts.py |
-| Category | `bank`, `saving_account`, `stock`, `bond`, `gold`, `real_estate`, `ppk`, `fund`, `etf`, `vehicle`, `mortgage`, `installment`, `other` | `String(100)` (Account.category), `String(100)` (Goal.category nullable) | Account, Goal; schemas/accounts.py, goals.py, investment.py |
-| Wrapper | `IKE`, `IKZE`, `PPK` | `String(50)` (Account.account_wrapper nullable), `String(10)` (RetirementLimit.account_wrapper) | Account, RetirementLimit; schemas/accounts.py, retirement.py |
-| Purpose | `retirement`, `emergency_fund`, `general` | `String(50)` (Account.purpose) | Account; schemas/accounts.py |
-| DebtType | `mortgage`, `installment_0percent` | `String(50)` (Debt.debt_type) | Debt; schemas/debts.py |
-| TransactionType | `employee`, `employer`, `withdrawal`, `government` | `String(20)` nullable (Transaction.transaction_type) | Transaction; schemas/transactions.py |
-| ContractType | `UOP`, `UZ`, `UoD`, `B2B` | `String(50)` (SalaryRecord.contract_type, BonusEvent.contract_type) | SalaryRecord, BonusEvent; schemas/salary_records.py, bonus_events.py |
-| BonusType | `annual`, `signon`, `spot`, `retention` | `String(20)` (BonusEvent.type) | BonusEvent; schemas/bonus_events.py |
-| EquityGrantType | `option`, `rsu` | `String(20)` (EquityGrant.type) | EquityGrant; schemas/equity_grants.py |
-| VestingFrequency | `monthly`, `quarterly`, `yearly` | `String(20)` (EquityGrant.vest_frequency) | EquityGrant; schemas/equity_grants.py |
-| EquityTaxTreatment | `capital_gains_19`, `employment_income` | `String(30)` (EquityGrant.tax_treatment, default `capital_gains_19`) | EquityGrant; schemas/equity_grants.py |
-| ValuationSource | `409a`, `preferred_round`, `tender`, `estimate` | `String(30)` (CompanyValuation.source) | CompanyValuation; schemas/company_valuations.py |
+| Enum               | Values                                                                                                                                | DB storage                                                                                      | Used by                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| AccountType        | `asset`, `liability`                                                                                                                  | `String(50)` (Account.type)                                                                     | Account; schemas/accounts.py                                         |
+| Category           | `bank`, `saving_account`, `stock`, `bond`, `gold`, `real_estate`, `ppk`, `fund`, `etf`, `vehicle`, `mortgage`, `installment`, `other` | `String(100)` (Account.category), `String(100)` (Goal.category nullable)                        | Account, Goal; schemas/accounts.py, goals.py, investment.py          |
+| Wrapper            | `IKE`, `IKZE`, `PPK`                                                                                                                  | `String(50)` (Account.account_wrapper nullable), `String(10)` (RetirementLimit.account_wrapper) | Account, RetirementLimit; schemas/accounts.py, retirement.py         |
+| Purpose            | `retirement`, `emergency_fund`, `general`                                                                                             | `String(50)` (Account.purpose)                                                                  | Account; schemas/accounts.py                                         |
+| DebtType           | `mortgage`, `installment_0percent`                                                                                                    | `String(50)` (Debt.debt_type)                                                                   | Debt; schemas/debts.py                                               |
+| TransactionType    | `employee`, `employer`, `withdrawal`, `government`                                                                                    | `String(20)` nullable (Transaction.transaction_type)                                            | Transaction; schemas/transactions.py                                 |
+| ContractType       | `UOP`, `UZ`, `UoD`, `B2B`                                                                                                             | `String(50)` (SalaryRecord.contract_type, BonusEvent.contract_type)                             | SalaryRecord, BonusEvent; schemas/salary_records.py, bonus_events.py |
+| BonusType          | `annual`, `signon`, `spot`, `retention`                                                                                               | `String(20)` (BonusEvent.type)                                                                  | BonusEvent; schemas/bonus_events.py                                  |
+| EquityGrantType    | `option`, `rsu`                                                                                                                       | `String(20)` (EquityGrant.type)                                                                 | EquityGrant; schemas/equity_grants.py                                |
+| VestingFrequency   | `monthly`, `quarterly`, `yearly`                                                                                                      | `String(20)` (EquityGrant.vest_frequency)                                                       | EquityGrant; schemas/equity_grants.py                                |
+| EquityTaxTreatment | `capital_gains_19`, `employment_income`                                                                                               | `String(30)` (EquityGrant.tax_treatment, default `capital_gains_19`)                            | EquityGrant; schemas/equity_grants.py                                |
+| ValuationSource    | `409a`, `preferred_round`, `tender`, `estimate`                                                                                       | `String(30)` (CompanyValuation.source)                                                          | CompanyValuation; schemas/company_valuations.py                      |
 
 Inline enum-like fields without `Enum` class (string with ad-hoc validation):
 
@@ -229,18 +229,19 @@ Inline enum-like fields without `Enum` class (string with ad-hoc validation):
 
 ## Foreign keys & cascade behavior
 
-| From | To | ON DELETE | ON UPDATE | Soft-delete on parent? |
-|---|---|---|---|---|
-| Debt.account_id | accounts.id | CASCADE | (default NO ACTION) | yes (Account.is_active) |
-| DebtPayment.account_id | accounts.id | CASCADE | (default NO ACTION) | yes (Account.is_active) |
-| Goal.account_id (nullable) | accounts.id | (default NO ACTION) | (default NO ACTION) | yes (Account.is_active) |
-| SnapshotValue.snapshot_id | snapshots.id | CASCADE | (default NO ACTION) | no (Snapshot has no is_active) |
-| SnapshotValue.asset_id (nullable) | assets.id | CASCADE | (default NO ACTION) | yes (Asset.is_active) |
-| SnapshotValue.account_id (nullable) | accounts.id | CASCADE | (default NO ACTION) | yes (Account.is_active) |
-| SnapshotAggregate.snapshot_id | snapshots.id | CASCADE | (default NO ACTION) | no |
-| Transaction.account_id | accounts.id | CASCADE | (default NO ACTION) | yes (Account.is_active) |
+| From                                | To           | ON DELETE           | ON UPDATE           | Soft-delete on parent?         |
+| ----------------------------------- | ------------ | ------------------- | ------------------- | ------------------------------ |
+| Debt.account_id                     | accounts.id  | CASCADE             | (default NO ACTION) | yes (Account.is_active)        |
+| DebtPayment.account_id              | accounts.id  | CASCADE             | (default NO ACTION) | yes (Account.is_active)        |
+| Goal.account_id (nullable)          | accounts.id  | (default NO ACTION) | (default NO ACTION) | yes (Account.is_active)        |
+| SnapshotValue.snapshot_id           | snapshots.id | CASCADE             | (default NO ACTION) | no (Snapshot has no is_active) |
+| SnapshotValue.asset_id (nullable)   | assets.id    | CASCADE             | (default NO ACTION) | yes (Asset.is_active)          |
+| SnapshotValue.account_id (nullable) | accounts.id  | CASCADE             | (default NO ACTION) | yes (Account.is_active)        |
+| SnapshotAggregate.snapshot_id       | snapshots.id | CASCADE             | (default NO ACTION) | no                             |
+| Transaction.account_id              | accounts.id  | CASCADE             | (default NO ACTION) | yes (Account.is_active)        |
 
 Notes:
+
 - Soft delete is the standard delete path through the API. Hard delete (cascade) only fires if a row is removed via direct SQL/admin — application code never calls `db.delete(account)`.
 - Goal → accounts.id has **no** ON DELETE — orphans Goal.account_id if Account row is hard-deleted (but soft-delete is the contract).
 - Indexes hot-path: `ix_accounts_owner`, `ix_transactions_account_id_date`, `ix_snapshot_values_asset_id`, `ix_snapshot_aggregates_month`.
@@ -251,19 +252,20 @@ Notes:
 
 Every model with `is_active: bool` (default `True`). No `deleted_at` columns anywhere. No `deleted_by`.
 
-| Model | Filter applied by | API endpoints that filter |
-|---|---|---|
-| Account | services/accounts.py, services/snapshots.py, services/snapshot_aggregates.py, services/transactions.py, services/debt_payments.py, services/debts.py, services/investment.py, services/retirement.py | GET /accounts (list), all account-scoped reads, dashboard, retirement |
-| Asset | services/assets.py, services/snapshots.py, services/snapshot_aggregates.py | GET /assets, snapshot reads, aggregates |
-| BonusEvent | services/bonus_events.py | GET /bonus-events (all reads) |
-| CompanyValuation | services/company_valuations.py | GET /company-valuations (all reads) |
-| Debt | services/debts.py | GET /debts (all reads) |
-| DebtPayment | services/debt_payments.py | GET /debt-payments (all reads) |
-| EquityGrant | services/equity_grants.py | GET /equity-grants (all reads) |
-| SalaryRecord | services/salary_records.py, services/zus_calculator.py, api/simulations.py | GET /salary-records, ZUS prefill, simulations prefill |
-| Transaction | services/transactions.py, services/retirement.py, services/investment.py | GET /transactions, retirement stats, investment stats |
+| Model            | Filter applied by                                                                                                                                                                                    | API endpoints that filter                                             |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Account          | services/accounts.py, services/snapshots.py, services/snapshot_aggregates.py, services/transactions.py, services/debt_payments.py, services/debts.py, services/investment.py, services/retirement.py | GET /accounts (list), all account-scoped reads, dashboard, retirement |
+| Asset            | services/assets.py, services/snapshots.py, services/snapshot_aggregates.py                                                                                                                           | GET /assets, snapshot reads, aggregates                               |
+| BonusEvent       | services/bonus_events.py                                                                                                                                                                             | GET /bonus-events (all reads)                                         |
+| CompanyValuation | services/company_valuations.py                                                                                                                                                                       | GET /company-valuations (all reads)                                   |
+| Debt             | services/debts.py                                                                                                                                                                                    | GET /debts (all reads)                                                |
+| DebtPayment      | services/debt_payments.py                                                                                                                                                                            | GET /debt-payments (all reads)                                        |
+| EquityGrant      | services/equity_grants.py                                                                                                                                                                            | GET /equity-grants (all reads)                                        |
+| SalaryRecord     | services/salary_records.py, services/zus_calculator.py, api/simulations.py                                                                                                                           | GET /salary-records, ZUS prefill, simulations prefill                 |
+| Transaction      | services/transactions.py, services/retirement.py, services/investment.py                                                                                                                             | GET /transactions, retirement stats, investment stats                 |
 
 Models WITHOUT soft-delete (hard delete or single-row config):
+
 - AppConfig — single-row table (CheckConstraint `id = 1`).
 - CpiIndex — reference data, PK on year, re-fetched idempotently.
 - FxRate — reference data, unique on (date, currency).


### PR DESCRIPTION
## Motivation

Defensive prep for the Python→Go backend rewrite. Phase 0 is read-only: document the surface and its silent gotchas before we touch any code. Per-endpoint cutover is the target, and that only works if we know which endpoints are actually independent.

## Implementation information

Four audit deliverables under `migration/`, produced by reading the FastAPI backend end-to-end. No code changes.

- `inventory.md` — every endpoint (75 total: S=50 M=17 L=8), one row each: method, path, schemas, side effects, pandas/money/date flags, risk
- `scheduler.md` — APScheduler audit (1 job: monthly CPI refresh from GUS BDL) + 3 migration options, recommended path
- `types.md` — money fields (27), date/datetime fields (33), enums (12), FKs (8), soft-delete tables (9). Calls out float-money on the wire, naive/aware datetime mismatch, currency assumptions, rounding policy
- `coupling.md` — 13 cutover groups ordered by risk; flags stealth writers (`fx.get_fx_rate_to_pln` writes on cache miss), persona PUT 5-table fan-out, dashboard depending on aggregates from many domains

Key findings to flag upfront:

- **Float-money on the wire** — DB is Numeric(15,2) but Pydantic exposes `float` almost everywhere. Frontend depends on JSON numbers, not strings. Go must emit numbers for parity.
- **Naive/aware datetime mismatch** — `default=lambda: datetime.now(UTC)` produces aware datetimes but most columns are plain `DateTime` (without TZ). Offset stripped on insert.
- **Stealth writers** — `fx.get_fx_rate_to_pln` writes `fx_rates` on cache miss; called from bonuses + equity-grants handlers.
- **`is_active` filter is service-layer, not model-level** — every read site must repeat it (recent fix in fd6f7fa proves this is load-bearing).
- **Recommended first cutover:** Group 1 (`/api/config`) — singleton table, no FKs, no shared services.

Next phases are tracked in the local task list and will land as separate PRs:

- Phase 1: freeze OpenAPI + frontend consumer audit
- Phase 2: black-box test harness against `BASE_URL`
- Phase 3: perf baseline
- Phase 4: cutover proxy
- Phase 5: Go skeleton (`/health` only) with golangci-lint + nilaway
- Phase 6: cutover protocol

## Supporting documentation

N/A — kicks off the migration prep series.

> Changelog: skip