### PR TITLE
fix(bonus): drop isoAware, unify on isoNaive

### DIFF
--- a/backend-go/internal/bonus_events/handler.go
+++ b/backend-go/internal/bonus_events/handler.go
@@ -32,10 +32,10 @@ var (
 
 // response mirrors backend/app/schemas/bonus_events.BonusEventResponse.
 //
-// CreatedAt uses isoAware (with trailing Z) because the bonus_events table
-// migrates created_at as TIMESTAMPTZ — Pydantic emits aware datetimes with
-// a UTC indicator. Other domains (personas, valuations) use plain TIMESTAMP
-// and serialize naive.
+// CreatedAt uses isoNaive — same format every Go-served endpoint emits.
+// Python's bonus_events column is TIMESTAMPTZ and Pydantic appends Z; the
+// Go API deliberately diverges (no Z) so the new API stays internally
+// coherent regardless of which migration declared which column type.
 type response struct {
 	ID           int      `json:"id"`
 	Date         isoDate  `json:"date"`
@@ -47,7 +47,7 @@ type response struct {
 	ContractType string   `json:"contract_type"`
 	Notes        *string  `json:"notes"`
 	IsActive     bool     `json:"is_active"`
-	CreatedAt    isoAware `json:"created_at"`
+	CreatedAt    isoNaive `json:"created_at"`
 	AmountPLN    *pyFloat `json:"amount_pln"`
 	FXRate       *pyFloat `json:"fx_rate"`
 }
@@ -104,7 +104,7 @@ func (h *Handler) toResponse(ctx context.Context, b *BonusEvent) (response, erro
 		ContractType: b.ContractType,
 		Notes:        b.Notes,
 		IsActive:     b.IsActive,
-		CreatedAt:    isoAware(b.CreatedAt),
+		CreatedAt:    isoNaive(b.CreatedAt.UTC()),
 	}
 	if hasPLN {
 		f, _ := plnAmount.Float64()
@@ -320,13 +320,13 @@ func (d *isoDate) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// isoAware emits a UTC-aware ISO timestamp with a trailing Z — matches the
-// Pydantic format for a TIMESTAMPTZ-backed column. bonus_events.created_at
-// migrated as TIMESTAMP WITH TIME ZONE so the response is always aware.
-type isoAware time.Time
+// isoNaive emits a UTC-normalized ISO timestamp without a TZ suffix — the
+// unified format the Go API uses on every created_at field, regardless of
+// whether the underlying Postgres column was declared TIMESTAMPTZ or not.
+type isoNaive time.Time
 
-func (t isoAware) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).UTC().Format("2006-01-02T15:04:05.999999") + `Z"`), nil
+func (t isoNaive) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
 }
 
 type pyFloat float64


### PR DESCRIPTION
## Motivation

Follow-up to the prior PR that merged with the wrong content. The squash-merged commit on main still carries \`isoAware\` for \`bonus_events.created_at\`, diverging from the user-requested unified-format policy.

## Implementation information

- `response.CreatedAt` switched to `isoNaive` (was `isoAware`).
- `toResponse` strips offset on the way out: `isoNaive(b.CreatedAt.UTC())`.
- `isoAware` type + its MarshalJSON dropped from the file.
- All other Go-served endpoints already emit `isoNaive`; the API is now internally coherent.

Slight wire-format divergence from Python's bonus response (Python keeps trailing `Z` because the column is TIMESTAMPTZ; Go does not) — accepted per the explicit policy on coherent new API.

## Parity proof

```
tests/test_bonus_events.py — 8/8 passing against the Go backend
```

> Changelog: skip