### PR TITLE
feat(go): cutover /api/goals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,8 @@ jobs:
             tests/test_health.py \
             tests/test_config.py \
             tests/test_personas.py \
-            tests/test_personas_mutations.py
+            tests/test_personas_mutations.py \
+            tests/test_goals.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/backend-go/internal/goals/errors.go
+++ b/backend-go/internal/goals/errors.go
@@ -1,0 +1,41 @@
+package goals
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{
+				"type":  "value_error",
+				"loc":   []string{"body", field},
+				"msg":   msg,
+				"input": input,
+			},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/goals/handler.go
+++ b/backend-go/internal/goals/handler.go
@@ -1,0 +1,293 @@
+package goals
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+)
+
+// validCategories mirrors backend/app/core/enums.Category. Only these strings
+// are accepted on the wire; anything else returns a Pydantic-shaped 422.
+var validCategories = map[string]struct{}{
+	"bank": {}, "saving_account": {}, "stock": {}, "bond": {}, "gold": {},
+	"real_estate": {}, "ppk": {}, "fund": {}, "etf": {}, "vehicle": {},
+	"mortgage": {}, "installment": {}, "other": {},
+}
+
+// response mirrors backend/app/schemas/goals.GoalResponse byte-for-byte.
+//
+// Money fields are JSON numbers (Pydantic emits them as floats here, not
+// strings — different convention from app_config + personas where the column
+// type drove the Pydantic Decimal -> string default).
+type response struct {
+	ID                  int      `json:"id"`
+	Name                string   `json:"name"`
+	TargetAmount        float64  `json:"target_amount"`
+	TargetDate          isoDate  `json:"target_date"`
+	CurrentAmount       float64  `json:"current_amount"`
+	MonthlyContribution float64  `json:"monthly_contribution"`
+	IsCompleted         bool     `json:"is_completed"`
+	AccountID           *int     `json:"account_id"`
+	AccountName         *string  `json:"account_name"`
+	Category            *string  `json:"category"`
+	CreatedAt           isoNaive `json:"created_at"`
+	ProgressPercent     float64  `json:"progress_percent"`
+	RemainingAmount     float64  `json:"remaining_amount"`
+	ProjectedHitDate    *isoDate `json:"projected_hit_date"`
+}
+
+type listResponse struct {
+	Goals          []response `json:"goals"`
+	TotalCount     int        `json:"total_count"`
+	CompletedCount int        `json:"completed_count"`
+}
+
+type createRequest struct {
+	Name                string  `json:"name"`
+	TargetAmount        float64 `json:"target_amount"`
+	TargetDate          isoDate `json:"target_date"`
+	CurrentAmount       float64 `json:"current_amount"`
+	MonthlyContribution float64 `json:"monthly_contribution"`
+	IsCompleted         bool    `json:"is_completed"`
+	AccountID           *int    `json:"account_id"`
+	Category            *string `json:"category"`
+}
+
+// Handler is the HTTP boundary for /api/goals.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+	now    func() time.Time
+}
+
+// NewHandler wires the store and logger. The `now` clock is injectable mainly
+// for testing; defaults to time.Now.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger, now: time.Now}
+}
+
+func (h *Handler) toResponse(g *Goal, accountName string) response {
+	target, _ := g.TargetAmount.Float64()
+	current, _ := g.CurrentAmount.Float64()
+	monthly, _ := g.MonthlyContribution.Float64()
+
+	remaining := target - current
+	if remaining < 0 {
+		remaining = 0
+	}
+	progress := 0.0
+	if target > 0 {
+		progress = math.Min(100.0, current/target*100.0)
+	}
+	projected := projectHitDate(g.TargetAmount, g.CurrentAmount, g.MonthlyContribution, g.IsCompleted, h.now())
+
+	out := response{
+		ID:                  g.ID,
+		Name:                g.Name,
+		TargetAmount:        target,
+		TargetDate:          isoDate(g.TargetDate),
+		CurrentAmount:       current,
+		MonthlyContribution: monthly,
+		IsCompleted:         g.IsCompleted,
+		AccountID:           g.AccountID,
+		Category:            g.Category,
+		CreatedAt:           isoNaive(g.CreatedAt),
+		ProgressPercent:     progress,
+		RemainingAmount:     remaining,
+	}
+	if accountName != "" {
+		name := accountName
+		out.AccountName = &name
+	}
+	if projected != nil {
+		d := isoDate(*projected)
+		out.ProjectedHitDate = &d
+	}
+	return out
+}
+
+// List serves GET /api/goals.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	rows, names, err := h.store.List(r.Context())
+	if err != nil {
+		h.logger.Error("list goals", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := listResponse{Goals: make([]response, 0, len(rows))}
+	completed := 0
+	for i := range rows {
+		g := &rows[i]
+		var name string
+		if g.AccountID != nil {
+			name = names[*g.AccountID]
+		}
+		out.Goals = append(out.Goals, h.toResponse(g, name))
+		if g.IsCompleted {
+			completed++
+		}
+	}
+	out.TotalCount = len(rows)
+	out.CompletedCount = completed
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Get serves GET /api/goals/{id}.
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	g, name, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			writeDetailError(w, http.StatusNotFound, "Goal not found")
+			return
+		}
+		h.logger.Error("get goal", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusOK, h.toResponse(g, name))
+}
+
+// Create serves POST /api/goals.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	var req createRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	if vErr := validateCreate(&req); vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	g := &Goal{
+		Name:                req.Name,
+		TargetAmount:        decimal.NewFromFloat(req.TargetAmount),
+		TargetDate:          time.Time(req.TargetDate),
+		CurrentAmount:       decimal.NewFromFloat(req.CurrentAmount),
+		MonthlyContribution: decimal.NewFromFloat(req.MonthlyContribution),
+		IsCompleted:         req.IsCompleted,
+		AccountID:           req.AccountID,
+		Category:            req.Category,
+	}
+	created, name, err := h.store.Create(r.Context(), g)
+	if err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, h.toResponse(created, name))
+}
+
+// Update serves PUT /api/goals/{id}.
+//
+// To distinguish "field omitted" from "field set to null" (Pydantic's
+// model_fields_set semantics), the body is first decoded to a map of raw
+// JSON tokens and each field is read explicitly.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	patch, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	g, name, err := h.store.Update(r.Context(), id, patch)
+	if err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, h.toResponse(g, name))
+}
+
+// Delete serves DELETE /api/goals/{id}.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.Delete(r.Context(), id); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			writeDetailError(w, http.StatusNotFound, "Goal not found")
+			return
+		}
+		h.logger.Error("delete goal", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) writeStoreError(w http.ResponseWriter, err error) {
+	var missing *AccountMissingError
+	switch {
+	case errors.Is(err, ErrNotFound):
+		writeDetailError(w, http.StatusNotFound, "Goal not found")
+	case errors.As(err, &missing):
+		writeDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("Account with id %d not found", missing.AccountID))
+	default:
+		h.logger.Error("goals store", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+	}
+}
+
+func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		writeValidationError(w, "goal_id", "must be an integer", raw)
+		return 0, false
+	}
+	return id, true
+}
+
+// isoDate is the same YYYY-MM-DD format used by config/personas/etc.
+type isoDate time.Time
+
+const isoDateLayout = "2006-01-02"
+
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
+}
+
+func (d *isoDate) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("date must be YYYY-MM-DD string: %w", err)
+	}
+	t, err := time.Parse(isoDateLayout, s)
+	if err != nil {
+		return fmt.Errorf("date must be YYYY-MM-DD: %w", err)
+	}
+	*d = isoDate(t)
+	return nil
+}
+
+// isoNaive serializes a time.Time as ISO without a timezone suffix; mirrors
+// Python's datetime.isoformat() on naive datetimes.
+type isoNaive time.Time
+
+func (t isoNaive) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
+}

