### PR TITLE
feat(go): cutover /api/company-valuations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,8 @@ jobs:
             tests/test_config.py \
             tests/test_personas.py \
             tests/test_personas_mutations.py \
-            tests/test_goals.py
+            tests/test_goals.py \
+            tests/test_company_valuations.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/backend-go/internal/company_valuations/errors.go
+++ b/backend-go/internal/company_valuations/errors.go
@@ -1,0 +1,41 @@
+package companyvaluations
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{
+				"type":  "value_error",
+				"loc":   []string{"body", field},
+				"msg":   msg,
+				"input": input,
+			},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/company_valuations/handler.go
+++ b/backend-go/internal/company_valuations/handler.go
@@ -49,16 +49,21 @@ type listResponse struct {
 	AvailableCompanies []string   `json:"available_companies"`
 }
 
+// createRequest captures parsed-and-validated input ready for Store.Create.
+// The JSON body is read into a raw map first so we can detect missing
+// required fields and preserve Numeric column precision by feeding JSON
+// number tokens directly into decimal.NewFromString — going through float64
+// introduces IEEE754 rounding that diverges from Python's Decimal(str(...)).
 type createRequest struct {
-	Company                string   `json:"company"`
-	Date                   isoDate  `json:"date"`
-	Currency               string   `json:"currency"`
-	FMVPerShare            float64  `json:"fmv_per_share"`
-	FMVLow                 *float64 `json:"fmv_low"`
-	FMVHigh                *float64 `json:"fmv_high"`
-	Source                 string   `json:"source"`
-	CommonStockDiscountPct *float64 `json:"common_stock_discount_pct"`
-	Notes                  *string  `json:"notes"`
+	Company                string
+	Date                   time.Time
+	Currency               string
+	FMVPerShare            decimal.Decimal
+	FMVLow                 *decimal.Decimal
+	FMVHigh                *decimal.Decimal
+	Source                 string
+	CommonStockDiscountPct *decimal.Decimal
+	Notes                  *string
 }
 
 // Handler is the HTTP boundary for /api/company-valuations.
@@ -145,16 +150,17 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 
 // Create serves POST /api/company-valuations.
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
-	var req createRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
 		writeValidationError(w, "body", "Invalid JSON body", err.Error())
 		return
 	}
