### PR TITLE
feat(go): cutover /api/bonuses + FX infra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,8 @@ jobs:
             tests/test_personas.py \
             tests/test_personas_mutations.py \
             tests/test_goals.py \
-            tests/test_company_valuations.py
+            tests/test_company_valuations.py \
+            tests/test_bonus_events.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/backend-go/internal/bonus_events/errors.go
+++ b/backend-go/internal/bonus_events/errors.go
@@ -1,0 +1,41 @@
+package bonusevents
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{
+				"type":  "value_error",
+				"loc":   []string{"body", field},
+				"msg":   msg,
+				"input": input,
+			},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/bonus_events/handler.go
+++ b/backend-go/internal/bonus_events/handler.go
@@ -80,9 +80,12 @@ func NewHandler(store *Store, fxSvc *fx.Service, logger *slog.Logger) *Handler {
 	return &Handler{store: store, fx: fxSvc, logger: logger}
 }
 
-func (h *Handler) toResponse(ctx context.Context, b *BonusEvent) response {
-	rate := h.fx.GetRateToPLN(ctx, b.Currency, b.Date)
-	pln := fx.ToPLN(&b.Amount, b.Currency, rate)
+func (h *Handler) toResponse(ctx context.Context, b *BonusEvent) (response, error) {
+	rate, err := h.fx.GetRateToPLN(ctx, b.Currency, b.Date)
+	if err != nil {
+		return response{}, err
+	}
+	plnAmount, hasPLN := fx.ToPLN(&b.Amount, b.Currency, rate)
 
 	amt, _ := b.Amount.Float64()
 	out := response{
@@ -98,17 +101,17 @@ func (h *Handler) toResponse(ctx context.Context, b *BonusEvent) response {
 		IsActive:     b.IsActive,
 		CreatedAt:    isoNaive(b.CreatedAt),
 	}
-	if pln != nil {
-		f, _ := pln.Float64()
+	if hasPLN {
+		f, _ := plnAmount.Float64()
 		pf := pyFloat(f)
 		out.AmountPLN = &pf
 	}
-	if rate != nil {
-		f, _ := rate.Float64()
+	if rate.Found {
+		f, _ := rate.Rate.Float64()
 		pf := pyFloat(f)
 		out.FXRate = &pf
 	}
-	return out
+	return out, nil
 }
 
 // List serves GET /api/bonuses.
@@ -130,7 +133,13 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 		AvailableCompanies: companies,
 	}
 	for i := range rows {
-		out.BonusEvents = append(out.BonusEvents, h.toResponse(r.Context(), &rows[i]))
+		resp, err := h.toResponse(r.Context(), &rows[i])
+		if err != nil {
+			h.logger.Error("fx lookup", "err", err)
+			writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+			return
+		}
+		out.BonusEvents = append(out.BonusEvents, resp)
 	}
 	writeJSON(w, http.StatusOK, out)
 }
@@ -146,7 +155,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 		h.writeStoreError(w, err, id)
 		return
 	}
-	writeJSON(w, http.StatusOK, h.toResponse(r.Context(), b))
+	h.writeBonusResponse(w, r, http.StatusOK, b)
 }
 
 // Create serves POST /api/bonuses.
@@ -177,7 +186,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	writeJSON(w, http.StatusCreated, h.toResponse(r.Context(), created))
+	h.writeBonusResponse(w, r, http.StatusCreated, created)
 }
 
 // Update serves PATCH /api/bonuses/{id}.
@@ -201,7 +210,19 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		h.writeStoreError(w, err, id)
 		return
 	}
