### PR TITLE
feat(go): cutover /api/equity-grants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,8 @@ jobs:
             tests/test_personas_mutations.py \
             tests/test_goals.py \
             tests/test_company_valuations.py \
-            tests/test_bonus_events.py
+            tests/test_bonus_events.py \
+            tests/test_equity_grants.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/backend-go/internal/company_valuations/store.go
+++ b/backend-go/internal/company_valuations/store.go
@@ -37,6 +37,10 @@ var (
 	ErrNotFound  = errors.New("company valuation not found")
 	ErrRangeLow  = errors.New("fmv_low cannot exceed fmv_per_share")
 	ErrRangeHigh = errors.New("fmv_high cannot be below fmv_per_share")
+	// ErrNoValuation signals "company has no active valuation" — a normal
+	// outcome for GetLatestForCompany that consumers (equity grants) treat
+	// as "skip paper-value computation", not as a failure.
+	ErrNoValuation = errors.New("no valuation for company")
 )
 
 // Store is the persistence boundary.
@@ -200,6 +204,30 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Valuation, 
 		return nil, fmt.Errorf("update valuation: %w", err)
 	}
 	return updated, nil
+}
+
+// GetLatestForCompany returns the most recent active valuation for a company
+// on/before onDate. Returns ErrNoValuation when no valuation exists — callers
+// (equity grants) treat that as a normal "skip paper-value computation"
+// branch rather than a failure.
+func (s *Store) GetLatestForCompany(ctx context.Context, company string, onDate *time.Time) (*Valuation, error) {
+	query := `SELECT ` + selectColumns + ` FROM company_valuations
+		WHERE company = $1 AND is_active = true`
+	args := []any{company}
+	if onDate != nil {
+		query += ` AND date <= $2`
+		args = append(args, *onDate)
+	}
+	query += ` ORDER BY date DESC LIMIT 1`
+	row := s.pool.QueryRow(ctx, query, args...)
+	v, err := scanValuation(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNoValuation
+		}
+		return nil, fmt.Errorf("select latest valuation: %w", err)
+	}
+	return v, nil
 }
 
 // Delete soft-deletes the row (matches Python's soft_delete helper).

--- a/backend-go/internal/equity_grants/errors.go
+++ b/backend-go/internal/equity_grants/errors.go
@@ -1,0 +1,41 @@
+package equitygrants
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{
+				"type":  "value_error",
+				"loc":   []string{"body", field},
+				"msg":   msg,
+				"input": input,
+			},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/equity_grants/handler.go
+++ b/backend-go/internal/equity_grants/handler.go
@@ -119,7 +119,10 @@ func (h *Handler) toResponse(ctx context.Context, g *EquityGrant) (response, err
 		LiquidityEventDate:     g.LiquidityEventDate,
 	}
 	vested := VestedSharesAt(sched, today)
