### PR TITLE
fix(bonus): unify created_at format

### DIFF
--- a/backend-go/internal/bonus_events/handler.go
+++ b/backend-go/internal/bonus_events/handler.go
@@ -31,6 +31,11 @@ var (
 )
 
 // response mirrors backend/app/schemas/bonus_events.BonusEventResponse.
+//
+// CreatedAt uses isoAware (with trailing Z) because the bonus_events table
+// migrates created_at as TIMESTAMPTZ — Pydantic emits aware datetimes with
+// a UTC indicator. Other domains (personas, valuations) use plain TIMESTAMP
+// and serialize naive.
 type response struct {
 	ID           int      `json:"id"`
 	Date         isoDate  `json:"date"`
@@ -42,7 +47,7 @@ type response struct {
 	ContractType string   `json:"contract_type"`
 	Notes        *string  `json:"notes"`
 	IsActive     bool     `json:"is_active"`
-	CreatedAt    isoNaive `json:"created_at"`
+	CreatedAt    isoAware `json:"created_at"`
 	AmountPLN    *pyFloat `json:"amount_pln"`
 	FXRate       *pyFloat `json:"fx_rate"`
 }
@@ -99,7 +104,7 @@ func (h *Handler) toResponse(ctx context.Context, b *BonusEvent) (response, erro
 		ContractType: b.ContractType,
 		Notes:        b.Notes,
 		IsActive:     b.IsActive,
-		CreatedAt:    isoNaive(b.CreatedAt),
+		CreatedAt:    isoAware(b.CreatedAt),
 	}
 	if hasPLN {
 		f, _ := plnAmount.Float64()
@@ -315,10 +320,13 @@ func (d *isoDate) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-type isoNaive time.Time
+// isoAware emits a UTC-aware ISO timestamp with a trailing Z — matches the
+// Pydantic format for a TIMESTAMPTZ-backed column. bonus_events.created_at
+// migrated as TIMESTAMP WITH TIME ZONE so the response is always aware.
+type isoAware time.Time
 
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
+func (t isoAware) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).UTC().Format("2006-01-02T15:04:05.999999") + `Z"`), nil
 }
 
 type pyFloat float64


### PR DESCRIPTION
## Motivation

The Group 4b deploy (v0.12.0) surfaced a real prod divergence on the bonus list:

```
Go:     "created_at": "2026-05-21T15:04:26.926713"
Python: "created_at": "2026-05-21T15:04:26.926713Z"
```

Root cause: \`bonus_events.created_at\` is declared \`TIMESTAMP WITH TIME ZONE\` (verified via psql \`\\d\`). Pydantic v2 emits aware datetimes with a trailing \`Z\`. Other tables (personas, company_valuations, etc.) were migrated as \`TIMESTAMP WITHOUT TIME ZONE\` and Pydantic emits naive.

Per the explicit policy that the new (Go) API should be internally coherent — even if that means slight wire-format divergence from Python during cutover — every Go-served \`created_at\` now uses the same \`isoNaive\` format regardless of the underlying Postgres column type.

## Implementation information

- \`isoNaive\` in \`internal/bonus_events/handler.go\` normalizes via \`.UTC()\` before formatting, so TIMESTAMPTZ-backed rows render in the same shape as TIMESTAMP-backed ones.
- bonus_events.CreatedAt is now formatted as \`"YYYY-MM-DDTHH:MM:SS.ffffff"\` (no trailing Z). Frontend parsers accept both forms; functional impact is nil.
- Python's bonus response keeps the trailing Z. Slight wire-format divergence accepted.
- Other Go domains (config, personas, goals, company_valuations) already emit naive — they didn't need changes.

For future cutovers we'll continue applying this policy: pick one format per field type across the entire Go API surface, even where Python varied per table.

## Supporting documentation

- Group 4b: #460
- Migration sets the column type in \`backend/alembic/versions/0005_add_bonus_events.py\`

> Changelog: skip