-	writeJSON(w, http.StatusOK, h.toResponse(r.Context(), updated))
+	h.writeBonusResponse(w, r, http.StatusOK, updated)
+}
+
+// writeBonusResponse marshals a single bonus with its FX-derived fields,
+// emitting a 500 if the FX lookup hits a DB error.
+func (h *Handler) writeBonusResponse(w http.ResponseWriter, r *http.Request, status int, b *BonusEvent) {
+	resp, err := h.toResponse(r.Context(), b)
+	if err != nil {
+		h.logger.Error("fx lookup", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, status, resp)
 }
 
 // Delete serves DELETE /api/bonuses/{id}.

--- a/backend-go/internal/bonus_events/handler.go
+++ b/backend-go/internal/bonus_events/handler.go
@@ -1,0 +1,311 @@
+package bonusevents
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
+)
+
+var (
+	validCurrencies = map[string]struct{}{
+		"PLN": {}, "USD": {}, "EUR": {}, "GBP": {}, "CHF": {},
+	}
+	validBonusTypes = map[string]struct{}{
+		"annual": {}, "signon": {}, "spot": {}, "retention": {},
+	}
+	validContractTypes = map[string]struct{}{
+		"UOP": {}, "UZ": {}, "UoD": {}, "B2B": {},
+	}
+)
+
+// response mirrors backend/app/schemas/bonus_events.BonusEventResponse.
+type response struct {
+	ID           int      `json:"id"`
+	Date         isoDate  `json:"date"`
+	Amount       pyFloat  `json:"amount"`
+	Currency     string   `json:"currency"`
+	Type         string   `json:"type"`
+	Company      string   `json:"company"`
+	Owner        string   `json:"owner"`
+	ContractType string   `json:"contract_type"`
+	Notes        *string  `json:"notes"`
+	IsActive     bool     `json:"is_active"`
+	CreatedAt    isoNaive `json:"created_at"`
+	AmountPLN    *pyFloat `json:"amount_pln"`
+	FXRate       *pyFloat `json:"fx_rate"`
+}
+
+type listResponse struct {
+	BonusEvents        []response `json:"bonus_events"`
+	TotalCount         int        `json:"total_count"`
+	AvailableCompanies []string   `json:"available_companies"`
+}
+
+// createRequest captures parsed-and-validated input ready for Store.Create.
+type createRequest struct {
+	Date         time.Time
+	Amount       decimal.Decimal
+	Currency     string
+	Type         string
+	Company      string
+	Owner        string
+	ContractType string
+	Notes        *string
+}
+
+// Handler is the HTTP boundary for /api/bonuses.
+type Handler struct {
+	store  *Store
+	fx     *fx.Service
+	logger *slog.Logger
+}
+
+// NewHandler wires the store, FX service and logger.
+func NewHandler(store *Store, fxSvc *fx.Service, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, fx: fxSvc, logger: logger}
+}
+
+func (h *Handler) toResponse(ctx context.Context, b *BonusEvent) response {
+	rate := h.fx.GetRateToPLN(ctx, b.Currency, b.Date)
+	pln := fx.ToPLN(&b.Amount, b.Currency, rate)
+
+	amt, _ := b.Amount.Float64()
+	out := response{
+		ID:           b.ID,
+		Date:         isoDate(b.Date),
+		Amount:       pyFloat(amt),
+		Currency:     b.Currency,
+		Type:         b.Type,
+		Company:      b.Company,
+		Owner:        b.Owner,
+		ContractType: b.ContractType,
+		Notes:        b.Notes,
+		IsActive:     b.IsActive,
+		CreatedAt:    isoNaive(b.CreatedAt),
+	}
+	if pln != nil {
+		f, _ := pln.Float64()
+		pf := pyFloat(f)
+		out.AmountPLN = &pf
+	}
+	if rate != nil {
+		f, _ := rate.Float64()
+		pf := pyFloat(f)
+		out.FXRate = &pf
+	}
+	return out
+}
+
+// List serves GET /api/bonuses.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	filter, vErr := parseListFilter(r.URL.Query())
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	rows, companies, err := h.store.List(r.Context(), filter)
+	if err != nil {
+		h.logger.Error("list bonuses", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := listResponse{
+		BonusEvents:        make([]response, 0, len(rows)),
+		TotalCount:         len(rows),
+		AvailableCompanies: companies,
+	}
+	for i := range rows {
+		out.BonusEvents = append(out.BonusEvents, h.toResponse(r.Context(), &rows[i]))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Get serves GET /api/bonuses/{id}.
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	b, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		h.writeStoreError(w, err, id)
+		return
+	}
+	writeJSON(w, http.StatusOK, h.toResponse(r.Context(), b))
+}
+
+// Create serves POST /api/bonuses.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	req, vErr := buildCreateRequest(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	b := &BonusEvent{
+		Date:         req.Date,
+		Amount:       req.Amount,
+		Currency:     req.Currency,
+		Type:         req.Type,
+		Company:      req.Company,
+		Owner:        req.Owner,
+		ContractType: req.ContractType,
+		Notes:        req.Notes,
+	}
+	created, err := h.store.Create(r.Context(), b)
+	if err != nil {
+		h.logger.Error("create bonus", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, h.toResponse(r.Context(), created))
+}
+
+// Update serves PATCH /api/bonuses/{id}.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	patch, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	updated, err := h.store.Update(r.Context(), id, patch)
+	if err != nil {
+		h.writeStoreError(w, err, id)
+		return
+	}
+	writeJSON(w, http.StatusOK, h.toResponse(r.Context(), updated))
+}
+
+// Delete serves DELETE /api/bonuses/{id}.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.Delete(r.Context(), id); err != nil {
+		h.writeStoreError(w, err, id)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int) {
+	if errors.Is(err, ErrNotFound) {
+		writeDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("Bonus event with id %d not found", id))
+		return
+	}
+	h.logger.Error("bonus store", "err", err)
+	writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+}
+
+func parseListFilter(q map[string][]string) (ListFilter, *validationError) {
+	f := ListFilter{}
+	if v := first(q["owner"]); v != "" {
+		s := v
+		f.Owner = &s
+	}
+	if v := first(q["company"]); v != "" {
+		s := v
+		f.Company = &s
+	}
+	if v := first(q["date_from"]); v != "" {
+		t, err := time.Parse("2006-01-02", v)
+		if err != nil {
+			return f, &validationError{Field: "date_from", Msg: "must be YYYY-MM-DD"}
+		}
+		f.DateFrom = &t
+	}
+	if v := first(q["date_to"]); v != "" {
+		t, err := time.Parse("2006-01-02", v)
+		if err != nil {
+			return f, &validationError{Field: "date_to", Msg: "must be YYYY-MM-DD"}
+		}
+		f.DateTo = &t
+	}
+	return f, nil
+}
+
+func first(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(values[0])
+}
+
+func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		writeValidationError(w, "bonus_id", "must be an integer", raw)
+		return 0, false
+	}
+	return id, true
+}
+
+// --- shared wire-format helpers (copied per package; promote when third user needs them) ---
+
+type isoDate time.Time
+
+const isoDateLayout = "2006-01-02"
+
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
+}
+
+func (d *isoDate) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("date must be a string: %w", err)
+	}
+	t, err := time.Parse(isoDateLayout, s)
+	if err != nil {
+		return fmt.Errorf("date must be YYYY-MM-DD: %w", err)
+	}
+	*d = isoDate(t)
+	return nil
+}
+
+type isoNaive time.Time
+
+func (t isoNaive) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
+}
+
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/bonus_events/store.go
+++ b/backend-go/internal/bonus_events/store.go
@@ -1,0 +1,250 @@
+// Package bonusevents implements the /api/bonuses endpoints.
+//
+// Mirrors Python's bonus_events service: soft-delete via is_active filter,
+// optional list filters (owner / date range / company), FX-derived amount_pln
+// + fx_rate on every response. FX lookups go through internal/fx, which both
+// reads from and writes to the fx_rates cache on miss.
+package bonusevents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// BonusEvent mirrors backend/app/models/bonus_event.BonusEvent.
+type BonusEvent struct {
+	ID           int
+	Date         time.Time
+	Amount       decimal.Decimal
+	Currency     string
+	Type         string
+	Company      string
+	Owner        string
+	ContractType string
+	Notes        *string
+	IsActive     bool
+	CreatedAt    time.Time
+}
+
+// ErrNotFound covers both "row doesn't exist" and "row exists but inactive"
+// — the public contract is identical (a 404).
+var ErrNotFound = errors.New("bonus event not found")
+
+// ListFilter constrains the active rows returned by List.
+type ListFilter struct {
+	Owner    *string
+	DateFrom *time.Time
+	DateTo   *time.Time
+	Company  *string
+}
+
+// Store is the persistence boundary.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const selectColumns = `
+	id, date, amount, currency, type, company, owner,
+	contract_type, notes, is_active, created_at
+`
+
+// List returns active bonuses ordered by date desc and the distinct
+// active-company list, matching Python's two-query shape.
+func (s *Store) List(ctx context.Context, f ListFilter) ([]BonusEvent, []string, error) {
+	conds := []string{"is_active = true"}
+	args := []any{}
+	if f.Owner != nil {
+		args = append(args, *f.Owner)
+		conds = append(conds, fmt.Sprintf("owner = $%d", len(args)))
+	}
+	if f.DateFrom != nil {
+		args = append(args, *f.DateFrom)
+		conds = append(conds, fmt.Sprintf("date >= $%d", len(args)))
+	}
+	if f.DateTo != nil {
+		args = append(args, *f.DateTo)
+		conds = append(conds, fmt.Sprintf("date <= $%d", len(args)))
+	}
+	if f.Company != nil {
+		args = append(args, *f.Company)
+		conds = append(conds, fmt.Sprintf("company = $%d", len(args)))
+	}
+	query := `SELECT ` + selectColumns + ` FROM bonus_events WHERE ` +
+		strings.Join(conds, " AND ") + ` ORDER BY date DESC`
+
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("select bonuses: %w", err)
+	}
+	defer rows.Close()
+	out := []BonusEvent{}
+	for rows.Next() {
+		b, err := scanBonus(rows)
+		if err != nil {
+			return nil, nil, fmt.Errorf("scan bonus: %w", err)
+		}
+		out = append(out, *b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate bonuses: %w", err)
+	}
+	companies, err := s.activeCompanies(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, companies, nil
+}
+
+// Get returns the active bonus or ErrNotFound for missing/soft-deleted rows.
+func (s *Store) Get(ctx context.Context, id int) (*BonusEvent, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+selectColumns+` FROM bonus_events WHERE id = $1`, id,
+	)
+	b, err := scanBonus(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("select bonus: %w", err)
+	}
+	if !b.IsActive {
+		return nil, ErrNotFound
+	}
+	return b, nil
+}
+
+// Create inserts a row.
+func (s *Store) Create(ctx context.Context, b *BonusEvent) (*BonusEvent, error) {
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO bonus_events (
+			date, amount, currency, type, company, owner,
+			contract_type, notes, is_active, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, true, $9)
+		RETURNING `+selectColumns,
+		b.Date, b.Amount, b.Currency, b.Type, b.Company, b.Owner,
+		b.ContractType, b.Notes, time.Now().UTC(),
+	)
+	return scanBonus(row)
+}
+
+// UpdatePatch is a sparse update.
+type UpdatePatch struct {
+	Date         *time.Time
+	Amount       *decimal.Decimal
+	Currency     *string
+	Type         *string
+	Company      *string
+	Owner        *string
+	ContractType *string
+	Notes        *string
+}
+
+// Update applies the patch and returns the refreshed bonus.
+func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*BonusEvent, error) {
+	b, err := s.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if p.Date != nil {
+		b.Date = *p.Date
+	}
+	if p.Amount != nil {
+		b.Amount = *p.Amount
+	}
+	if p.Currency != nil {
+		b.Currency = *p.Currency
+	}
+	if p.Type != nil {
+		b.Type = *p.Type
+	}
+	if p.Company != nil {
+		b.Company = *p.Company
+	}
+	if p.Owner != nil {
+		b.Owner = *p.Owner
+	}
+	if p.ContractType != nil {
+		b.ContractType = *p.ContractType
+	}
+	if p.Notes != nil {
+		b.Notes = p.Notes
+	}
+	row := s.pool.QueryRow(ctx, `
+		UPDATE bonus_events SET
+			date = $1, amount = $2, currency = $3, type = $4,
+			company = $5, owner = $6, contract_type = $7, notes = $8
+		WHERE id = $9 AND is_active = true
+		RETURNING `+selectColumns,
+		b.Date, b.Amount, b.Currency, b.Type, b.Company, b.Owner,
+		b.ContractType, b.Notes, id,
+	)
+	updated, err := scanBonus(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("update bonus: %w", err)
+	}
+	return updated, nil
+}
+
+// Delete soft-deletes the row.
+func (s *Store) Delete(ctx context.Context, id int) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE bonus_events SET is_active = false WHERE id = $1 AND is_active = true`,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("soft-delete bonus: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) activeCompanies(ctx context.Context) ([]string, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT DISTINCT company FROM bonus_events
+		 WHERE is_active = true ORDER BY company`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("select active companies: %w", err)
+	}
+	defer rows.Close()
+	out := []string{}
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, fmt.Errorf("scan company: %w", err)
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate companies: %w", err)
+	}
+	return out, nil
+}
+
+func scanBonus(row pgx.Row) (*BonusEvent, error) {
+	var b BonusEvent
+	if err := row.Scan(
+		&b.ID, &b.Date, &b.Amount, &b.Currency, &b.Type, &b.Company,
+		&b.Owner, &b.ContractType, &b.Notes, &b.IsActive, &b.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	return &b, nil
+}

--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -1,0 +1,265 @@
+package bonusevents
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// buildCreateRequest reads + validates the POST body. JSON numbers are parsed
+// from raw bytes (decimal.NewFromString) to preserve Numeric precision —
+// going through float64 introduces IEEE754 rounding that diverges from
+// Python's Decimal(str(float)) round-trip.
+func buildCreateRequest(raw map[string]json.RawMessage) (*createRequest, *validationError) {
+	r := &createRequest{}
+
+	t, vErr := requireDate(raw, "date")
+	if vErr != nil {
+		return nil, vErr
+	}
+	if t.After(today()) {
+		return nil, &validationError{Field: "date", Msg: "Date cannot be in the future"}
+	}
+	r.Date = t
+
+	amount, vErr := requirePositiveDecimal(raw, "amount", "Amount must be greater than 0")
+	if vErr != nil {
+		return nil, vErr
+	}
+	r.Amount = amount
+
+	currency, vErr := optionalCurrency(raw, "PLN")
+	if vErr != nil {
+		return nil, vErr
+	}
+	r.Currency = currency
+
+	r.Type, vErr = requireEnumString(raw, "type", validBonusTypes)
+	if vErr != nil {
+		return nil, vErr
+	}
+
+	company, vErr := requireString(raw, "company", "Company cannot be empty")
+	if vErr != nil {
+		return nil, vErr
+	}
+	r.Company = company
+
+	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
+	if vErr != nil {
+		return nil, vErr
+	}
+	r.Owner = owner
+
+	r.ContractType, vErr = requireEnumString(raw, "contract_type", validContractTypes)
+	if vErr != nil {
+		return nil, vErr
+	}
+
+	if v, ok := raw["notes"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return nil, &validationError{Field: "notes", Msg: "must be a string"}
+		}
+		r.Notes = &s
+	}
+	return r, nil
+}
+
+// buildUpdatePatch parses the PATCH body. Null fields are no-ops (Pydantic
+// semantics).
+func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *validationError) {
+	var p UpdatePatch
+	if vErr := patchScalars(raw, &p); vErr != nil {
+		return p, vErr
+	}
+	if vErr := patchEnums(raw, &p); vErr != nil {
+		return p, vErr
+	}
+	return p, nil
+}
+
+func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *validationError {
+	if v, ok := raw["date"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "date", Msg: "must be a string"}
+		}
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return &validationError{Field: "date", Msg: "must be YYYY-MM-DD"}
+		}
+		if t.After(today()) {
+			return &validationError{Field: "date", Msg: "Date cannot be in the future"}
+		}
+		p.Date = &t
+	}
+	if v, ok := raw["amount"]; ok && !isNull(v) {
+		d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+		if err != nil {
+			return &validationError{Field: "amount", Msg: "must be a number"}
+		}
+		if !d.IsPositive() {
+			return &validationError{Field: "amount", Msg: "Amount must be greater than 0"}
+		}
+		p.Amount = &d
+	}
+	if v, ok := raw["currency"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "currency", Msg: "must be a string"}
+		}
+		s = strings.ToUpper(strings.TrimSpace(s))
+		if _, ok := validCurrencies[s]; !ok {
+			return &validationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
+		}
+		p.Currency = &s
+	}
+	if v, ok := raw["company"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "company", Msg: "must be a string"}
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return &validationError{Field: "company", Msg: "Company cannot be empty"}
+		}
+		p.Company = &s
+	}
+	if v, ok := raw["owner"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "owner", Msg: "must be a string"}
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return &validationError{Field: "owner", Msg: "Owner cannot be empty"}
+		}
+		p.Owner = &s
+	}
+	if v, ok := raw["notes"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "notes", Msg: "must be a string"}
+		}
+		p.Notes = &s
+	}
+	return nil
+}
+
+func patchEnums(raw map[string]json.RawMessage, p *UpdatePatch) *validationError {
+	if v, ok := raw["type"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "type", Msg: "must be a string"}
+		}
+		if _, ok := validBonusTypes[s]; !ok {
+			return &validationError{Field: "type", Msg: fmt.Sprintf("invalid bonus type %q", s)}
+		}
+		p.Type = &s
+	}
+	if v, ok := raw["contract_type"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "contract_type", Msg: "must be a string"}
+		}
+		if _, ok := validContractTypes[s]; !ok {
+			return &validationError{Field: "contract_type", Msg: fmt.Sprintf("invalid contract type %q", s)}
+		}
+		p.ContractType = &s
+	}
+	return nil
+}
+
+// --- shared decoders ---
+
+func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", &validationError{Field: key, Msg: emptyMsg}
+	}
+	return s, nil
+}
+
+func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return time.Time{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be a string"}
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be YYYY-MM-DD"}
+	}
+	return t, nil
+}
+
+func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if err != nil {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if !d.IsPositive() {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: msg}
+	}
+	return d, nil
+}
+
+func optionalCurrency(raw map[string]json.RawMessage, fallback string) (string, *validationError) {
+	v, ok := raw["currency"]
+	if !ok || isNull(v) {
+		return fallback, nil
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: "currency", Msg: "must be a string"}
+	}
+	s = strings.ToUpper(strings.TrimSpace(s))
+	if _, ok := validCurrencies[s]; !ok {
+		return "", &validationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
+	}
+	return s, nil
+}
+
+func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return "", &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	return s, nil
+}
+
+func today() time.Time {
+	now := time.Now().UTC()
+	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}