-	progress := math.Round(VestingProgressPct(sched, today)*100) / 100
+	// Python uses round(x, 2) which is banker's rounding (ties-to-even).
+	// math.RoundToEven matches that semantics; math.Round would diverge on
+	// .005 ties.
+	progress := math.RoundToEven(VestingProgressPct(sched, today)*100) / 100
 
 	paper, err := computePaperValues(ctx, h.valuations, g, vested)
 	if err != nil {
@@ -341,6 +344,11 @@ func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int) {
 	if errors.Is(err, ErrNotFound) {
 		writeDetailError(w, http.StatusNotFound,
 			fmt.Sprintf("Equity grant with id %d not found", id))
+		return
+	}
+	var inv *InvariantError
+	if errors.As(err, &inv) {
+		writeValidationError(w, inv.Field, inv.Msg, "")
 		return
 	}
 	h.logger.Error("equity grant store", "err", err)

--- a/backend-go/internal/equity_grants/handler.go
+++ b/backend-go/internal/equity_grants/handler.go
@@ -1,0 +1,397 @@
+package equitygrants
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+
+	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
+	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
+)
+
+var (
+	validCurrencies = map[string]struct{}{
+		"PLN": {}, "USD": {}, "EUR": {}, "GBP": {}, "CHF": {},
+	}
+	validGrantTypes = map[string]struct{}{
+		"option": {}, "rsu": {},
+	}
+	validFrequencies = map[string]struct{}{
+		"monthly": {}, "quarterly": {}, "yearly": {},
+	}
+	validTaxTreatments = map[string]struct{}{
+		"capital_gains_19": {}, "employment_income": {},
+	}
+)
+
+// response mirrors backend/app/schemas/equity_grants.EquityGrantResponse.
+type response struct {
+	ID                     int                   `json:"id"`
+	GrantDate              isoDate               `json:"grant_date"`
+	Type                   string                `json:"type"`
+	Company                string                `json:"company"`
+	Owner                  string                `json:"owner"`
+	TotalShares            int                   `json:"total_shares"`
+	StrikePrice            *pyFloat              `json:"strike_price"`
+	Currency               string                `json:"currency"`
+	VestStartDate          isoDate               `json:"vest_start_date"`
+	VestCliffMonths        int                   `json:"vest_cliff_months"`
+	VestTotalMonths        int                   `json:"vest_total_months"`
+	VestFrequency          string                `json:"vest_frequency"`
+	VestCustomSchedule     []CustomScheduleEntry `json:"vest_custom_schedule"`
+	RequiresLiquidityEvent bool                  `json:"requires_liquidity_event"`
+	LiquidityEventDate     *isoDate              `json:"liquidity_event_date"`
+	TaxTreatment           string                `json:"tax_treatment"`
+	Notes                  *string               `json:"notes"`
+	IsActive               bool                  `json:"is_active"`
+	CreatedAt              isoNaive              `json:"created_at"`
+
+	// Computed
+	VestedSharesToday  int      `json:"vested_shares_today"`
+	VestingProgressPct pyFloat  `json:"vesting_progress_pct"`
+	PaperValueBase     *pyFloat `json:"paper_value_base"`
+	PaperValueLow      *pyFloat `json:"paper_value_low"`
+	PaperValueHigh     *pyFloat `json:"paper_value_high"`
+	PaperValueCurrency *string  `json:"paper_value_currency"`
+	PaperValueBasePLN  *pyFloat `json:"paper_value_base_pln"`
+	PaperValueLowPLN   *pyFloat `json:"paper_value_low_pln"`
+	PaperValueHighPLN  *pyFloat `json:"paper_value_high_pln"`
+	FXRate             *pyFloat `json:"fx_rate"`
+	ValuationDate      *isoDate `json:"valuation_date"`
+	ValuationSource    *string  `json:"valuation_source"`
+}
+
+type listResponse struct {
+	EquityGrants       []response `json:"equity_grants"`
+	TotalCount         int        `json:"total_count"`
+	AvailableCompanies []string   `json:"available_companies"`
+}
+
+// Handler is the HTTP boundary for /api/equity-grants.
+type Handler struct {
+	store      *Store
+	valuations *companyvaluations.Store
+	fx         *fx.Service
+	logger     *slog.Logger
+	now        func() time.Time
+}
+
+// NewHandler wires the equity-grant store + valuations + FX dependencies.
+func NewHandler(
+	store *Store,
+	valuations *companyvaluations.Store,
+	fxSvc *fx.Service,
+	logger *slog.Logger,
+) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{
+		store:      store,
+		valuations: valuations,
+		fx:         fxSvc,
+		logger:     logger,
+		now:        time.Now,
+	}
+}
+
+func (h *Handler) toResponse(ctx context.Context, g *EquityGrant) (response, error) {
+	today := h.now().UTC().Truncate(24 * time.Hour)
+	sched := Schedule{
+		TotalShares:            g.TotalShares,
+		VestStartDate:          g.VestStartDate,
+		VestCliffMonths:        g.VestCliffMonths,
+		VestTotalMonths:        g.VestTotalMonths,
+		VestFrequencyMonths:    FreqMonthsFromString(g.VestFrequency),
+		CustomSchedule:         g.VestCustomSchedule,
+		RequiresLiquidityEvent: g.RequiresLiquidityEvent,
+		LiquidityEventDate:     g.LiquidityEventDate,
+	}
+	vested := VestedSharesAt(sched, today)
+	progress := math.Round(VestingProgressPct(sched, today)*100) / 100
+
+	paper, err := computePaperValues(ctx, h.valuations, g, vested)
+	if err != nil {
+		return response{}, err
+	}
+
+	rate, err := fxRateFor(ctx, h.fx, paper.Currency, paper.ValuationDate)
+	if err != nil {
+		return response{}, err
+	}
+
+	out := response{
+		ID:                     g.ID,
+		GrantDate:              isoDate(g.GrantDate),
+		Type:                   g.Type,
+		Company:                g.Company,
+		Owner:                  g.Owner,
+		TotalShares:            g.TotalShares,
+		Currency:               g.Currency,
+		VestStartDate:          isoDate(g.VestStartDate),
+		VestCliffMonths:        g.VestCliffMonths,
+		VestTotalMonths:        g.VestTotalMonths,
+		VestFrequency:          g.VestFrequency,
+		VestCustomSchedule:     g.VestCustomSchedule,
+		RequiresLiquidityEvent: g.RequiresLiquidityEvent,
+		TaxTreatment:           g.TaxTreatment,
+		Notes:                  g.Notes,
+		IsActive:               g.IsActive,
+		CreatedAt:              isoNaive(g.CreatedAt.UTC()),
+		VestedSharesToday:      vested,
+		VestingProgressPct:     pyFloat(progress),
+	}
+	if g.StrikePrice != nil {
+		f, _ := g.StrikePrice.Float64()
+		pf := pyFloat(f)
+		out.StrikePrice = &pf
+	}
+	if g.LiquidityEventDate != nil {
+		d := isoDate(*g.LiquidityEventDate)
+		out.LiquidityEventDate = &d
+	}
+	attachPaperValues(&out, paper)
+	attachFX(&out, rate, paper.Currency, paper)
+	return out, nil
+}
+
+func attachPaperValues(out *response, paper paperValueResult) {
+	if paper.Base != nil {
+		f, _ := paper.Base.Float64()
+		pf := pyFloat(f)
+		out.PaperValueBase = &pf
+	}
+	if paper.Low != nil {
+		f, _ := paper.Low.Float64()
+		pf := pyFloat(f)
+		out.PaperValueLow = &pf
+	}
+	if paper.High != nil {
+		f, _ := paper.High.Float64()
+		pf := pyFloat(f)
+		out.PaperValueHigh = &pf
+	}
+	if paper.Currency != "" {
+		c := paper.Currency
+		out.PaperValueCurrency = &c
+	}
+	if paper.ValuationDate != nil {
+		d := isoDate(*paper.ValuationDate)
+		out.ValuationDate = &d
+	}
+	if paper.ValuationSource != "" {
+		s := paper.ValuationSource
+		out.ValuationSource = &s
+	}
+}
+
+func attachFX(out *response, rate fx.Result, currency string, paper paperValueResult) {
+	if currency == "" {
+		return
+	}
+	if rate.Found {
+		f, _ := rate.Rate.Float64()
+		pf := pyFloat(f)
+		out.FXRate = &pf
+	}
+	out.PaperValueBasePLN = pln(paper.Base, currency, rate)
+	out.PaperValueLowPLN = pln(paper.Low, currency, rate)
+	out.PaperValueHighPLN = pln(paper.High, currency, rate)
+}
+
+func pln(amount *decimal.Decimal, currency string, rate fx.Result) *pyFloat {
+	v, ok := fx.ToPLN(amount, currency, rate)
+	if !ok {
+		return nil
+	}
+	f, _ := v.Float64()
+	pf := pyFloat(f)
+	return &pf
+}
+
+// --- HTTP handlers ---
+
+// List serves GET /api/equity-grants.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	filter := ListFilter{}
+	if v := strings.TrimSpace(r.URL.Query().Get("owner")); v != "" {
+		filter.Owner = &v
+	}
+	if v := strings.TrimSpace(r.URL.Query().Get("company")); v != "" {
+		filter.Company = &v
+	}
+	rows, companies, err := h.store.List(r.Context(), filter)
+	if err != nil {
+		h.logger.Error("list equity grants", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := listResponse{
+		EquityGrants:       make([]response, 0, len(rows)),
+		TotalCount:         len(rows),
+		AvailableCompanies: companies,
+	}
+	for i := range rows {
+		resp, err := h.toResponse(r.Context(), &rows[i])
+		if err != nil {
+			h.logger.Error("equity grant response", "err", err)
+			writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+			return
+		}
+		out.EquityGrants = append(out.EquityGrants, resp)
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Get serves GET /api/equity-grants/{id}.
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	g, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		h.writeStoreError(w, err, id)
+		return
+	}
+	h.writeGrant(w, r, http.StatusOK, g)
+}
+
+// Create serves POST /api/equity-grants.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	req, vErr := buildCreateRequest(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	g := requestToGrant(req)
+	created, err := h.store.Create(r.Context(), g)
+	if err != nil {
+		h.logger.Error("create equity grant", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	h.writeGrant(w, r, http.StatusCreated, created)
+}
+
+// Update serves PATCH /api/equity-grants/{id}.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	patch, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	updated, err := h.store.Update(r.Context(), id, patch)
+	if err != nil {
+		h.writeStoreError(w, err, id)
+		return
+	}
+	h.writeGrant(w, r, http.StatusOK, updated)
+}
+
+// Delete serves DELETE /api/equity-grants/{id}.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.Delete(r.Context(), id); err != nil {
+		h.writeStoreError(w, err, id)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) writeGrant(w http.ResponseWriter, r *http.Request, status int, g *EquityGrant) {
+	resp, err := h.toResponse(r.Context(), g)
+	if err != nil {
+		h.logger.Error("equity grant response", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, status, resp)
+}
+
+func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int) {
+	if errors.Is(err, ErrNotFound) {
+		writeDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("Equity grant with id %d not found", id))
+		return
+	}
+	h.logger.Error("equity grant store", "err", err)
+	writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+}
+
+func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		writeValidationError(w, "grant_id", "must be an integer", raw)
+		return 0, false
+	}
+	return id, true
+}
+
+// --- shared wire types ---
+
+type isoDate time.Time
+
+const isoDateLayout = "2006-01-02"
+
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
+}
+
+func (d *isoDate) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("date must be a string: %w", err)
+	}
+	t, err := time.Parse(isoDateLayout, s)
+	if err != nil {
+		return fmt.Errorf("date must be YYYY-MM-DD: %w", err)
+	}
+	*d = isoDate(t)
+	return nil
+}
+
+type isoNaive time.Time
+
+func (t isoNaive) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
+}
+
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/equity_grants/paper_value.go
+++ b/backend-go/internal/equity_grants/paper_value.go
@@ -1,0 +1,112 @@
+package equitygrants
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
+	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
+)
+
+// paperValueResult bundles the per-share-vested values (base / low / high)
+// plus the valuation metadata that drove them. Mirrors the tuple Python
+// returns from _paper_values.
+type paperValueResult struct {
+	Base            *decimal.Decimal
+	Low             *decimal.Decimal
+	High            *decimal.Decimal
+	Currency        string
+	ValuationDate   *time.Time
+	ValuationSource string
+}
+
+// computePaperValues replicates backend/app/services/equity_grants._paper_values.
+//
+// Only computes when grant and valuation currencies match (Python keeps FX-
+// across-share-value out of scope). All-nil result when no valuation exists
+// or zero shares are vested.
+func computePaperValues(
+	ctx context.Context,
+	valuations *companyvaluations.Store,
+	g *EquityGrant,
+	vested int,
+) (paperValueResult, error) {
+	result := paperValueResult{}
+	valuation, err := valuations.GetLatestForCompany(ctx, g.Company, nil)
+	if err != nil {
+		if errors.Is(err, companyvaluations.ErrNoValuation) {
+			return result, nil
+		}
+		return result, err
+	}
+	if vested <= 0 {
+		return result, nil
+	}
+	// Capture metadata that's also surfaced when currencies mismatch.
+	valDate := valuation.Date
+	result.ValuationDate = &valDate
+	result.ValuationSource = valuation.Source
+	if valuation.Currency != g.Currency {
+		return result, nil
+	}
+
+	fmvBase := valuation.FMVPerShare
+	fmvLow := fmvBase
+	if valuation.FMVLow != nil {
+		fmvLow = *valuation.FMVLow
+	}
+	fmvHigh := fmvBase
+	if valuation.FMVHigh != nil {
+		fmvHigh = *valuation.FMVHigh
+	}
+	perShareBase := intrinsicShareValue(g.Type, fmvBase, g.StrikePrice)
+	perShareLow := intrinsicShareValue(g.Type, fmvLow, g.StrikePrice)
+	perShareHigh := intrinsicShareValue(g.Type, fmvHigh, g.StrikePrice)
+	vestedDec := decimal.NewFromInt(int64(vested))
+	base := perShareBase.Mul(vestedDec)
+	low := perShareLow.Mul(vestedDec)
+	high := perShareHigh.Mul(vestedDec)
+	result.Base = &base
+	result.Low = &low
+	result.High = &high
+	result.Currency = valuation.Currency
+	return result, nil
+}
+
+// intrinsicShareValue: FMV for RSU, max(FMV - strike, 0) for options.
+func intrinsicShareValue(grantType string, fmv decimal.Decimal, strike *decimal.Decimal) decimal.Decimal {
+	if grantType != "option" {
+		return fmv
+	}
+	if strike == nil {
+		return decimal.Zero
+	}
+	diff := fmv.Sub(*strike)
+	if diff.IsNegative() {
+		return decimal.Zero
+	}
+	return diff
+}
+
+// fxRateFor returns the rate for the valuation's currency on its date. Used
+// to convert paper_value_*_pln so the PLN figure matches when the valuation
+// was set, not today's FX (parity with Python's get_fx_rate_to_pln(db,
+// pv_currency, pv_date)).
+func fxRateFor(
+	ctx context.Context,
+	fxSvc *fx.Service,
+	currency string,
+	on *time.Time,
+) (fx.Result, error) {
+	if currency == "" {
+		return fx.Result{}, nil
+	}
+	target := time.Time{}
+	if on != nil {
+		target = *on
+	}
+	return fxSvc.GetRateToPLN(ctx, currency, target)
+}