--- a/backend-go/internal/goals/projection.go
+++ b/backend-go/internal/goals/projection.go
@@ -1,0 +1,55 @@
+package goals
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// projectHitDate mirrors backend/app/services/goals._project_hit_date.
+//
+// Returns today (UTC) if the goal is already completed or current >= target.
+// Returns nil if monthly_contribution is non-positive — projection isn't
+// possible. Otherwise ceil((target - current) / monthly) months forward from
+// today.
+func projectHitDate(target, current, monthly decimal.Decimal, isCompleted bool, now time.Time) *time.Time {
+	today := now.UTC().Truncate(24 * time.Hour)
+	if isCompleted || current.GreaterThanOrEqual(target) {
+		return &today
+	}
+	if monthly.LessThanOrEqual(decimal.Zero) {
+		return nil
+	}
+	remaining := target.Sub(current)
+	months := remaining.Div(monthly)
+	monthsCeil := months.Ceil().IntPart()
+	hit := addMonths(today, int(monthsCeil))
+	return &hit
+}
+
+// addMonths is the Go port of backend/app/services/goals._add_months — adds
+// calendar months and clamps the day to the last valid day of the target
+// month (so e.g. Jan 31 + 1 month = Feb 28/29, not Mar 3).
+func addMonths(d time.Time, months int) time.Time {
+	monthIndex := int(d.Month()) - 1 + months
+	year := d.Year() + monthIndex/12
+	monthOffset := monthIndex % 12
+	if monthOffset < 0 {
+		monthOffset += 12
+		year--
+	}
+	month := time.Month(monthOffset + 1)
+	day := d.Day()
+	lastDay := daysIn(year, month)
+	if day > lastDay {
+		day = lastDay
+	}
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}
+
+// daysIn returns the last day-of-month for the given (year, month) — mirrors
+// Python's calendar.monthrange()[1].
+func daysIn(year int, month time.Month) int {
+	first := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+	return first.AddDate(0, 1, -1).Day()
+}

