### PR TITLE
chore(migration): freeze openapi + frontend audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,17 @@ jobs:
           APP_PASSWORD: test
           CORS_ORIGINS: http://localhost:3000
 
+      - name: OpenAPI drift check
+        run: |
+          uv run python scripts/dump_openapi.py
+          if ! git diff --exit-code ../api/openapi.v1.json; then
+            echo "::error::api/openapi.v1.json is out of date." \
+                 "Regenerate with: (cd backend && uv run python scripts/dump_openapi.py)" \
+                 "and commit the result, or bump to openapi.v2.json if the change is intentional."
+            exit 1
+          fi
+        working-directory: backend
+
       - name: Upload backend coverage
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:

--- a/.prettierignore
+++ b/.prettierignore
@@ -40,3 +40,6 @@ playwright-report
 test-results
 blob-report
 playwright/.cache
+
+# Migration: OpenAPI spec is Python-dumped; CI drift check owns its format
+api/openapi.v1.json

--- a/api/openapi.v1.json
+++ b/api/openapi.v1.json
@@ -1,0 +1,8551 @@
+{
+  "components": {
+    "schemas": {
+      "AccountCreate": {
+        "properties": {
+          "account_wrapper": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Wrapper"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "currency": {
+            "default": "PLN",
+            "title": "Currency",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "purpose": {
+            "$ref": "#/components/schemas/Purpose"
+          },
+          "receives_contributions": {
+            "default": true,
+            "title": "Receives Contributions",
+            "type": "boolean"
+          },
+          "square_meters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Square Meters"
+          },
+          "type": {
+            "$ref": "#/components/schemas/AccountType"
+          }
+        },
+        "required": [
+          "name",
+          "type",
+          "category",
+          "owner",
+          "purpose"
+        ],
+        "title": "AccountCreate",
+        "type": "object"
+      },
+      "AccountResponse": {
+        "properties": {
+          "account_wrapper": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Wrapper"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "current_value": {
+            "title": "Current Value",
+            "type": "number"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "purpose": {
+            "$ref": "#/components/schemas/Purpose"
+          },
+          "receives_contributions": {
+            "title": "Receives Contributions",
+            "type": "boolean"
+          },
+          "square_meters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Square Meters"
+          },
+          "type": {
+            "$ref": "#/components/schemas/AccountType"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "category",
+          "owner",
+          "currency",
+          "account_wrapper",
+          "purpose",
+          "square_meters",
+          "is_active",
+          "receives_contributions",
+          "created_at",
+          "current_value"
+        ],
+        "title": "AccountResponse",
+        "type": "object"
+      },
+      "AccountSimulation": {
+        "description": "Simulation results for a single account",
+        "properties": {
+          "account_name": {
+            "title": "Account Name",
+            "type": "string"
+          },
+          "final_balance": {
+            "title": "Final Balance",
+            "type": "number"
+          },
+          "starting_balance": {
+            "title": "Starting Balance",
+            "type": "number"
+          },
+          "total_contributions": {
+            "title": "Total Contributions",
+            "type": "number"
+          },
+          "total_returns": {
+            "title": "Total Returns",
+            "type": "number"
+          },
+          "total_subsidies": {
+            "default": 0.0,
+            "title": "Total Subsidies",
+            "type": "number"
+          },
+          "total_tax_savings": {
+            "title": "Total Tax Savings",
+            "type": "number"
+          },
+          "yearly_projections": {
+            "items": {
+              "$ref": "#/components/schemas/YearlyProjection"
+            },
+            "title": "Yearly Projections",
+            "type": "array"
+          }
+        },
+        "required": [
+          "account_name",
+          "starting_balance",
+          "total_contributions",
+          "total_returns",
+          "total_tax_savings",
+          "final_balance",
+          "yearly_projections"
+        ],
+        "title": "AccountSimulation",
+        "type": "object"
+      },
+      "AccountType": {
+        "description": "Account type classification.",
+        "enum": [
+          "asset",
+          "liability"
+        ],
+        "title": "AccountType",
+        "type": "string"
+      },
+      "AccountUpdate": {
+        "properties": {
+          "account_wrapper": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Wrapper"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "category": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Category"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "owner": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner"
+          },
+          "purpose": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Purpose"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "receives_contributions": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Receives Contributions"
+          },
+          "square_meters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Square Meters"
+          }
+        },
+        "title": "AccountUpdate",
+        "type": "object"
+      },
+      "AccountWrapperBreakdown": {
+        "properties": {
+          "percentage": {
+            "title": "Percentage",
+            "type": "number"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          },
+          "wrapper": {
+            "title": "Wrapper",
+            "type": "string"
+          }
+        },
+        "required": [
+          "wrapper",
+          "value",
+          "percentage"
+        ],
+        "title": "AccountWrapperBreakdown",
+        "type": "object"
+      },
+      "AccountsListResponse": {
+        "properties": {
+          "assets": {
+            "items": {
+              "$ref": "#/components/schemas/AccountResponse"
+            },
+            "title": "Assets",
+            "type": "array"
+          },
+          "liabilities": {
+            "items": {
+              "$ref": "#/components/schemas/AccountResponse"
+            },
+            "title": "Liabilities",
+            "type": "array"
+          }
+        },
+        "required": [
+          "assets",
+          "liabilities"
+        ],
+        "title": "AccountsListResponse",
+        "type": "object"
+      },
+      "AdjustRequest": {
+        "properties": {
+          "amount": {
+            "title": "Amount",
+            "type": "number"
+          },
+          "from_date": {
+            "format": "date",
+            "title": "From Date",
+            "type": "string"
+          },
+          "to_date": {
+            "format": "date",
+            "title": "To Date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount",
+          "from_date",
+          "to_date"
+        ],
+        "title": "AdjustRequest",
+        "type": "object"
+      },
+      "AdjustResponse": {
+        "properties": {
+          "adjusted_amount": {
+            "title": "Adjusted Amount",
+            "type": "number"
+          },
+          "as_of_year": {
+            "title": "As Of Year",
+            "type": "integer"
+          },
+          "factor": {
+            "title": "Factor",
+            "type": "number"
+          },
+          "from_date": {
+            "format": "date",
+            "title": "From Date",
+            "type": "string"
+          },
+          "original_amount": {
+            "title": "Original Amount",
+            "type": "number"
+          },
+          "to_date": {
+            "format": "date",
+            "title": "To Date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "original_amount",
+          "adjusted_amount",
+          "factor",
+          "from_date",
+          "to_date",
+          "as_of_year"
+        ],
+        "title": "AdjustResponse",
+        "type": "object"
+      },
+      "AllocationAnalysis": {
+        "properties": {
+          "by_category": {
+            "items": {
+              "$ref": "#/components/schemas/AllocationBreakdown"
+            },
+            "title": "By Category",
+            "type": "array"
+          },
+          "by_wrapper": {
+            "items": {
+              "$ref": "#/components/schemas/AccountWrapperBreakdown"
+            },
+            "title": "By Wrapper",
+            "type": "array"
+          },
+          "rebalancing": {
+            "items": {
+              "$ref": "#/components/schemas/RebalancingSuggestion"
+            },
+            "title": "Rebalancing",
+            "type": "array"
+          },
+          "total_investment_value": {
+            "title": "Total Investment Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "by_category",
+          "by_wrapper",
+          "rebalancing",
+          "total_investment_value"
+        ],
+        "title": "AllocationAnalysis",
+        "type": "object"
+      },
+      "AllocationBreakdown": {
+        "properties": {
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "current_percentage": {
+            "title": "Current Percentage",
+            "type": "number"
+          },
+          "current_value": {
+            "title": "Current Value",
+            "type": "number"
+          },
+          "difference": {
+            "title": "Difference",
+            "type": "number"
+          },
+          "target_percentage": {
+            "title": "Target Percentage",
+            "type": "number"
+          }
+        },
+        "required": [
+          "category",
+          "current_value",
+          "current_percentage",
+          "target_percentage",
+          "difference"
+        ],
+        "title": "AllocationBreakdown",
+        "type": "object"
+      },
+      "AllocationItem": {
+        "properties": {
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "owner": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "category",
+          "owner",
+          "value"
+        ],
+        "title": "AllocationItem",
+        "type": "object"
+      },
+      "AssetCreate": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "AssetCreate",
+        "type": "object"
+      },
+      "AssetResponse": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "current_value": {
+            "title": "Current Value",
+            "type": "number"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "is_active",
+          "created_at",
+          "current_value"
+        ],
+        "title": "AssetResponse",
+        "type": "object"
+      },
+      "AssetUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "title": "AssetUpdate",
+        "type": "object"
+      },
+      "AssetsListResponse": {
+        "properties": {
+          "assets": {
+            "items": {
+              "$ref": "#/components/schemas/AssetResponse"
+            },
+            "title": "Assets",
+            "type": "array"
+          }
+        },
+        "required": [
+          "assets"
+        ],
+        "title": "AssetsListResponse",
+        "type": "object"
+      },
+      "BonusEventCreate": {
+        "properties": {
+          "amount": {
+            "title": "Amount",
+            "type": "number"
+          },
+          "company": {
+            "title": "Company",
+            "type": "string"
+          },
+          "contract_type": {
+            "$ref": "#/components/schemas/ContractType"
+          },
+          "currency": {
+            "default": "PLN",
+            "title": "Currency",
+            "type": "string"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/BonusType"
+          }
+        },
+        "required": [
+          "date",
+          "amount",
+          "type",
+          "company",
+          "owner",
+          "contract_type"
+        ],
+        "title": "BonusEventCreate",
+        "type": "object"
+      },
+      "BonusEventResponse": {
+        "properties": {
+          "amount": {
+            "title": "Amount",
+            "type": "number"
+          },
+          "amount_pln": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Amount Pln"
+          },
+          "company": {
+            "title": "Company",
+            "type": "string"
+          },
+          "contract_type": {
+            "$ref": "#/components/schemas/ContractType"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "fx_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fx Rate"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/BonusType"
+          }
+        },
+        "required": [
+          "id",
+          "date",
+          "amount",
+          "currency",
+          "type",
+          "company",
+          "owner",
+          "contract_type",
+          "notes",
+          "is_active",
+          "created_at"
+        ],
+        "title": "BonusEventResponse",
+        "type": "object"
+      },
+      "BonusEventUpdate": {
+        "properties": {
+          "amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Amount"
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "contract_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ContractType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency"
+          },
+          "date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "owner": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BonusType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "title": "BonusEventUpdate",
+        "type": "object"
+      },
+      "BonusEventsListResponse": {
+        "properties": {
+          "available_companies": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Available Companies",
+            "type": "array"
+          },
+          "bonus_events": {
+            "items": {
+              "$ref": "#/components/schemas/BonusEventResponse"
+            },
+            "title": "Bonus Events",
+            "type": "array"
+          },
+          "total_count": {
+            "title": "Total Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "bonus_events",
+          "total_count"
+        ],
+        "title": "BonusEventsListResponse",
+        "type": "object"
+      },
+      "BonusType": {
+        "description": "Compensation bonus event types.",
+        "enum": [
+          "annual",
+          "signon",
+          "spot",
+          "retention"
+        ],
+        "title": "BonusType",
+        "type": "string"
+      },
+      "BrokerageAccountInput": {
+        "description": "Input for a single brokerage account simulation",
+        "properties": {
+          "balance": {
+            "default": 0,
+            "title": "Balance",
+            "type": "number"
+          },
+          "enabled": {
+            "default": false,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "monthly_contribution": {
+            "default": 0,
+            "title": "Monthly Contribution",
+            "type": "number"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner"
+        ],
+        "title": "BrokerageAccountInput",
+        "type": "object"
+      },
+      "Category": {
+        "description": "Account category for asset allocation.",
+        "enum": [
+          "bank",
+          "saving_account",
+          "stock",
+          "bond",
+          "gold",
+          "real_estate",
+          "ppk",
+          "fund",
+          "etf",
+          "vehicle",
+          "mortgage",
+          "installment",
+          "other"
+        ],
+        "title": "Category",
+        "type": "string"
+      },
+      "CategoryStatsResponse": {
+        "properties": {
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "returns": {
+            "title": "Returns",
+            "type": "number"
+          },
+          "roi_percentage": {
+            "title": "Roi Percentage",
+            "type": "number"
+          },
+          "total_contributed": {
+            "title": "Total Contributed",
+            "type": "number"
+          },
+          "total_value": {
+            "title": "Total Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "category",
+          "total_value",
+          "total_contributed",
+          "returns",
+          "roi_percentage"
+        ],
+        "title": "CategoryStatsResponse",
+        "type": "object"
+      },
+      "CategoryTimeSeries": {
+        "properties": {
+          "bond": {
+            "items": {
+              "$ref": "#/components/schemas/InvestmentTimeSeriesPoint"
+            },
+            "title": "Bond",
+            "type": "array"
+          },
+          "stock": {
+            "items": {
+              "$ref": "#/components/schemas/InvestmentTimeSeriesPoint"
+            },
+            "title": "Stock",
+            "type": "array"
+          }
+        },
+        "required": [
+          "stock",
+          "bond"
+        ],
+        "title": "CategoryTimeSeries",
+        "type": "object"
+      },
+      "CompanyValuationCreate": {
+        "properties": {
+          "common_stock_discount_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Common Stock Discount Pct"
+          },
+          "company": {
+            "title": "Company",
+            "type": "string"
+          },
+          "currency": {
+            "default": "USD",
+            "title": "Currency",
+            "type": "string"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "fmv_high": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fmv High"
+          },
+          "fmv_low": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fmv Low"
+          },
+          "fmv_per_share": {
+            "title": "Fmv Per Share",
+            "type": "number"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "source": {
+            "$ref": "#/components/schemas/ValuationSource"
+          }
+        },
+        "required": [
+          "company",
+          "date",
+          "fmv_per_share",
+          "source"
+        ],
+        "title": "CompanyValuationCreate",
+        "type": "object"
+      },
+      "CompanyValuationResponse": {
+        "properties": {
+          "common_stock_discount_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Common Stock Discount Pct"
+          },
+          "company": {
+            "title": "Company",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "fmv_high": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fmv High"
+          },
+          "fmv_low": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fmv Low"
+          },
+          "fmv_per_share": {
+            "title": "Fmv Per Share",
+            "type": "number"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "source": {
+            "$ref": "#/components/schemas/ValuationSource"
+          }
+        },
+        "required": [
+          "id",
+          "company",
+          "date",
+          "currency",
+          "fmv_per_share",
+          "fmv_low",
+          "fmv_high",
+          "source",
+          "common_stock_discount_pct",
+          "notes",
+          "is_active",
+          "created_at"
+        ],
+        "title": "CompanyValuationResponse",
+        "type": "object"
+      },
+      "CompanyValuationUpdate": {
+        "properties": {
+          "common_stock_discount_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Common Stock Discount Pct"
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency"
+          },
+          "date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "fmv_high": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fmv High"
+          },
+          "fmv_low": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fmv Low"
+          },
+          "fmv_per_share": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fmv Per Share"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ValuationSource"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "title": "CompanyValuationUpdate",
+        "type": "object"
+      },
+      "CompanyValuationsListResponse": {
+        "properties": {
+          "available_companies": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Available Companies",
+            "type": "array"
+          },
+          "company_valuations": {
+            "items": {
+              "$ref": "#/components/schemas/CompanyValuationResponse"
+            },
+            "title": "Company Valuations",
+            "type": "array"
+          },
+          "total_count": {
+            "title": "Total Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "company_valuations",
+          "total_count"
+        ],
+        "title": "CompanyValuationsListResponse",
+        "type": "object"
+      },
+      "ConfigCreate": {
+        "description": "Request to create or update app configuration",
+        "properties": {
+          "allocation_bonds": {
+            "title": "Allocation Bonds",
+            "type": "integer"
+          },
+          "allocation_commodities": {
+            "title": "Allocation Commodities",
+            "type": "integer"
+          },
+          "allocation_gold": {
+            "title": "Allocation Gold",
+            "type": "integer"
+          },
+          "allocation_real_estate": {
+            "title": "Allocation Real Estate",
+            "type": "integer"
+          },
+          "allocation_stocks": {
+            "title": "Allocation Stocks",
+            "type": "integer"
+          },
+          "birth_date": {
+            "format": "date",
+            "title": "Birth Date",
+            "type": "string"
+          },
+          "monthly_expenses": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              }
+            ],
+            "title": "Monthly Expenses"
+          },
+          "monthly_mortgage_payment": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              }
+            ],
+            "title": "Monthly Mortgage Payment"
+          },
+          "retirement_age": {
+            "title": "Retirement Age",
+            "type": "integer"
+          },
+          "retirement_monthly_salary": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              }
+            ],
+            "title": "Retirement Monthly Salary"
+          }
+        },
+        "required": [
+          "birth_date",
+          "retirement_age",
+          "retirement_monthly_salary",
+          "allocation_real_estate",
+          "allocation_stocks",
+          "allocation_bonds",
+          "allocation_gold",
+          "allocation_commodities",
+          "monthly_expenses",
+          "monthly_mortgage_payment"
+        ],
+        "title": "ConfigCreate",
+        "type": "object"
+      },
+      "ConfigResponse": {
+        "description": "App configuration response",
+        "properties": {
+          "allocation_bonds": {
+            "title": "Allocation Bonds",
+            "type": "integer"
+          },
+          "allocation_commodities": {
+            "title": "Allocation Commodities",
+            "type": "integer"
+          },
+          "allocation_gold": {
+            "title": "Allocation Gold",
+            "type": "integer"
+          },
+          "allocation_real_estate": {
+            "title": "Allocation Real Estate",
+            "type": "integer"
+          },
+          "allocation_stocks": {
+            "title": "Allocation Stocks",
+            "type": "integer"
+          },
+          "birth_date": {
+            "format": "date",
+            "title": "Birth Date",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "monthly_expenses": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Monthly Expenses",
+            "type": "string"
+          },
+          "monthly_mortgage_payment": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Monthly Mortgage Payment",
+            "type": "string"
+          },
+          "retirement_age": {
+            "title": "Retirement Age",
+            "type": "integer"
+          },
+          "retirement_monthly_salary": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Retirement Monthly Salary",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "birth_date",
+          "retirement_age",
+          "retirement_monthly_salary",
+          "allocation_real_estate",
+          "allocation_stocks",
+          "allocation_bonds",
+          "allocation_gold",
+          "allocation_commodities",
+          "monthly_expenses",
+          "monthly_mortgage_payment"
+        ],
+        "title": "ConfigResponse",
+        "type": "object"
+      },
+      "ContractType": {
+        "description": "Polish employment contract types.",
+        "enum": [
+          "UOP",
+          "UZ",
+          "UoD",
+          "B2B"
+        ],
+        "title": "ContractType",
+        "type": "string"
+      },
+      "CpiPoint": {
+        "properties": {
+          "cumulative_index": {
+            "title": "Cumulative Index",
+            "type": "number"
+          },
+          "year": {
+            "title": "Year",
+            "type": "integer"
+          },
+          "yoy_rate": {
+            "title": "Yoy Rate",
+            "type": "number"
+          }
+        },
+        "required": [
+          "year",
+          "yoy_rate",
+          "cumulative_index"
+        ],
+        "title": "CpiPoint",
+        "type": "object"
+      },
+      "CpiSeriesResponse": {
+        "properties": {
+          "base_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Year"
+          },
+          "latest_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Year"
+          },
+          "points": {
+            "items": {
+              "$ref": "#/components/schemas/CpiPoint"
+            },
+            "title": "Points",
+            "type": "array"
+          },
+          "source": {
+            "default": "GUS-BDL-217230",
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "points",
+          "base_year",
+          "latest_year"
+        ],
+        "title": "CpiSeriesResponse",
+        "type": "object"
+      },
+      "DashboardResponse": {
+        "properties": {
+          "allocation": {
+            "items": {
+              "$ref": "#/components/schemas/AllocationItem"
+            },
+            "title": "Allocation",
+            "type": "array"
+          },
+          "allocation_analysis": {
+            "$ref": "#/components/schemas/AllocationAnalysis"
+          },
+          "category_time_series": {
+            "$ref": "#/components/schemas/CategoryTimeSeries"
+          },
+          "change_vs_last_month": {
+            "title": "Change Vs Last Month",
+            "type": "number"
+          },
+          "current_net_worth": {
+            "title": "Current Net Worth",
+            "type": "number"
+          },
+          "investment_time_series": {
+            "items": {
+              "$ref": "#/components/schemas/InvestmentTimeSeriesPoint"
+            },
+            "title": "Investment Time Series",
+            "type": "array"
+          },
+          "metric_cards": {
+            "$ref": "#/components/schemas/MetricCards"
+          },
+          "net_worth_history": {
+            "items": {
+              "$ref": "#/components/schemas/NetWorthPoint"
+            },
+            "title": "Net Worth History",
+            "type": "array"
+          },
+          "retirement_account_value": {
+            "title": "Retirement Account Value",
+            "type": "number"
+          },
+          "tile_deltas": {
+            "$ref": "#/components/schemas/TileDeltas"
+          },
+          "total_assets": {
+            "title": "Total Assets",
+            "type": "number"
+          },
+          "total_liabilities": {
+            "title": "Total Liabilities",
+            "type": "number"
+          },
+          "wrapper_time_series": {
+            "$ref": "#/components/schemas/WrapperTimeSeries"
+          }
+        },
+        "required": [
+          "net_worth_history",
+          "current_net_worth",
+          "change_vs_last_month",
+          "total_assets",
+          "total_liabilities",
+          "allocation",
+          "retirement_account_value",
+          "metric_cards",
+          "allocation_analysis",
+          "investment_time_series",
+          "wrapper_time_series",
+          "category_time_series",
+          "tile_deltas"
+        ],
+        "title": "DashboardResponse",
+        "type": "object"
+      },
+      "DebtCreate": {
+        "properties": {
+          "currency": {
+            "default": "PLN",
+            "title": "Currency",
+            "type": "string"
+          },
+          "debt_type": {
+            "$ref": "#/components/schemas/DebtType"
+          },
+          "initial_amount": {
+            "title": "Initial Amount",
+            "type": "number"
+          },
+          "interest_rate": {
+            "title": "Interest Rate",
+            "type": "number"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "start_date": {
+            "format": "date",
+            "title": "Start Date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "debt_type",
+          "start_date",
+          "initial_amount",
+          "interest_rate"
+        ],
+        "title": "DebtCreate",
+        "type": "object"
+      },
+      "DebtPaymentCreate": {
+        "properties": {
+          "amount": {
+            "title": "Amount",
+            "type": "number"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount",
+          "date",
+          "owner"
+        ],
+        "title": "DebtPaymentCreate",
+        "type": "object"
+      },
+      "DebtPaymentResponse": {
+        "properties": {
+          "account_id": {
+            "title": "Account Id",
+            "type": "integer"
+          },
+          "account_name": {
+            "title": "Account Name",
+            "type": "string"
+          },
+          "amount": {
+            "title": "Amount",
+            "type": "number"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "account_id",
+          "account_name",
+          "amount",
+          "date",
+          "owner",
+          "created_at"
+        ],
+        "title": "DebtPaymentResponse",
+        "type": "object"
+      },
+      "DebtPaymentsListResponse": {
+        "properties": {
+          "payment_count": {
+            "title": "Payment Count",
+            "type": "integer"
+          },
+          "payments": {
+            "items": {
+              "$ref": "#/components/schemas/DebtPaymentResponse"
+            },
+            "title": "Payments",
+            "type": "array"
+          },
+          "total_paid": {
+            "title": "Total Paid",
+            "type": "number"
+          }
+        },
+        "required": [
+          "payments",
+          "total_paid",
+          "payment_count"
+        ],
+        "title": "DebtPaymentsListResponse",
+        "type": "object"
+      },
+      "DebtResponse": {
+        "properties": {
+          "account_id": {
+            "title": "Account Id",
+            "type": "integer"
+          },
+          "account_name": {
+            "title": "Account Name",
+            "type": "string"
+          },
+          "account_owner": {
+            "title": "Account Owner",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "debt_type": {
+            "$ref": "#/components/schemas/DebtType"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "initial_amount": {
+            "title": "Initial Amount",
+            "type": "number"
+          },
+          "interest_paid": {
+            "default": 0,
+            "title": "Interest Paid",
+            "type": "number"
+          },
+          "interest_rate": {
+            "title": "Interest Rate",
+            "type": "number"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "latest_balance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Balance"
+          },
+          "latest_balance_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Balance Date"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "start_date": {
+            "format": "date",
+            "title": "Start Date",
+            "type": "string"
+          },
+          "total_paid": {
+            "default": 0,
+            "title": "Total Paid",
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "account_id",
+          "account_name",
+          "account_owner",
+          "name",
+          "debt_type",
+          "start_date",
+          "initial_amount",
+          "interest_rate",
+          "currency",
+          "notes",
+          "is_active",
+          "created_at"
+        ],
+        "title": "DebtResponse",
+        "type": "object"
+      },
+      "DebtType": {
+        "description": "Debt classification.",
+        "enum": [
+          "mortgage",
+          "installment_0percent"
+        ],
+        "title": "DebtType",
+        "type": "string"
+      },
+      "DebtUpdate": {
+        "properties": {
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency"
+          },
+          "debt_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DebtType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "initial_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Initial Amount"
+          },
+          "interest_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interest Rate"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Date"
+          }
+        },
+        "title": "DebtUpdate",
+        "type": "object"
+      },
+      "DebtsListResponse": {
+        "properties": {
+          "active_debts_count": {
+            "title": "Active Debts Count",
+            "type": "integer"
+          },
+          "debts": {
+            "items": {
+              "$ref": "#/components/schemas/DebtResponse"
+            },
+            "title": "Debts",
+            "type": "array"
+          },
+          "total_count": {
+            "title": "Total Count",
+            "type": "integer"
+          },
+          "total_initial_amount": {
+            "title": "Total Initial Amount",
+            "type": "number"
+          }
+        },
+        "required": [
+          "debts",
+          "total_count",
+          "total_initial_amount",
+          "active_debts_count"
+        ],
+        "title": "DebtsListResponse",
+        "type": "object"
+      },
+      "DeltaValue": {
+        "properties": {
+          "absolute": {
+            "title": "Absolute",
+            "type": "number"
+          },
+          "percentage": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Percentage"
+          }
+        },
+        "required": [
+          "absolute",
+          "percentage"
+        ],
+        "title": "DeltaValue",
+        "type": "object"
+      },
+      "EquityGrantCreate": {
+        "properties": {
+          "company": {
+            "title": "Company",
+            "type": "string"
+          },
+          "currency": {
+            "default": "USD",
+            "title": "Currency",
+            "type": "string"
+          },
+          "grant_date": {
+            "format": "date",
+            "title": "Grant Date",
+            "type": "string"
+          },
+          "liquidity_event_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Liquidity Event Date"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "requires_liquidity_event": {
+            "default": false,
+            "title": "Requires Liquidity Event",
+            "type": "boolean"
+          },
+          "strike_price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strike Price"
+          },
+          "tax_treatment": {
+            "$ref": "#/components/schemas/EquityTaxTreatment",
+            "default": "capital_gains_19"
+          },
+          "total_shares": {
+            "title": "Total Shares",
+            "type": "integer"
+          },
+          "type": {
+            "$ref": "#/components/schemas/EquityGrantType"
+          },
+          "vest_cliff_months": {
+            "default": 0,
+            "title": "Vest Cliff Months",
+            "type": "integer"
+          },
+          "vest_custom_schedule": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vest Custom Schedule"
+          },
+          "vest_frequency": {
+            "$ref": "#/components/schemas/VestingFrequency"
+          },
+          "vest_start_date": {
+            "format": "date",
+            "title": "Vest Start Date",
+            "type": "string"
+          },
+          "vest_total_months": {
+            "title": "Vest Total Months",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "grant_date",
+          "type",
+          "company",
+          "owner",
+          "total_shares",
+          "vest_start_date",
+          "vest_total_months",
+          "vest_frequency"
+        ],
+        "title": "EquityGrantCreate",
+        "type": "object"
+      },
+      "EquityGrantResponse": {
+        "properties": {
+          "company": {
+            "title": "Company",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "fx_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fx Rate"
+          },
+          "grant_date": {
+            "format": "date",
+            "title": "Grant Date",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "liquidity_event_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Liquidity Event Date"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "paper_value_base": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paper Value Base"
+          },
+          "paper_value_base_pln": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paper Value Base Pln"
+          },
+          "paper_value_currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paper Value Currency"
+          },
+          "paper_value_high": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paper Value High"
+          },
+          "paper_value_high_pln": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paper Value High Pln"
+          },
+          "paper_value_low": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paper Value Low"
+          },
+          "paper_value_low_pln": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paper Value Low Pln"
+          },
+          "requires_liquidity_event": {
+            "title": "Requires Liquidity Event",
+            "type": "boolean"
+          },
+          "strike_price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strike Price"
+          },
+          "tax_treatment": {
+            "$ref": "#/components/schemas/EquityTaxTreatment"
+          },
+          "total_shares": {
+            "title": "Total Shares",
+            "type": "integer"
+          },
+          "type": {
+            "$ref": "#/components/schemas/EquityGrantType"
+          },
+          "valuation_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Valuation Date"
+          },
+          "valuation_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Valuation Source"
+          },
+          "vest_cliff_months": {
+            "title": "Vest Cliff Months",
+            "type": "integer"
+          },
+          "vest_custom_schedule": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vest Custom Schedule"
+          },
+          "vest_frequency": {
+            "$ref": "#/components/schemas/VestingFrequency"
+          },
+          "vest_start_date": {
+            "format": "date",
+            "title": "Vest Start Date",
+            "type": "string"
+          },
+          "vest_total_months": {
+            "title": "Vest Total Months",
+            "type": "integer"
+          },
+          "vested_shares_today": {
+            "title": "Vested Shares Today",
+            "type": "integer"
+          },
+          "vesting_progress_pct": {
+            "title": "Vesting Progress Pct",
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "grant_date",
+          "type",
+          "company",
+          "owner",
+          "total_shares",
+          "strike_price",
+          "currency",
+          "vest_start_date",
+          "vest_cliff_months",
+          "vest_total_months",
+          "vest_frequency",
+          "vest_custom_schedule",
+          "requires_liquidity_event",
+          "liquidity_event_date",
+          "tax_treatment",
+          "notes",
+          "is_active",
+          "created_at",
+          "vested_shares_today",
+          "vesting_progress_pct"
+        ],
+        "title": "EquityGrantResponse",
+        "type": "object"
+      },
+      "EquityGrantType": {
+        "description": "Equity grant instrument.",
+        "enum": [
+          "option",
+          "rsu"
+        ],
+        "title": "EquityGrantType",
+        "type": "string"
+      },
+      "EquityGrantUpdate": {
+        "properties": {
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency"
+          },
+          "grant_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Date"
+          },
+          "liquidity_event_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Liquidity Event Date"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "owner": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner"
+          },
+          "requires_liquidity_event": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Requires Liquidity Event"
+          },
+          "strike_price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strike Price"
+          },
+          "tax_treatment": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EquityTaxTreatment"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "total_shares": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Shares"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EquityGrantType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "vest_cliff_months": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vest Cliff Months"
+          },
+          "vest_custom_schedule": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vest Custom Schedule"
+          },
+          "vest_frequency": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VestingFrequency"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "vest_start_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vest Start Date"
+          },
+          "vest_total_months": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vest Total Months"
+          }
+        },
+        "title": "EquityGrantUpdate",
+        "type": "object"
+      },
+      "EquityGrantsListResponse": {
+        "properties": {
+          "available_companies": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Available Companies",
+            "type": "array"
+          },
+          "equity_grants": {
+            "items": {
+              "$ref": "#/components/schemas/EquityGrantResponse"
+            },
+            "title": "Equity Grants",
+            "type": "array"
+          },
+          "total_count": {
+            "title": "Total Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "equity_grants",
+          "total_count"
+        ],
+        "title": "EquityGrantsListResponse",
+        "type": "object"
+      },
+      "EquityTaxTreatment": {
+        "description": "Polish tax treatment for equity grants.",
+        "enum": [
+          "capital_gains_19",
+          "employment_income"
+        ],
+        "title": "EquityTaxTreatment",
+        "type": "string"
+      },
+      "GoalCreate": {
+        "properties": {
+          "account_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Account Id"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Category"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "current_amount": {
+            "default": 0,
+            "title": "Current Amount",
+            "type": "number"
+          },
+          "is_completed": {
+            "default": false,
+            "title": "Is Completed",
+            "type": "boolean"
+          },
+          "monthly_contribution": {
+            "default": 0,
+            "title": "Monthly Contribution",
+            "type": "number"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "target_amount": {
+            "title": "Target Amount",
+            "type": "number"
+          },
+          "target_date": {
+            "format": "date",
+            "title": "Target Date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "target_amount",
+          "target_date"
+        ],
+        "title": "GoalCreate",
+        "type": "object"
+      },
+      "GoalResponse": {
+        "properties": {
+          "account_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Account Id"
+          },
+          "account_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Account Name"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Category"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "current_amount": {
+            "title": "Current Amount",
+            "type": "number"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_completed": {
+            "title": "Is Completed",
+            "type": "boolean"
+          },
+          "monthly_contribution": {
+            "title": "Monthly Contribution",
+            "type": "number"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "progress_percent": {
+            "title": "Progress Percent",
+            "type": "number"
+          },
+          "projected_hit_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Projected Hit Date"
+          },
+          "remaining_amount": {
+            "title": "Remaining Amount",
+            "type": "number"
+          },
+          "target_amount": {
+            "title": "Target Amount",
+            "type": "number"
+          },
+          "target_date": {
+            "format": "date",
+            "title": "Target Date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "target_amount",
+          "target_date",
+          "current_amount",
+          "monthly_contribution",
+          "is_completed",
+          "account_id",
+          "account_name",
+          "category",
+          "created_at",
+          "progress_percent",
+          "remaining_amount",
+          "projected_hit_date"
+        ],
+        "title": "GoalResponse",
+        "type": "object"
+      },
+      "GoalUpdate": {
+        "properties": {
+          "account_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Account Id"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Category"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "current_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Amount"
+          },
+          "is_completed": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Completed"
+          },
+          "monthly_contribution": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Monthly Contribution"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "target_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Amount"
+          },
+          "target_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Date"
+          }
+        },
+        "title": "GoalUpdate",
+        "type": "object"
+      },
+      "GoalsListResponse": {
+        "properties": {
+          "completed_count": {
+            "title": "Completed Count",
+            "type": "integer"
+          },
+          "goals": {
+            "items": {
+              "$ref": "#/components/schemas/GoalResponse"
+            },
+            "title": "Goals",
+            "type": "array"
+          },
+          "total_count": {
+            "title": "Total Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "goals",
+          "total_count",
+          "completed_count"
+        ],
+        "title": "GoalsListResponse",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "IkeIkzeAccountInput": {
+        "description": "Input for a single IKE/IKZE account simulation",
+        "properties": {
+          "auto_fill_limit": {
+            "default": false,
+            "title": "Auto Fill Limit",
+            "type": "boolean"
+          },
+          "balance": {
+            "default": 0,
+            "title": "Balance",
+            "type": "number"
+          },
+          "enabled": {
+            "default": false,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "monthly_contribution": {
+            "default": 0,
+            "title": "Monthly Contribution",
+            "type": "number"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "tax_rate": {
+            "default": 0,
+            "title": "Tax Rate",
+            "type": "number"
+          },
+          "wrapper": {
+            "title": "Wrapper",
+            "type": "string"
+          }
+        },
+        "required": [
+          "wrapper",
+          "owner"
+        ],
+        "title": "IkeIkzeAccountInput",
+        "type": "object"
+      },
+      "InflationContext": {
+        "properties": {
+          "cpi_as_of_year": {
+            "title": "Cpi As Of Year",
+            "type": "integer"
+          },
+          "current_salary": {
+            "title": "Current Salary",
+            "type": "number"
+          },
+          "last_change_date": {
+            "format": "date",
+            "title": "Last Change Date",
+            "type": "string"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "previous_change_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Previous Change Date"
+          },
+          "previous_salary": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Previous Salary"
+          },
+          "previous_salary_in_today_pln": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Previous Salary In Today Pln"
+          },
+          "real_change_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Real Change Pct"
+          },
+          "real_change_pln": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Real Change Pln"
+          }
+        },
+        "required": [
+          "owner",
+          "last_change_date",
+          "previous_change_date",
+          "previous_salary",
+          "previous_salary_in_today_pln",
+          "current_salary",
+          "real_change_pln",
+          "real_change_pct",
+          "cpi_as_of_year"
+        ],
+        "title": "InflationContext",
+        "type": "object"
+      },
+      "InvestmentTimeSeriesPoint": {
+        "properties": {
+          "contributions": {
+            "title": "Contributions",
+            "type": "number"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "returns": {
+            "title": "Returns",
+            "type": "number"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "date",
+          "value",
+          "contributions",
+          "returns"
+        ],
+        "title": "InvestmentTimeSeriesPoint",
+        "type": "object"
+      },
+      "MetricCards": {
+        "properties": {
+          "debt_to_income_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Debt To Income Ratio"
+          },
+          "emergency_fund_months": {
+            "title": "Emergency Fund Months",
+            "type": "number"
+          },
+          "hour_of_life_cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hour Of Life Cost"
+          },
+          "hour_of_work_cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hour Of Work Cost"
+          },
+          "investment_contributions": {
+            "title": "Investment Contributions",
+            "type": "number"
+          },
+          "investment_returns": {
+            "title": "Investment Returns",
+            "type": "number"
+          },
+          "mortgage_months_left": {
+            "title": "Mortgage Months Left",
+            "type": "integer"
+          },
+          "mortgage_remaining": {
+            "title": "Mortgage Remaining",
+            "type": "number"
+          },
+          "mortgage_years_left": {
+            "title": "Mortgage Years Left",
+            "type": "number"
+          },
+          "property_sqm": {
+            "title": "Property Sqm",
+            "type": "number"
+          },
+          "retirement_income_monthly": {
+            "title": "Retirement Income Monthly",
+            "type": "number"
+          },
+          "retirement_total": {
+            "title": "Retirement Total",
+            "type": "number"
+          },
+          "savings_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Savings Rate"
+          }
+        },
+        "required": [
+          "property_sqm",
+          "emergency_fund_months",
+          "retirement_income_monthly",
+          "mortgage_remaining",
+          "mortgage_months_left",
+          "mortgage_years_left",
+          "retirement_total",
+          "investment_contributions",
+          "investment_returns"
+        ],
+        "title": "MetricCards",
+        "type": "object"
+      },
+      "MortgageVsInvestInputs": {
+        "properties": {
+          "annual_interest_rate": {
+            "title": "Annual Interest Rate",
+            "type": "number"
+          },
+          "enable_variable_rate": {
+            "default": false,
+            "title": "Enable Variable Rate",
+            "type": "boolean"
+          },
+          "expected_annual_return": {
+            "title": "Expected Annual Return",
+            "type": "number"
+          },
+          "inflation_rate": {
+            "default": 3.0,
+            "title": "Inflation Rate",
+            "type": "number"
+          },
+          "remaining_months": {
+            "title": "Remaining Months",
+            "type": "integer"
+          },
+          "remaining_principal": {
+            "title": "Remaining Principal",
+            "type": "number"
+          },
+          "total_monthly_budget": {
+            "title": "Total Monthly Budget",
+            "type": "number"
+          }
+        },
+        "required": [
+          "remaining_principal",
+          "annual_interest_rate",
+          "remaining_months",
+          "total_monthly_budget",
+          "expected_annual_return"
+        ],
+        "title": "MortgageVsInvestInputs",
+        "type": "object"
+      },
+      "MortgageVsInvestResponse": {
+        "properties": {
+          "inputs": {
+            "$ref": "#/components/schemas/MortgageVsInvestInputs"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/MortgageVsInvestSummary"
+          },
+          "yearly_projections": {
+            "items": {
+              "$ref": "#/components/schemas/MortgageVsInvestYearlyRow"
+            },
+            "title": "Yearly Projections",
+            "type": "array"
+          }
+        },
+        "required": [
+          "inputs",
+          "yearly_projections",
+          "summary"
+        ],
+        "title": "MortgageVsInvestResponse",
+        "type": "object"
+      },
+      "MortgageVsInvestSummary": {
+        "properties": {
+          "belka_tax_a": {
+            "title": "Belka Tax A",
+            "type": "number"
+          },
+          "belka_tax_b": {
+            "title": "Belka Tax B",
+            "type": "number"
+          },
+          "break_even_gross_return": {
+            "title": "Break Even Gross Return",
+            "type": "number"
+          },
+          "final_investment_portfolio": {
+            "title": "Final Investment Portfolio",
+            "type": "number"
+          },
+          "final_portfolio_a_real": {
+            "title": "Final Portfolio A Real",
+            "type": "number"
+          },
+          "final_portfolio_b_real": {
+            "title": "Final Portfolio B Real",
+            "type": "number"
+          },
+          "interest_saved": {
+            "title": "Interest Saved",
+            "type": "number"
+          },
+          "months_saved": {
+            "title": "Months Saved",
+            "type": "integer"
+          },
+          "net_advantage": {
+            "title": "Net Advantage",
+            "type": "number"
+          },
+          "regular_monthly_payment": {
+            "title": "Regular Monthly Payment",
+            "type": "number"
+          },
+          "total_interest_a": {
+            "title": "Total Interest A",
+            "type": "number"
+          },
+          "total_interest_b": {
+            "title": "Total Interest B",
+            "type": "number"
+          },
+          "winning_strategy": {
+            "title": "Winning Strategy",
+            "type": "string"
+          }
+        },
+        "required": [
+          "regular_monthly_payment",
+          "total_interest_a",
+          "total_interest_b",
+          "interest_saved",
+          "final_investment_portfolio",
+          "belka_tax_a",
+          "belka_tax_b",
+          "final_portfolio_a_real",
+          "final_portfolio_b_real",
+          "months_saved",
+          "winning_strategy",
+          "net_advantage",
+          "break_even_gross_return"
+        ],
+        "title": "MortgageVsInvestSummary",
+        "type": "object"
+      },
+      "MortgageVsInvestYearlyRow": {
+        "properties": {
+          "annual_rate": {
+            "title": "Annual Rate",
+            "type": "number"
+          },
+          "net_advantage_invest": {
+            "title": "Net Advantage Invest",
+            "type": "number"
+          },
+          "scenario_a_after_tax_portfolio": {
+            "title": "Scenario A After Tax Portfolio",
+            "type": "number"
+          },
+          "scenario_a_cumulative_interest": {
+            "title": "Scenario A Cumulative Interest",
+            "type": "number"
+          },
+          "scenario_a_investment_balance": {
+            "title": "Scenario A Investment Balance",
+            "type": "number"
+          },
+          "scenario_a_mortgage_balance": {
+            "title": "Scenario A Mortgage Balance",
+            "type": "number"
+          },
+          "scenario_a_paid_off": {
+            "title": "Scenario A Paid Off",
+            "type": "boolean"
+          },
+          "scenario_a_real_mortgage_balance": {
+            "title": "Scenario A Real Mortgage Balance",
+            "type": "number"
+          },
+          "scenario_a_real_portfolio": {
+            "title": "Scenario A Real Portfolio",
+            "type": "number"
+          },
+          "scenario_b_after_tax_portfolio": {
+            "title": "Scenario B After Tax Portfolio",
+            "type": "number"
+          },
+          "scenario_b_cumulative_interest": {
+            "title": "Scenario B Cumulative Interest",
+            "type": "number"
+          },
+          "scenario_b_investment_balance": {
+            "title": "Scenario B Investment Balance",
+            "type": "number"
+          },
+          "scenario_b_mortgage_balance": {
+            "title": "Scenario B Mortgage Balance",
+            "type": "number"
+          },
+          "scenario_b_real_mortgage_balance": {
+            "title": "Scenario B Real Mortgage Balance",
+            "type": "number"
+          },
+          "scenario_b_real_portfolio": {
+            "title": "Scenario B Real Portfolio",
+            "type": "number"
+          },
+          "year": {
+            "title": "Year",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "year",
+          "annual_rate",
+          "scenario_a_mortgage_balance",
+          "scenario_a_real_mortgage_balance",
+          "scenario_a_cumulative_interest",
+          "scenario_a_investment_balance",
+          "scenario_a_after_tax_portfolio",
+          "scenario_a_real_portfolio",
+          "scenario_a_paid_off",
+          "scenario_b_mortgage_balance",
+          "scenario_b_real_mortgage_balance",
+          "scenario_b_investment_balance",
+          "scenario_b_after_tax_portfolio",
+          "scenario_b_real_portfolio",
+          "scenario_b_cumulative_interest",
+          "net_advantage_invest"
+        ],
+        "title": "MortgageVsInvestYearlyRow",
+        "type": "object"
+      },
+      "NetWorthPoint": {
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "date",
+          "value"
+        ],
+        "title": "NetWorthPoint",
+        "type": "object"
+      },
+      "PPKContributionGenerateRequest": {
+        "properties": {
+          "month": {
+            "title": "Month",
+            "type": "integer"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "year": {
+            "title": "Year",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "owner",
+          "month",
+          "year"
+        ],
+        "title": "PPKContributionGenerateRequest",
+        "type": "object"
+      },
+      "PPKContributionGenerateResponse": {
+        "properties": {
+          "employee_amount": {
+            "title": "Employee Amount",
+            "type": "number"
+          },
+          "employer_amount": {
+            "title": "Employer Amount",
+            "type": "number"
+          },
+          "gross_salary": {
+            "title": "Gross Salary",
+            "type": "number"
+          },
+          "month": {
+            "title": "Month",
+            "type": "integer"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "total_amount": {
+            "title": "Total Amount",
+            "type": "number"
+          },
+          "transactions_created": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Transactions Created",
+            "type": "array"
+          },
+          "year": {
+            "title": "Year",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "owner",
+          "month",
+          "year",
+          "gross_salary",
+          "employee_amount",
+          "employer_amount",
+          "total_amount",
+          "transactions_created"
+        ],
+        "title": "PPKContributionGenerateResponse",
+        "type": "object"
+      },
+      "PPKSimulationConfig": {
+        "description": "Configuration for PPK (Employee Capital Plan) simulation",
+        "properties": {
+          "employee_rate": {
+            "title": "Employee Rate",
+            "type": "number"
+          },
+          "employer_rate": {
+            "title": "Employer Rate",
+            "type": "number"
+          },
+          "enabled": {
+            "default": false,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "include_annual_subsidy": {
+            "default": true,
+            "title": "Include Annual Subsidy",
+            "type": "boolean"
+          },
+          "include_welcome_bonus": {
+            "default": true,
+            "title": "Include Welcome Bonus",
+            "type": "boolean"
+          },
+          "monthly_gross_salary": {
+            "title": "Monthly Gross Salary",
+            "type": "number"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "salary_below_threshold": {
+            "default": false,
+            "title": "Salary Below Threshold",
+            "type": "boolean"
+          },
+          "starting_balance": {
+            "default": 0.0,
+            "title": "Starting Balance",
+            "type": "number"
+          }
+        },
+        "required": [
+          "owner",
+          "monthly_gross_salary",
+          "employee_rate",
+          "employer_rate"
+        ],
+        "title": "PPKSimulationConfig",
+        "type": "object"
+      },
+      "PPKStatsResponse": {
+        "properties": {
+          "employee_contributed": {
+            "title": "Employee Contributed",
+            "type": "number"
+          },
+          "employer_contributed": {
+            "title": "Employer Contributed",
+            "type": "number"
+          },
+          "government_contributed": {
+            "title": "Government Contributed",
+            "type": "number"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "returns": {
+            "title": "Returns",
+            "type": "number"
+          },
+          "roi_percentage": {
+            "title": "Roi Percentage",
+            "type": "number"
+          },
+          "total_contributed": {
+            "title": "Total Contributed",
+            "type": "number"
+          },
+          "total_value": {
+            "title": "Total Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "owner",
+          "total_value",
+          "employee_contributed",
+          "employer_contributed",
+          "government_contributed",
+          "total_contributed",
+          "returns",
+          "roi_percentage"
+        ],
+        "title": "PPKStatsResponse",
+        "type": "object"
+      },
+      "PersonaCreate": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "ppk_employee_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              }
+            ],
+            "default": "2.0",
+            "title": "Ppk Employee Rate"
+          },
+          "ppk_employer_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              }
+            ],
+            "default": "1.5",
+            "title": "Ppk Employer Rate"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "PersonaCreate",
+        "type": "object"
+      },
+      "PersonaResponse": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "ppk_employee_rate": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Ppk Employee Rate",
+            "type": "string"
+          },
+          "ppk_employer_rate": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Ppk Employer Rate",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "ppk_employee_rate",
+          "ppk_employer_rate",
+          "created_at"
+        ],
+        "title": "PersonaResponse",
+        "type": "object"
+      },
+      "PersonaUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "ppk_employee_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ppk Employee Rate"
+          },
+          "ppk_employer_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ppk Employer Rate"
+          }
+        },
+        "title": "PersonaUpdate",
+        "type": "object"
+      },
+      "PrefillBalances": {
+        "additionalProperties": true,
+        "description": "Current balances for retirement accounts, keyed by {wrapper}_{owner} lowercase",
+        "properties": {},
+        "title": "PrefillBalances",
+        "type": "object"
+      },
+      "PrefillResponse": {
+        "description": "Response for prefill endpoint with current config and balances",
+        "properties": {
+          "balances": {
+            "$ref": "#/components/schemas/PrefillBalances"
+          },
+          "current_age": {
+            "title": "Current Age",
+            "type": "integer"
+          },
+          "monthly_salaries": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "default": {},
+            "title": "Monthly Salaries",
+            "type": "object"
+          },
+          "ppk_balances": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "default": {},
+            "title": "Ppk Balances",
+            "type": "object"
+          },
+          "ppk_rates": {
+            "additionalProperties": {
+              "additionalProperties": {
+                "type": "number"
+              },
+              "type": "object"
+            },
+            "default": {},
+            "title": "Ppk Rates",
+            "type": "object"
+          },
+          "retirement_age": {
+            "title": "Retirement Age",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "current_age",
+          "retirement_age",
+          "balances"
+        ],
+        "title": "PrefillResponse",
+        "type": "object"
+      },
+      "Purpose": {
+        "description": "Account purpose classification.",
+        "enum": [
+          "retirement",
+          "emergency_fund",
+          "general"
+        ],
+        "title": "Purpose",
+        "type": "string"
+      },
+      "RebalancingSuggestion": {
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "amount": {
+            "title": "Amount",
+            "type": "number"
+          },
+          "category": {
+            "title": "Category",
+            "type": "string"
+          }
+        },
+        "required": [
+          "category",
+          "action",
+          "amount"
+        ],
+        "title": "RebalancingSuggestion",
+        "type": "object"
+      },
+      "RefreshResponse": {
+        "properties": {
+          "latest_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Year"
+          },
+          "rows_written": {
+            "title": "Rows Written",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "rows_written",
+          "latest_year"
+        ],
+        "title": "RefreshResponse",
+        "type": "object"
+      },
+      "RetirementLimitCreate": {
+        "properties": {
+          "account_wrapper": {
+            "$ref": "#/components/schemas/Wrapper"
+          },
+          "limit_amount": {
+            "title": "Limit Amount",
+            "type": "number"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "year": {
+            "title": "Year",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "year",
+          "account_wrapper",
+          "owner",
+          "limit_amount"
+        ],
+        "title": "RetirementLimitCreate",
+        "type": "object"
+      },
+      "RetirementLimitResponse": {
+        "properties": {
+          "account_wrapper": {
+            "$ref": "#/components/schemas/Wrapper"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "limit_amount": {
+            "title": "Limit Amount",
+            "type": "number"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "year": {
+            "title": "Year",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "year",
+          "account_wrapper",
+          "owner",
+          "limit_amount",
+          "id"
+        ],
+        "title": "RetirementLimitResponse",
+        "type": "object"
+      },
+      "SalaryHistoryEntry": {
+        "properties": {
+          "annual_gross": {
+            "title": "Annual Gross",
+            "type": "number"
+          },
+          "year": {
+            "title": "Year",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "year",
+          "annual_gross"
+        ],
+        "title": "SalaryHistoryEntry",
+        "type": "object"
+      },
+      "SalaryRecordCreate": {
+        "properties": {
+          "company": {
+            "title": "Company",
+            "type": "string"
+          },
+          "contract_type": {
+            "$ref": "#/components/schemas/ContractType"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "gross_amount": {
+            "title": "Gross Amount",
+            "type": "number"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          }
+        },
+        "required": [
+          "date",
+          "gross_amount",
+          "contract_type",
+          "company",
+          "owner"
+        ],
+        "title": "SalaryRecordCreate",
+        "type": "object"
+      },
+      "SalaryRecordResponse": {
+        "properties": {
+          "company": {
+            "title": "Company",
+            "type": "string"
+          },
+          "contract_type": {
+            "$ref": "#/components/schemas/ContractType"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "gross_amount": {
+            "title": "Gross Amount",
+            "type": "number"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "date",
+          "gross_amount",
+          "contract_type",
+          "company",
+          "owner",
+          "is_active",
+          "created_at"
+        ],
+        "title": "SalaryRecordResponse",
+        "type": "object"
+      },
+      "SalaryRecordUpdate": {
+        "properties": {
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "contract_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ContractType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "gross_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gross Amount"
+          },
+          "owner": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner"
+          }
+        },
+        "title": "SalaryRecordUpdate",
+        "type": "object"
+      },
+      "SalaryRecordsListResponse": {
+        "properties": {
+          "available_companies": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Available Companies",
+            "type": "array"
+          },
+          "current_salaries": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "default": {},
+            "title": "Current Salaries",
+            "type": "object"
+          },
+          "inflation_context": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/InflationContext"
+            },
+            "default": {},
+            "title": "Inflation Context",
+            "type": "object"
+          },
+          "salary_records": {
+            "items": {
+              "$ref": "#/components/schemas/SalaryRecordResponse"
+            },
+            "title": "Salary Records",
+            "type": "array"
+          },
+          "total_count": {
+            "title": "Total Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "salary_records",
+          "total_count"
+        ],
+        "title": "SalaryRecordsListResponse",
+        "type": "object"
+      },
+      "SimulationInputs": {
+        "description": "Input parameters for retirement simulation",
+        "properties": {
+          "annual_return_rate": {
+            "default": 7.0,
+            "title": "Annual Return Rate",
+            "type": "number"
+          },
+          "brokerage_accounts": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/BrokerageAccountInput"
+            },
+            "title": "Brokerage Accounts",
+            "type": "array"
+          },
+          "current_age": {
+            "title": "Current Age",
+            "type": "integer"
+          },
+          "expected_salary_growth": {
+            "default": 3.0,
+            "title": "Expected Salary Growth",
+            "type": "number"
+          },
+          "ike_ikze_accounts": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/IkeIkzeAccountInput"
+            },
+            "title": "Ike Ikze Accounts",
+            "type": "array"
+          },
+          "inflation_rate": {
+            "default": 3.0,
+            "title": "Inflation Rate",
+            "type": "number"
+          },
+          "limit_growth_rate": {
+            "default": 5.0,
+            "title": "Limit Growth Rate",
+            "type": "number"
+          },
+          "ppk_accounts": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/PPKSimulationConfig"
+            },
+            "title": "Ppk Accounts",
+            "type": "array"
+          },
+          "retirement_age": {
+            "title": "Retirement Age",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "current_age",
+          "retirement_age"
+        ],
+        "title": "SimulationInputs",
+        "type": "object"
+      },
+      "SimulationResponse": {
+        "description": "Complete simulation response",
+        "properties": {
+          "inputs": {
+            "$ref": "#/components/schemas/SimulationInputs"
+          },
+          "simulations": {
+            "items": {
+              "$ref": "#/components/schemas/AccountSimulation"
+            },
+            "title": "Simulations",
+            "type": "array"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/SimulationSummary"
+          }
+        },
+        "required": [
+          "inputs",
+          "simulations",
+          "summary"
+        ],
+        "title": "SimulationResponse",
+        "type": "object"
+      },
+      "SimulationSummary": {
+        "description": "Overall summary of all simulations",
+        "properties": {
+          "estimated_monthly_income": {
+            "title": "Estimated Monthly Income",
+            "type": "number"
+          },
+          "estimated_monthly_income_today": {
+            "title": "Estimated Monthly Income Today",
+            "type": "number"
+          },
+          "total_contributions": {
+            "title": "Total Contributions",
+            "type": "number"
+          },
+          "total_final_balance": {
+            "title": "Total Final Balance",
+            "type": "number"
+          },
+          "total_returns": {
+            "title": "Total Returns",
+            "type": "number"
+          },
+          "total_subsidies": {
+            "default": 0.0,
+            "title": "Total Subsidies",
+            "type": "number"
+          },
+          "total_tax_savings": {
+            "title": "Total Tax Savings",
+            "type": "number"
+          },
+          "years_until_retirement": {
+            "title": "Years Until Retirement",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total_final_balance",
+          "total_contributions",
+          "total_returns",
+          "total_tax_savings",
+          "estimated_monthly_income",
+          "estimated_monthly_income_today",
+          "years_until_retirement"
+        ],
+        "title": "SimulationSummary",
+        "type": "object"
+      },
+      "SnapshotCreate": {
+        "description": "Request to create new snapshot",
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "values": {
+            "items": {
+              "$ref": "#/components/schemas/SnapshotValueInput"
+            },
+            "title": "Values",
+            "type": "array"
+          }
+        },
+        "required": [
+          "date",
+          "values"
+        ],
+        "title": "SnapshotCreate",
+        "type": "object"
+      },
+      "SnapshotListItem": {
+        "description": "Snapshot summary for list view",
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "total_net_worth": {
+            "title": "Total Net Worth",
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "date",
+          "notes",
+          "total_net_worth"
+        ],
+        "title": "SnapshotListItem",
+        "type": "object"
+      },
+      "SnapshotResponse": {
+        "description": "Snapshot with all account values",
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "values": {
+            "items": {
+              "$ref": "#/components/schemas/SnapshotValueResponse"
+            },
+            "title": "Values",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "date",
+          "notes",
+          "values"
+        ],
+        "title": "SnapshotResponse",
+        "type": "object"
+      },
+      "SnapshotUpdate": {
+        "description": "Update snapshot - all fields optional",
+        "properties": {
+          "date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "values": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SnapshotValueInput"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Values"
+          }
+        },
+        "title": "SnapshotUpdate",
+        "type": "object"
+      },
+      "SnapshotValueInput": {
+        "description": "Input for single account or asset value in snapshot",
+        "properties": {
+          "account_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Account Id"
+          },
+          "asset_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Asset Id"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "SnapshotValueInput",
+        "type": "object"
+      },
+      "SnapshotValueResponse": {
+        "description": "Snapshot value for single account or asset",
+        "properties": {
+          "account_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Account Id"
+          },
+          "account_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Account Name"
+          },
+          "asset_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Asset Id"
+          },
+          "asset_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Asset Name"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "value"
+        ],
+        "title": "SnapshotValueResponse",
+        "type": "object"
+      },
+      "TileDelta": {
+        "properties": {
+          "mom": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DeltaValue"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "yoy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DeltaValue"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "mom",
+          "yoy"
+        ],
+        "title": "TileDelta",
+        "type": "object"
+      },
+      "TileDeltas": {
+        "properties": {
+          "assets": {
+            "$ref": "#/components/schemas/TileDelta"
+          },
+          "liabilities": {
+            "$ref": "#/components/schemas/TileDelta"
+          },
+          "net_worth": {
+            "$ref": "#/components/schemas/TileDelta"
+          }
+        },
+        "required": [
+          "net_worth",
+          "assets",
+          "liabilities"
+        ],
+        "title": "TileDeltas",
+        "type": "object"
+      },
+      "TransactionCreate": {
+        "properties": {
+          "amount": {
+            "title": "Amount",
+            "type": "number"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "transaction_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TransactionType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "amount",
+          "date",
+          "owner"
+        ],
+        "title": "TransactionCreate",
+        "type": "object"
+      },
+      "TransactionResponse": {
+        "properties": {
+          "account_id": {
+            "title": "Account Id",
+            "type": "integer"
+          },
+          "account_name": {
+            "title": "Account Name",
+            "type": "string"
+          },
+          "amount": {
+            "title": "Amount",
+            "type": "number"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "transaction_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TransactionType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "account_id",
+          "account_name",
+          "amount",
+          "date",
+          "owner",
+          "transaction_type",
+          "created_at"
+        ],
+        "title": "TransactionResponse",
+        "type": "object"
+      },
+      "TransactionType": {
+        "description": "Retirement transaction types.",
+        "enum": [
+          "employee",
+          "employer",
+          "withdrawal",
+          "government"
+        ],
+        "title": "TransactionType",
+        "type": "string"
+      },
+      "TransactionsListResponse": {
+        "properties": {
+          "total_invested": {
+            "title": "Total Invested",
+            "type": "number"
+          },
+          "transaction_count": {
+            "title": "Transaction Count",
+            "type": "integer"
+          },
+          "transactions": {
+            "items": {
+              "$ref": "#/components/schemas/TransactionResponse"
+            },
+            "title": "Transactions",
+            "type": "array"
+          }
+        },
+        "required": [
+          "transactions",
+          "total_invested",
+          "transaction_count"
+        ],
+        "title": "TransactionsListResponse",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      },
+      "ValuationSource": {
+        "description": "Source of a private-company FMV estimate.",
+        "enum": [
+          "409a",
+          "preferred_round",
+          "tender",
+          "estimate"
+        ],
+        "title": "ValuationSource",
+        "type": "string"
+      },
+      "VestingFrequency": {
+        "description": "Vesting cadence after the cliff.",
+        "enum": [
+          "monthly",
+          "quarterly",
+          "yearly"
+        ],
+        "title": "VestingFrequency",
+        "type": "string"
+      },
+      "Wrapper": {
+        "description": "Polish retirement account wrappers.",
+        "enum": [
+          "IKE",
+          "IKZE",
+          "PPK"
+        ],
+        "title": "Wrapper",
+        "type": "string"
+      },
+      "WrapperTimeSeries": {
+        "properties": {
+          "ike": {
+            "items": {
+              "$ref": "#/components/schemas/InvestmentTimeSeriesPoint"
+            },
+            "title": "Ike",
+            "type": "array"
+          },
+          "ikze": {
+            "items": {
+              "$ref": "#/components/schemas/InvestmentTimeSeriesPoint"
+            },
+            "title": "Ikze",
+            "type": "array"
+          },
+          "ppk": {
+            "items": {
+              "$ref": "#/components/schemas/InvestmentTimeSeriesPoint"
+            },
+            "title": "Ppk",
+            "type": "array"
+          }
+        },
+        "required": [
+          "ike",
+          "ikze",
+          "ppk"
+        ],
+        "title": "WrapperTimeSeries",
+        "type": "object"
+      },
+      "YearlyProjection": {
+        "description": "Projection for a single year",
+        "properties": {
+          "age": {
+            "title": "Age",
+            "type": "integer"
+          },
+          "annual_contribution": {
+            "title": "Annual Contribution",
+            "type": "number"
+          },
+          "annual_limit": {
+            "title": "Annual Limit",
+            "type": "number"
+          },
+          "balance_end_of_year": {
+            "title": "Balance End Of Year",
+            "type": "number"
+          },
+          "cumulative_contributions": {
+            "title": "Cumulative Contributions",
+            "type": "number"
+          },
+          "cumulative_returns": {
+            "title": "Cumulative Returns",
+            "type": "number"
+          },
+          "government_subsidies": {
+            "default": 0.0,
+            "title": "Government Subsidies",
+            "type": "number"
+          },
+          "limit_utilized_pct": {
+            "title": "Limit Utilized Pct",
+            "type": "number"
+          },
+          "monthly_salary": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Monthly Salary"
+          },
+          "return_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Return Rate"
+          },
+          "tax_savings": {
+            "title": "Tax Savings",
+            "type": "number"
+          },
+          "year": {
+            "title": "Year",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "year",
+          "age",
+          "annual_contribution",
+          "balance_end_of_year",
+          "cumulative_contributions",
+          "cumulative_returns",
+          "annual_limit",
+          "limit_utilized_pct",
+          "tax_savings"
+        ],
+        "title": "YearlyProjection",
+        "type": "object"
+      },
+      "YearlyStatsResponse": {
+        "properties": {
+          "account_wrapper": {
+            "$ref": "#/components/schemas/Wrapper"
+          },
+          "employee_contributed": {
+            "title": "Employee Contributed",
+            "type": "number"
+          },
+          "employer_contributed": {
+            "title": "Employer Contributed",
+            "type": "number"
+          },
+          "is_warning": {
+            "title": "Is Warning",
+            "type": "boolean"
+          },
+          "limit_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit Amount"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "percentage_used": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Percentage Used"
+          },
+          "remaining": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remaining"
+          },
+          "total_contributed": {
+            "title": "Total Contributed",
+            "type": "number"
+          },
+          "year": {
+            "title": "Year",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "year",
+          "account_wrapper",
+          "owner",
+          "limit_amount",
+          "total_contributed",
+          "employee_contributed",
+          "employer_contributed",
+          "remaining",
+          "percentage_used",
+          "is_warning"
+        ],
+        "title": "YearlyStatsResponse",
+        "type": "object"
+      },
+      "ZusCalculatorInputs": {
+        "properties": {
+          "birth_date": {
+            "format": "date",
+            "title": "Birth Date",
+            "type": "string"
+          },
+          "current_gross_monthly_salary": {
+            "title": "Current Gross Monthly Salary",
+            "type": "number"
+          },
+          "gender": {
+            "title": "Gender",
+            "type": "string"
+          },
+          "has_ofe": {
+            "default": false,
+            "title": "Has Ofe",
+            "type": "boolean"
+          },
+          "inflation_rate": {
+            "default": 3.0,
+            "title": "Inflation Rate",
+            "type": "number"
+          },
+          "kapital_poczatkowy": {
+            "default": 0.0,
+            "title": "Kapital Poczatkowy",
+            "type": "number"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "retirement_age": {
+            "default": 65,
+            "title": "Retirement Age",
+            "type": "integer"
+          },
+          "salary_growth_rate": {
+            "default": 3.0,
+            "title": "Salary Growth Rate",
+            "type": "number"
+          },
+          "salary_history": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SalaryHistoryEntry"
+            },
+            "title": "Salary History",
+            "type": "array"
+          },
+          "valorization_rate_konto": {
+            "default": 5.0,
+            "title": "Valorization Rate Konto",
+            "type": "number"
+          },
+          "valorization_rate_subkonto": {
+            "default": 4.0,
+            "title": "Valorization Rate Subkonto",
+            "type": "number"
+          },
+          "work_start_year": {
+            "title": "Work Start Year",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "owner",
+          "birth_date",
+          "gender",
+          "current_gross_monthly_salary",
+          "work_start_year"
+        ],
+        "title": "ZusCalculatorInputs",
+        "type": "object"
+      },
+      "ZusCalculatorResponse": {
+        "properties": {
+          "inputs": {
+            "$ref": "#/components/schemas/ZusCalculatorInputs"
+          },
+          "kapital_poczatkowy_valorized": {
+            "title": "Kapital Poczatkowy Valorized",
+            "type": "number"
+          },
+          "konto_at_retirement": {
+            "title": "Konto At Retirement",
+            "type": "number"
+          },
+          "last_gross_salary": {
+            "title": "Last Gross Salary",
+            "type": "number"
+          },
+          "life_expectancy_months": {
+            "title": "Life Expectancy Months",
+            "type": "number"
+          },
+          "monthly_pension_gross": {
+            "title": "Monthly Pension Gross",
+            "type": "number"
+          },
+          "monthly_pension_net": {
+            "title": "Monthly Pension Net",
+            "type": "number"
+          },
+          "replacement_rate": {
+            "title": "Replacement Rate",
+            "type": "number"
+          },
+          "sensitivity": {
+            "items": {
+              "$ref": "#/components/schemas/ZusSensitivityScenario"
+            },
+            "title": "Sensitivity",
+            "type": "array"
+          },
+          "subkonto_at_retirement": {
+            "title": "Subkonto At Retirement",
+            "type": "number"
+          },
+          "total_capital": {
+            "title": "Total Capital",
+            "type": "number"
+          },
+          "yearly_projections": {
+            "items": {
+              "$ref": "#/components/schemas/ZusYearlyProjection"
+            },
+            "title": "Yearly Projections",
+            "type": "array"
+          }
+        },
+        "required": [
+          "inputs",
+          "yearly_projections",
+          "life_expectancy_months",
+          "konto_at_retirement",
+          "subkonto_at_retirement",
+          "kapital_poczatkowy_valorized",
+          "total_capital",
+          "monthly_pension_gross",
+          "monthly_pension_net",
+          "replacement_rate",
+          "last_gross_salary",
+          "sensitivity"
+        ],
+        "title": "ZusCalculatorResponse",
+        "type": "object"
+      },
+      "ZusPrefillResponse": {
+        "properties": {
+          "birth_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Birth Date"
+          },
+          "current_gross_monthly_salary": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Gross Monthly Salary"
+          },
+          "gender": {
+            "default": "M",
+            "title": "Gender",
+            "type": "string"
+          },
+          "owner": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner"
+          },
+          "retirement_age": {
+            "default": 65,
+            "title": "Retirement Age",
+            "type": "integer"
+          },
+          "salary_history": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SalaryHistoryEntry"
+            },
+            "title": "Salary History",
+            "type": "array"
+          },
+          "work_start_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Work Start Year"
+          }
+        },
+        "title": "ZusPrefillResponse",
+        "type": "object"
+      },
+      "ZusSensitivityScenario": {
+        "properties": {
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "monthly_pension_gross": {
+            "title": "Monthly Pension Gross",
+            "type": "number"
+          },
+          "monthly_pension_net": {
+            "title": "Monthly Pension Net",
+            "type": "number"
+          },
+          "replacement_rate": {
+            "title": "Replacement Rate",
+            "type": "number"
+          },
+          "valorization_konto": {
+            "title": "Valorization Konto",
+            "type": "number"
+          },
+          "valorization_subkonto": {
+            "title": "Valorization Subkonto",
+            "type": "number"
+          }
+        },
+        "required": [
+          "label",
+          "valorization_konto",
+          "valorization_subkonto",
+          "monthly_pension_gross",
+          "monthly_pension_net",
+          "replacement_rate"
+        ],
+        "title": "ZusSensitivityScenario",
+        "type": "object"
+      },
+      "ZusYearlyProjection": {
+        "properties": {
+          "age": {
+            "title": "Age",
+            "type": "integer"
+          },
+          "annual_gross_salary": {
+            "title": "Annual Gross Salary",
+            "type": "number"
+          },
+          "contribution_konto": {
+            "title": "Contribution Konto",
+            "type": "number"
+          },
+          "contribution_subkonto": {
+            "title": "Contribution Subkonto",
+            "type": "number"
+          },
+          "konto_balance": {
+            "title": "Konto Balance",
+            "type": "number"
+          },
+          "salary_capped": {
+            "title": "Salary Capped",
+            "type": "boolean"
+          },
+          "subkonto_balance": {
+            "title": "Subkonto Balance",
+            "type": "number"
+          },
+          "total_balance": {
+            "title": "Total Balance",
+            "type": "number"
+          },
+          "year": {
+            "title": "Year",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "year",
+          "age",
+          "annual_gross_salary",
+          "salary_capped",
+          "contribution_konto",
+          "contribution_subkonto",
+          "konto_balance",
+          "subkonto_balance",
+          "total_balance"
+        ],
+        "title": "ZusYearlyProjection",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Finance Buddy API",
+    "version": "1.0.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/accounts": {
+      "get": {
+        "description": "Get all active accounts with their latest snapshot values",
+        "operationId": "get_accounts_api_accounts_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountsListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Accounts",
+        "tags": [
+          "accounts"
+        ]
+      },
+      "post": {
+        "description": "Create new account",
+        "operationId": "create_account_api_accounts_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Account",
+        "tags": [
+          "accounts"
+        ]
+      }
+    },
+    "/api/accounts/{account_id}": {
+      "delete": {
+        "description": "Delete account (soft delete by setting is_active=False)",
+        "operationId": "delete_account_api_accounts__account_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "title": "Account Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Account",
+        "tags": [
+          "accounts"
+        ]
+      },
+      "put": {
+        "description": "Update existing account",
+        "operationId": "update_account_api_accounts__account_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "title": "Account Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Account",
+        "tags": [
+          "accounts"
+        ]
+      }
+    },
+    "/api/accounts/{account_id}/debts": {
+      "post": {
+        "description": "Create new debt for a liability account",
+        "operationId": "create_debt_api_accounts__account_id__debts_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "title": "Account Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DebtCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebtResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Debt",
+        "tags": [
+          "debts"
+        ]
+      }
+    },
+    "/api/accounts/{account_id}/payments": {
+      "get": {
+        "description": "Get all active payments for a specific liability account",
+        "operationId": "get_account_payments_api_accounts__account_id__payments_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "title": "Account Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebtPaymentsListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Account Payments",
+        "tags": [
+          "debt_payments"
+        ]
+      },
+      "post": {
+        "description": "Create new payment for a liability account",
+        "operationId": "create_payment_api_accounts__account_id__payments_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "title": "Account Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DebtPaymentCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebtPaymentResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Payment",
+        "tags": [
+          "debt_payments"
+        ]
+      }
+    },
+    "/api/accounts/{account_id}/payments/{payment_id}": {
+      "delete": {
+        "description": "Delete payment (soft delete by setting is_active=False)",
+        "operationId": "delete_payment_api_accounts__account_id__payments__payment_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "title": "Account Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "payment_id",
+            "required": true,
+            "schema": {
+              "title": "Payment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Payment",
+        "tags": [
+          "debt_payments"
+        ]
+      }
+    },
+    "/api/accounts/{account_id}/transactions": {
+      "get": {
+        "description": "Get all active transactions for a specific account",
+        "operationId": "get_account_transactions_api_accounts__account_id__transactions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "title": "Account Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionsListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Account Transactions",
+        "tags": [
+          "transactions"
+        ]
+      },
+      "post": {
+        "description": "Create new transaction for an investment account",
+        "operationId": "create_transaction_api_accounts__account_id__transactions_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "title": "Account Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransactionCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Transaction",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/accounts/{account_id}/transactions/{transaction_id}": {
+      "delete": {
+        "description": "Delete transaction (soft delete by setting is_active=False)",
+        "operationId": "delete_transaction_api_accounts__account_id__transactions__transaction_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "title": "Account Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "transaction_id",
+            "required": true,
+            "schema": {
+              "title": "Transaction Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Transaction",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/assets": {
+      "get": {
+        "description": "Get all active assets with their latest snapshot values",
+        "operationId": "get_assets_api_assets_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetsListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Assets",
+        "tags": [
+          "assets"
+        ]
+      },
+      "post": {
+        "description": "Create new asset",
+        "operationId": "create_asset_api_assets_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssetCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Asset",
+        "tags": [
+          "assets"
+        ]
+      }
+    },
+    "/api/assets/{asset_id}": {
+      "delete": {
+        "description": "Delete asset (soft delete by setting is_active=False)",
+        "operationId": "delete_asset_api_assets__asset_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "asset_id",
+            "required": true,
+            "schema": {
+              "title": "Asset Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Asset",
+        "tags": [
+          "assets"
+        ]
+      },
+      "put": {
+        "description": "Update existing asset",
+        "operationId": "update_asset_api_assets__asset_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "asset_id",
+            "required": true,
+            "schema": {
+              "title": "Asset Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssetUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Asset",
+        "tags": [
+          "assets"
+        ]
+      }
+    },
+    "/api/bonuses": {
+      "get": {
+        "description": "Get all active bonus events with optional filters.",
+        "operationId": "get_all_bonus_events_api_bonuses_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "owner",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Owner"
+            }
+          },
+          {
+            "in": "query",
+            "name": "date_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Date From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "date_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Date To"
+            }
+          },
+          {
+            "in": "query",
+            "name": "company",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Company"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BonusEventsListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get All Bonus Events",
+        "tags": [
+          "bonuses"
+        ]
+      },
+      "post": {
+        "description": "Create new bonus event.",
+        "operationId": "create_bonus_event_api_bonuses_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BonusEventCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BonusEventResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Bonus Event",
+        "tags": [
+          "bonuses"
+        ]
+      }
+    },
+    "/api/bonuses/{bonus_id}": {
+      "delete": {
+        "description": "Delete bonus event (soft delete by setting is_active=False).",
+        "operationId": "delete_bonus_event_api_bonuses__bonus_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "bonus_id",
+            "required": true,
+            "schema": {
+              "title": "Bonus Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Bonus Event",
+        "tags": [
+          "bonuses"
+        ]
+      },
+      "get": {
+        "description": "Get a single bonus event by ID.",
+        "operationId": "get_bonus_event_api_bonuses__bonus_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "bonus_id",
+            "required": true,
+            "schema": {
+              "title": "Bonus Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BonusEventResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Bonus Event",
+        "tags": [
+          "bonuses"
+        ]
+      },
+      "patch": {
+        "description": "Update bonus event fields.",
+        "operationId": "update_bonus_event_api_bonuses__bonus_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "bonus_id",
+            "required": true,
+            "schema": {
+              "title": "Bonus Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BonusEventUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BonusEventResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Bonus Event",
+        "tags": [
+          "bonuses"
+        ]
+      }
+    },
+    "/api/company-valuations": {
+      "get": {
+        "operationId": "get_all_company_valuations_api_company_valuations_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "company",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Company"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompanyValuationsListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get All Company Valuations",
+        "tags": [
+          "equity"
+        ]
+      },
+      "post": {
+        "operationId": "create_company_valuation_api_company_valuations_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompanyValuationCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompanyValuationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Company Valuation",
+        "tags": [
+          "equity"
+        ]
+      }
+    },
+    "/api/company-valuations/{valuation_id}": {
+      "delete": {
+        "operationId": "delete_company_valuation_api_company_valuations__valuation_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "valuation_id",
+            "required": true,
+            "schema": {
+              "title": "Valuation Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Company Valuation",
+        "tags": [
+          "equity"
+        ]
+      },
+      "get": {
+        "operationId": "get_company_valuation_api_company_valuations__valuation_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "valuation_id",
+            "required": true,
+            "schema": {
+              "title": "Valuation Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompanyValuationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Company Valuation",
+        "tags": [
+          "equity"
+        ]
+      },
+      "patch": {
+        "operationId": "update_company_valuation_api_company_valuations__valuation_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "valuation_id",
+            "required": true,
+            "schema": {
+              "title": "Valuation Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompanyValuationUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompanyValuationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Company Valuation",
+        "tags": [
+          "equity"
+        ]
+      }
+    },
+    "/api/config": {
+      "get": {
+        "description": "Get app configuration",
+        "operationId": "get_app_config_api_config_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfigResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get App Config",
+        "tags": [
+          "config"
+        ]
+      },
+      "put": {
+        "description": "Create or update app configuration",
+        "operationId": "update_app_config_api_config_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfigCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfigResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update App Config",
+        "tags": [
+          "config"
+        ]
+      }
+    },
+    "/api/cpi/adjust": {
+      "post": {
+        "description": "Inflate (or deflate) ``amount`` between two calendar dates.",
+        "operationId": "adjust_amount_api_cpi_adjust_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdjustRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdjustResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Adjust Amount",
+        "tags": [
+          "cpi"
+        ]
+      }
+    },
+    "/api/cpi/refresh": {
+      "post": {
+        "description": "Pull fresh CPI from GUS BDL and upsert into the database.\n\nIntended for development and manual recovery. In normal operation the\nin-process scheduler refreshes monthly (and on startup if stale). This\nendpoint is reachable to anyone who can hit the backend — finance-buddy\nis a single-user self-hosted app, so the worst case is an unsolicited\nnetwork call to a public GUS endpoint. Gate it behind auth before\nexposing the backend to untrusted networks.",
+        "operationId": "refresh_cpi_api_cpi_refresh_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefreshResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Refresh Cpi",
+        "tags": [
+          "cpi"
+        ]
+      }
+    },
+    "/api/cpi/series": {
+      "get": {
+        "description": "Return the full annual CPI series with derived cumulative index.",
+        "operationId": "get_cpi_series_api_cpi_series_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CpiSeriesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Cpi Series",
+        "tags": [
+          "cpi"
+        ]
+      }
+    },
+    "/api/dashboard": {
+      "get": {
+        "description": "Get dashboard data with net worth history and allocation",
+        "operationId": "get_dashboard_api_dashboard_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Dashboard",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/api/debts": {
+      "get": {
+        "description": "Get all active debts with optional filters",
+        "operationId": "get_all_debts_api_debts_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "account_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Account Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "debt_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Debt Type"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebtsListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get All Debts",
+        "tags": [
+          "debts"
+        ]
+      }
+    },
+    "/api/debts/{debt_id}": {
+      "delete": {
+        "description": "Delete debt (soft delete by setting is_active=False)",
+        "operationId": "delete_debt_api_debts__debt_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "debt_id",
+            "required": true,
+            "schema": {
+              "title": "Debt Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Debt",
+        "tags": [
+          "debts"
+        ]
+      },
+      "get": {
+        "description": "Get a single debt by ID",
+        "operationId": "get_debt_api_debts__debt_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "debt_id",
+            "required": true,
+            "schema": {
+              "title": "Debt Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebtResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Debt",
+        "tags": [
+          "debts"
+        ]
+      },
+      "put": {
+        "description": "Update debt fields",
+        "operationId": "update_debt_api_debts__debt_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "debt_id",
+            "required": true,
+            "schema": {
+              "title": "Debt Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DebtUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebtResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Debt",
+        "tags": [
+          "debts"
+        ]
+      }
+    },
+    "/api/equity-grants": {
+      "get": {
+        "description": "Get all active equity grants with optional filters.",
+        "operationId": "get_all_equity_grants_api_equity_grants_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "owner",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Owner"
+            }
+          },
+          {
+            "in": "query",
+            "name": "company",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Company"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EquityGrantsListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get All Equity Grants",
+        "tags": [
+          "equity"
+        ]
+      },
+      "post": {
+        "description": "Create new equity grant.",
+        "operationId": "create_equity_grant_api_equity_grants_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EquityGrantCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EquityGrantResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Equity Grant",
+        "tags": [
+          "equity"
+        ]
+      }
+    },
+    "/api/equity-grants/{grant_id}": {
+      "delete": {
+        "description": "Delete equity grant (soft delete by setting is_active=False).",
+        "operationId": "delete_equity_grant_api_equity_grants__grant_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grant_id",
+            "required": true,
+            "schema": {
+              "title": "Grant Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Equity Grant",
+        "tags": [
+          "equity"
+        ]
+      },
+      "get": {
+        "description": "Get a single equity grant by ID.",
+        "operationId": "get_equity_grant_api_equity_grants__grant_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grant_id",
+            "required": true,
+            "schema": {
+              "title": "Grant Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EquityGrantResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Equity Grant",
+        "tags": [
+          "equity"
+        ]
+      },
+      "patch": {
+        "description": "Update equity grant fields.",
+        "operationId": "update_equity_grant_api_equity_grants__grant_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grant_id",
+            "required": true,
+            "schema": {
+              "title": "Grant Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EquityGrantUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EquityGrantResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Equity Grant",
+        "tags": [
+          "equity"
+        ]
+      }
+    },
+    "/api/goals": {
+      "get": {
+        "description": "Get all goals with progress and projected hit date.",
+        "operationId": "get_goals_api_goals_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoalsListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Goals",
+        "tags": [
+          "goals"
+        ]
+      },
+      "post": {
+        "description": "Create a new goal.",
+        "operationId": "create_goal_api_goals_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GoalCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoalResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Goal",
+        "tags": [
+          "goals"
+        ]
+      }
+    },
+    "/api/goals/{goal_id}": {
+      "delete": {
+        "description": "Delete a goal.",
+        "operationId": "delete_goal_api_goals__goal_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "schema": {
+              "title": "Goal Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Goal",
+        "tags": [
+          "goals"
+        ]
+      },
+      "get": {
+        "description": "Get a single goal by ID.",
+        "operationId": "get_goal_api_goals__goal_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "schema": {
+              "title": "Goal Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoalResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Goal",
+        "tags": [
+          "goals"
+        ]
+      },
+      "put": {
+        "description": "Update a goal.",
+        "operationId": "update_goal_api_goals__goal_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "schema": {
+              "title": "Goal Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GoalUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoalResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Goal",
+        "tags": [
+          "goals"
+        ]
+      }
+    },
+    "/api/investment/bond-stats": {
+      "get": {
+        "description": "Get aggregate statistics for bond investments",
+        "operationId": "get_bond_stats_api_investment_bond_stats_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryStatsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Bond Stats",
+        "tags": [
+          "investment"
+        ]
+      }
+    },
+    "/api/investment/stock-stats": {
+      "get": {
+        "description": "Get aggregate statistics for stock investments",
+        "operationId": "get_stock_stats_api_investment_stock_stats_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryStatsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Stock Stats",
+        "tags": [
+          "investment"
+        ]
+      }
+    },
+    "/api/payments": {
+      "get": {
+        "description": "Get all active payments with optional filters",
+        "operationId": "get_all_payments_api_payments_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "account_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Account Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "owner",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Owner"
+            }
+          },
+          {
+            "in": "query",
+            "name": "date_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Date From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "date_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Date To"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebtPaymentsListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get All Payments",
+        "tags": [
+          "debt_payments"
+        ]
+      }
+    },
+    "/api/payments/counts": {
+      "get": {
+        "description": "Get payment count per account",
+        "operationId": "get_payment_counts_api_payments_counts_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "title": "Response Get Payment Counts Api Payments Counts Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Payment Counts",
+        "tags": [
+          "debt_payments"
+        ]
+      }
+    },
+    "/api/personas": {
+      "get": {
+        "operationId": "list_personas_api_personas_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/PersonaResponse"
+                  },
+                  "title": "Response List Personas Api Personas Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Personas",
+        "tags": [
+          "personas"
+        ]
+      },
+      "post": {
+        "operationId": "create_persona_api_personas_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PersonaCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonaResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Persona",
+        "tags": [
+          "personas"
+        ]
+      }
+    },
+    "/api/personas/{persona_id}": {
+      "delete": {
+        "operationId": "delete_persona_api_personas__persona_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "persona_id",
+            "required": true,
+            "schema": {
+              "title": "Persona Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Persona",
+        "tags": [
+          "personas"
+        ]
+      },
+      "put": {
+        "operationId": "update_persona_api_personas__persona_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "persona_id",
+            "required": true,
+            "schema": {
+              "title": "Persona Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PersonaUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonaResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Persona",
+        "tags": [
+          "personas"
+        ]
+      }
+    },
+    "/api/retirement/limits/{year}": {
+      "get": {
+        "description": "Get all limits for a specific year",
+        "operationId": "get_limits_for_year_api_retirement_limits__year__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "year",
+            "required": true,
+            "schema": {
+              "title": "Year",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/RetirementLimitResponse"
+                  },
+                  "title": "Response Get Limits For Year Api Retirement Limits  Year  Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Limits For Year",
+        "tags": [
+          "retirement"
+        ]
+      }
+    },
+    "/api/retirement/limits/{year}/{wrapper}/{owner}": {
+      "put": {
+        "description": "Create or update retirement limit",
+        "operationId": "upsert_limit_api_retirement_limits__year___wrapper___owner__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "year",
+            "required": true,
+            "schema": {
+              "title": "Year",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "wrapper",
+            "required": true,
+            "schema": {
+              "title": "Wrapper",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RetirementLimitCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetirementLimitResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Upsert Limit",
+        "tags": [
+          "retirement"
+        ]
+      }
+    },
+    "/api/retirement/ppk-contributions/generate": {
+      "post": {
+        "description": "Generate monthly PPK contributions based on salary and configured rates",
+        "operationId": "generate_ppk_contributions_api_retirement_ppk_contributions_generate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PPKContributionGenerateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PPKContributionGenerateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Generate Ppk Contributions",
+        "tags": [
+          "retirement"
+        ]
+      }
+    },
+    "/api/retirement/ppk-stats": {
+      "get": {
+        "description": "Get PPK contribution breakdown and returns per owner",
+        "operationId": "get_ppk_stats_api_retirement_ppk_stats_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "owner",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Owner"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/PPKStatsResponse"
+                  },
+                  "title": "Response Get Ppk Stats Api Retirement Ppk Stats Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Ppk Stats",
+        "tags": [
+          "retirement"
+        ]
+      }
+    },
+    "/api/retirement/stats": {
+      "get": {
+        "description": "Get yearly contribution stats for all retirement accounts",
+        "operationId": "get_retirement_stats_api_retirement_stats_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "year",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Year"
+            }
+          },
+          {
+            "in": "query",
+            "name": "owner",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Owner"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/YearlyStatsResponse"
+                  },
+                  "title": "Response Get Retirement Stats Api Retirement Stats Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Retirement Stats",
+        "tags": [
+          "retirement"
+        ]
+      }
+    },
+    "/api/salaries": {
+      "get": {
+        "description": "Get all active salary records with optional filters",
+        "operationId": "get_all_salary_records_api_salaries_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "owner",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Owner"
+            }
+          },
+          {
+            "in": "query",
+            "name": "date_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Date From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "date_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Date To"
+            }
+          },
+          {
+            "in": "query",
+            "name": "company",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Company"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SalaryRecordsListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get All Salary Records",
+        "tags": [
+          "salaries"
+        ]
+      },
+      "post": {
+        "description": "Create new salary record",
+        "operationId": "create_salary_record_api_salaries_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SalaryRecordCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SalaryRecordResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Salary Record",
+        "tags": [
+          "salaries"
+        ]
+      }
+    },
+    "/api/salaries/{salary_id}": {
+      "delete": {
+        "description": "Delete salary record (soft delete by setting is_active=False)",
+        "operationId": "delete_salary_record_api_salaries__salary_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "salary_id",
+            "required": true,
+            "schema": {
+              "title": "Salary Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Salary Record",
+        "tags": [
+          "salaries"
+        ]
+      },
+      "get": {
+        "description": "Get a single salary record by ID",
+        "operationId": "get_salary_record_api_salaries__salary_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "salary_id",
+            "required": true,
+            "schema": {
+              "title": "Salary Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SalaryRecordResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Salary Record",
+        "tags": [
+          "salaries"
+        ]
+      },
+      "patch": {
+        "description": "Update salary record fields",
+        "operationId": "update_salary_record_api_salaries__salary_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "salary_id",
+            "required": true,
+            "schema": {
+              "title": "Salary Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SalaryRecordUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SalaryRecordResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Salary Record",
+        "tags": [
+          "salaries"
+        ]
+      }
+    },
+    "/api/simulations/mortgage-vs-invest": {
+      "post": {
+        "description": "Compare overpaying mortgage vs investing extra amount",
+        "operationId": "simulate_mortgage_vs_invest_api_simulations_mortgage_vs_invest_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MortgageVsInvestInputs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MortgageVsInvestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Simulate Mortgage Vs Invest",
+        "tags": [
+          "simulations"
+        ]
+      }
+    },
+    "/api/simulations/prefill": {
+      "get": {
+        "description": "Get current balances and config for form prefill",
+        "operationId": "get_prefill_data_api_simulations_prefill_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrefillResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Prefill Data",
+        "tags": [
+          "simulations"
+        ]
+      }
+    },
+    "/api/simulations/retirement": {
+      "post": {
+        "description": "Calculate retirement account projections",
+        "operationId": "simulate_retirement_api_simulations_retirement_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SimulationInputs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimulationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Simulate Retirement",
+        "tags": [
+          "simulations"
+        ]
+      }
+    },
+    "/api/snapshots": {
+      "get": {
+        "description": "Get all snapshots ordered by date descending",
+        "operationId": "get_snapshots_api_snapshots_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/SnapshotListItem"
+                  },
+                  "title": "Response Get Snapshots Api Snapshots Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Snapshots",
+        "tags": [
+          "snapshots"
+        ]
+      },
+      "post": {
+        "description": "Create new snapshot with all account values",
+        "operationId": "create_snapshot_api_snapshots_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SnapshotCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnapshotResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Snapshot",
+        "tags": [
+          "snapshots"
+        ]
+      }
+    },
+    "/api/snapshots/{snapshot_id}": {
+      "get": {
+        "description": "Get single snapshot with all account values",
+        "operationId": "get_snapshot_api_snapshots__snapshot_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "snapshot_id",
+            "required": true,
+            "schema": {
+              "title": "Snapshot Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnapshotResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Snapshot",
+        "tags": [
+          "snapshots"
+        ]
+      },
+      "put": {
+        "description": "Update existing snapshot",
+        "operationId": "update_snapshot_api_snapshots__snapshot_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "snapshot_id",
+            "required": true,
+            "schema": {
+              "title": "Snapshot Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SnapshotUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnapshotResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Snapshot",
+        "tags": [
+          "snapshots"
+        ]
+      }
+    },
+    "/api/transactions": {
+      "get": {
+        "description": "Get all active transactions with optional filters",
+        "operationId": "get_all_transactions_api_transactions_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "account_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Account Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "owner",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Owner"
+            }
+          },
+          {
+            "in": "query",
+            "name": "date_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Date From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "date_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Date To"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionsListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get All Transactions",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/transactions/counts": {
+      "get": {
+        "description": "Get transaction count per account",
+        "operationId": "get_transaction_counts_api_transactions_counts_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "title": "Response Get Transaction Counts Api Transactions Counts Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Transaction Counts",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/zus/calculate": {
+      "post": {
+        "description": "Calculate projected ZUS retirement pension.",
+        "operationId": "calculate_zus_pension_api_zus_calculate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ZusCalculatorInputs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ZusCalculatorResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Calculate Zus Pension",
+        "tags": [
+          "zus"
+        ]
+      }
+    },
+    "/api/zus/prefill": {
+      "get": {
+        "description": "Prefill ZUS calculator form from salary records and config.",
+        "operationId": "get_zus_prefill_api_zus_prefill_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "owner",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Owner"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ZusPrefillResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Zus Prefill",
+        "tags": [
+          "zus"
+        ]
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "health_check_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Health Check Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health Check"
+      }
+    }
+  }
+}

--- a/backend/scripts/dump_openapi.py
+++ b/backend/scripts/dump_openapi.py
@@ -1,0 +1,45 @@
+"""Dump the FastAPI OpenAPI spec to api/openapi.v1.json (repo root).
+
+Used as the frozen contract for the Python→Go backend migration. The Go
+backend must satisfy this schema byte-for-byte. A CI check re-runs this
+script and fails if the live FastAPI output diverges from the committed
+file.
+
+Run from backend/:
+    uv run python scripts/dump_openapi.py
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = BACKEND_DIR.parent
+OUTPUT = REPO_ROOT / "api" / "openapi.v1.json"
+
+
+def _prepare_environment() -> None:
+    os.environ.setdefault("DATABASE_URL", "postgresql://placeholder/placeholder")
+    os.environ.setdefault("APP_PASSWORD", "placeholder")
+    os.environ.setdefault("CORS_ORIGINS", "http://localhost:3000")
+    if str(BACKEND_DIR) not in sys.path:
+        sys.path.insert(0, str(BACKEND_DIR))
+
+
+def main() -> None:
+    _prepare_environment()
+    app_module = importlib.import_module("app.main")
+    spec = app_module.app.openapi()
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    with OUTPUT.open("w", encoding="utf-8") as f:
+        json.dump(spec, f, indent=2, sort_keys=True, ensure_ascii=False)
+        f.write("\n")
+    print(f"Wrote {OUTPUT.relative_to(REPO_ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/frontend-contract.md
+++ b/migration/frontend-contract.md
@@ -1,0 +1,618 @@
+# Frontend API Contract Audit
+
+Audit of every endpoint the SvelteKit UI calls under `src/`, with the exact fields the UI sends and reads. Anything not listed is internal-only and may be dropped during the Python→Go backend migration without breaking the UI.
+
+Sections are ordered alphabetically by URL path.
+
+---
+
+### `GET /api/accounts`
+
+- **Called from:**
+  - `src/routes/accounts/+page.ts:46`
+  - `src/routes/debts/+page.svelte:122` (POST — see separate section; this entry is the load fetch only)
+  - `src/routes/goals/+page.ts:41`
+  - `src/routes/snapshots/[id]/edit/+page.ts:10`
+  - `src/routes/snapshots/new/+page.ts:14`
+  - `src/routes/transactions/+page.ts:45`
+- **Response fields read by UI:**
+  - top-level: `assets[]`, `liabilities[]`
+  - per-account (assets + liabilities): `id`, `name`, `type`, `category`, `owner`, `currency`, `account_wrapper`, `purpose`, `receives_contributions`, `square_meters`, `current_value`, `account_id` (via SnapshotForm props)
+- **Optional fields tolerated:** `account_wrapper` (nullable), `square_meters` (nullable)
+- **Notes:** goals page flattens `assets + liabilities` into `accounts` (only reads `id`, `name`). Transactions page reads `assets` only, filters by `category ∈ INVESTMENT_CATEGORIES`. SnapshotForm consumes the full per-account shape including `current_value`. `is_active` / `created_at` declared in type but not read by UI.
+
+---
+
+### `POST /api/accounts`
+
+- **Called from:**
+  - `src/routes/accounts/+page.svelte:143` (create)
+  - `src/lib/components/SnapshotForm.svelte:173` (create from snapshot form)
+  - `src/routes/debts/+page.svelte:122` (create temp account before creating debt)
+- **Request fields sent:** `name`, `type`, `category`, `owner`, `currency`, `account_wrapper`, `purpose`, `receives_contributions` (only when `account_wrapper === 'PPK'`), `square_meters` (only when `category === 'real_estate'`)
+- **Response fields read by UI:** SnapshotForm reads full `Account` (see GET above); debts page reads `id` (to chain `/accounts/{id}/debts`); accounts page only checks `response.ok` + reads `detail` on error.
+- **Notes:** debts page sends a minimal subset: `name`, `type='liability'`, `category`, `owner`, `currency`.
+
+---
+
+### `PUT /api/accounts/{id}`
+
+- **Called from:** `src/routes/accounts/+page.svelte:143` (edit branch)
+- **Request fields sent:** same as POST `/api/accounts`
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `DELETE /api/accounts/{id}`
+
+- **Called from:** `src/routes/accounts/+page.svelte:179`
+- **Response fields read by UI:** only `response.ok`.
+
+---
+
+### `GET /api/accounts/{id}/payments`
+
+- **Called from:** `src/routes/debts/+page.svelte:221`
+- **Response fields read by UI:** `payments[]`, `total_paid`, `payment_count`; per-payment: `id`, `date`, `amount`, `owner` (declared also `account_id`, `account_name`, `created_at` but not rendered).
+
+---
+
+### `POST /api/accounts/{id}/payments`
+
+- **Called from:** `src/routes/debts/+page.svelte:241`
+- **Request fields sent:** `amount`, `date`, `owner`
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `DELETE /api/accounts/{id}/payments/{paymentId}`
+
+- **Called from:** `src/routes/debts/+page.svelte:284`
+- **Response fields read by UI:** only `response.ok`.
+
+---
+
+### `GET /api/accounts/{id}/transactions`
+
+- **Called from:**
+  - `src/routes/accounts/+page.svelte:230`
+- **Response fields read by UI:** `transactions[]`, `total_invested`; per-transaction: `id`, `date`, `amount`, `owner` (also `transaction_count` declared in type, not rendered here).
+
+---
+
+### `POST /api/accounts/{id}/transactions`
+
+- **Called from:**
+  - `src/routes/accounts/+page.svelte:265`
+  - `src/routes/transactions/+page.svelte:152`
+- **Request fields sent:** `amount`, `date`, `owner`, `transaction_type` (nullable; only sent from accounts page when account is PPK-wrapped)
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `DELETE /api/accounts/{id}/transactions/{transactionId}`
+
+- **Called from:**
+  - `src/routes/accounts/+page.svelte:298`
+  - `src/routes/transactions/+page.svelte:68`
+- **Response fields read by UI:** only `response.ok`.
+
+---
+
+### `POST /api/accounts/{id}/debts`
+
+- **Called from:** `src/routes/debts/+page.svelte:138` (create branch)
+- **Request fields sent:** `name`, `debt_type`, `start_date`, `initial_amount`, `interest_rate`, `currency`, `notes`
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `GET /api/assets`
+
+- **Called from:**
+  - `src/routes/assets/+page.ts:24`
+  - `src/routes/snapshots/[id]/edit/+page.ts:11`
+  - `src/routes/snapshots/new/+page.ts:15`
+- **Response fields read by UI:**
+  - top-level: `assets[]`
+  - per-asset: `id`, `name`, `current_value` (SnapshotForm also reads same)
+- **Optional fields tolerated:** `is_active`, `created_at` declared but unused.
+
+---
+
+### `POST /api/assets`
+
+- **Called from:**
+  - `src/routes/assets/+page.svelte:60` (create branch)
+  - `src/lib/components/SnapshotForm.svelte:253`
+- **Request fields sent:** `name`
+- **Response fields read by UI:** SnapshotForm reads full `Asset` (`id`, `name`, `current_value`); assets page only `response.ok` + error `detail`.
+
+---
+
+### `PUT /api/assets/{id}`
+
+- **Called from:** `src/routes/assets/+page.svelte:60` (edit branch)
+- **Request fields sent:** `name`
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `DELETE /api/assets/{id}`
+
+- **Called from:** `src/routes/assets/+page.svelte:96`
+- **Response fields read by UI:** only `response.ok`.
+
+---
+
+### `GET /api/bonuses`
+
+- **Called from:** `src/routes/salaries/+page.ts:62`
+- **Response fields read by UI:**
+  - top-level: `bonus_events[]`
+  - per-event: `id`, `date`, `amount`, `currency`, `type`, `company`, `owner`, `notes`, `amount_pln`, `fx_rate`
+- **Optional fields tolerated:** `notes` (null), `amount_pln` (null fallback to `amount` when PLN), `fx_rate` (null)
+- **Notes:** `total_count` and `available_companies` declared in type but not read. `contract_type`, `is_active`, `created_at` declared but unused.
+
+---
+
+### `POST /api/bonuses`
+
+- **Called from:** `src/routes/salaries/+page.svelte:371`
+- **Request fields sent:** `date`, `amount`, `currency`, `type`, `company`, `owner`, `contract_type`, `notes`
+- **Response fields read by UI:** only `response.ok`; error path walks `detail` (string or array of `{msg}`).
+
+---
+
+### `PATCH /api/bonuses/{id}`
+
+- **Called from:** `src/routes/salaries/+page.svelte:371` (edit branch)
+- **Request fields sent:** same as POST.
+- **Response fields read by UI:** only `response.ok`; error path walks `detail`.
+
+---
+
+### `DELETE /api/bonuses/{id}`
+
+- **Called from:** `src/routes/salaries/+page.svelte:413`
+- **Response fields read by UI:** only `response.ok`.
+
+---
+
+### `GET /api/company-valuations`
+
+- **Called from:** `src/routes/salaries/+page.ts:64`
+- **Response fields read by UI:**
+  - top-level: `company_valuations[]`
+  - per-valuation: `id`, `company`, `date`, `currency`, `fmv_per_share`, `fmv_low`, `fmv_high`, `source`, `common_stock_discount_pct`, `notes`
+- **Optional fields tolerated:** `fmv_low`, `fmv_high`, `common_stock_discount_pct`, `notes` (all nullable)
+- **Notes:** `total_count`, `available_companies`, `is_active`, `created_at` declared but unused.
+
+---
+
+### `POST /api/company-valuations`
+
+- **Called from:** `src/routes/salaries/+page.svelte:881`
+- **Request fields sent:** `company`, `date`, `currency`, `fmv_per_share`, `fmv_low`, `fmv_high`, `source`, `common_stock_discount_pct`, `notes`
+- **Response fields read by UI:** only `response.ok`; error path walks `detail`.
+
+---
+
+### `PATCH /api/company-valuations/{id}`
+
+- **Called from:** `src/routes/salaries/+page.svelte:881` (edit branch)
+- **Request fields sent:** same as POST.
+- **Response fields read by UI:** only `response.ok`; error path walks `detail`.
+
+---
+
+### `DELETE /api/company-valuations/{id}`
+
+- **Called from:** `src/routes/salaries/+page.svelte:918`
+- **Response fields read by UI:** only `response.ok`.
+
+---
+
+### `GET /api/config`
+
+- **Called from:** `src/routes/config/+page.ts:14`
+- **Response fields read by UI:** `birth_date`, `retirement_age`, `retirement_monthly_salary`, `allocation_real_estate`, `allocation_stocks`, `allocation_bonds`, `allocation_gold`, `allocation_commodities`, `monthly_expenses`, `monthly_mortgage_payment`
+- **Notes:** `404` is treated as "first-time, use defaults"; `id`, `ppk_employee_rate_marcin`, `ppk_employer_rate_marcin`, `ppk_employee_rate_ewa`, `ppk_employer_rate_ewa` declared in type but not read.
+
+---
+
+### `PUT /api/config`
+
+- **Called from:** `src/routes/config/+page.svelte:105`
+- **Request fields sent:** `birth_date`, `retirement_age`, `retirement_monthly_salary`, `allocation_real_estate`, `allocation_stocks`, `allocation_bonds`, `allocation_gold`, `allocation_commodities`, `monthly_expenses`, `monthly_mortgage_payment`
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `GET /api/cpi/series`
+
+- **Called from:** `src/routes/salaries/+page.ts:61`
+- **Response fields read by UI:** `points[]` (each: `year`, `yoy_rate`, `cumulative_index`), `base_year`, `latest_year`
+- **Optional fields tolerated:** `base_year`/`latest_year` nullable; whole response defaults to empty on non-OK
+- **Notes:** `source` declared but only used as fallback in defaults; not rendered. Consumed via `buildCpiLookup` in `src/lib/utils/inflation.ts`.
+
+---
+
+### `GET /api/dashboard`
+
+- **Called from:**
+  - `src/routes/+page.ts:21`
+  - `src/routes/config/+page.ts:34` (reads only `retirement_account_value`)
+  - `src/routes/metryki/+page.ts:12`
+- **Response fields read by UI:**
+  - Dashboard (`/`): `current_net_worth`, `total_assets`, `total_liabilities`, `net_worth_history[]` (each `{date, value}`), `allocation[]` (each `{category, owner, value}`), `tile_deltas.{net_worth,assets,liabilities}.{mom,yoy}.{absolute,percentage}`
+  - Config (`/config`): `retirement_account_value`
+  - Metryki (`/metryki`):
+    - `metric_cards.{property_sqm, emergency_fund_months, retirement_income_monthly, mortgage_remaining, mortgage_months_left, mortgage_years_left, retirement_total, investment_contributions, investment_returns, savings_rate, debt_to_income_ratio, hour_of_work_cost, hour_of_life_cost}`
+    - `allocation_analysis.{by_category[], by_wrapper[], rebalancing[], total_investment_value}` — per-category: `category, current_percentage, target_percentage`; per-wrapper: `wrapper, value`; rebalancing: `category, amount`
+    - `investment_time_series[]` — each `{date, value?, contributions?, total_value?, cumulative_contributions?}`
+    - `wrapper_time_series.{ike, ikze, ppk}` — same point shape as above
+    - `category_time_series.{stock, bond}` — same point shape
+- **Optional fields tolerated:** `tile_deltas.*.{mom,yoy}.absolute/percentage` all nullable; `metric_cards.savings_rate`, `metric_cards.debt_to_income_ratio`, `metric_cards.hour_of_work_cost`, `metric_cards.hour_of_life_cost` nullable; `allocation[].owner` nullable; `total_value`, `cumulative_contributions` are fallbacks when `value`/`contributions` absent.
+- **Notes:** UI accesses via dotted chains with `?.` — backend must keep these nested paths intact even when sections are empty.
+
+---
+
+### `GET /api/debts`
+
+- **Called from:** `src/routes/debts/+page.ts:46`
+- **Response fields read by UI:** top-level `debts[]`, `total_count` (declared, not rendered), `completed_count`/`active_debts_count` (declared, not rendered);
+  per-debt: `id`, `account_id`, `account_owner`, `name`, `debt_type`, `start_date`, `initial_amount`, `interest_rate`, `total_paid`, `interest_paid`, `latest_balance`, `latest_balance_date`, `currency`, `notes`
+- **Optional fields tolerated:** `latest_balance`, `latest_balance_date`, `notes` nullable.
+- **Notes:** `account_name`, `is_active`, `created_at` declared in type but not read.
+
+---
+
+### `PUT /api/debts/{id}`
+
+- **Called from:** `src/routes/debts/+page.svelte:138` (edit branch)
+- **Request fields sent:** `name`, `debt_type`, `start_date`, `initial_amount`, `interest_rate`, `currency`, `notes`
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `DELETE /api/debts/{id}`
+
+- **Called from:** `src/routes/debts/+page.svelte:174`
+- **Response fields read by UI:** only `response.ok`.
+
+---
+
+### `GET /api/equity-grants`
+
+- **Called from:** `src/routes/salaries/+page.ts:63`
+- **Response fields read by UI:**
+  - top-level: `equity_grants[]`
+  - per-grant: `id`, `grant_date`, `type`, `company`, `owner`, `total_shares`, `strike_price`, `currency`, `vest_start_date`, `vest_cliff_months`, `vest_total_months`, `vest_frequency`, `vest_custom_schedule[]` (each `{month, pct}`), `requires_liquidity_event`, `liquidity_event_date`, `tax_treatment`, `notes`, `vested_shares_today`, `vesting_progress_pct`, `paper_value_base`, `paper_value_low`, `paper_value_high`, `paper_value_currency`, `paper_value_base_pln`, `paper_value_low_pln`, `paper_value_high_pln`, `fx_rate`, `valuation_date`
+- **Optional fields tolerated:** `strike_price`, `vest_custom_schedule`, `liquidity_event_date`, `notes`, `paper_value_*`, `fx_rate`, `valuation_date` all nullable.
+- **Notes:** `total_count`, `available_companies`, `is_active`, `created_at`, `valuation_source` declared but unused by UI.
+
+---
+
+### `POST /api/equity-grants`
+
+- **Called from:** `src/routes/salaries/+page.svelte:713`
+- **Request fields sent:** `grant_date`, `type`, `company`, `owner`, `total_shares`, `strike_price`, `currency`, `vest_start_date`, `vest_cliff_months`, `vest_total_months`, `vest_frequency`, `vest_custom_schedule`, `requires_liquidity_event`, `liquidity_event_date`, `tax_treatment`, `notes`
+- **Response fields read by UI:** only `response.ok`; error path walks `detail`.
+
+---
+
+### `PATCH /api/equity-grants/{id}`
+
+- **Called from:** `src/routes/salaries/+page.svelte:713` (edit branch)
+- **Request fields sent:** same as POST.
+- **Response fields read by UI:** only `response.ok`; error path walks `detail`.
+
+---
+
+### `DELETE /api/equity-grants/{id}`
+
+- **Called from:** `src/routes/salaries/+page.svelte:752`
+- **Response fields read by UI:** only `response.ok`.
+
+---
+
+### `GET /api/goals`
+
+- **Called from:** `src/routes/goals/+page.ts:40`
+- **Response fields read by UI:** top-level `goals[]`, `total_count`, `completed_count`;
+  per-goal: `id`, `name`, `target_amount`, `target_date`, `current_amount`, `monthly_contribution`, `is_completed`, `account_id`, `account_name`, `category`, `progress_percent`, `remaining_amount`, `projected_hit_date`
+- **Optional fields tolerated:** `account_id`, `account_name`, `category`, `projected_hit_date` nullable.
+- **Notes:** `created_at` declared but unused.
+
+---
+
+### `POST /api/goals`
+
+- **Called from:** `src/routes/goals/+page.svelte:100` (create branch)
+- **Request fields sent:** `name`, `target_amount`, `target_date`, `current_amount`, `monthly_contribution`, `is_completed`, `account_id`, `category`
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `PUT /api/goals/{id}`
+
+- **Called from:** `src/routes/goals/+page.svelte:100` (edit branch)
+- **Request fields sent:** same as POST.
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `DELETE /api/goals/{id}`
+
+- **Called from:** `src/routes/goals/+page.svelte:131`
+- **Response fields read by UI:** only `response.ok`.
+
+---
+
+### `GET /api/investment/bond-stats`
+
+- **Called from:** `src/routes/metryki/+page.ts:35`
+- **Response fields read by UI:** `total_value`, `total_contributed`, `returns`, `roi_percentage`
+- **Notes:** whole response tolerated as `null` (rendering gated by `{#if data.bondStats}`).
+
+---
+
+### `GET /api/investment/stock-stats`
+
+- **Called from:** `src/routes/metryki/+page.ts:28`
+- **Response fields read by UI:** `total_value`, `total_contributed`, `returns`, `roi_percentage`
+- **Notes:** whole response tolerated as `null`.
+
+---
+
+### `GET /api/payments/counts`
+
+- **Called from:** `src/routes/debts/+page.svelte:194`
+- **Response fields read by UI:** treated as `Record<account_id (number), count (number)>` — keys are account IDs, values are payment counts.
+
+---
+
+### `GET /api/personas`
+
+- **Called from:**
+  - `src/routes/+page.ts:14`
+  - `src/routes/accounts/+page.ts:38`
+  - `src/routes/debts/+page.ts:47`
+  - `src/routes/goals/+page.ts` (not directly — goals page only fetches accounts)
+  - `src/routes/settings/+page.ts:11`
+  - `src/routes/simulations/+page.ts:13`
+  - `src/routes/simulations/zus/+page.ts:13`
+  - `src/routes/snapshots/[id]/edit/+page.ts:12`
+  - `src/routes/snapshots/new/+page.ts:16`
+  - `src/routes/salaries/+page.ts:60`
+  - `src/routes/transactions/+page.ts:56`
+- **Response fields read by UI:**
+  - `id`, `name`, `ppk_employee_rate`, `ppk_employer_rate`
+- **Notes:** `created_at` declared but unused. Most consumers iterate `personas` reading only `id`/`name`; settings page reads/edits `ppk_employee_rate` and `ppk_employer_rate`.
+
+---
+
+### `POST /api/personas`
+
+- **Called from:** `src/routes/settings/+page.svelte:61` (create branch)
+- **Request fields sent:** `name`, `ppk_employee_rate`, `ppk_employer_rate`
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `PUT /api/personas/{id}`
+
+- **Called from:** `src/routes/settings/+page.svelte:61` (edit branch)
+- **Request fields sent:** same as POST.
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `DELETE /api/personas/{id}`
+
+- **Called from:** `src/routes/settings/+page.svelte:92`
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `POST /api/retirement/ppk-contributions/generate`
+
+- **Called from:** `src/routes/transactions/+page.svelte:120`
+- **Request fields sent:** `owner`, `month`, `year`
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+- **Notes:** declared response shape includes `gross_salary`, `employee_amount`, `employer_amount`, `total_amount`, `transactions_created` but none are read.
+
+---
+
+### `GET /api/retirement/ppk-stats`
+
+- **Called from:** `src/routes/metryki/+page.ts:21`
+- **Response fields read by UI (per row in array):** `owner`, `total_value`, `employee_contributed`, `employer_contributed`, `government_contributed`, `total_contributed`, `returns`, `roi_percentage`
+
+---
+
+### `PUT /api/retirement/limits/{year}/{wrapper}/{owner}`
+
+- **Called from:** `src/routes/+page.svelte:77`
+- **Request fields sent:** `year`, `account_wrapper`, `owner`, `limit_amount`, `notes`
+- **Response fields read by UI:** only `response.ok`.
+
+---
+
+### `GET /api/retirement/stats`
+
+- **Called from:** `src/routes/+page.ts:22` (query param `year={currentYear}`)
+- **Response fields read by UI (per row in array):** `account_wrapper`, `owner`, `total_contributed`, `limit_amount`, `remaining`, `percentage_used`
+- **Notes:** response defaults to `[]` on non-OK; UI tolerates empty.
+
+---
+
+### `GET /api/salaries`
+
+- **Called from:**
+  - `src/routes/salaries/+page.ts:59` (with query params `owner`, `date_from`, `date_to`, `company`)
+  - `src/routes/simulations/kalkulator/+page.ts:11`
+- **Response fields read by UI:**
+  - top-level: `salary_records[]`, `current_salaries` (Record<owner, salary | null>), `inflation_context` (Record<owner, InflationContext>), `available_companies[]`
+  - per-record: `id`, `date`, `gross_amount`, `contract_type`, `company`, `owner`
+  - inflation_context entries: `owner`, `last_change_date`, `previous_change_date`, `previous_salary`, `previous_salary_in_today_pln`, `current_salary`, `real_change_pln`, `real_change_pct`, `cpi_as_of_year`
+- **Optional fields tolerated:** `inflation_context.*` nullable fields (`previous_change_date`, `previous_salary`, `previous_salary_in_today_pln`, `real_change_pln`, `real_change_pct`); `current_salaries` values nullable.
+- **Notes:** `total_count`, `is_active`, `created_at` declared but unused. `/simulations/kalkulator` only reads `salary_records`.
+
+---
+
+### `POST /api/salaries`
+
+- **Called from:** `src/routes/salaries/+page.svelte:1020` (create branch)
+- **Request fields sent:** `date`, `gross_amount`, `contract_type`, `company`, `owner`
+- **Response fields read by UI:** only `response.ok`; error path walks `detail`.
+
+---
+
+### `PATCH /api/salaries/{id}`
+
+- **Called from:** `src/routes/salaries/+page.svelte:1020` (edit branch)
+- **Request fields sent:** same as POST.
+- **Response fields read by UI:** only `response.ok`; error path walks `detail`.
+
+---
+
+### `DELETE /api/salaries/{id}`
+
+- **Called from:** `src/routes/salaries/+page.svelte:1062`
+- **Response fields read by UI:** only `response.ok`.
+
+---
+
+### `POST /api/simulations/mortgage-vs-invest`
+
+- **Called from:** `src/routes/simulations/mortgage/+page.svelte:80`
+- **Request fields sent:** `remaining_principal`, `annual_interest_rate`, `remaining_months`, `total_monthly_budget`, `expected_annual_return`, `inflation_rate`, `enable_variable_rate`
+- **Response fields read by UI:**
+  - `yearly_projections[]` per row: `year`, `annual_rate`, `scenario_a_mortgage_balance`, `scenario_a_real_mortgage_balance`, `scenario_a_cumulative_interest`, `scenario_a_investment_balance`, `scenario_a_after_tax_portfolio`, `scenario_a_real_portfolio`, `scenario_a_paid_off`, `scenario_b_mortgage_balance`, `scenario_b_real_mortgage_balance`, `scenario_b_investment_balance`, `scenario_b_after_tax_portfolio`, `scenario_b_real_portfolio`, `scenario_b_cumulative_interest`, `net_advantage_invest`
+  - `summary.{regular_monthly_payment, total_interest_a, total_interest_b, interest_saved, final_investment_portfolio, belka_tax_a, belka_tax_b, final_portfolio_a_real, final_portfolio_b_real, months_saved, winning_strategy, net_advantage, break_even_gross_return}`
+
+---
+
+### `GET /api/simulations/prefill`
+
+- **Called from:** `src/routes/simulations/+page.ts:12`
+- **Response fields read by UI:** `current_age`, `retirement_age`, `balances` (Record<`{wrapper_lower}_{owner_lower}`, number>), `ppk_balances` (Record<owner_lower, number>), `monthly_salaries` (Record<owner_lower, number>), `ppk_rates` (Record<owner_lower, `{employee, employer}`>)
+- **Optional fields tolerated:** all lookups use `?? default` fallbacks.
+
+---
+
+### `POST /api/simulations/retirement`
+
+- **Called from:** `src/routes/simulations/+page.svelte:202`
+- **Request fields sent:** `current_age`, `retirement_age`, `ike_ikze_accounts[]` (`{enabled, wrapper, owner, balance, auto_fill_limit, monthly_contribution, tax_rate}`), `ppk_accounts[]` (`{owner, enabled, starting_balance, monthly_gross_salary, employee_rate, employer_rate, salary_below_threshold, include_welcome_bonus, include_annual_subsidy}`), `brokerage_accounts[]` (`{enabled, owner, balance, monthly_contribution}`), `annual_return_rate`, `limit_growth_rate`, `expected_salary_growth`, `inflation_rate`
+- **Response fields read by UI:**
+  - `summary.{total_final_balance, total_contributions, total_returns, total_tax_savings, total_subsidies?, estimated_monthly_income, estimated_monthly_income_today, years_until_retirement}`
+  - `simulations[]` per item: `account_name`, `final_balance`, `yearly_projections[]`
+  - per yearly_projection: `year`, `age`, `annual_contribution`, `balance_end_of_year`, `cumulative_contributions`, `cumulative_returns`, `limit_utilized_pct`, `tax_savings`, `government_subsidies?`, `monthly_salary?`, `return_rate?`
+- **Optional fields tolerated:** `total_subsidies`, `government_subsidies`, `monthly_salary`, `return_rate` optional; `annual_limit`, `starting_balance`, `total_contributions`, `total_returns`, `total_tax_savings` declared but not read in UI.
+
+---
+
+### `GET /api/snapshots`
+
+- **Called from:** `src/routes/snapshots/+page.ts:20`
+- **Response fields read by UI (per row):** `id`, `date`, `notes`, `total_net_worth`
+- **Optional fields tolerated:** `notes` nullable.
+
+---
+
+### `POST /api/snapshots`
+
+- **Called from:** `src/lib/components/SnapshotForm.svelte:362` (create branch — `editingSnapshot === null`)
+- **Request fields sent:** `date`, `notes`, `values[]` where each entry is either `{account_id, value}` or `{asset_id, value}`
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `GET /api/snapshots/{id}`
+
+- **Called from:** `src/routes/snapshots/[id]/edit/+page.ts:9`
+- **Response fields read by UI:** `id`, `date`, `notes`, `values[]`; per value: `id`, `asset_id`, `account_id`, `value` (also `asset_name`, `account_name` declared but unused).
+- **Optional fields tolerated:** `notes`, `asset_id`, `account_id` nullable.
+
+---
+
+### `PUT /api/snapshots/{id}`
+
+- **Called from:** `src/lib/components/SnapshotForm.svelte:362` (edit branch)
+- **Request fields sent:** same as POST `/api/snapshots`.
+- **Response fields read by UI:** only `response.ok`; error path reads `detail`.
+
+---
+
+### `GET /api/transactions`
+
+- **Called from:** `src/routes/transactions/+page.ts:36` (query params: `account_id`, `owner`, `date_from`, `date_to`)
+- **Response fields read by UI:** top-level `transactions[]`, `total_invested`;
+  per-transaction: `id`, `account_id`, `account_name`, `amount`, `date`, `owner`
+- **Notes:** `created_at`, `transaction_count` declared but unused on this page.
+
+---
+
+### `GET /api/transactions/counts`
+
+- **Called from:** `src/routes/accounts/+page.svelte:201`
+- **Response fields read by UI:** treated as `Record<account_id (number), count (number)>`.
+
+---
+
+### `POST /api/zus/calculate`
+
+- **Called from:** `src/routes/simulations/zus/+page.svelte:99`
+- **Request fields sent:** `owner`, `birth_date`, `gender`, `retirement_age`, `current_gross_monthly_salary`, `salary_growth_rate`, `inflation_rate`, `valorization_rate_konto`, `valorization_rate_subkonto`, `has_ofe`, `kapital_poczatkowy`, `work_start_year`, `salary_history`
+- **Response fields read by UI:**
+  - top-level: `yearly_projections[]`, `life_expectancy_months`, `konto_at_retirement`, `subkonto_at_retirement`, `kapital_poczatkowy_valorized`, `total_capital`, `monthly_pension_gross`, `monthly_pension_net`, `replacement_rate`, `last_gross_salary`, `sensitivity[]`
+  - per yearly_projection: `year`, `age`, `annual_gross_salary`, `salary_capped`, `contribution_konto`, `contribution_subkonto`, `konto_balance`, `subkonto_balance`, `total_balance`
+  - per sensitivity scenario: `label`, `valorization_konto`, `valorization_subkonto`, `monthly_pension_gross`, `monthly_pension_net`, `replacement_rate`
+- **Notes:** error path reads `detail`.
+
+---
+
+### `GET /api/zus/prefill`
+
+- **Called from:** `src/routes/simulations/zus/+page.ts:12`
+- **Response fields read by UI:** `birth_date`, `retirement_age`, `gender`, `current_gross_monthly_salary`, `owner`, `salary_history[]` (each `{year, annual_gross}`), `work_start_year`
+- **Optional fields tolerated:** `birth_date`, `current_gross_monthly_salary`, `owner`, `work_start_year` nullable.
+
+---
+
+## Summary
+
+- **Total distinct endpoints called:** 51
+
+### Endpoints declared in `src/lib/types/*.ts`
+
+- `src/lib/types/personas.ts` — `Persona` covers GET/POST/PUT/DELETE `/api/personas`
+- `src/lib/types/transactions.ts` — `Transaction` + `TransactionsData` cover GET `/api/transactions` and GET `/api/accounts/{id}/transactions`
+- `src/lib/types/cpi.ts` — `CpiSeries`, `CpiPoint` cover GET `/api/cpi/series`
+- `src/lib/types/config.ts` — `AppConfig` covers GET/PUT `/api/config`
+- `src/lib/types/retirement.ts` — `PPKStats` covers GET `/api/retirement/ppk-stats`; `PPKContributionGenerateRequest`/`PPKContributionGenerateResponse` cover POST `/api/retirement/ppk-contributions/generate` (response unused at runtime)
+- `src/lib/types/salaries.ts` — `SalaryRecord`, `SalariesData`, `InflationContext` cover GET `/api/salaries`; `BonusEvent`, `BonusEventsData` cover GET `/api/bonuses`; `EquityGrant`, `EquityGrantsData`, `CustomVestingEvent` cover GET `/api/equity-grants`; `CompanyValuation`, `CompanyValuationsData`, `ValuationSource` cover GET `/api/company-valuations`
+- `src/lib/types.ts` — `Account`, `Asset`, `SnapshotResponse`, `SnapshotValueResponse` cover GET `/api/accounts`, GET `/api/assets`, GET `/api/snapshots/{id}` (and bodies of POST/PUT/DELETE variants)
+
+### Endpoints WITH NO type definition (inference / inline interface) — silent-drift risks
+
+- `GET /api/dashboard` — fully inferred; dotted accesses to `tile_deltas`, `metric_cards`, `allocation_analysis`, `*_time_series` are the highest-risk contract surface.
+- `GET /api/retirement/stats` — only a local `RetirementStat` type in `src/routes/+page.svelte` (lines 45-52).
+- `PUT /api/retirement/limits/{year}/{wrapper}/{owner}` — request shape inline only.
+- `GET /api/debts` — `Debt`/`DebtPayment`/`DebtsListResponse` declared inline in `src/routes/debts/+page.ts` (not under `src/lib/types/`).
+- `GET /api/goals` — `Goal`/`GoalsListResponse`/`AccountOption` declared inline in `src/routes/goals/+page.ts`.
+- `GET /api/accounts` shape used outside `src/lib/types.ts` re-declared inline in `src/routes/accounts/+page.ts` (`Account`, `AccountsData`) and `src/routes/transactions/+page.ts` (slim `Account` with `category`).
+- `GET /api/assets` re-declared inline in `src/routes/assets/+page.ts` (parallel `Asset`/`AssetsData` to `src/lib/types.ts`).
+- `GET /api/snapshots` — `SnapshotListItem` declared inline in `src/routes/snapshots/+page.ts`.
+- `GET /api/accounts/{id}/payments` and its POST/DELETE — response shape only typed by `paymentsData` inline `$state` in `src/routes/debts/+page.svelte`.
+- `GET /api/payments/counts`, `GET /api/transactions/counts` — inferred as `Record<number, number>`, no type.
+- `GET /api/investment/stock-stats`, `GET /api/investment/bond-stats` — fully inferred (no type), tolerated as `null`.
+- `GET /api/simulations/prefill` — inferred record-keyed nested object (`balances`, `ppk_balances`, `monthly_salaries`, `ppk_rates`); no type.
+- `POST /api/simulations/retirement` — request inline; response interfaces declared inline in `src/routes/simulations/+page.svelte` (`SimulationSummary`, `SimulationResponse`) and `src/lib/utils/charts/simulations.ts` (`AccountSimulation`, `YearlyProjection`).
+- `GET /api/zus/prefill` — inline `Props.data.prefill` interface inside `src/routes/simulations/zus/+page.svelte`.
+- `POST /api/zus/calculate` — inline `ZusCalculatorResponse`, `ZusYearlyProjection`, `ZusSensitivityScenario` interfaces in `src/routes/simulations/zus/+page.svelte`.
+- `POST /api/simulations/mortgage-vs-invest` — inline `MortgageVsInvestResponse`, `MortgageVsInvestYearlyRow`, `MortgageVsInvestSummary` in `src/routes/simulations/mortgage/+page.svelte`.
+- All POST/PUT/PATCH/DELETE request bodies — none have shared types; built inline in each call site.

--- a/migration/frontend-contract.md
+++ b/migration/frontend-contract.md
@@ -17,9 +17,10 @@ Sections are ordered alphabetically by URL path.
   - `src/routes/transactions/+page.ts:45`
 - **Response fields read by UI:**
   - top-level: `assets[]`, `liabilities[]`
-  - per-account (assets + liabilities): `id`, `name`, `type`, `category`, `owner`, `currency`, `account_wrapper`, `purpose`, `receives_contributions`, `square_meters`, `current_value`, `account_id` (via SnapshotForm props)
+  - per-account (assets + liabilities): `id`, `name`, `type`, `category`, `owner`, `currency`, `account_wrapper`, `purpose`, `receives_contributions`, `square_meters`, `current_value`
 - **Optional fields tolerated:** `account_wrapper` (nullable), `square_meters` (nullable)
-- **Notes:** goals page flattens `assets + liabilities` into `accounts` (only reads `id`, `name`). Transactions page reads `assets` only, filters by `category ∈ INVESTMENT_CATEGORIES`. SnapshotForm consumes the full per-account shape including `current_value`. `is_active` / `created_at` declared in type but not read by UI.
+- **Declared but not read by UI:** `is_active`, `created_at`
+- **Notes:** goals page flattens `assets + liabilities` into `accounts` (only reads `id`, `name`). Transactions page reads `assets` only, filters by `category ∈ INVESTMENT_CATEGORIES`. SnapshotForm consumes the full per-account shape including `current_value`. (SnapshotForm's child rows reference `account_id` against snapshot-value payloads, not against the accounts list response.)
 
 ---
 
@@ -116,7 +117,7 @@ Sections are ordered alphabetically by URL path.
 - **Response fields read by UI:**
   - top-level: `assets[]`
   - per-asset: `id`, `name`, `current_value` (SnapshotForm also reads same)
-- **Optional fields tolerated:** `is_active`, `created_at` declared but unused.
+- **Declared but not read by UI:** `is_active`, `created_at`
 
 ---
 
@@ -369,7 +370,7 @@ Sections are ordered alphabetically by URL path.
 ### `GET /api/payments/counts`
 
 - **Called from:** `src/routes/debts/+page.svelte:194`
-- **Response fields read by UI:** treated as `Record<account_id (number), count (number)>` — keys are account IDs, values are payment counts.
+- **Response fields read by UI:** treated as `Record<string, number>` — keys are account IDs serialized as strings (JSON object keys are always strings on the wire), values are payment counts.
 
 ---
 
@@ -559,7 +560,7 @@ Sections are ordered alphabetically by URL path.
 ### `GET /api/transactions/counts`
 
 - **Called from:** `src/routes/accounts/+page.svelte:201`
-- **Response fields read by UI:** treated as `Record<account_id (number), count (number)>`.
+- **Response fields read by UI:** treated as `Record<string, number>` — keys are account IDs serialized as strings (JSON object keys are always strings on the wire), values are transaction counts.
 
 ---
 


### PR DESCRIPTION
## Motivation

Phase 1 of the Python→Go backend migration prep. The Go backend must satisfy the current FastAPI contract byte-for-byte during per-endpoint cutover. To pin that, we (a) freeze the current OpenAPI schema, (b) add a CI drift check so any unintentional contract change blocks merge, and (c) audit which fields the frontend actually reads (so we know what's load-bearing vs. internal).

Phase 0 (audits) merged in #423.

## Implementation information

- `api/openapi.v1.json` — `app.openapi()` dumped via `backend/scripts/dump_openapi.py` with sorted keys and indent=2. 8551 lines.
- `backend/scripts/dump_openapi.py` — small script that sets placeholder env vars (settings need them at import time), adds backend/ to sys.path, dynamically imports `app.main`, dumps the spec. Uses `importlib` so module-level imports stay at file top (ruff E402 clean).
- `.github/workflows/ci.yml` — new `OpenAPI drift check` step in the backend job: re-runs the dump and `git diff --exit-code`s the committed file. Error message points at the regenerate command and reminds that an intentional change means bumping to `openapi.v2.json`.
- `.prettierignore` — excludes `api/openapi.v1.json`. The file's canonical formatter is Python's `json.dump`; prettier would reformat (different key/indent rules) and fight the drift check.
- `migration/frontend-contract.md` — every UI-called endpoint (51 total), per-endpoint: caller files, request fields, response fields the UI actually reads, optional/nullable handling, quirks.

Risks flagged in the audit:
- **`GET /api/dashboard` has no shared type** — UI reads deeply nested paths (`tile_deltas.*.{mom,yoy}.{absolute,percentage}`, `metric_cards.*`, `allocation_analysis.*`, `*_time_series.*`). Highest silent-drift risk.
- **Simulation endpoints use inline interfaces** — `/api/simulations/retirement`, `/api/simulations/mortgage-vs-invest`, `/api/zus/calculate`, `/api/zus/prefill`, `/api/simulations/prefill`. Not in `src/lib/types/`.
- **`Account`/`Asset` types duplicated** between `src/lib/types.ts` and inline in `src/routes/accounts/+page.ts`, `src/routes/assets/+page.ts`, `src/routes/transactions/+page.ts`.
- **Fields declared but not read**: `is_active`, `created_at`, `total_count`, `available_companies`, `transactions_created` — droppable on the Go side without breaking UI.

## Supporting documentation

- Phase 0: #423
- Plan tracked locally; next phase = black-box test harness.

> Changelog: skip