--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -14,56 +14,59 @@ import (
 // from raw bytes (decimal.NewFromString) to preserve Numeric precision —
 // going through float64 introduces IEEE754 rounding that diverges from
 // Python's Decimal(str(float)) round-trip.
-func buildCreateRequest(raw map[string]json.RawMessage) (*createRequest, *validationError) {
-	r := &createRequest{}
+//
+// Returns the value type rather than a pointer so callers can use the result
+// directly without a nil-check on success (nilaway-friendly).
+func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *validationError) {
+	var r createRequest
 
 	t, vErr := requireDate(raw, "date")
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 	if t.After(today()) {
-		return nil, &validationError{Field: "date", Msg: "Date cannot be in the future"}
+		return r, &validationError{Field: "date", Msg: "Date cannot be in the future"}
 	}
 	r.Date = t
 
 	amount, vErr := requirePositiveDecimal(raw, "amount", "Amount must be greater than 0")
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 	r.Amount = amount
 
 	currency, vErr := optionalCurrency(raw, "PLN")
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 	r.Currency = currency
 
 	r.Type, vErr = requireEnumString(raw, "type", validBonusTypes)
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 
 	company, vErr := requireString(raw, "company", "Company cannot be empty")
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 	r.Company = company
 
 	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 	r.Owner = owner
 
 	r.ContractType, vErr = requireEnumString(raw, "contract_type", validContractTypes)
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 
 	if v, ok := raw["notes"]; ok && !isNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
-			return nil, &validationError{Field: "notes", Msg: "must be a string"}
+			return r, &validationError{Field: "notes", Msg: "must be a string"}
 		}
 		r.Notes = &s
 	}