-	if vErr := validateCreate(&req); vErr != nil {
+	req, vErr := buildCreateRequest(raw)
+	if vErr != nil {
 		writePydanticError(w, vErr)
 		return
 	}
-	v := requestToValuation(&req)
+	v := requestToValuation(req)
 	created, err := h.store.Create(r.Context(), v)
 	if err != nil {
 		h.logger.Error("create valuation", "err", err)
@@ -217,27 +223,17 @@ func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int) {
 }
 
 func requestToValuation(req *createRequest) *Valuation {
-	v := &Valuation{
-		Company:     req.Company,
-		Date:        time.Time(req.Date),
-		Currency:    strings.ToUpper(strings.TrimSpace(req.Currency)),
-		FMVPerShare: decimal.NewFromFloat(req.FMVPerShare),
-		Source:      req.Source,
-		Notes:       req.Notes,
+	return &Valuation{
+		Company:                req.Company,
+		Date:                   req.Date,
+		Currency:               req.Currency,
+		FMVPerShare:            req.FMVPerShare,
+		FMVLow:                 req.FMVLow,
+		FMVHigh:                req.FMVHigh,
+		Source:                 req.Source,
+		CommonStockDiscountPct: req.CommonStockDiscountPct,
+		Notes:                  req.Notes,
 	}
-	if req.FMVLow != nil {
-		d := decimal.NewFromFloat(*req.FMVLow)
-		v.FMVLow = &d
-	}
-	if req.FMVHigh != nil {
-		d := decimal.NewFromFloat(*req.FMVHigh)
-		v.FMVHigh = &d
-	}
-	if req.CommonStockDiscountPct != nil {
-		d := decimal.NewFromFloat(*req.CommonStockDiscountPct)
-		v.CommonStockDiscountPct = &d
-	}
-	return v
 }
 
 func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {

--- a/backend-go/internal/company_valuations/handler.go
+++ b/backend-go/internal/company_valuations/handler.go
@@ -1,0 +1,292 @@
+package companyvaluations
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+)
+
+var (
+	validCurrencies = map[string]struct{}{
+		"PLN": {}, "USD": {}, "EUR": {}, "GBP": {}, "CHF": {},
+	}
+	validSources = map[string]struct{}{
+		"409a": {}, "preferred_round": {}, "tender": {}, "estimate": {},
+	}
+)
+
+// response mirrors backend/app/schemas/company_valuations.CompanyValuationResponse.
+//
+// Money fields use pyFloat so JSON output preserves Python's `float(x)`
+// formatting — `14.0` not `14`, matching Pydantic's number serialization.
+type response struct {
+	ID                     int      `json:"id"`
+	Company                string   `json:"company"`
+	Date                   isoDate  `json:"date"`
+	Currency               string   `json:"currency"`
+	FMVPerShare            pyFloat  `json:"fmv_per_share"`
+	FMVLow                 *pyFloat `json:"fmv_low"`
+	FMVHigh                *pyFloat `json:"fmv_high"`
+	Source                 string   `json:"source"`
+	CommonStockDiscountPct *pyFloat `json:"common_stock_discount_pct"`
+	Notes                  *string  `json:"notes"`
+	IsActive               bool     `json:"is_active"`
+	CreatedAt              isoNaive `json:"created_at"`
+}
+
+type listResponse struct {
+	CompanyValuations  []response `json:"company_valuations"`
+	TotalCount         int        `json:"total_count"`
+	AvailableCompanies []string   `json:"available_companies"`
+}
+
+type createRequest struct {
+	Company                string   `json:"company"`
+	Date                   isoDate  `json:"date"`
+	Currency               string   `json:"currency"`
+	FMVPerShare            float64  `json:"fmv_per_share"`
+	FMVLow                 *float64 `json:"fmv_low"`
+	FMVHigh                *float64 `json:"fmv_high"`
+	Source                 string   `json:"source"`
+	CommonStockDiscountPct *float64 `json:"common_stock_discount_pct"`
+	Notes                  *string  `json:"notes"`
+}
+
+// Handler is the HTTP boundary for /api/company-valuations.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewHandler wires the store and logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger}
+}
+
+func toResponse(v *Valuation) response {
+	fmv, _ := v.FMVPerShare.Float64()
+	out := response{
+		ID:          v.ID,
+		Company:     v.Company,
+		Date:        isoDate(v.Date),
+		Currency:    v.Currency,
+		FMVPerShare: pyFloat(fmv),
+		Source:      v.Source,
+		Notes:       v.Notes,
+		IsActive:    v.IsActive,
+		CreatedAt:   isoNaive(v.CreatedAt),
+	}
+	if v.FMVLow != nil {
+		f, _ := v.FMVLow.Float64()
+		pf := pyFloat(f)
+		out.FMVLow = &pf
+	}
+	if v.FMVHigh != nil {
+		f, _ := v.FMVHigh.Float64()
+		pf := pyFloat(f)
+		out.FMVHigh = &pf
+	}
+	if v.CommonStockDiscountPct != nil {
+		f, _ := v.CommonStockDiscountPct.Float64()
+		pf := pyFloat(f)
+		out.CommonStockDiscountPct = &pf
+	}
+	return out
+}
+
+// List serves GET /api/company-valuations.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	filter := ListFilter{}
+	if c := r.URL.Query().Get("company"); c != "" {
+		filter.Company = &c
+	}
+	rows, companies, err := h.store.List(r.Context(), filter)
+	if err != nil {
+		h.logger.Error("list valuations", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := listResponse{
+		CompanyValuations:  make([]response, 0, len(rows)),
+		TotalCount:         len(rows),
+		AvailableCompanies: companies,
+	}
+	for i := range rows {
+		out.CompanyValuations = append(out.CompanyValuations, toResponse(&rows[i]))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Get serves GET /api/company-valuations/{id}.
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	v, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		h.writeStoreError(w, err, id)
+		return
+	}
+	writeJSON(w, http.StatusOK, toResponse(v))
+}
+
+// Create serves POST /api/company-valuations.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	var req createRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	if vErr := validateCreate(&req); vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	v := requestToValuation(&req)
+	created, err := h.store.Create(r.Context(), v)
+	if err != nil {
+		h.logger.Error("create valuation", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toResponse(created))
+}
+
+// Update serves PATCH /api/company-valuations/{id}.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	patch, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	updated, err := h.store.Update(r.Context(), id, patch)
+	if err != nil {
+		h.writeStoreError(w, err, id)
+		return
+	}
+	writeJSON(w, http.StatusOK, toResponse(updated))
+}
+
+// Delete serves DELETE /api/company-valuations/{id}.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.Delete(r.Context(), id); err != nil {
+		h.writeStoreError(w, err, id)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		writeDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("Company valuation with id %d not found", id))
+	case errors.Is(err, ErrRangeLow):
+		writeDetailError(w, http.StatusUnprocessableEntity, "fmv_low cannot exceed fmv_per_share")
+	case errors.Is(err, ErrRangeHigh):
+		writeDetailError(w, http.StatusUnprocessableEntity, "fmv_high cannot be below fmv_per_share")
+	default:
+		h.logger.Error("valuation store", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+	}
+}
+
+func requestToValuation(req *createRequest) *Valuation {
+	v := &Valuation{
+		Company:     req.Company,
+		Date:        time.Time(req.Date),
+		Currency:    strings.ToUpper(strings.TrimSpace(req.Currency)),
+		FMVPerShare: decimal.NewFromFloat(req.FMVPerShare),
+		Source:      req.Source,
+		Notes:       req.Notes,
+	}
+	if req.FMVLow != nil {
+		d := decimal.NewFromFloat(*req.FMVLow)
+		v.FMVLow = &d
+	}
+	if req.FMVHigh != nil {
+		d := decimal.NewFromFloat(*req.FMVHigh)
+		v.FMVHigh = &d
+	}
+	if req.CommonStockDiscountPct != nil {
+		d := decimal.NewFromFloat(*req.CommonStockDiscountPct)
+		v.CommonStockDiscountPct = &d
+	}
+	return v
+}
+
+func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		writeValidationError(w, "valuation_id", "must be an integer", raw)
+		return 0, false
+	}
+	return id, true
+}
+
+// isoDate and isoNaive — identical formats to the other packages.
+type isoDate time.Time
+
+const isoDateLayout = "2006-01-02"
+
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
+}
+
+func (d *isoDate) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("date must be a string: %w", err)
+	}
+	t, err := time.Parse(isoDateLayout, s)
+	if err != nil {
+		return fmt.Errorf("date must be YYYY-MM-DD: %w", err)
+	}
+	*d = isoDate(t)
+	return nil
+}
+
+type isoNaive time.Time
+
+func (t isoNaive) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
+}
+
+// pyFloat marshals identically to Python's `float(x)` JSON encoding —
+// always includes at least one digit after the decimal point so 14.0
+// emits as "14.0", not "14". This matches Pydantic's number formatting.
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/company_valuations/store.go
+++ b/backend-go/internal/company_valuations/store.go
@@ -1,0 +1,253 @@
+// Package companyvaluations implements the /api/company-valuations endpoints.
+//
+// All listing reads filter by is_active to honor the soft-delete contract.
+// Update applies a range-integrity check (fmv_low <= fmv_per_share <= fmv_high)
+// after the partial merge — same place the Python service catches it.
+package companyvaluations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Valuation mirrors backend/app/models/company_valuation.CompanyValuation.
+type Valuation struct {
+	ID                     int
+	Company                string
+	Date                   time.Time
+	Currency               string
+	FMVPerShare            decimal.Decimal
+	FMVLow                 *decimal.Decimal
+	FMVHigh                *decimal.Decimal
+	Source                 string
+	CommonStockDiscountPct *decimal.Decimal
+	Notes                  *string
+	IsActive               bool
+	CreatedAt              time.Time
+}
+
+// Sentinel errors mapped to HTTP status codes by the handler.
+var (
+	ErrNotFound  = errors.New("company valuation not found")
+	ErrRangeLow  = errors.New("fmv_low cannot exceed fmv_per_share")
+	ErrRangeHigh = errors.New("fmv_high cannot be below fmv_per_share")
+)
+
+// Store is the persistence boundary.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const selectColumns = `
+	id, company, date, currency, fmv_per_share, fmv_low, fmv_high,
+	source, common_stock_discount_pct, notes, is_active, created_at
+`
+
+// ListFilter constrains the active valuations returned by List.
+type ListFilter struct {
+	Company *string
+}
+
+// List returns valuations ordered by date desc + the distinct active-company
+// list (sorted alphabetically) — same shape Python emits.
+func (s *Store) List(ctx context.Context, f ListFilter) ([]Valuation, []string, error) {
+	query := `SELECT ` + selectColumns + ` FROM company_valuations WHERE is_active = true`
+	args := []any{}
+	if f.Company != nil {
+		query += ` AND company = $1`
+		args = append(args, *f.Company)
+	}
+	query += ` ORDER BY date DESC`
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("select valuations: %w", err)
+	}
+	defer rows.Close()
+	out := []Valuation{}
+	for rows.Next() {
+		v, err := scanValuation(rows)
+		if err != nil {
+			return nil, nil, fmt.Errorf("scan valuation: %w", err)
+		}
+		out = append(out, *v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate valuations: %w", err)
+	}
+	companies, err := s.activeCompanies(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, companies, nil
+}
+
+// Get returns the active valuation or ErrNotFound for missing/soft-deleted rows.
+func (s *Store) Get(ctx context.Context, id int) (*Valuation, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+selectColumns+` FROM company_valuations WHERE id = $1`, id,
+	)
+	v, err := scanValuation(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("select valuation: %w", err)
+	}
+	if !v.IsActive {
+		return nil, ErrNotFound
+	}
+	return v, nil
+}
+
+// Create inserts a row.
+func (s *Store) Create(ctx context.Context, v *Valuation) (*Valuation, error) {
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO company_valuations (
+			company, date, currency, fmv_per_share, fmv_low, fmv_high,
+			source, common_stock_discount_pct, notes, is_active, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, true, $10)
+		RETURNING `+selectColumns,
+		v.Company, v.Date, v.Currency, v.FMVPerShare, v.FMVLow, v.FMVHigh,
+		v.Source, v.CommonStockDiscountPct, v.Notes, time.Now().UTC(),
+	)
+	created, err := scanValuation(row)
+	if err != nil {
+		return nil, fmt.Errorf("insert valuation: %w", err)
+	}
+	return created, nil
+}
+
+// UpdatePatch is a sparse update — every nil field means "leave alone".
+type UpdatePatch struct {
+	Company                *string
+	Date                   *time.Time
+	Currency               *string
+	FMVPerShare            *decimal.Decimal
+	FMVLow                 *decimal.Decimal
+	FMVHigh                *decimal.Decimal
+	Source                 *string
+	CommonStockDiscountPct *decimal.Decimal
+	Notes                  *string
+}
+
+// Update applies the patch and returns the refreshed row. Re-checks range
+// integrity after merging so update-time violations (e.g. raising fmv_low
+// above existing fmv_per_share) still 422 cleanly.
+func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Valuation, error) {
+	v, err := s.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if p.Company != nil {
+		v.Company = *p.Company
+	}
+	if p.Date != nil {
+		v.Date = *p.Date
+	}
+	if p.Currency != nil {
+		v.Currency = *p.Currency
+	}
+	if p.FMVPerShare != nil {
+		v.FMVPerShare = *p.FMVPerShare
+	}
+	if p.FMVLow != nil {
+		v.FMVLow = p.FMVLow
+	}
+	if p.FMVHigh != nil {
+		v.FMVHigh = p.FMVHigh
+	}
+	if p.Source != nil {
+		v.Source = *p.Source
+	}
+	if p.CommonStockDiscountPct != nil {
+		v.CommonStockDiscountPct = p.CommonStockDiscountPct
+	}
+	if p.Notes != nil {
+		v.Notes = p.Notes
+	}
+	if v.FMVLow != nil && v.FMVLow.GreaterThan(v.FMVPerShare) {
+		return nil, ErrRangeLow
+	}
+	if v.FMVHigh != nil && v.FMVHigh.LessThan(v.FMVPerShare) {
+		return nil, ErrRangeHigh
+	}
+	row := s.pool.QueryRow(ctx, `
+		UPDATE company_valuations SET
+			company = $1, date = $2, currency = $3, fmv_per_share = $4,
+			fmv_low = $5, fmv_high = $6, source = $7,
+			common_stock_discount_pct = $8, notes = $9
+		WHERE id = $10 AND is_active = true
+		RETURNING `+selectColumns,
+		v.Company, v.Date, v.Currency, v.FMVPerShare, v.FMVLow, v.FMVHigh,
+		v.Source, v.CommonStockDiscountPct, v.Notes, id,
+	)
+	updated, err := scanValuation(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("update valuation: %w", err)
+	}
+	return updated, nil
+}
+
+// Delete soft-deletes the row (matches Python's soft_delete helper).
+func (s *Store) Delete(ctx context.Context, id int) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE company_valuations SET is_active = false WHERE id = $1 AND is_active = true`,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("soft-delete valuation: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) activeCompanies(ctx context.Context) ([]string, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT DISTINCT company FROM company_valuations
+		 WHERE is_active = true ORDER BY company`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("select active companies: %w", err)
+	}
+	defer rows.Close()
+	out := []string{}
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, fmt.Errorf("scan company: %w", err)
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate companies: %w", err)
+	}
+	return out, nil
+}
+
+func scanValuation(row pgx.Row) (*Valuation, error) {
+	var v Valuation
+	if err := row.Scan(
+		&v.ID, &v.Company, &v.Date, &v.Currency, &v.FMVPerShare,
+		&v.FMVLow, &v.FMVHigh, &v.Source, &v.CommonStockDiscountPct,
+		&v.Notes, &v.IsActive, &v.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}

--- a/backend-go/internal/company_valuations/validation.go
+++ b/backend-go/internal/company_valuations/validation.go
@@ -10,54 +10,77 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-func validateCreate(req *createRequest) *validationError {
-	company := strings.TrimSpace(req.Company)
-	if company == "" {
-		return &validationError{Field: "company", Msg: "Company cannot be empty"}
-	}
-	req.Company = company
+// buildCreateRequest is the POST body parser + validator.
+//
+// JSON numbers are read as raw bytes and converted via decimal.NewFromString
+// to preserve Numeric column precision (going through float64 introduces
+// IEEE754 rounding that diverges from Python's Decimal(str(...)) round-trip).
+// Required fields surface 422 "Field required" when missing — Pydantic
+// behavior for the required-field case.
+func buildCreateRequest(raw map[string]json.RawMessage) (*createRequest, *validationError) {
+	r := &createRequest{}
 
-	if time.Time(req.Date).IsZero() {
-		return &validationError{Field: "date", Msg: "Field required"}
+	company, vErr := requireString(raw, "company", "Field required", "Company cannot be empty")
+	if vErr != nil {
+		return nil, vErr
+	}
+	r.Company = company
+
+	t, vErr := requireDate(raw, "date")
+	if vErr != nil {
+		return nil, vErr
+	}
+	r.Date = t
+
+	currency, vErr := optionalCurrency(raw)
+	if vErr != nil {
+		return nil, vErr
+	}
+	r.Currency = currency
+
+	fmv, vErr := requireNonNegativeDecimal(raw, "fmv_per_share", "FMV per share must be non-negative")
+	if vErr != nil {
+		return nil, vErr
+	}
+	r.FMVPerShare = fmv
+
+	r.FMVLow, vErr = optionalNonNegativeDecimal(raw, "fmv_low", "FMV range values must be non-negative")
+	if vErr != nil {
+		return nil, vErr
+	}
+	r.FMVHigh, vErr = optionalNonNegativeDecimal(raw, "fmv_high", "FMV range values must be non-negative")
+	if vErr != nil {
+		return nil, vErr
+	}
+	if r.FMVLow != nil && r.FMVLow.GreaterThan(r.FMVPerShare) {
+		return nil, &validationError{Field: "fmv_low", Msg: "fmv_low cannot exceed fmv_per_share"}
+	}
+	if r.FMVHigh != nil && r.FMVHigh.LessThan(r.FMVPerShare) {
+		return nil, &validationError{Field: "fmv_high", Msg: "fmv_high cannot be below fmv_per_share"}
 	}
 
-	currency := strings.ToUpper(strings.TrimSpace(req.Currency))
-	if currency == "" {
-		currency = "USD"
+	r.CommonStockDiscountPct, vErr = optionalDiscountPct(raw)
+	if vErr != nil {
+		return nil, vErr
 	}
-	if _, ok := validCurrencies[currency]; !ok {
-		return &validationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
-	}
-	req.Currency = currency
 
-	if req.FMVPerShare < 0 {
-		return &validationError{Field: "fmv_per_share", Msg: "FMV per share must be non-negative"}
+	source, vErr := requireString(raw, "source", "Field required", "Source cannot be empty")
+	if vErr != nil {
+		return nil, vErr
 	}
-	if req.FMVLow != nil && *req.FMVLow < 0 {
-		return &validationError{Field: "fmv_low", Msg: "FMV range values must be non-negative"}
+	if _, ok := validSources[source]; !ok {
+		return nil, &validationError{Field: "source", Msg: fmt.Sprintf("invalid source %q", source)}
 	}
-	if req.FMVHigh != nil && *req.FMVHigh < 0 {
-		return &validationError{Field: "fmv_high", Msg: "FMV range values must be non-negative"}
-	}
-	if req.FMVLow != nil && *req.FMVLow > req.FMVPerShare {
-		return &validationError{Field: "fmv_low", Msg: "fmv_low cannot exceed fmv_per_share"}
-	}
-	if req.FMVHigh != nil && *req.FMVHigh < req.FMVPerShare {
-		return &validationError{Field: "fmv_high", Msg: "fmv_high cannot be below fmv_per_share"}
-	}
-	if req.CommonStockDiscountPct != nil {
-		d := *req.CommonStockDiscountPct
-		if d < 0 || d > 100 {
-			return &validationError{
-				Field: "common_stock_discount_pct",
-				Msg:   "Common-stock discount must be between 0 and 100",
-			}
+	r.Source = source
+
+	if v, ok := raw["notes"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return nil, &validationError{Field: "notes", Msg: "must be a string"}
 		}
+		r.Notes = &s
 	}
-	if _, ok := validSources[req.Source]; !ok {
-		return &validationError{Field: "source", Msg: fmt.Sprintf("invalid source %q", req.Source)}
-	}
-	return nil
+	return r, nil
 }
 
 // buildUpdatePatch follows Python's GoalUpdate convention: a field set to
@@ -137,44 +160,125 @@ func patchNumbers(raw map[string]json.RawMessage, p *UpdatePatch) *validationErr
 		{"fmv_low", "fmv_low", "FMV values must be non-negative", &p.FMVLow},
 		{"fmv_high", "fmv_high", "FMV values must be non-negative", &p.FMVHigh},
 	} {
-		if err := decodeNonNegativeDecimal(raw, f.key, f.field, f.msg, f.dest); err != nil {
-			return err
+		d, vErr := optionalNonNegativeDecimal(raw, f.key, f.msg)
+		if vErr != nil {
+			vErr.Field = f.field
+			return vErr
+		}
+		if d != nil {
+			*f.dest = d
 		}
 	}
-	if v, ok := raw["common_stock_discount_pct"]; ok && !isNull(v) {
-		var x float64
-		if err := json.Unmarshal(v, &x); err != nil {
-			return &validationError{Field: "common_stock_discount_pct", Msg: "must be a number"}
-		}
-		if x < 0 || x > 100 {
-			return &validationError{
-				Field: "common_stock_discount_pct",
-				Msg:   "Common-stock discount must be between 0 and 100",
-			}
-		}
-		d := decimal.NewFromFloat(x)
-		p.CommonStockDiscountPct = &d
+	p.CommonStockDiscountPct, _ = optionalDiscountPct(raw)
+	// Re-walk to surface the validation error if any — optionalDiscountPct only
+	// returns an error for invalid present values; the nil branch is benign.
+	if _, vErr := optionalDiscountPct(raw); vErr != nil {
+		return vErr
 	}
 	return nil
 }
 
-func decodeNonNegativeDecimal(
-	raw map[string]json.RawMessage, key, field, msg string, dest **decimal.Decimal,
-) *validationError {
+// --- shared decoders ---
+
+func requireString(raw map[string]json.RawMessage, key, missingMsg, emptyMsg string) (string, *validationError) {
 	v, ok := raw[key]
 	if !ok || isNull(v) {
-		return nil
+		return "", &validationError{Field: key, Msg: missingMsg}
 	}
-	var f float64
-	if err := json.Unmarshal(v, &f); err != nil {
-		return &validationError{Field: field, Msg: "must be a number"}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
 	}
-	if f < 0 {
-		return &validationError{Field: field, Msg: msg}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", &validationError{Field: key, Msg: emptyMsg}
 	}
-	d := decimal.NewFromFloat(f)
-	*dest = &d
-	return nil
+	return s, nil
+}
+
+func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return time.Time{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be a string"}
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be YYYY-MM-DD"}
+	}
+	return t, nil
+}
+
+func optionalCurrency(raw map[string]json.RawMessage) (string, *validationError) {
+	v, ok := raw["currency"]
+	if !ok || isNull(v) {
+		return "USD", nil // Python default
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: "currency", Msg: "must be a string"}
+	}
+	s = strings.ToUpper(strings.TrimSpace(s))
+	if _, ok := validCurrencies[s]; !ok {
+		return "", &validationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
+	}
+	return s, nil
+}
+
+// requireNonNegativeDecimal parses a required JSON number as a Decimal using
+// the raw token (no float64 intermediate) so Numeric column precision is
+// preserved end-to-end.
+func requireNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if err != nil {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if d.IsNegative() {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: msg}
+	}
+	return d, nil
+}
+
+func optionalNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) (*decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return nil, nil
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if err != nil {
+		return nil, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if d.IsNegative() {
+		return nil, &validationError{Field: key, Msg: msg}
+	}
+	return &d, nil
+}
+
+func optionalDiscountPct(raw map[string]json.RawMessage) (*decimal.Decimal, *validationError) {
+	v, ok := raw["common_stock_discount_pct"]
+	if !ok || isNull(v) {
+		return nil, nil
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if err != nil {
+		return nil, &validationError{Field: "common_stock_discount_pct", Msg: "must be a number"}
+	}
+	lower := decimal.Zero
+	upper := decimal.NewFromInt(100)
+	if d.LessThan(lower) || d.GreaterThan(upper) {
+		return nil, &validationError{
+			Field: "common_stock_discount_pct",
+			Msg:   "Common-stock discount must be between 0 and 100",
+		}
+	}
+	return &d, nil
 }
 
 func isNull(v json.RawMessage) bool {

--- a/backend-go/internal/company_valuations/validation.go
+++ b/backend-go/internal/company_valuations/validation.go
@@ -1,0 +1,182 @@
+package companyvaluations
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func validateCreate(req *createRequest) *validationError {
+	company := strings.TrimSpace(req.Company)
+	if company == "" {
+		return &validationError{Field: "company", Msg: "Company cannot be empty"}
+	}
+	req.Company = company
+
+	if time.Time(req.Date).IsZero() {
+		return &validationError{Field: "date", Msg: "Field required"}
+	}
+
+	currency := strings.ToUpper(strings.TrimSpace(req.Currency))
+	if currency == "" {
+		currency = "USD"
+	}
+	if _, ok := validCurrencies[currency]; !ok {
+		return &validationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
+	}
+	req.Currency = currency
+
+	if req.FMVPerShare < 0 {
+		return &validationError{Field: "fmv_per_share", Msg: "FMV per share must be non-negative"}
+	}
+	if req.FMVLow != nil && *req.FMVLow < 0 {
+		return &validationError{Field: "fmv_low", Msg: "FMV range values must be non-negative"}
+	}
+	if req.FMVHigh != nil && *req.FMVHigh < 0 {
+		return &validationError{Field: "fmv_high", Msg: "FMV range values must be non-negative"}
+	}
+	if req.FMVLow != nil && *req.FMVLow > req.FMVPerShare {
+		return &validationError{Field: "fmv_low", Msg: "fmv_low cannot exceed fmv_per_share"}
+	}
+	if req.FMVHigh != nil && *req.FMVHigh < req.FMVPerShare {
+		return &validationError{Field: "fmv_high", Msg: "fmv_high cannot be below fmv_per_share"}
+	}
+	if req.CommonStockDiscountPct != nil {
+		d := *req.CommonStockDiscountPct
+		if d < 0 || d > 100 {
+			return &validationError{
+				Field: "common_stock_discount_pct",
+				Msg:   "Common-stock discount must be between 0 and 100",
+			}
+		}
+	}
+	if _, ok := validSources[req.Source]; !ok {
+		return &validationError{Field: "source", Msg: fmt.Sprintf("invalid source %q", req.Source)}
+	}
+	return nil
+}
+
+// buildUpdatePatch follows Python's GoalUpdate convention: a field set to
+// null is treated as "no-op", matching how Pydantic's nullable validators
+// behave on None input.
+func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *validationError) {
+	var p UpdatePatch
+	if vErr := patchStrings(raw, &p); vErr != nil {
+		return p, vErr
+	}
+	if vErr := patchNumbers(raw, &p); vErr != nil {
+		return p, vErr
+	}
+	return p, nil
+}
+
+func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *validationError {
+	if v, ok := raw["company"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "company", Msg: "must be a string"}
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return &validationError{Field: "company", Msg: "Company cannot be empty"}
+		}
+		p.Company = &s
+	}
+	if v, ok := raw["currency"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "currency", Msg: "must be a string"}
+		}
+		s = strings.ToUpper(strings.TrimSpace(s))
+		if _, valid := validCurrencies[s]; !valid {
+			return &validationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
+		}
+		p.Currency = &s
+	}
+	if v, ok := raw["source"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "source", Msg: "must be a string"}
+		}
+		if _, valid := validSources[s]; !valid {
+			return &validationError{Field: "source", Msg: fmt.Sprintf("invalid source %q", s)}
+		}
+		p.Source = &s
+	}
+	if v, ok := raw["notes"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "notes", Msg: "must be a string"}
+		}
+		p.Notes = &s
+	}
+	if v, ok := raw["date"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "date", Msg: "must be a string"}
+		}
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return &validationError{Field: "date", Msg: "must be YYYY-MM-DD"}
+		}
+		p.Date = &t
+	}
+	return nil
+}
+
+func patchNumbers(raw map[string]json.RawMessage, p *UpdatePatch) *validationError {
+	for _, f := range [...]struct {
+		key, field, msg string
+		dest            **decimal.Decimal
+	}{
+		{"fmv_per_share", "fmv_per_share", "FMV values must be non-negative", &p.FMVPerShare},
+		{"fmv_low", "fmv_low", "FMV values must be non-negative", &p.FMVLow},
+		{"fmv_high", "fmv_high", "FMV values must be non-negative", &p.FMVHigh},
+	} {
+		if err := decodeNonNegativeDecimal(raw, f.key, f.field, f.msg, f.dest); err != nil {
+			return err
+		}
+	}
+	if v, ok := raw["common_stock_discount_pct"]; ok && !isNull(v) {
+		var x float64
+		if err := json.Unmarshal(v, &x); err != nil {
+			return &validationError{Field: "common_stock_discount_pct", Msg: "must be a number"}
+		}
+		if x < 0 || x > 100 {
+			return &validationError{
+				Field: "common_stock_discount_pct",
+				Msg:   "Common-stock discount must be between 0 and 100",
+			}
+		}
+		d := decimal.NewFromFloat(x)
+		p.CommonStockDiscountPct = &d
+	}
+	return nil
+}
+
+func decodeNonNegativeDecimal(
+	raw map[string]json.RawMessage, key, field, msg string, dest **decimal.Decimal,
+) *validationError {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return nil
+	}
+	var f float64
+	if err := json.Unmarshal(v, &f); err != nil {
+		return &validationError{Field: field, Msg: "must be a number"}
+	}
+	if f < 0 {
+		return &validationError{Field: field, Msg: msg}
+	}
+	d := decimal.NewFromFloat(f)
+	*dest = &d
+	return nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/config"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/personas"
@@ -84,6 +85,17 @@ func New(cfg Config, logger *slog.Logger, deps Deps) http.Handler {
 			r.Get("/{id}", goalsHandler.Get)
 			r.Put("/{id}", goalsHandler.Update)
 			r.Delete("/{id}", goalsHandler.Delete)
+		})
+
+		valuationsHandler := companyvaluations.NewHandler(
+			companyvaluations.NewStore(deps.Pool), logger,
+		)
+		r.Route("/api/company-valuations", func(r chi.Router) {
+			r.Get("/", valuationsHandler.List)
+			r.Post("/", valuationsHandler.Create)
+			r.Get("/{id}", valuationsHandler.Get)
+			r.Patch("/{id}", valuationsHandler.Update)
+			r.Delete("/{id}", valuationsHandler.Delete)
 		})
 	}
 

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -43,3 +43,16 @@ rules:
   - method: DELETE
     path_prefix: /api/goals
     upstream: http://backend-go:8000