--- a/backend-go/internal/goals/store.go
+++ b/backend-go/internal/goals/store.go
@@ -1,0 +1,294 @@
+// Package goals implements the /api/goals endpoints.
+//
+// Hard-delete semantics: DELETE removes the row, not a soft-delete flag.
+// PUT distinguishes "field omitted" from "field explicitly set to null" so
+// nullable foreign keys (account_id, category) behave like the Python PATCH
+// using model_fields_set.
+package goals
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Goal mirrors backend/app/models/goal.Goal.
+type Goal struct {
+	ID                  int
+	Name                string
+	TargetAmount        decimal.Decimal
+	TargetDate          time.Time
+	CurrentAmount       decimal.Decimal
+	MonthlyContribution decimal.Decimal
+	IsCompleted         bool
+	AccountID           *int
+	Category            *string
+	CreatedAt           time.Time
+}
+
+// ErrNotFound is returned when no row matches the supplied id.
+var ErrNotFound = errors.New("goal not found")
+
+// AccountMissingError is returned when create/update references a non-existent
+// account_id; mapped to a 404 with a Python-shaped detail.
+type AccountMissingError struct {
+	AccountID int
+}
+
+func (e *AccountMissingError) Error() string {
+	return fmt.Sprintf("account with id %d not found", e.AccountID)
+}
+
+// Store is the persistence boundary for goals + account-name lookup.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const selectColumns = `
+	id, name, target_amount, target_date, current_amount,
+	monthly_contribution, is_completed, account_id, category, created_at
+`
+
+// List returns every goal ordered by target_date plus the account_name lookup
+// map (same shape Python's _get_account_names returns).
+func (s *Store) List(ctx context.Context) ([]Goal, map[int]string, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+selectColumns+` FROM goals ORDER BY target_date`,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("select goals: %w", err)
+	}
+	defer rows.Close()
+	out := []Goal{}
+	for rows.Next() {
+		g, err := scanGoal(rows)
+		if err != nil {
+			return nil, nil, fmt.Errorf("scan goal: %w", err)
+		}
+		out = append(out, *g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate goals: %w", err)
+	}
+	ids := []int{}
+	for i := range out {
+		if out[i].AccountID != nil {
+			ids = append(ids, *out[i].AccountID)
+		}
+	}
+	names, err := s.accountNames(ctx, ids)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, names, nil
+}
+
+// Get returns a goal by id and the optional account name (empty if no account
+// linked).
+func (s *Store) Get(ctx context.Context, id int) (*Goal, string, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+selectColumns+` FROM goals WHERE id = $1`, id,
+	)
+	g, err := scanGoal(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, "", ErrNotFound
+		}
+		return nil, "", fmt.Errorf("select goal: %w", err)
+	}
+	name, err := s.accountName(ctx, g.AccountID)
+	if err != nil {
+		return nil, "", err
+	}
+	return g, name, nil
+}
+
+// Create inserts a new goal. Returns AccountMissingError if account_id is set
+// and the referenced account doesn't exist.
+func (s *Store) Create(ctx context.Context, g *Goal) (*Goal, string, error) {
+	if err := s.validateAccount(ctx, g.AccountID); err != nil {
+		return nil, "", err
+	}
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO goals (
+			name, target_amount, target_date, current_amount,
+			monthly_contribution, is_completed, account_id, category, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		RETURNING `+selectColumns,
+		g.Name, g.TargetAmount, g.TargetDate, g.CurrentAmount,
+		g.MonthlyContribution, g.IsCompleted, g.AccountID, g.Category,
+		time.Now().UTC(),
+	)
+	created, err := scanGoal(row)
+	if err != nil {
+		return nil, "", fmt.Errorf("insert goal: %w", err)
+	}
+	name, err := s.accountName(ctx, created.AccountID)
+	if err != nil {
+		return nil, "", err
+	}
+	return created, name, nil
+}
+
+// UpdatePatch applies a sparse update. Only fields present in `set` are
+// touched. account_id and category can be explicitly set to nil to clear them
+// (caller signals this by including the key in `set` with a nil value).
+type UpdatePatch struct {
+	Name                *string
+	TargetAmount        *decimal.Decimal
+	TargetDate          *time.Time
+	CurrentAmount       *decimal.Decimal
+	MonthlyContribution *decimal.Decimal
+	IsCompleted         *bool
+	AccountIDSet        bool
+	AccountID           *int
+	CategorySet         bool
+	Category            *string
+}
+
+// Update applies the patch and returns the refreshed goal + account name.
+func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Goal, string, error) {
+	if p.AccountIDSet {
+		if err := s.validateAccount(ctx, p.AccountID); err != nil {
+			return nil, "", err
+		}
+	}
+	g, _, err := s.Get(ctx, id)
+	if err != nil {
+		return nil, "", err
+	}
+	if p.Name != nil {
+		g.Name = *p.Name
+	}
+	if p.TargetAmount != nil {
+		g.TargetAmount = *p.TargetAmount
+	}
+	if p.TargetDate != nil {
+		g.TargetDate = *p.TargetDate
+	}
+	if p.CurrentAmount != nil {
+		g.CurrentAmount = *p.CurrentAmount
+	}
+	if p.MonthlyContribution != nil {
+		g.MonthlyContribution = *p.MonthlyContribution
+	}
+	if p.IsCompleted != nil {
+		g.IsCompleted = *p.IsCompleted
+	}
+	if p.AccountIDSet {
+		g.AccountID = p.AccountID
+	}
+	if p.CategorySet {
+		g.Category = p.Category
+	}
+
+	_, err = s.pool.Exec(ctx, `
+		UPDATE goals SET
+			name = $1, target_amount = $2, target_date = $3, current_amount = $4,
+			monthly_contribution = $5, is_completed = $6, account_id = $7, category = $8
+		WHERE id = $9`,
+		g.Name, g.TargetAmount, g.TargetDate, g.CurrentAmount,
+		g.MonthlyContribution, g.IsCompleted, g.AccountID, g.Category, id,
+	)
+	if err != nil {
+		return nil, "", fmt.Errorf("update goal: %w", err)
+	}
+	name, err := s.accountName(ctx, g.AccountID)
+	if err != nil {
+		return nil, "", err
+	}
+	return g, name, nil
+}
+
+// Delete removes the goal (hard delete — Python does the same).
+func (s *Store) Delete(ctx context.Context, id int) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM goals WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete goal: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) validateAccount(ctx context.Context, accountID *int) error {
+	if accountID == nil {
+		return nil
+	}
+	var exists bool
+	err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM accounts WHERE id = $1)`, *accountID,
+	).Scan(&exists)
+	if err != nil {
+		return fmt.Errorf("check account: %w", err)
+	}
+	if !exists {
+		return &AccountMissingError{AccountID: *accountID}
+	}
+	return nil
+}
+
+func (s *Store) accountNames(ctx context.Context, ids []int) (map[int]string, error) {
+	if len(ids) == 0 {
+		return map[int]string{}, nil
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, name FROM accounts WHERE id = ANY($1)`, ids,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("select account names: %w", err)
+	}
+	defer rows.Close()
+	out := map[int]string{}
+	for rows.Next() {
+		var id int
+		var name string
+		if err := rows.Scan(&id, &name); err != nil {
+			return nil, fmt.Errorf("scan account name: %w", err)
+		}
+		out[id] = name
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate account names: %w", err)
+	}
+	return out, nil
+}
+
+func (s *Store) accountName(ctx context.Context, accountID *int) (string, error) {
+	if accountID == nil {
+		return "", nil
+	}
+	var name string
+	err := s.pool.QueryRow(ctx,
+		`SELECT name FROM accounts WHERE id = $1`, *accountID,
+	).Scan(&name)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("select account name: %w", err)
+	}
+	return name, nil
+}
+
+func scanGoal(row pgx.Row) (*Goal, error) {
+	var g Goal
+	if err := row.Scan(
+		&g.ID, &g.Name, &g.TargetAmount, &g.TargetDate, &g.CurrentAmount,
+		&g.MonthlyContribution, &g.IsCompleted, &g.AccountID, &g.Category, &g.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	return &g, nil
+}

--- a/backend-go/internal/goals/store.go
+++ b/backend-go/internal/goals/store.go
@@ -192,22 +192,30 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Goal, strin
 		g.Category = p.Category
 	}
 