--- a/backend-go/internal/equity_grants/store.go
+++ b/backend-go/internal/equity_grants/store.go
@@ -1,0 +1,324 @@
+package equitygrants
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// EquityGrant mirrors backend/app/models/equity_grant.EquityGrant.
+type EquityGrant struct {
+	ID                     int
+	GrantDate              time.Time
+	Type                   string
+	Company                string
+	Owner                  string
+	TotalShares            int
+	StrikePrice            *decimal.Decimal
+	Currency               string
+	VestStartDate          time.Time
+	VestCliffMonths        int
+	VestTotalMonths        int
+	VestFrequency          string
+	VestCustomSchedule     []CustomScheduleEntry
+	RequiresLiquidityEvent bool
+	LiquidityEventDate     *time.Time
+	TaxTreatment           string
+	Notes                  *string
+	IsActive               bool
+	CreatedAt              time.Time
+}
+
+// ErrNotFound is returned when a row is missing or soft-deleted.
+var ErrNotFound = errors.New("equity grant not found")
+
+// ListFilter narrows the active rows.
+type ListFilter struct {
+	Owner   *string
+	Company *string
+}
+
+// Store is the persistence boundary.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const selectColumns = `
+	id, grant_date, type, company, owner, total_shares, strike_price, currency,
+	vest_start_date, vest_cliff_months, vest_total_months, vest_frequency,
+	vest_custom_schedule, requires_liquidity_event, liquidity_event_date,
+	tax_treatment, notes, is_active, created_at
+`
+
+// List returns active grants ordered by grant_date desc + distinct active companies.
+func (s *Store) List(ctx context.Context, f ListFilter) ([]EquityGrant, []string, error) {
+	conds := []string{"is_active = true"}
+	args := []any{}
+	if f.Owner != nil {
+		args = append(args, *f.Owner)
+		conds = append(conds, fmt.Sprintf("owner = $%d", len(args)))
+	}
+	if f.Company != nil {
+		args = append(args, *f.Company)
+		conds = append(conds, fmt.Sprintf("company = $%d", len(args)))
+	}
+	query := `SELECT ` + selectColumns + ` FROM equity_grants WHERE ` +
+		strings.Join(conds, " AND ") + ` ORDER BY grant_date DESC`
+
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("select equity grants: %w", err)
+	}
+	defer rows.Close()
+	out := []EquityGrant{}
+	for rows.Next() {
+		g, err := scanGrant(rows)
+		if err != nil {
+			return nil, nil, fmt.Errorf("scan equity grant: %w", err)
+		}
+		out = append(out, *g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate equity grants: %w", err)
+	}
+	companies, err := s.activeCompanies(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, companies, nil
+}
+
+// Get returns the active grant or ErrNotFound.
+func (s *Store) Get(ctx context.Context, id int) (*EquityGrant, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+selectColumns+` FROM equity_grants WHERE id = $1`, id,
+	)
+	g, err := scanGrant(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("select equity grant: %w", err)
+	}
+	if !g.IsActive {
+		return nil, ErrNotFound
+	}
+	return g, nil
+}
+
+// Create inserts a row.
+func (s *Store) Create(ctx context.Context, g *EquityGrant) (*EquityGrant, error) {
+	customJSON, err := encodeSchedule(g.VestCustomSchedule)
+	if err != nil {
+		return nil, fmt.Errorf("encode schedule: %w", err)
+	}
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO equity_grants (
+			grant_date, type, company, owner, total_shares, strike_price, currency,
+			vest_start_date, vest_cliff_months, vest_total_months, vest_frequency,
+			vest_custom_schedule, requires_liquidity_event, liquidity_event_date,
+			tax_treatment, notes, is_active, created_at
+		) VALUES (
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
+			true, $17
+		) RETURNING `+selectColumns,
+		g.GrantDate, g.Type, g.Company, g.Owner, g.TotalShares, g.StrikePrice, g.Currency,
+		g.VestStartDate, g.VestCliffMonths, g.VestTotalMonths, g.VestFrequency,
+		customJSON, g.RequiresLiquidityEvent, g.LiquidityEventDate,
+		g.TaxTreatment, g.Notes, time.Now().UTC(),
+	)
+	return scanGrant(row)
+}
+
+// UpdatePatch is the sparse update set; nil means "leave alone".
+type UpdatePatch struct {
+	GrantDate              *time.Time
+	Type                   *string
+	Company                *string
+	Owner                  *string
+	TotalShares            *int
+	StrikePrice            *decimal.Decimal
+	Currency               *string
+	VestStartDate          *time.Time
+	VestCliffMonths        *int
+	VestTotalMonths        *int
+	VestFrequency          *string
+	VestCustomScheduleSet  bool
+	VestCustomSchedule     []CustomScheduleEntry
+	RequiresLiquidityEvent *bool
+	LiquidityEventDate     *time.Time
+	TaxTreatment           *string
+	Notes                  *string
+}
+
+// Update applies the patch.
+func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*EquityGrant, error) {
+	g, err := s.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	applyPatch(g, p)
+	customJSON, err := encodeSchedule(g.VestCustomSchedule)
+	if err != nil {
+		return nil, fmt.Errorf("encode schedule: %w", err)
+	}
+	row := s.pool.QueryRow(ctx, `
+		UPDATE equity_grants SET
+			grant_date = $1, type = $2, company = $3, owner = $4,
+			total_shares = $5, strike_price = $6, currency = $7,
+			vest_start_date = $8, vest_cliff_months = $9, vest_total_months = $10,
+			vest_frequency = $11, vest_custom_schedule = $12,
+			requires_liquidity_event = $13, liquidity_event_date = $14,
+			tax_treatment = $15, notes = $16
+		WHERE id = $17 AND is_active = true
+		RETURNING `+selectColumns,
+		g.GrantDate, g.Type, g.Company, g.Owner,
+		g.TotalShares, g.StrikePrice, g.Currency,
+		g.VestStartDate, g.VestCliffMonths, g.VestTotalMonths,
+		g.VestFrequency, customJSON,
+		g.RequiresLiquidityEvent, g.LiquidityEventDate,
+		g.TaxTreatment, g.Notes, id,
+	)
+	updated, err := scanGrant(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("update equity grant: %w", err)
+	}
+	return updated, nil
+}
+
+// Delete soft-deletes.
+func (s *Store) Delete(ctx context.Context, id int) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE equity_grants SET is_active = false WHERE id = $1 AND is_active = true`,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("soft-delete equity grant: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) activeCompanies(ctx context.Context) ([]string, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT DISTINCT company FROM equity_grants
+		 WHERE is_active = true ORDER BY company`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("select active companies: %w", err)
+	}
+	defer rows.Close()
+	out := []string{}
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, fmt.Errorf("scan company: %w", err)
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate companies: %w", err)
+	}
+	return out, nil
+}
+
+func scanGrant(row pgx.Row) (*EquityGrant, error) {
+	var g EquityGrant
+	var customJSON []byte
+	err := row.Scan(
+		&g.ID, &g.GrantDate, &g.Type, &g.Company, &g.Owner,
+		&g.TotalShares, &g.StrikePrice, &g.Currency,
+		&g.VestStartDate, &g.VestCliffMonths, &g.VestTotalMonths,
+		&g.VestFrequency, &customJSON,
+		&g.RequiresLiquidityEvent, &g.LiquidityEventDate,
+		&g.TaxTreatment, &g.Notes, &g.IsActive, &g.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(customJSON) > 0 && string(customJSON) != "null" {
+		var parsed []CustomScheduleEntry
+		if err := json.Unmarshal(customJSON, &parsed); err != nil {
+			return nil, fmt.Errorf("decode vest_custom_schedule: %w", err)
+		}
+		g.VestCustomSchedule = parsed
+	}
+	return &g, nil
+}
+
+// encodeSchedule returns the JSON encoding of entries, or nil bytes to write
+// SQL NULL into the vest_custom_schedule column when there is no schedule.
+func encodeSchedule(entries []CustomScheduleEntry) ([]byte, error) {
+	if entries == nil {
+		return nil, nil
+	}
+	return json.Marshal(entries)
+}
+
+func applyPatch(g *EquityGrant, p UpdatePatch) {
+	if p.GrantDate != nil {
+		g.GrantDate = *p.GrantDate
+	}
+	if p.Type != nil {
+		g.Type = *p.Type
+	}
+	if p.Company != nil {
+		g.Company = *p.Company
+	}
+	if p.Owner != nil {
+		g.Owner = *p.Owner
+	}
+	if p.TotalShares != nil {
+		g.TotalShares = *p.TotalShares
+	}
+	if p.StrikePrice != nil {
+		g.StrikePrice = p.StrikePrice
+	}
+	if p.Currency != nil {
+		g.Currency = *p.Currency
+	}
+	if p.VestStartDate != nil {
+		g.VestStartDate = *p.VestStartDate
+	}
+	if p.VestCliffMonths != nil {
+		g.VestCliffMonths = *p.VestCliffMonths
+	}
+	if p.VestTotalMonths != nil {
+		g.VestTotalMonths = *p.VestTotalMonths
+	}
+	if p.VestFrequency != nil {
+		g.VestFrequency = *p.VestFrequency
+	}
+	if p.VestCustomScheduleSet {
+		g.VestCustomSchedule = p.VestCustomSchedule
+	}
+	if p.RequiresLiquidityEvent != nil {
+		g.RequiresLiquidityEvent = *p.RequiresLiquidityEvent
+	}
+	if p.LiquidityEventDate != nil {
+		g.LiquidityEventDate = p.LiquidityEventDate
+	}
+	if p.TaxTreatment != nil {
+		g.TaxTreatment = *p.TaxTreatment
+	}
+	if p.Notes != nil {
+		g.Notes = p.Notes
+	}
+}

--- a/backend-go/internal/equity_grants/store.go
+++ b/backend-go/internal/equity_grants/store.go
@@ -39,6 +39,18 @@ type EquityGrant struct {
 // ErrNotFound is returned when a row is missing or soft-deleted.
 var ErrNotFound = errors.New("equity grant not found")
 
+// InvariantError is returned by Update when applying a patch violates a
+// cross-field invariant (cliff > total, option without strike, etc). The
+// handler maps it to a 422.
+type InvariantError struct {
+	Field string
+	Msg   string
+}
+
+func (e *InvariantError) Error() string {
+	return e.Field + ": " + e.Msg
+}
+
 // ListFilter narrows the active rows.
 type ListFilter struct {
 	Owner   *string
@@ -170,6 +182,24 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*EquityGrant
 		return nil, err
 	}
 	applyPatch(g, p)
+	// Mirror Python's cross-field invariants on the merged record.
+	// RSU clears any lingering strike — Python's schema enforces this in
+	// the model validator; we do it post-patch.
+	if g.Type == "rsu" {
+		g.StrikePrice = nil
+	}
+	if g.VestCliffMonths > g.VestTotalMonths {
+		return nil, &InvariantError{
+			Field: "vest_cliff_months",
+			Msg:   "Cliff months cannot exceed total vesting months",
+		}
+	}
+	if g.Type == "option" && g.StrikePrice == nil {
+		return nil, &InvariantError{
+			Field: "strike_price",
+			Msg:   "Stock options require a strike price",
+		}
+	}
 	customJSON, err := encodeSchedule(g.VestCustomSchedule)
 	if err != nil {
 		return nil, fmt.Errorf("encode schedule: %w", err)

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -1,0 +1,599 @@
+package equitygrants
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// createRequest is the parsed-and-validated input ready for Store.Create.
+type createRequest struct {
+	GrantDate              time.Time
+	Type                   string
+	Company                string
+	Owner                  string
+	TotalShares            int
+	StrikePrice            *decimal.Decimal
+	Currency               string
+	VestStartDate          time.Time
+	VestCliffMonths        int
+	VestTotalMonths        int
+	VestFrequency          string
+	VestCustomSchedule     []CustomScheduleEntry
+	RequiresLiquidityEvent bool
+	LiquidityEventDate     *time.Time
+	TaxTreatment           string
+	Notes                  *string
+}
+
+func requestToGrant(req createRequest) *EquityGrant {
+	return &EquityGrant{
+		GrantDate:              req.GrantDate,
+		Type:                   req.Type,
+		Company:                req.Company,
+		Owner:                  req.Owner,
+		TotalShares:            req.TotalShares,
+		StrikePrice:            req.StrikePrice,
+		Currency:               req.Currency,
+		VestStartDate:          req.VestStartDate,
+		VestCliffMonths:        req.VestCliffMonths,
+		VestTotalMonths:        req.VestTotalMonths,
+		VestFrequency:          req.VestFrequency,
+		VestCustomSchedule:     req.VestCustomSchedule,
+		RequiresLiquidityEvent: req.RequiresLiquidityEvent,
+		LiquidityEventDate:     req.LiquidityEventDate,
+		TaxTreatment:           req.TaxTreatment,
+		Notes:                  req.Notes,
+	}
+}
+
+// buildCreateRequest validates the POST body. Numbers go through
+// decimal.NewFromString on the raw token to preserve Numeric precision.
+func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *validationError) {
+	var r createRequest
+	if vErr := requireGrantBasics(raw, &r); vErr != nil {
+		return r, vErr
+	}
+	if vErr := requireGrantVesting(raw, &r); vErr != nil {
+		return r, vErr
+	}
+	if vErr := optionalGrantLiquidity(raw, &r); vErr != nil {
+		return r, vErr
+	}
+	if vErr := optionalGrantTaxNotes(raw, &r); vErr != nil {
+		return r, vErr
+	}
+	if r.VestCliffMonths > r.VestTotalMonths {
+		return r, &validationError{
+			Field: "vest_cliff_months",
+			Msg:   "Cliff months cannot exceed total vesting months",
+		}
+	}
+	if r.Type == "option" && r.StrikePrice == nil {
+		return r, &validationError{
+			Field: "strike_price", Msg: "Stock options require a strike price",
+		}
+	}
+	return r, nil
+}
+
+func requireGrantBasics(raw map[string]json.RawMessage, r *createRequest) *validationError {
+	t, vErr := requireDate(raw, "grant_date")
+	if vErr != nil {
+		return vErr
+	}
+	r.GrantDate = t
+
+	grantType, vErr := requireEnumString(raw, "type", validGrantTypes)
+	if vErr != nil {
+		return vErr
+	}
+	r.Type = grantType
+
+	company, vErr := requireString(raw, "company", "Company cannot be empty")
+	if vErr != nil {
+		return vErr
+	}
+	r.Company = company
+
+	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
+	if vErr != nil {
+		return vErr
+	}
+	r.Owner = owner
+
+	totalShares, vErr := requirePositiveInt(raw, "total_shares", "Total shares must be greater than 0")
+	if vErr != nil {
+		return vErr
+	}
+	r.TotalShares = totalShares
+
+	strike, vErr := optionalNonNegativeDecimal(raw, "strike_price", "Strike price must be non-negative")
+	if vErr != nil {
+		return vErr
+	}
+	r.StrikePrice = strike
+
+	currency, vErr := optionalCurrency(raw, "USD")
+	if vErr != nil {
+		return vErr
+	}
+	r.Currency = currency
+	return nil
+}
+
+func requireGrantVesting(raw map[string]json.RawMessage, r *createRequest) *validationError {
+	vsd, vErr := requireDate(raw, "vest_start_date")
+	if vErr != nil {
+		return vErr
+	}
+	r.VestStartDate = vsd
+
+	cliff, vErr := optionalNonNegativeInt(raw, "vest_cliff_months", "Cliff months must be non-negative", 0)
+	if vErr != nil {
+		return vErr
+	}
+	r.VestCliffMonths = cliff
+
+	total, vErr := requirePositiveInt(raw, "vest_total_months", "Total vesting months must be greater than 0")
+	if vErr != nil {
+		return vErr
+	}
+	r.VestTotalMonths = total
+
+	freq, vErr := requireEnumString(raw, "vest_frequency", validFrequencies)
+	if vErr != nil {
+		return vErr
+	}
+	r.VestFrequency = freq
+
+	schedule, vErr := optionalCustomSchedule(raw)
+	if vErr != nil {
+		return vErr
+	}
+	r.VestCustomSchedule = schedule
+	return nil
+}
+
+func optionalGrantLiquidity(raw map[string]json.RawMessage, r *createRequest) *validationError {
+	if v, ok := raw["requires_liquidity_event"]; ok && !isNull(v) {
+		var b bool
+		if err := json.Unmarshal(v, &b); err != nil {
+			return &validationError{Field: "requires_liquidity_event", Msg: "must be a boolean"}
+		}
+		r.RequiresLiquidityEvent = b
+	}
+	if v, ok := raw["liquidity_event_date"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "liquidity_event_date", Msg: "must be a string"}
+		}
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return &validationError{Field: "liquidity_event_date", Msg: "must be YYYY-MM-DD"}
+		}
+		r.LiquidityEventDate = &t
+	}
+	return nil
+}
+
+func optionalGrantTaxNotes(raw map[string]json.RawMessage, r *createRequest) *validationError {
+	tax, vErr := optionalEnumString(raw, "tax_treatment", validTaxTreatments, "capital_gains_19")
+	if vErr != nil {
+		return vErr
+	}
+	r.TaxTreatment = tax
+
+	if v, ok := raw["notes"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "notes", Msg: "must be a string"}
+		}
+		r.Notes = &s
+	}
+	return nil
+}
+
+// buildUpdatePatch reads the PATCH body. Null = no-op for scalar fields;
+// vest_custom_schedule explicit-null clears the JSON column.
+func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *validationError) {
+	var p UpdatePatch
+	if vErr := patchStrings(raw, &p); vErr != nil {
+		return p, vErr
+	}
+	if vErr := patchNumbersAndBools(raw, &p); vErr != nil {
+		return p, vErr
+	}
+	if vErr := patchDates(raw, &p); vErr != nil {
+		return p, vErr
+	}
+	if vErr := patchSchedule(raw, &p); vErr != nil {
+		return p, vErr
+	}
+	return p, nil
+}
+
+func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *validationError {
+	if vErr := patchEnumString(raw, "type", validGrantTypes, &p.Type); vErr != nil {
+		return vErr
+	}
+	if vErr := patchNonEmptyString(raw, "company", "Company cannot be empty", &p.Company); vErr != nil {
+		return vErr
+	}
+	if vErr := patchNonEmptyString(raw, "owner", "Owner cannot be empty", &p.Owner); vErr != nil {
+		return vErr
+	}
+	if vErr := patchCurrency(raw, &p.Currency); vErr != nil {
+		return vErr
+	}
+	if vErr := patchEnumString(raw, "vest_frequency", validFrequencies, &p.VestFrequency); vErr != nil {
+		return vErr
+	}
+	if vErr := patchEnumString(raw, "tax_treatment", validTaxTreatments, &p.TaxTreatment); vErr != nil {
+		return vErr
+	}
+	if v, ok := raw["notes"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: "notes", Msg: "must be a string"}
+		}
+		p.Notes = &s
+	}
+	return nil
+}
+
+func patchNumbersAndBools(raw map[string]json.RawMessage, p *UpdatePatch) *validationError {
+	if vErr := patchPositiveInt(raw, "total_shares", "Total shares must be greater than 0", &p.TotalShares); vErr != nil {
+		return vErr
+	}
+	if vErr := patchNonNegativeIntPtr(raw, "vest_cliff_months", "Cliff months must be non-negative", &p.VestCliffMonths); vErr != nil {
+		return vErr
+	}
+	if vErr := patchPositiveInt(raw, "vest_total_months", "Total vesting months must be greater than 0", &p.VestTotalMonths); vErr != nil {
+		return vErr
+	}
+	if v, ok := raw["strike_price"]; ok && !isNull(v) {
+		d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+		if err != nil {
+			return &validationError{Field: "strike_price", Msg: "must be a number"}
+		}
+		if d.IsNegative() {
+			return &validationError{Field: "strike_price", Msg: "Strike price must be non-negative"}
+		}
+		p.StrikePrice = &d
+	}
+	if v, ok := raw["requires_liquidity_event"]; ok && !isNull(v) {
+		var b bool
+		if err := json.Unmarshal(v, &b); err != nil {
+			return &validationError{Field: "requires_liquidity_event", Msg: "must be a boolean"}
+		}
+		p.RequiresLiquidityEvent = &b
+	}
+	return nil
+}
+
+func patchDates(raw map[string]json.RawMessage, p *UpdatePatch) *validationError {
+	for _, f := range [...]struct {
+		key  string
+		dest **time.Time
+	}{
+		{"grant_date", &p.GrantDate},
+		{"vest_start_date", &p.VestStartDate},
+		{"liquidity_event_date", &p.LiquidityEventDate},
+	} {
+		v, ok := raw[f.key]
+		if !ok || isNull(v) {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return &validationError{Field: f.key, Msg: "must be a string"}
+		}
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return &validationError{Field: f.key, Msg: "must be YYYY-MM-DD"}
+		}
+		*f.dest = &t
+	}
+	return nil
+}
+
+func patchSchedule(raw map[string]json.RawMessage, p *UpdatePatch) *validationError {
+	v, ok := raw["vest_custom_schedule"]
+	if !ok {
+		return nil
+	}
+	p.VestCustomScheduleSet = true
+	if isNull(v) {
+		return nil
+	}
+	schedule, vErr := parseCustomSchedule(v)
+	if vErr != nil {
+		return vErr
+	}
+	p.VestCustomSchedule = schedule
+	return nil
+}
+
+// --- shared decoders ---
+
+func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", &validationError{Field: key, Msg: emptyMsg}
+	}
+	return s, nil
+}
+
+func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return time.Time{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be a string"}
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be YYYY-MM-DD"}
+	}
+	return t, nil
+}
+
+func requirePositiveInt(raw map[string]json.RawMessage, key, msg string) (int, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return 0, &validationError{Field: key, Msg: "Field required"}
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return 0, &validationError{Field: key, Msg: "must be an integer"}
+	}
+	if n <= 0 {
+		return 0, &validationError{Field: key, Msg: msg}
+	}
+	return n, nil
+}
+
+func optionalNonNegativeInt(raw map[string]json.RawMessage, key, msg string, fallback int) (int, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return fallback, nil
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return 0, &validationError{Field: key, Msg: "must be an integer"}
+	}
+	if n < 0 {
+		return 0, &validationError{Field: key, Msg: msg}
+	}
+	return n, nil
+}
+
+func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return "", &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	return s, nil
+}
+
+func optionalEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}, fallback string) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return fallback, nil
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return "", &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	return s, nil
+}
+
+func optionalCurrency(raw map[string]json.RawMessage, fallback string) (string, *validationError) {
+	v, ok := raw["currency"]
+	if !ok || isNull(v) {
+		return fallback, nil
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: "currency", Msg: "must be a string"}
+	}
+	s = strings.ToUpper(strings.TrimSpace(s))
+	if _, ok := validCurrencies[s]; !ok {
+		return "", &validationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
+	}
+	return s, nil
+}
+
+func optionalNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) (*decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return nil, nil
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if err != nil {
+		return nil, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if d.IsNegative() {
+		return nil, &validationError{Field: key, Msg: msg}
+	}
+	return &d, nil
+}
+
+func optionalCustomSchedule(raw map[string]json.RawMessage) ([]CustomScheduleEntry, *validationError) {
+	v, ok := raw["vest_custom_schedule"]
+	if !ok || isNull(v) {
+		return nil, nil
+	}
+	return parseCustomSchedule(v)
+}
+
+func parseCustomSchedule(v json.RawMessage) ([]CustomScheduleEntry, *validationError) {
+	var entries []map[string]any
+	if err := json.Unmarshal(v, &entries); err != nil {
+		return nil, &validationError{Field: "vest_custom_schedule", Msg: "must be an array of objects"}
+	}
+	out := make([]CustomScheduleEntry, 0, len(entries))
+	for _, entry := range entries {
+		monthVal, hasMonth := entry["month"]
+		pctVal, hasPct := entry["pct"]
+		if !hasMonth || !hasPct {
+			return nil, &validationError{
+				Field: "vest_custom_schedule",
+				Msg:   "Custom schedule entries require 'month' and 'pct'",
+			}
+		}
+		month, mErr := toInt(monthVal)
+		if mErr != nil || month < 0 {
+			return nil, &validationError{
+				Field: "vest_custom_schedule",
+				Msg:   "Custom schedule month must be a non-negative integer",
+			}
+		}
+		pct, pErr := toFloat(pctVal)
+		if pErr != nil || pct < 0 {
+			return nil, &validationError{
+				Field: "vest_custom_schedule",
+				Msg:   "Custom schedule pct must be a non-negative number",
+			}
+		}
+		out = append(out, CustomScheduleEntry{Month: month, Pct: pct})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Month < out[j].Month })
+	return out, nil
+}
+
+func toInt(v any) (int, error) {
+	switch x := v.(type) {
+	case float64:
+		return int(x), nil
+	case int:
+		return x, nil
+	default:
+		return 0, fmt.Errorf("not a number")
+	}
+}
+
+func toFloat(v any) (float64, error) {
+	switch x := v.(type) {
+	case float64:
+		return x, nil
+	case int:
+		return float64(x), nil
+	default:
+		return 0, fmt.Errorf("not a number")
+	}
+}
+
+// --- PATCH helpers ---
+
+func patchEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}, dest **string) *validationError {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return &validationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	*dest = &s
+	return nil
+}
+
+func patchNonEmptyString(raw map[string]json.RawMessage, key, emptyMsg string, dest **string) *validationError {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return &validationError{Field: key, Msg: "must be a string"}
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return &validationError{Field: key, Msg: emptyMsg}
+	}
+	*dest = &s
+	return nil
+}
+
+func patchCurrency(raw map[string]json.RawMessage, dest **string) *validationError {
+	v, ok := raw["currency"]
+	if !ok || isNull(v) {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return &validationError{Field: "currency", Msg: "must be a string"}
+	}
+	s = strings.ToUpper(strings.TrimSpace(s))
+	if _, ok := validCurrencies[s]; !ok {
+		return &validationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
+	}
+	*dest = &s
+	return nil
+}
+
+func patchPositiveInt(raw map[string]json.RawMessage, key, msg string, dest **int) *validationError {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return nil
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return &validationError{Field: key, Msg: "must be an integer"}
+	}
+	if n <= 0 {
+		return &validationError{Field: key, Msg: msg}
+	}
+	*dest = &n
+	return nil
+}
+
+func patchNonNegativeIntPtr(raw map[string]json.RawMessage, key, msg string, dest **int) *validationError {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return nil
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return &validationError{Field: key, Msg: "must be an integer"}
+	}
+	if n < 0 {
+		return &validationError{Field: key, Msg: msg}
+	}
+	*dest = &n
+	return nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -303,19 +303,19 @@ func patchDates(raw map[string]json.RawMessage, p *UpdatePatch) *validationError
 	return nil
 }
 
