### PR TITLE
feat(deploy): flip /api/config to Go via proxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,3 +373,25 @@ jobs:
             ghcr.io/automaat/finance-buddy-backend:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Build and push backend-go
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./backend-go
+          push: true
+          tags: |
+            ghcr.io/automaat/finance-buddy-backend-go:latest
+            ghcr.io/automaat/finance-buddy-backend-go:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push proxy
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./migration/proxy
+          push: true
+          tags: |
+            ghcr.io/automaat/finance-buddy-proxy:latest
+            ghcr.io/automaat/finance-buddy-proxy:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,3 +91,25 @@ jobs:
             ghcr.io/automaat/finance-buddy-backend:v${{ env.VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Build and push backend-go
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./backend-go
+          push: true
+          tags: |
+            ghcr.io/automaat/finance-buddy-backend-go:latest
+            ghcr.io/automaat/finance-buddy-backend-go:v${{ env.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push proxy
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./migration/proxy
+          push: true
+          tags: |
+            ghcr.io/automaat/finance-buddy-proxy:latest
+            ghcr.io/automaat/finance-buddy-proxy:v${{ env.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/backend-go/Dockerfile
+++ b/backend-go/Dockerfile
@@ -11,4 +11,6 @@ FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=build /out/api /usr/local/bin/api
 EXPOSE 8000
 USER nonroot:nonroot
+HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=5 \
+    CMD ["/usr/local/bin/api", "healthcheck"]
 ENTRYPOINT ["/usr/local/bin/api"]

--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -7,10 +7,13 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -19,7 +22,39 @@ import (
 )
 
 func main() {
+	if len(os.Args) >= 2 && os.Args[1] == "healthcheck" {
+		os.Exit(healthcheck())
+	}
 	os.Exit(run())
+}
+
+// healthcheck probes our own /health endpoint via HTTP.
+//
+// Designed for Docker HEALTHCHECK on the distroless image, which has no shell
+// or curl. Reads FB_ADDR for the port (default :8000) and pings on localhost.
+// Exits 0 on a 200 response, 1 otherwise.
+func healthcheck() int {
+	addr := envOr("FB_ADDR", ":8000")
+	host, port, ok := strings.Cut(addr, ":")
+	if !ok {
+		port = addr
+	}
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	url := "http://" + net.JoinHostPort(host, port) + "/health"
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "healthcheck:", err)
+		return 1
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintln(os.Stderr, "healthcheck: status", resp.StatusCode)
+		return 1
+	}
+	return 0
 }
 
 func run() int {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,8 +23,8 @@ services:
     container_name: finance-backend
     volumes:
       - ./backend:/app
-    ports:
-      - '8000:8000'
+    expose:
+      - '8000'
     environment:
       - DATABASE_URL=postgresql://finance:${POSTGRES_PASSWORD:-password}@postgres:5432/finance
       - APP_PASSWORD=${APP_PASSWORD:-changeme}
@@ -46,6 +46,34 @@ services:
       retries: 5
       start_period: 10s
 
+  backend-go:
+    build:
+      context: ./backend-go
+    container_name: finance-backend-go
+    expose:
+      - '8000'
+    environment:
+      - DATABASE_URL=postgresql://finance:${POSTGRES_PASSWORD:-password}@postgres:5432/finance
+      - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:5174,http://localhost:3000}
+      - FB_ADDR=:8000
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  proxy:
+    build:
+      context: ./migration/proxy
+    container_name: finance-proxy
+    ports:
+      - '8080:8080'
+    volumes:
+      - ./migration/proxy/routes.yaml:/etc/proxy/routes.yaml:ro
+    depends_on:
+      backend:
+        condition: service_healthy
+      backend-go:
+        condition: service_started
+
   frontend:
     build:
       context: .
@@ -57,11 +85,10 @@ services:
     ports:
       - '5174:5173'
     environment:
-      - PUBLIC_API_URL=http://backend:8000
-      - PUBLIC_API_URL_BROWSER=http://localhost:8000
+      - PUBLIC_API_URL=http://proxy:8080
+      - PUBLIC_API_URL_BROWSER=http://localhost:8080
     depends_on:
-      backend:
-        condition: service_healthy
+      - proxy
 
 volumes:
   postgres-data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -59,6 +59,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ['CMD', '/usr/local/bin/api', 'healthcheck']
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
 
   proxy:
     build:
@@ -72,7 +78,7 @@ services:
       backend:
         condition: service_healthy
       backend-go:
-        condition: service_started
+        condition: service_healthy
 
   frontend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
   proxy:
     image: ghcr.io/automaat/finance-buddy-proxy:latest
     container_name: finance-proxy
+    ports:
+      - '8080:8080'
     restart: unless-stopped
     depends_on:
       - backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  finance-backend:
+  backend:
     image: ghcr.io/automaat/finance-buddy-backend:latest
     container_name: finance-backend
     environment:
@@ -10,19 +10,38 @@ services:
     depends_on:
       - postgres
 
-  finance-app:
+  backend-go:
+    image: ghcr.io/automaat/finance-buddy-backend-go:latest
+    container_name: finance-backend-go
+    environment:
+      - DATABASE_URL=${DATABASE_URL:-postgresql://finance:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/finance}
+      - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:3000}
+      - FB_ADDR=:8000
+    restart: unless-stopped
+    depends_on:
+      - postgres
+
+  proxy:
+    image: ghcr.io/automaat/finance-buddy-proxy:latest
+    container_name: finance-proxy
+    restart: unless-stopped
+    depends_on:
+      - backend
+      - backend-go
+
+  frontend:
     image: ghcr.io/automaat/finance-buddy-frontend:latest
     container_name: finance-buddy
     ports:
       - '3000:3000'
     environment:
-      - PUBLIC_API_URL=http://finance-backend:8000
-      - PUBLIC_API_URL_BROWSER=${PUBLIC_API_URL_BROWSER:-http://localhost:8000}
+      - PUBLIC_API_URL=http://proxy:8080
+      - PUBLIC_API_URL_BROWSER=${PUBLIC_API_URL_BROWSER:-http://localhost:8080}
       - ORIGIN=${ORIGIN:-http://localhost:3000}
       - APP_PASSWORD=${APP_PASSWORD:?APP_PASSWORD must be set}
     restart: unless-stopped
     depends_on:
-      - finance-backend
+      - proxy
 
   postgres:
     image: postgres:18-alpine

--- a/migration/proxy/Dockerfile
+++ b/migration/proxy/Dockerfile
@@ -9,7 +9,7 @@ RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/proxy .
 # Run
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=build /out/proxy /usr/local/bin/proxy
-COPY routes.example.yaml /etc/proxy/routes.yaml
+COPY routes.yaml /etc/proxy/routes.yaml
 EXPOSE 8080
 USER nonroot:nonroot
 ENTRYPOINT ["/usr/local/bin/proxy", "--config", "/etc/proxy/routes.yaml", "--addr", ":8080"]

--- a/migration/proxy/README.md
+++ b/migration/proxy/README.md
@@ -1,12 +1,12 @@
 # Cutover proxy
 
-A tiny reverse proxy that lets us flip individual endpoints from the Python backend to the Go backend, one at a time, during the migration. It's built but **not used yet** — Phase 4 ships the infrastructure; flipping doesn't happen until each endpoint passes the `backend-bb-tests/` parity suite against the Go backend.
+A tiny reverse proxy that flips individual endpoints from the Python backend to the Go backend, one at a time, during the migration. Now active in both `docker-compose.dev.yml` and `docker-compose.yml`: the frontend hits the proxy on `:8080`; the proxy forwards each request to either `backend` (Python) or `backend-go` based on `routes.yaml`.
 
 ## How it works
 
 ```
-client → proxy:8080 ──┬──→ backend:8000   (default, Python)
-                      └──→ backend-go:9000 (per-rule, Go)
+client → proxy:8080 ──┬──→ backend:8000     (default, Python)
+                      └──→ backend-go:8000  (per-rule, Go)
 ```
 
 `routes.yaml` defines:
@@ -14,22 +14,9 @@ client → proxy:8080 ──┬──→ backend:8000   (default, Python)
 - `default`: where anything that doesn't match a rule goes (Python during migration).
 - `rules`: list of `{method, path_prefix, upstream}`, evaluated top-down, first match wins.
 
-To cut over `/api/config` to Go:
+Current `routes.yaml` cuts over `/api/config` (Group 1). Adding a group means appending its rules and shipping the change as a "PR B" alongside the corresponding Go handler PR.
 
-```yaml
-default: http://backend:8000
-rules:
-  - method: GET
-    path_prefix: /api/config
-    upstream: http://backend-go:9000
-  - method: PUT
-    path_prefix: /api/config
-    upstream: http://backend-go:9000
-```
-
-Restart the proxy; the rest of the API stays on Python.
-
-## Run
+## Run (standalone)
 
 ```bash
 cd migration/proxy
@@ -43,21 +30,23 @@ go run . --config routes.yaml --addr :8080
 go test ./...
 ```
 
-Tests use `httptest.Server` echo backends so no Postgres or external state is needed.
+Tests use `httptest.Server` echo backends — no Postgres or external state needed.
 
 ## Docker
 
 ```bash
 docker build -t finance-buddy-proxy migration/proxy
-docker run --rm -p 8080:8080 -v $(pwd)/migration/proxy/routes.yaml:/etc/proxy/routes.yaml finance-buddy-proxy
+docker run --rm -p 8080:8080 \
+    -v $(pwd)/migration/proxy/routes.yaml:/etc/proxy/routes.yaml \
+    finance-buddy-proxy
 ```
 
-`docker-compose.dev.yml` doesn't wire it in by default — adding the proxy between the frontend and the backends is a deliberate cutover step that should land alongside the first Go endpoint, not before.
+Both compose files build/pull the proxy image and mount `routes.yaml` (dev) or use the baked-in copy (prod). Image published as `ghcr.io/automaat/finance-buddy-proxy:{latest,vX.Y.Z}` by the release workflow.
 
 ## What's intentionally missing (yet)
 
 - **Shadow-diff mode** — send each request to both backends, return Python's response, log the diff. Defer until the first L-risk endpoint (dashboard, simulations) cuts over.
-- **Reload on SIGHUP** — restart is fine for now; flips are deliberate and infrequent.
+- **Reload on SIGHUP** — restart is fine; flips are deliberate and infrequent.
 - **Per-rule weights / canary** — not needed for binary cutover.
 
 These are easy to add when the corresponding cutover step demands them.

--- a/migration/proxy/README.md
+++ b/migration/proxy/README.md
@@ -33,7 +33,7 @@ Restart the proxy; the rest of the API stays on Python.
 
 ```bash
 cd migration/proxy
-cp routes.example.yaml routes.yaml
+# routes.yaml lives in this directory — edit it directly.
 go run . --config routes.yaml --addr :8080
 ```
 

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -9,13 +9,11 @@
 
 default: http://backend:8000
 
-rules: []
-
-# Example for when /api/config is ready to flip:
-# rules:
-#   - method: GET
-#     path_prefix: /api/config
-#     upstream: http://backend-go:9000
-#   - method: PUT
-#     path_prefix: /api/config
-#     upstream: http://backend-go:9000
+rules:
+  # Group 1 — /api/config cut over to Go (see migration/CUTOVER.md).
+  - method: GET
+    path_prefix: /api/config
+    upstream: http://backend-go:8000
+  - method: PUT
+    path_prefix: /api/config
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

PR B of the Group 1 cutover (per `migration/CUTOVER.md` step 7). PR A (#452, merged) shipped the Go handler and proved parity in CI. This PR is the smaller, separate change that actually flips production traffic for `/api/config` to backend-go via the proxy.

Part of #435; finishes #436.

## Implementation information

### What flips

- **`migration/proxy/routes.yaml`**: GET + PUT `/api/config` → `backend-go:8000`. `default` stays on `backend:8000` (Python). 73 endpoints remain on Python.

### Compose wiring

Both compose files now run the full 4-service stack: `backend` (Python), `backend-go`, `proxy`, `frontend`, plus `postgres`. The frontend's `PUBLIC_API_URL` repoints from the Python backend to the proxy (`:8080` in dev, `proxy:8080` in prod). Direct host port `8000` is no longer exposed in dev — anyone curling `:8000` now hits the proxy on `:8080`.

Service names aligned to `backend` / `backend-go` / `proxy` in both files so the baked `routes.yaml` works without per-environment substitution. Container names keep the `finance-` prefix for log readability.

### Image builds

`docker-publish` (and `release.yml`) now build two more images alongside the existing backend + frontend:

- `ghcr.io/automaat/finance-buddy-backend-go:{latest,sha,vX.Y.Z}` from `./backend-go`
- `ghcr.io/automaat/finance-buddy-proxy:{latest,sha,vX.Y.Z}` from `./migration/proxy`

Cache layers: `type=gha`. Same pattern as backend + frontend.

### File rename

`migration/proxy/routes.example.yaml` → `routes.yaml`. Single source of truth used by:

- Proxy `Dockerfile` `COPY` (bakes into prod image)
- Dev `docker-compose.dev.yml` volume mount

No more "copy the example" step.

### Smoke verified locally

```text
$ curl -s http://localhost:8080/api/config | jq '.id, .monthly_expenses'
1
"9500.00"
# → backend-go served this (Decimal as quoted string, matches Python)

$ curl -s http://localhost:8080/api/personas | jq '.[0].name'
"Ewa"
# → backend (Python) served this

$ curl -X PUT http://localhost:8080/api/config -d '{...invalid allocations...}'
{"detail":[{"type":"value_error","loc":["body","allocation_stocks"],
            "msg":"Market allocations must sum to 100%, got 60%","input":""}]}
# → Pydantic-shaped 422 from Go

$ docker logs finance-proxy
loaded config path=/etc/proxy/routes.yaml default=http://backend:8000 rules=2
proxy listening addr=:8080
```

### Rollback

One-line: revert this PR (or just delete the two rules from `routes.yaml` and redeploy). Proxy falls back to default = Python; frontend keeps hitting `:8080` but gets identical responses.

### What's next

After this merges and v0.8.0 is released:

1. Bump home-nas `finance-buddy-stack.yml` to v0.8.0 + add `backend-go` and `proxy` services
2. Deploy via ansible
3. 24-hour monitor
4. Start #437 (Group 2: personas + 5-table cascade)

## Supporting documentation

- Umbrella: #435
- Group 1 subissue: #436
- Go handler PR (PR A): #452
- Procedure: `migration/CUTOVER.md` step 7

> Changelog: skip