-	_, err = s.pool.Exec(ctx, `
+	row := s.pool.QueryRow(ctx, `
 		UPDATE goals SET
 			name = $1, target_amount = $2, target_date = $3, current_amount = $4,
 			monthly_contribution = $5, is_completed = $6, account_id = $7, category = $8
-		WHERE id = $9`,
+		WHERE id = $9
+		RETURNING `+selectColumns,
 		g.Name, g.TargetAmount, g.TargetDate, g.CurrentAmount,
 		g.MonthlyContribution, g.IsCompleted, g.AccountID, g.Category, id,
 	)
+	updated, err := scanGoal(row)
 	if err != nil {
+		// pgx.ErrNoRows here means the row was concurrently deleted between
+		// the Get above and this UPDATE; surface as a 404 instead of 200ing
+		// with stale in-memory state.
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, "", ErrNotFound
+		}
 		return nil, "", fmt.Errorf("update goal: %w", err)
 	}
-	name, err := s.accountName(ctx, g.AccountID)
+	name, err := s.accountName(ctx, updated.AccountID)
 	if err != nil {
 		return nil, "", err
 	}
-	return g, name, nil
+	return updated, name, nil
 }
 
 // Delete removes the goal (hard delete — Python does the same).

--- a/backend-go/internal/goals/validation.go
+++ b/backend-go/internal/goals/validation.go
@@ -16,6 +16,9 @@ func validateCreate(req *createRequest) *validationError {
 		return &validationError{Field: "name", Msg: "Name cannot be empty"}
 	}
 	req.Name = name