+// patchSchedule reads vest_custom_schedule. Matches Python's update_equity_grant
+// behavior: explicit null is treated the same as omitted (no-op); only an
+// actual JSON array reassigns the field.
 func patchSchedule(raw map[string]json.RawMessage, p *UpdatePatch) *validationError {
 	v, ok := raw["vest_custom_schedule"]
-	if !ok {
-		return nil
-	}
-	p.VestCustomScheduleSet = true
-	if isNull(v) {
+	if !ok || isNull(v) {
 		return nil
 	}
 	schedule, vErr := parseCustomSchedule(v)
 	if vErr != nil {
 		return vErr
 	}
+	p.VestCustomScheduleSet = true
 	p.VestCustomSchedule = schedule
 	return nil
 }

--- a/backend-go/internal/equity_grants/vesting.go
+++ b/backend-go/internal/equity_grants/vesting.go
@@ -1,0 +1,108 @@
+// Package equitygrants implements /api/equity-grants — CRUD + vesting math
+// + paper-value computation (FMV per share × vested × FX).
+//
+// Vesting math is a pure-functions port of backend/app/services/vesting.py
+// kept in this file so the equity package owns its own math.
+package equitygrants
+
+import (
+	"time"
+)
+
+// Schedule is the input to vesting calculations.
+type Schedule struct {
+	TotalShares            int
+	VestStartDate          time.Time
+	VestCliffMonths        int
+	VestTotalMonths        int
+	VestFrequencyMonths    int // 1 monthly / 3 quarterly / 12 yearly
+	CustomSchedule         []CustomScheduleEntry
+	RequiresLiquidityEvent bool
+	LiquidityEventDate     *time.Time
+}
+
+// CustomScheduleEntry is a {month, pct} event — pct is added at the month
+// index, summed across all events at or before the elapsed month count.
+type CustomScheduleEntry struct {
+	Month int     `json:"month"`
+	Pct   float64 `json:"pct"`
+}
+
+// MonthsBetween returns whole months elapsed from start to end. Uses
+// anniversary semantics: if end.day < start.day, the current month hasn't
+// completed yet. Matches Python's months_between.
+func MonthsBetween(start, end time.Time) int {
+	months := (end.Year()-start.Year())*12 + (int(end.Month()) - int(start.Month()))
+	if end.Day() < start.Day() {
+		months--
+	}
+	return months
+}
+
+// VestedSharesAt computes vested share count at on_date.
+func VestedSharesAt(s Schedule, onDate time.Time) int {
+	if s.RequiresLiquidityEvent {
+		if s.LiquidityEventDate == nil {
+			return 0
+		}
+		if onDate.Before(*s.LiquidityEventDate) {
+			return 0
+		}
+	}
+	if onDate.Before(s.VestStartDate) {
+		return 0
+	}
+	elapsed := MonthsBetween(s.VestStartDate, onDate)
+	if elapsed < s.VestCliffMonths {
+		return 0
+	}
+	capped := min(elapsed, s.VestTotalMonths)
+	if len(s.CustomSchedule) > 0 {
+		totalPct := 0.0
+		for _, event := range s.CustomSchedule {
+			if event.Month <= capped {
+				totalPct += event.Pct
+			}
+		}
+		vested := int(float64(s.TotalShares) * totalPct / 100)
+		if vested > s.TotalShares {
+			return s.TotalShares
+		}
+		return vested
+	}
+	if s.VestTotalMonths <= 0 {
+		return s.TotalShares
+	}
+	freq := s.VestFrequencyMonths
+	if freq <= 0 {
+		freq = 1
+	}
+	monthsAfterCliff := capped - s.VestCliffMonths
+	extraPeriods := monthsAfterCliff / freq
+	vestingMonthCount := min(s.VestCliffMonths+extraPeriods*freq, s.VestTotalMonths)
+	return int(float64(s.TotalShares) * float64(vestingMonthCount) / float64(s.VestTotalMonths))
+}
+
+// VestingProgressPct returns the vested fraction as a percentage (0–100).
+func VestingProgressPct(s Schedule, onDate time.Time) float64 {
+	if s.TotalShares <= 0 {
+		return 0
+	}
+	vested := VestedSharesAt(s, onDate)
+	return float64(vested) / float64(s.TotalShares) * 100
+}
+
+// FreqMonthsFromString maps the Python VestingFrequency enum string to the
+// month count used in the math.
+func FreqMonthsFromString(freq string) int {
+	switch freq {
+	case "monthly":
+		return 1
+	case "quarterly":
+		return 3
+	case "yearly":
+		return 12
+	default:
+		return 1
+	}
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 	bonusevents "github.com/Automaat/finance-buddy/backend-go/internal/bonus_events"
 	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/config"
+	equitygrants "github.com/Automaat/finance-buddy/backend-go/internal/equity_grants"
 	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/personas"
@@ -110,6 +111,20 @@ func New(cfg Config, logger *slog.Logger, deps Deps) http.Handler {
 			r.Get("/{id}", bonusesHandler.Get)
 			r.Patch("/{id}", bonusesHandler.Update)
 			r.Delete("/{id}", bonusesHandler.Delete)
+		})
+
+		grantsHandler := equitygrants.NewHandler(
+			equitygrants.NewStore(deps.Pool),
+			companyvaluations.NewStore(deps.Pool),
+			fxSvc,
+			logger,
+		)
+		r.Route("/api/equity-grants", func(r chi.Router) {
+			r.Get("/", grantsHandler.List)
+			r.Post("/", grantsHandler.Create)
+			r.Get("/{id}", grantsHandler.Get)
+			r.Patch("/{id}", grantsHandler.Update)
+			r.Delete("/{id}", grantsHandler.Delete)
 		})
 	}
 

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -69,3 +69,16 @@ rules:
   - method: DELETE
     path_prefix: /api/bonuses
     upstream: http://backend-go:8000