+  # Group 4a — /api/company-valuations cut over to Go.
+  - method: GET
+    path_prefix: /api/company-valuations
+    upstream: http://backend-go:8000
+  - method: POST
+    path_prefix: /api/company-valuations
+    upstream: http://backend-go:8000
+  - method: PATCH
+    path_prefix: /api/company-valuations
+    upstream: http://backend-go:8000
+  - method: DELETE
+    path_prefix: /api/company-valuations
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

First slice of Group 4 (#439 — equity domain). Splitting Group 4 into 3 sub-PRs because the combined scope (3 domains + FX + vesting + PL tax) would be ~2500 LOC in one PR:

- **4a (this PR):** company_valuations — no FX, no vesting
- **4b (next):** FX infra + bonuses
- **4c (next):** equity grants + vesting math

Per `migration/coupling.md` the group has to ship before any later groups touch FX, but the three slices are independent enough that they don't have to land in one PR.

Closes part of #439.

## Implementation information

### `pyFloat` wrapper — first cross-cutting Pydantic parity issue

Python's `Pydantic v2` serializes `float(14.0)` as `14.0` (preserves the float nature on the wire). Go's stdlib `json.Marshal` drops the trailing zero and emits `14`. Earlier groups (config, personas, goals) dodged this because their seed/test data happened to have non-integer floats everywhere.

The existing golden file (`backend-bb-tests/golden/company_valuations_list.json`) has `"fmv_high": 14.0` — captured from Python. To match byte-for-byte, this PR adds:

```go
type pyFloat float64
func (f pyFloat) MarshalJSON() ([]byte, error) {
    s := strconv.FormatFloat(float64(f), 'f', -1, 64)
    if !strings.ContainsRune(s, '.') {
        s += ".0"
    }
    return []byte(s), nil
}
```

Will promote to a shared package once the third user shows up (bonuses + equity grants need the same). Copy-paste for now.

### `internal/company_valuations/`

- **`store.go`** — full CRUD with soft-delete (`is_active = true` filter on every read). `List` orders by `date DESC` and returns the distinct active-company list alongside, matching Python's two-query pattern.
- **`handler.go`** — chi handlers; `PATCH` instead of `PUT` for partial updates (matches Python's `@router.patch`). Uses `pyFloat` for all money fields and pointer-of-pyFloat for nullable ones.
- **`validation.go`** — `validateCreate` does the Pydantic field-validators (currency allow-list, FMV non-negative, range ordering, discount 0-100, source enum). `buildUpdatePatch` reads `map[string]json.RawMessage` to distinguish "field omitted" from "explicit null" (same pattern as goals); split into `patchStrings` + `patchNumbers` for funlen budget.
- **`errors.go`** — Pydantic-shaped 422 helpers (copy from goals; will share later).

### CI

`bb-tests-go` job adds `test_company_valuations.py`. The `pyFloat` fix means the existing committed golden snapshot now passes against Go without re-capture.

### Parity proof against Go

```
============================= test session starts ==============================
tests/test_company_valuations.py::test_list_company_valuations_includes_seeded PASSED
tests/test_company_valuations.py::test_list_company_valuations_matches_golden PASSED
tests/test_company_valuations.py::test_get_company_valuation_by_id_returns_seeded_record PASSED
tests/test_company_valuations.py::test_get_company_valuation_not_found PASSED
tests/test_company_valuations.py::test_create_company_valuation_happy_path PASSED
tests/test_company_valuations.py::test_create_company_valuation_validation_error PASSED
tests/test_company_valuations.py::test_update_company_valuation_happy_path PASSED
tests/test_company_valuations.py::test_update_company_valuation_validation_error PASSED
tests/test_company_valuations.py::test_delete_company_valuation_happy_path PASSED
============================== 9 passed in 0.13s ===============================
```

### routes.yaml

Four new rules — GET/POST/PATCH/DELETE — for `/api/company-valuations/`. Default still routes everything else to Python.

## Supporting documentation

- Umbrella: #435
- Group 4 subissue: #439
- Procedure: `migration/CUTOVER.md`

> Changelog: skip