+	if time.Time(req.TargetDate).IsZero() {
+		return &validationError{Field: "target_date", Msg: "Field required"}
+	}
 	if req.TargetAmount <= 0 {
 		return &validationError{Field: "target_amount", Msg: "Target amount must be greater than 0"}
 	}
@@ -53,13 +56,11 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *validationE
 	return p, nil
 }
 
-// patchScalarFields handles fields where "null" is invalid (omitting them =
-// no-op, present = validate + apply).
+// patchScalarFields handles non-nullable-but-omittable update fields.
+// Matches Python's GoalUpdate validators: explicit null is treated as
+// "no-op" (the validator returns None and the service skips that field).
 func patchScalarFields(raw map[string]json.RawMessage, p *UpdatePatch) *validationError {
-	if v, ok := raw["name"]; ok {
-		if isNull(v) {
-			return &validationError{Field: "name", Msg: "Name cannot be empty"}
-		}
+	if v, ok := raw["name"]; ok && !isNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &validationError{Field: "name", Msg: "must be a string"}

--- a/backend-go/internal/goals/validation.go
+++ b/backend-go/internal/goals/validation.go
@@ -1,0 +1,171 @@
+package goals
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func validateCreate(req *createRequest) *validationError {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return &validationError{Field: "name", Msg: "Name cannot be empty"}
+	}
+	req.Name = name
+	if req.TargetAmount <= 0 {
+		return &validationError{Field: "target_amount", Msg: "Target amount must be greater than 0"}
+	}
+	if req.CurrentAmount < 0 {
+		return &validationError{Field: "current_amount", Msg: "Current amount must be non-negative"}
+	}
+	if req.MonthlyContribution < 0 {
+		return &validationError{
+			Field: "monthly_contribution",
+			Msg:   "Monthly contribution must be non-negative",
+		}
+	}
+	if req.Category != nil {
+		if _, ok := validCategories[*req.Category]; !ok {
+			return &validationError{
+				Field: "category",
+				Msg:   fmt.Sprintf("invalid category %q", *req.Category),
+			}
+		}
+	}
+	return nil
+}
+
+// buildUpdatePatch reads a raw JSON object and decides, per field, whether
+// it was omitted, explicitly null, or set to a value. This is the Go analogue
+// of Pydantic's model_fields_set used in update_goal.
+func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *validationError) {
+	var p UpdatePatch
+	if vErr := patchScalarFields(raw, &p); vErr != nil {
+		return p, vErr
+	}
+	if vErr := patchNullableRefs(raw, &p); vErr != nil {
+		return p, vErr
+	}
+	return p, nil
+}
+
+// patchScalarFields handles fields where "null" is invalid (omitting them =
+// no-op, present = validate + apply).
+func patchScalarFields(raw map[string]json.RawMessage, p *UpdatePatch) *validationError {
+	if v, ok := raw["name"]; ok {
+		if isNull(v) {
+			return &validationError{Field: "name", Msg: "Name cannot be empty"}
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "name", Msg: "must be a string"}
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return &validationError{Field: "name", Msg: "Name cannot be empty"}
+		}
+		p.Name = &s
+	}
+	if vErr := patchPositiveAmount(raw, "target_amount", &p.TargetAmount, "Target amount must be greater than 0"); vErr != nil {
+		return vErr
+	}
+	if v, ok := raw["target_date"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "target_date", Msg: "must be a string"}
+		}
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return &validationError{Field: "target_date", Msg: "must be YYYY-MM-DD"}
+		}
+		p.TargetDate = &t
+	}
+	if vErr := patchNonNegativeAmount(raw, "current_amount", &p.CurrentAmount, "Current amount must be non-negative"); vErr != nil {
+		return vErr
+	}
+	if vErr := patchNonNegativeAmount(raw, "monthly_contribution", &p.MonthlyContribution, "Monthly contribution must be non-negative"); vErr != nil {
+		return vErr
+	}
+	if v, ok := raw["is_completed"]; ok && !isNull(v) {
+		var b bool
+		if err := json.Unmarshal(v, &b); err != nil {
+			return &validationError{Field: "is_completed", Msg: "must be a boolean"}
+		}
+		p.IsCompleted = &b
+	}
+	return nil
+}
+
+// patchNullableRefs handles the two fields where the caller can explicitly
+// send null to clear the link (account_id, category).
+func patchNullableRefs(raw map[string]json.RawMessage, p *UpdatePatch) *validationError {
+	if v, ok := raw["account_id"]; ok {
+		p.AccountIDSet = true
+		if !isNull(v) {
+			var id int
+			if err := json.Unmarshal(v, &id); err != nil {
+				return &validationError{Field: "account_id", Msg: "must be an integer"}
+			}
+			p.AccountID = &id
+		}
+	}
+	if v, ok := raw["category"]; ok {
+		p.CategorySet = true
+		if !isNull(v) {
+			var s string
+			if err := json.Unmarshal(v, &s); err != nil {
+				return &validationError{Field: "category", Msg: "must be a string"}
+			}
+			if _, valid := validCategories[s]; !valid {
+				return &validationError{
+					Field: "category",
+					Msg:   fmt.Sprintf("invalid category %q", s),
+				}
+			}
+			p.Category = &s
+		}
+	}
+	return nil
+}
+
+func patchPositiveAmount(raw map[string]json.RawMessage, field string, dest **decimal.Decimal, msg string) *validationError {
+	v, ok := raw[field]
+	if !ok || isNull(v) {
+		return nil
+	}
+	var f float64
+	if err := json.Unmarshal(v, &f); err != nil {
+		return &validationError{Field: field, Msg: "must be a number"}
+	}
+	if f <= 0 {
+		return &validationError{Field: field, Msg: msg}
+	}
+	d := decimal.NewFromFloat(f)
+	*dest = &d
+	return nil
+}
+
+func patchNonNegativeAmount(raw map[string]json.RawMessage, field string, dest **decimal.Decimal, msg string) *validationError {
+	v, ok := raw[field]
+	if !ok || isNull(v) {
+		return nil
+	}
+	var f float64
+	if err := json.Unmarshal(v, &f); err != nil {
+		return &validationError{Field: field, Msg: "must be a number"}
+	}
+	if f < 0 {
+		return &validationError{Field: field, Msg: msg}
+	}
+	d := decimal.NewFromFloat(f)
+	*dest = &d
+	return nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/config"
+	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/personas"
 )
 