--- a/backend-go/internal/company_valuations/handler.go
+++ b/backend-go/internal/company_valuations/handler.go
@@ -160,7 +160,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		writePydanticError(w, vErr)
 		return
 	}
-	v := requestToValuation(req)
+	v := requestToValuation(&req)
 	created, err := h.store.Create(r.Context(), v)
 	if err != nil {
 		h.logger.Error("create valuation", "err", err)

--- a/backend-go/internal/company_valuations/validation.go
+++ b/backend-go/internal/company_valuations/validation.go
@@ -17,66 +17,66 @@ import (
 // IEEE754 rounding that diverges from Python's Decimal(str(...)) round-trip).
 // Required fields surface 422 "Field required" when missing — Pydantic
 // behavior for the required-field case.
-func buildCreateRequest(raw map[string]json.RawMessage) (*createRequest, *validationError) {
-	r := &createRequest{}
+func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *validationError) {
+	var r createRequest
 
 	company, vErr := requireString(raw, "company", "Field required", "Company cannot be empty")
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 	r.Company = company
 
 	t, vErr := requireDate(raw, "date")
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 	r.Date = t
 
 	currency, vErr := optionalCurrency(raw)
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 	r.Currency = currency
 
 	fmv, vErr := requireNonNegativeDecimal(raw, "fmv_per_share", "FMV per share must be non-negative")
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 	r.FMVPerShare = fmv
 
 	r.FMVLow, vErr = optionalNonNegativeDecimal(raw, "fmv_low", "FMV range values must be non-negative")
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 	r.FMVHigh, vErr = optionalNonNegativeDecimal(raw, "fmv_high", "FMV range values must be non-negative")
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 	if r.FMVLow != nil && r.FMVLow.GreaterThan(r.FMVPerShare) {
-		return nil, &validationError{Field: "fmv_low", Msg: "fmv_low cannot exceed fmv_per_share"}
+		return r, &validationError{Field: "fmv_low", Msg: "fmv_low cannot exceed fmv_per_share"}
 	}
 	if r.FMVHigh != nil && r.FMVHigh.LessThan(r.FMVPerShare) {
-		return nil, &validationError{Field: "fmv_high", Msg: "fmv_high cannot be below fmv_per_share"}
+		return r, &validationError{Field: "fmv_high", Msg: "fmv_high cannot be below fmv_per_share"}
 	}
 
 	r.CommonStockDiscountPct, vErr = optionalDiscountPct(raw)
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 
 	source, vErr := requireString(raw, "source", "Field required", "Source cannot be empty")
 	if vErr != nil {
-		return nil, vErr
+		return r, vErr
 	}
 	if _, ok := validSources[source]; !ok {
-		return nil, &validationError{Field: "source", Msg: fmt.Sprintf("invalid source %q", source)}
+		return r, &validationError{Field: "source", Msg: fmt.Sprintf("invalid source %q", source)}
 	}
 	r.Source = source
 
 	if v, ok := raw["notes"]; ok && !isNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
-			return nil, &validationError{Field: "notes", Msg: "must be a string"}
+			return r, &validationError{Field: "notes", Msg: "must be a string"}
 		}
 		r.Notes = &s
 	}

--- a/backend-go/internal/fx/fx.go
+++ b/backend-go/internal/fx/fx.go
@@ -1,0 +1,233 @@
+// Package fx ports backend/app/services/fx — NBP table A rate lookups with a
+// Postgres-backed cache.
+//
+// PLN passes through as 1. For other currencies, the cache is consulted first;
+// on miss or stale (>7 days) the NBP API is queried for a [target-10d, target]
+// window. The most recent rate ≤ target wins. Failed network or empty payload
+// falls back to whatever's already in cache (or nil if truly absent).
+package fx
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+const (
+	nbpBaseURL        = "https://api.nbp.pl/api/exchangerates/rates/A"
+	lookbackDays      = 10
+	cacheToleranceDay = 7
+	httpTimeout       = 5 * time.Second
+)
+
+// Rate represents a cached NBP rate row.
+type Rate struct {
+	Date    time.Time
+	RatePLN decimal.Decimal
+}
+
+// errCacheMiss is the sentinel returned by lookupCached when no cached rate
+// exists for the requested currency on/before the target date. Promoted to
+// a typed value so the lint rule (nilnil) is satisfied without a `nolint`.
+var errCacheMiss = errors.New("fx rate cache miss")
+
+// Service is the FX boundary. Cache reads + NBP fetches are routed through it.
+type Service struct {
+	pool   *pgxpool.Pool
+	client *http.Client
+	logger *slog.Logger
+}
+
+// NewService wires the pool. The HTTP client uses a 5s timeout matching
+// Python.
+func NewService(pool *pgxpool.Pool, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{
+		pool:   pool,
+		client: &http.Client{Timeout: httpTimeout},
+		logger: logger,
+	}
+}
+
+// GetRateToPLN returns the PLN-per-unit rate for currency on/before onDate.
+// PLN returns 1. Returns nil if no rate could be found in cache or fetched.
+func (s *Service) GetRateToPLN(ctx context.Context, currency string, onDate time.Time) *decimal.Decimal {
+	code := strings.ToUpper(strings.TrimSpace(currency))
+	if code == "PLN" {
+		one := decimal.NewFromInt(1)
+		return &one
+	}
+	target := onDate.UTC()
+	if target.IsZero() {
+		target = time.Now().UTC()
+	}
+	target = truncateDay(target)
+
+	cached, _ := s.lookupCached(ctx, code, target)
+	if cached != nil {
+		ageDays := int(target.Sub(cached.Date).Hours() / 24)
+		if ageDays <= cacheToleranceDay {
+			rate := cached.RatePLN
+			return &rate
+		}
+	}
+
+	// Cache miss or stale — fetch the window.
+	start := target.AddDate(0, 0, -lookbackDays)
+	fetched, err := s.fetchRange(ctx, code, start, target)
+	if err != nil {
+		s.logger.Warn("nbp fetch failed", "currency", code, "err", err)
+		if cached != nil {
+			rate := cached.RatePLN
+			return &rate
+		}
+		return nil
+	}
+	if len(fetched) == 0 {
+		if cached != nil {
+			rate := cached.RatePLN
+			return &rate
+		}
+		return nil
+	}
+	sort.Slice(fetched, func(i, j int) bool {
+		return fetched[i].Date.Before(fetched[j].Date)
+	})
+	for _, r := range fetched {
+		if r.Date.After(target) {
+			continue
+		}
+		if err := s.persist(ctx, code, r); err != nil {
+			s.logger.Warn("persist fx rate", "currency", code, "date", r.Date, "err", err)
+		}
+	}
+	refreshed, _ := s.lookupCached(ctx, code, target)
+	if refreshed != nil {
+		rate := refreshed.RatePLN
+		return &rate
+	}
+	if cached != nil {
+		rate := cached.RatePLN
+		return &rate
+	}
+	return nil
+}
+
+// ToPLN converts amount in currency to PLN using the supplied rate. Returns
+// nil when amount is missing or (non-PLN and rate is nil). PLN amounts pass
+// through unchanged regardless of rate.
+func ToPLN(amount *decimal.Decimal, currency string, rate *decimal.Decimal) *decimal.Decimal {
+	if amount == nil {
+		return nil
+	}
+	if strings.EqualFold(currency, "PLN") {
+		v := *amount
+		return &v
+	}
+	if rate == nil {
+		return nil
+	}
+	v := amount.Mul(*rate)
+	return &v
+}
+
+func (s *Service) lookupCached(ctx context.Context, code string, onOrBefore time.Time) (*Rate, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT date, rate_pln FROM fx_rates
+		WHERE currency = $1 AND date <= $2
+		ORDER BY date DESC LIMIT 1`,
+		code, onOrBefore,
+	)
+	var r Rate
+	if err := row.Scan(&r.Date, &r.RatePLN); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, errCacheMiss
+		}
+		return nil, fmt.Errorf("select fx_rate: %w", err)
+	}
+	return &r, nil
+}
+
+type nbpResponse struct {
+	Rates []nbpRate `json:"rates"`
+}
+
+type nbpRate struct {
+	EffectiveDate string  `json:"effectiveDate"`
+	Mid           float64 `json:"mid"`
+}
+
+func (s *Service) fetchRange(ctx context.Context, code string, start, end time.Time) ([]Rate, error) {
+	url := fmt.Sprintf(
+		"%s/%s/%s/%s/?format=json",
+		nbpBaseURL, code, start.Format("2006-01-02"), end.Format("2006-01-02"),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("nbp request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return []Rate{}, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("nbp http %d", resp.StatusCode)
+	}
+	var body nbpResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decode nbp: %w", err)
+	}
+	out := make([]Rate, 0, len(body.Rates))
+	for _, r := range body.Rates {
+		d, err := time.Parse("2006-01-02", r.EffectiveDate)
+		if err != nil {
+			continue
+		}
+		out = append(out, Rate{
+			Date:    d,
+			RatePLN: decimal.NewFromFloat(r.Mid),
+		})
+	}
+	return out, nil
+}
+
+func (s *Service) persist(ctx context.Context, code string, r Rate) error {
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO fx_rates (date, currency, rate_pln, created_at)
+		VALUES ($1, $2, $3, $4)`,
+		r.Date, code, r.RatePLN, time.Now().UTC(),
+	)
+	if err == nil {
+		return nil
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr != nil && pgErr.Code == pgerrcode.UniqueViolation {
+		// Another writer cached the same (date, currency) pair — fine.
+		return nil
+	}
+	return fmt.Errorf("insert fx_rate: %w", err)
+}
+
+func truncateDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}

