### PR TITLE
fix(go): accept libpq PG* env vars

### DIFF
--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -70,7 +70,13 @@ func run() int {
 	defer stop()
 
 	deps := server.Deps{}
-	if dsn := os.Getenv("DATABASE_URL"); dsn != "" {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn != "" || os.Getenv("PGHOST") != "" {
+		// pgx's URL parser is strict — special chars in the password (@, :,
+		// /, ?, #) must be percent-encoded. If callers prefer to skip that
+		// hazard, they can leave DATABASE_URL empty and provide the libpq
+		// env vars (PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE); pgx picks
+		// them up from an empty DSN.
 		pool, err := db.New(ctx, dsn)
 		if err != nil {
 			logger.Error("open db pool", "err", err)
@@ -80,7 +86,7 @@ func run() int {
 		deps.Pool = pool
 		logger.Info("db pool ready")
 	} else {
-		logger.Warn("DATABASE_URL not set — DB-backed endpoints will 404")
+		logger.Warn("no DB config (DATABASE_URL or PGHOST) — DB-backed endpoints will 404")
 	}
 
 	srv := &http.Server{


### PR DESCRIPTION
## Motivation

v0.8.0 deploy to home-nas failed: backend-go crashlooped with

```
parse db dsn: cannot parse `postgresql://finance:xxxxxx@finance-postgres:5432/finance`:
failed to parse as URL (invalid port ":dg1Yc" after host)
```

The SOPS-managed `FINANCE_DB_PASSWORD` contains URL-special chars (likely `@`). pgx's URL parser is strict and requires percent-encoding; psycopg2 parses the same string leniently, which is why the Python backend keeps working with the same DSN.

## Implementation information

Broaden backend-go's DB-init gate from `DATABASE_URL != ""` to `DATABASE_URL != "" OR PGHOST != ""`. When the DSN is empty, pgx reads libpq env vars (`PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`) natively — no URL encoding hazard.

After this lands and v0.8.1 is released, the home-nas stack file will be updated to set the five `PG*` vars instead of `DATABASE_URL` for `finance-backend-go`. The Python backend keeps its `DATABASE_URL` (psycopg2 parses it fine; no need to change what works).

## Supporting documentation

- Original v0.8.0 cutover: #452, #453
- Symptom logged on pet-projects: 14 restart cycles with the same parse error before docker compose gave up

> Changelog: skip