+  # Group 4c — /api/equity-grants cut over to Go (vesting math + paper-value + FX).
+  - method: GET
+    path_prefix: /api/equity-grants
+    upstream: http://backend-go:8000
+  - method: POST
+    path_prefix: /api/equity-grants
+    upstream: http://backend-go:8000
+  - method: PATCH
+    path_prefix: /api/equity-grants
+    upstream: http://backend-go:8000
+  - method: DELETE
+    path_prefix: /api/equity-grants
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

Closes Group 4 (#439) — equity grants + vesting math + paper-value computation. Depends on Group 4a (company_valuations, #459) and Group 4b (FX + bonuses, #460/#462) which are already merged.

## Implementation information

### `internal/equity_grants/vesting.go`

Pure-functions port of `backend/app/services/vesting.py`:

- `MonthsBetween(start, end)` — whole months with anniversary semantics (drops the partial month when `end.day < start.day`)
- `VestedSharesAt(schedule, on_date)` — handles cliff, custom-schedule, double-trigger, frequency (monthly/quarterly/yearly)
- `VestingProgressPct(schedule, on_date)` — convenience wrapper

### `internal/equity_grants/store.go`

- Full CRUD with soft-delete (`is_active = true` filter)
- `vest_custom_schedule` stored/loaded via JSON column as raw bytes; nil writes SQL NULL, present writes the JSON encoding
- `UpdatePatch` distinguishes "leave schedule alone" from "clear schedule" via a `VestCustomScheduleSet` bool

### `internal/equity_grants/paper_value.go`

- `computePaperValues` — fetches the latest active company_valuation, computes per-share intrinsic value (RSU = FMV; OPTION = max(FMV − strike, 0)), multiplies by vested shares for base/low/high
- Currency mismatch between grant and valuation → no paper value (matches Python)
- FX rate fetched against the **valuation date** so an old valuation is converted at its own date's FX, not today's (parity with Python's `get_fx_rate_to_pln(db, pv_currency, pv_date)`)

### `internal/company_valuations` exposure

- New `Store.GetLatestForCompany(ctx, company, onDate)` for cross-package use
- New `ErrNoValuation` sentinel — "no valuation exists" is normal in the equity flow, not a failure

### `internal/equity_grants/validation.go`

- POST: required fields (grant_date, type, company, owner, total_shares, vest_start_date, vest_total_months, vest_frequency) surface 422 "Field required" on missing
- Cross-field rules: `vest_cliff_months ≤ vest_total_months`; OPTION requires a non-null strike price
- Numbers parsed via `decimal.NewFromString` on raw token bytes (no float64 intermediate)
- PATCH: null = no-op for scalars; `vest_custom_schedule` distinguishes omit / null-to-clear / explicit array
- Split into focused helpers (`requireGrantBasics`, `requireGrantVesting`, `optionalGrantLiquidity`, `optionalGrantTaxNotes`, `patchStrings`, `patchNumbersAndBools`, `patchDates`, `patchSchedule`) to stay under the funlen=100 budget

### Parity proof against Go

```
============================= test session starts ==============================
tests/test_equity_grants.py::test_list_equity_grants_includes_seeded         PASSED
tests/test_equity_grants.py::test_get_equity_grant_by_id_returns_seeded_record PASSED
tests/test_equity_grants.py::test_get_equity_grant_not_found                 PASSED
tests/test_equity_grants.py::test_create_equity_grant_happy_path             PASSED
tests/test_equity_grants.py::test_create_equity_grant_validation_error       PASSED
tests/test_equity_grants.py::test_update_equity_grant_happy_path             PASSED
tests/test_equity_grants.py::test_update_equity_grant_validation_error       PASSED
tests/test_equity_grants.py::test_delete_equity_grant_happy_path             PASSED
============================== 8 passed in 0.32s ===============================
```

NBP returned 403 from the test runner — same as Group 4b. Falls back to cached USD rate via the FX service's stale-cache logic.

### `routes.yaml`

Four new rules — GET/POST/PATCH/DELETE — for `/api/equity-grants/`. Group 4 fully on Go after this lands.

## Supporting documentation

- Umbrella: #435
- Subissue: #439
- Slice 4a: #459 (merged)
- Slice 4b: #460 (merged), #462 (TZ fix, merged)
- Procedure: `migration/CUTOVER.md`

> Changelog: skip