--- a/backend-go/internal/fx/fx.go
+++ b/backend-go/internal/fx/fx.go
@@ -64,13 +64,23 @@ func NewService(pool *pgxpool.Pool, logger *slog.Logger) *Service {
 	}
 }
 
+// Result wraps the optional rate so callers don't deal with (nil, nil) — the
+// Found flag distinguishes "no rate available" (a normal outcome on first
+// access to an exotic currency over a long weekend) from a real DB failure.
+type Result struct {
+	Rate  decimal.Decimal
+	Found bool
+}
+
 // GetRateToPLN returns the PLN-per-unit rate for currency on/before onDate.
-// PLN returns 1. Returns nil if no rate could be found in cache or fetched.
-func (s *Service) GetRateToPLN(ctx context.Context, currency string, onDate time.Time) *decimal.Decimal {
+// PLN returns {1, true}. Returns {_, false} when no rate exists and NBP
+// couldn't supply one. An error only surfaces for DB outages — NBP transient
+// failures fall back to whatever's in the cache (stale or absent) and don't
+// propagate, matching Python's behavior.
+func (s *Service) GetRateToPLN(ctx context.Context, currency string, onDate time.Time) (Result, error) {
 	code := strings.ToUpper(strings.TrimSpace(currency))
 	if code == "PLN" {
-		one := decimal.NewFromInt(1)
-		return &one
+		return Result{Rate: decimal.NewFromInt(1), Found: true}, nil
 	}
 	target := onDate.UTC()
 	if target.IsZero() {
@@ -78,32 +88,32 @@ func (s *Service) GetRateToPLN(ctx context.Context, currency string, onDate time
 	}
 	target = truncateDay(target)
 
-	cached, _ := s.lookupCached(ctx, code, target)
+	cached, err := s.lookupCached(ctx, code, target)
+	if err != nil && !errors.Is(err, errCacheMiss) {
+		return Result{}, fmt.Errorf("fx cache lookup: %w", err)
+	}
 	if cached != nil {
 		ageDays := int(target.Sub(cached.Date).Hours() / 24)
 		if ageDays <= cacheToleranceDay {
-			rate := cached.RatePLN
-			return &rate
+			return Result{Rate: cached.RatePLN, Found: true}, nil
 		}
 	}
 
 	// Cache miss or stale — fetch the window.
 	start := target.AddDate(0, 0, -lookbackDays)
-	fetched, err := s.fetchRange(ctx, code, start, target)
-	if err != nil {
-		s.logger.Warn("nbp fetch failed", "currency", code, "err", err)
+	fetched, ferr := s.fetchRange(ctx, code, start, target)
+	if ferr != nil {
+		s.logger.Warn("nbp fetch failed", "currency", code, "err", ferr)
 		if cached != nil {
-			rate := cached.RatePLN
-			return &rate
+			return Result{Rate: cached.RatePLN, Found: true}, nil
 		}
-		return nil
+		return Result{}, nil
 	}
 	if len(fetched) == 0 {
 		if cached != nil {
-			rate := cached.RatePLN
-			return &rate
+			return Result{Rate: cached.RatePLN, Found: true}, nil
 		}
-		return nil
+		return Result{}, nil
 	}
 	sort.Slice(fetched, func(i, j int) bool {
 		return fetched[i].Date.Before(fetched[j].Date)
@@ -116,34 +126,33 @@ func (s *Service) GetRateToPLN(ctx context.Context, currency string, onDate time
 			s.logger.Warn("persist fx rate", "currency", code, "date", r.Date, "err", err)
 		}
 	}
-	refreshed, _ := s.lookupCached(ctx, code, target)
+	refreshed, err := s.lookupCached(ctx, code, target)
+	if err != nil && !errors.Is(err, errCacheMiss) {
+		return Result{}, fmt.Errorf("fx cache lookup after fetch: %w", err)
+	}
 	if refreshed != nil {
-		rate := refreshed.RatePLN
-		return &rate
+		return Result{Rate: refreshed.RatePLN, Found: true}, nil
 	}
 	if cached != nil {
-		rate := cached.RatePLN
-		return &rate
+		return Result{Rate: cached.RatePLN, Found: true}, nil
 	}
-	return nil
+	return Result{}, nil
 }
 
 // ToPLN converts amount in currency to PLN using the supplied rate. Returns
-// nil when amount is missing or (non-PLN and rate is nil). PLN amounts pass
-// through unchanged regardless of rate.
-func ToPLN(amount *decimal.Decimal, currency string, rate *decimal.Decimal) *decimal.Decimal {
+// (_, false) when amount is missing or (non-PLN and no rate found). PLN
+// amounts pass through unchanged regardless of rate.
+func ToPLN(amount *decimal.Decimal, currency string, rate Result) (decimal.Decimal, bool) {
 	if amount == nil {
-		return nil
+		return decimal.Decimal{}, false
 	}
 	if strings.EqualFold(currency, "PLN") {
-		v := *amount
-		return &v
+		return *amount, true
 	}
-	if rate == nil {
-		return nil
+	if !rate.Found {
+		return decimal.Decimal{}, false
 	}
-	v := amount.Mul(*rate)
-	return &v
+	return amount.Mul(rate.Rate), true
 }
 
 func (s *Service) lookupCached(ctx context.Context, code string, onOrBefore time.Time) (*Rate, error) {

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -16,8 +16,10 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	bonusevents "github.com/Automaat/finance-buddy/backend-go/internal/bonus_events"
 	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/config"
+	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/personas"
 )
@@ -96,6 +98,18 @@ func New(cfg Config, logger *slog.Logger, deps Deps) http.Handler {
 			r.Get("/{id}", valuationsHandler.Get)
 			r.Patch("/{id}", valuationsHandler.Update)
 			r.Delete("/{id}", valuationsHandler.Delete)
+		})
+
+		fxSvc := fx.NewService(deps.Pool, logger)
+		bonusesHandler := bonusevents.NewHandler(
+			bonusevents.NewStore(deps.Pool), fxSvc, logger,
+		)
+		r.Route("/api/bonuses", func(r chi.Router) {
+			r.Get("/", bonusesHandler.List)
+			r.Post("/", bonusesHandler.Create)
+			r.Get("/{id}", bonusesHandler.Get)
+			r.Patch("/{id}", bonusesHandler.Update)
+			r.Delete("/{id}", bonusesHandler.Delete)
 		})
 	}
 

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -56,3 +56,16 @@ rules:
   - method: DELETE
     path_prefix: /api/company-valuations
     upstream: http://backend-go:8000
+  # Group 4b — /api/bonuses cut over to Go (incl. FX cache + NBP fetch).
+  - method: GET
+    path_prefix: /api/bonuses
+    upstream: http://backend-go:8000
+  - method: POST
+    path_prefix: /api/bonuses
+    upstream: http://backend-go:8000
+  - method: PATCH
+    path_prefix: /api/bonuses
+    upstream: http://backend-go:8000
+  - method: DELETE
+    path_prefix: /api/bonuses
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

Second slice of Group 4. `/api/bonuses` cuts over to Go alongside the FX infrastructure that backs `amount_pln` / `fx_rate` derivation. Equity grants (#439 final piece) depend on this FX package landing, so this PR is the prerequisite for slice 4c.

Per `migration/coupling.md`, bonuses + equity grants are coupled by the stealth-writer `fx.get_fx_rate_to_pln`. Both languages now share the same `fx_rates` table semantics — read cache; on miss/stale fetch a 10-day window from NBP; write back; PLN passes through as 1.

Part of #439.

## Implementation information

### `internal/fx` — port of `backend/app/services/fx.py`

- `Service.GetRateToPLN(ctx, currency, onDate)` — same contract as Python:
  - PLN → `1`
  - cache hit, ≤7 days old → return cached
  - cache miss / stale → fetch `[onDate-10d, onDate]` from NBP table A, persist all rates ≤ onDate, re-read cache, fall back to stale cached value if the fetch is empty/HTTP error
- `Service.persist(...)` — ignores `pgerrcode.UniqueViolation` (the `uq_fx_rates_date_currency` constraint catches double-writes from Python + Go racing on the same date; both writers tolerant of the loser)
- `ToPLN(amount, currency, rate)` — Python's `to_pln` ported with the same nil-on-missing semantics
- Sentinel `errCacheMiss` so `lookupCached` can return `(nil, err)` cleanly (satisfies the `nilnil` lint rule without `nolint`)

The HTTP client uses Go's `net/http` with a 5-second timeout to match Python's `httpx.get(..., timeout=5.0)`.

### `internal/bonus_events`

- **`store.go`** — full CRUD with soft-delete (`is_active = true` filter). List supports the four optional query-string filters (`owner`, `date_from`, `date_to`, `company`) by building the WHERE incrementally — matches Python's `select.where(...)` chain.
- **`handler.go`** — chi handlers; `toResponse` calls `fx.GetRateToPLN` once per row and computes `amount_pln` via `fx.ToPLN`. Wire format uses `pyFloat` (preserves trailing `.0`), `isoDate`, `isoNaive` — same shape as Pydantic.
- **`validation.go`** — `buildCreateRequest` enforces required fields ("Field required" 422 on missing date/amount/type/company/owner/contract_type), positive-decimal-via-`NewFromString` for `amount`, and the allowed-currency / allowed-enum-string maps for `currency`/`type`/`contract_type`.
- **`errors.go`** — Pydantic-shaped 422 helpers (will share once Group 4c lands).

### Parity proof against Go

```
============================= test session starts ==============================
tests/test_bonus_events.py::test_list_bonuses_includes_seeded
   nbp fetch failed currency=USD err="nbp http 403"
   PASSED [12%]
tests/test_bonus_events.py::test_get_bonus_by_id_returns_seeded_record   PASSED
tests/test_bonus_events.py::test_get_bonus_not_found                     PASSED
tests/test_bonus_events.py::test_create_bonus_happy_path                 PASSED
tests/test_bonus_events.py::test_create_bonus_validation_error           PASSED
tests/test_bonus_events.py::test_update_bonus_happy_path                 PASSED
tests/test_bonus_events.py::test_update_bonus_validation_error           PASSED
tests/test_bonus_events.py::test_delete_bonus_happy_path                 PASSED
============================== 8 passed in 0.33s ===============================
```

NBP returned 403 from the local test runner (rate-limit / non-PL IP); the cache fallback worked exactly as the Python service does — same behavior on transient NBP outage.

### `routes.yaml`

Four new rules — GET/POST/PATCH/DELETE — for `/api/bonuses/`. Group 4 progress: 2 of 3 slices live; equity grants (4c) next.

## Supporting documentation

- Umbrella: #435
- Group 4 subissue: #439
- Slice 4a: #459 (merged)
- Procedure: `migration/CUTOVER.md`

> Changelog: skip