@@ -74,6 +75,15 @@ func New(cfg Config, logger *slog.Logger, deps Deps) http.Handler {
 			r.Post("/", personasHandler.Create)
 			r.Put("/{id}", personasHandler.Update)
 			r.Delete("/{id}", personasHandler.Delete)
+		})
+
+		goalsHandler := goals.NewHandler(goals.NewStore(deps.Pool), logger)
+		r.Route("/api/goals", func(r chi.Router) {
+			r.Get("/", goalsHandler.List)
+			r.Post("/", goalsHandler.Create)
+			r.Get("/{id}", goalsHandler.Get)
+			r.Put("/{id}", goalsHandler.Update)
+			r.Delete("/{id}", goalsHandler.Delete)
 		})
 	}
 

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -30,3 +30,16 @@ rules:
   - method: DELETE
     path_prefix: /api/personas
     upstream: http://backend-go:8000
+  # Group 3 — /api/goals cut over to Go.
+  - method: GET
+    path_prefix: /api/goals
+    upstream: http://backend-go:8000
+  - method: POST
+    path_prefix: /api/goals
+    upstream: http://backend-go:8000
+  - method: PUT
+    path_prefix: /api/goals
+    upstream: http://backend-go:8000
+  - method: DELETE
+    path_prefix: /api/goals
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

Group 3 of the migration (#438). `/api/goals` (5 endpoints) moves to backend-go. Independent of personas — no FK fan-out — so this could have parallelized with Group 4/5; we're going serial for safety.

Closes #438. Part of #435.

## Implementation information

### Wire format note

Goals is the first endpoint group where money fields go on the wire as **JSON numbers** (float), not the `"X.XX"` strings used by app_config + personas. This matches Pydantic's behavior — `GoalResponse.target_amount: float` vs `ConfigResponse.retirement_monthly_salary: Decimal`. The Go side uses `float64` in the response struct directly and converts from `decimal.Decimal` at the handler edge. Numeric(15,2) precision survives float64 for the magnitudes app_config handles.

### PUT semantics

`account_id` and `category` are nullable FKs where the Python handler uses `model_fields_set` to distinguish:

- **omitted** → leave the existing value alone
- **explicitly null** → clear the FK
- **value** → update

Go can't tell omitted from null via a `*int` pointer, so the PUT handler decodes the body into `map[string]json.RawMessage` first and per-field checks `key present?` and `value is JSON null?`. Same path Pydantic takes.

### Files

- `internal/goals/store.go` — pgx `List/Get/Create/Update/Delete`. Batch account-name lookup via `WHERE id = ANY($1)` mirrors Python's batched `_get_account_names`. Validates `account_id` existence on create + update, returns `AccountMissingError` for the 404 mapping.
- `internal/goals/handler.go` — chi routes. `response` struct mirrors `GoalResponse` byte-for-byte; conversion in `toResponse` computes `progress_percent`, `remaining_amount`, `projected_hit_date` exactly like the Python service.
- `internal/goals/projection.go` — `projectHitDate` + `addMonths` ported from `_project_hit_date`/`_add_months`. Day-clamping rule preserved (Jan 31 + 1mo = Feb 28/29).
- `internal/goals/validation.go` — `validateCreate` for POST + `buildUpdatePatch` (split into `patchScalarFields` / `patchNullableRefs` to stay under the funlen=100 budget) for PUT.

### CI

`bb-tests-go` now runs `test_goals.py` against backend-go alongside the existing health/config/personas suite. Group 3 is independent of Group 2 in terms of upstream DB cascades but shares the same parity gate.

### Parity proof against Go

```
============================= test session starts ==============================
tests/test_health.py::test_health PASSED                                 [  5%]
tests/test_config.py::test_get_config_matches_golden PASSED              [ 11%]
tests/test_config.py::test_get_config_required_fields PASSED             [ 17%]
tests/test_personas.py::test_list_personas_includes_seeded PASSED        [ 23%]
tests/test_personas.py::test_persona_response_shape PASSED               [ 29%]
tests/test_personas_mutations.py::test_create_persona_happy_path PASSED  [ 35%]
tests/test_personas_mutations.py::test_create_persona_validation_error PASSED [ 41%]
tests/test_personas_mutations.py::test_update_persona_happy_path PASSED  [ 47%]
tests/test_personas_mutations.py::test_update_persona_validation_error PASSED [ 52%]
tests/test_personas_mutations.py::test_delete_persona_happy_path PASSED  [ 58%]
tests/test_goals.py::test_list_goals_seeded_shape PASSED                 [ 64%]
tests/test_goals.py::test_get_goal_by_id_happy_path PASSED               [ 70%]
tests/test_goals.py::test_create_goal_happy_path PASSED                  [ 76%]
tests/test_goals.py::test_create_goal_validation_error PASSED            [ 82%]
tests/test_goals.py::test_update_goal_happy_path PASSED                  [ 88%]
tests/test_goals.py::test_update_goal_validation_error PASSED            [ 94%]
tests/test_goals.py::test_delete_goal_happy_path PASSED                  [100%]
============================== 17 passed in 0.16s ==============================
```

### routes.yaml

Four new rules — GET/POST/PUT/DELETE — for `/api/goals/`. `default` unchanged; 67 endpoints remain on Python.

## Supporting documentation

- Umbrella: #435
- Subissue: #438
- Group 1 PRs: #452, #453
- Group 2 PR: #456
- Procedure: `migration/CUTOVER.md`

> Changelog: skip