### PR TITLE
feat(go): cutover /api/cpi (Group 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,8 @@ jobs:
             tests/test_goals.py \
             tests/test_company_valuations.py \
             tests/test_bonus_events.py \
-            tests/test_equity_grants.py
+            tests/test_equity_grants.py \
+            tests/test_cpi.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - nilerr
     - nilnesserr
     - nilnil
+    - nonamedreturns
     - reassign
     - recvcheck
     - sloglint
@@ -137,7 +138,6 @@ linters:
         - typeDefFirst
         - typeUnparen
         - unlabelStmt
-        - unnamedResult
         - unnecessaryBlock
         - unnecessaryDefer
         - weakCond

--- a/backend-go/internal/cpi/errors.go
+++ b/backend-go/internal/cpi/errors.go
@@ -1,0 +1,41 @@
+package cpi
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{
+				"type":  "value_error",
+				"loc":   []string{"body", field},
+				"msg":   msg,
+				"input": input,
+			},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/cpi/gus.go
+++ b/backend-go/internal/cpi/gus.go
@@ -1,0 +1,91 @@
+package cpi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// GUS BDL configuration — matches backend/app/services/inflation.py.
+const (
+	GUSVariableID = 217230
+	GUSBaseURL    = "https://bdl.stat.gov.pl/api/v1"
+	GUSSourceTag  = "GUS-BDL-217230"
+	gusTimeout    = 15 * time.Second
+)
+
+// GUSFetcher pulls annual yoy CPI from the GUS BDL API.
+type GUSFetcher struct {
+	client *http.Client
+}
+
+// NewGUSFetcher wires a fetcher with the standard 15s timeout.
+func NewGUSFetcher() *GUSFetcher {
+	return &GUSFetcher{
+		client: &http.Client{Timeout: gusTimeout},
+	}
+}
+
+type gusValue struct {
+	Year string `json:"year"`
+	Val  any    `json:"val"`
+}
+
+type gusResult struct {
+	Values []gusValue `json:"values"`
+}
+
+type gusResponse struct {
+	Results []gusResult `json:"results"`
+}
+
+// Fetch returns (year, yoy_rate) tuples sorted ascending by year. Empty slice
+// when GUS responds with no data. Non-2xx responses surface as errors.
+func (g *GUSFetcher) Fetch(ctx context.Context) ([]YearRate, error) {
+	url := fmt.Sprintf(
+		"%s/data/by-variable/%d?unit-level=0&format=json&page-size=100",
+		GUSBaseURL, GUSVariableID,
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("gus fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("gus http %d", resp.StatusCode)
+	}
+	var body gusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decode gus payload: %w", err)
+	}
+	if len(body.Results) == 0 {
+		return []YearRate{}, nil
+	}
+	values := body.Results[0].Values
+	out := make([]YearRate, 0, len(values))
+	for _, v := range values {
+		year, err := strconv.Atoi(v.Year)
+		if err != nil {
+			continue
+		}
+		rate, err := decimal.NewFromString(fmt.Sprintf("%v", v.Val))
+		if err != nil {
+			continue
+		}
+		out = append(out, YearRate{Year: year, YoY: rate})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Year < out[j].Year })
+	return out, nil
+}

--- a/backend-go/internal/cpi/gus.go
+++ b/backend-go/internal/cpi/gus.go
@@ -75,14 +75,14 @@ func (g *GUSFetcher) Fetch(ctx context.Context) ([]YearRate, error) {
 	}
 	values := body.Results[0].Values
 	out := make([]YearRate, 0, len(values))
-	for _, v := range values {
+	for i, v := range values {
 		year, err := strconv.Atoi(v.Year)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("gus value[%d]: invalid year %q: %w", i, v.Year, err)
 		}
 		rate, err := decimal.NewFromString(fmt.Sprintf("%v", v.Val))
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("gus value[%d] year=%d: invalid yoy %v: %w", i, year, v.Val, err)
 		}
 		out = append(out, YearRate{Year: year, YoY: rate})
 	}

--- a/backend-go/internal/cpi/handler.go
+++ b/backend-go/internal/cpi/handler.go
@@ -1,0 +1,246 @@
+package cpi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Handler is the HTTP boundary for /api/cpi.
+type Handler struct {
+	store   *Store
+	fetcher *GUSFetcher
+	logger  *slog.Logger
+}
+
+// NewHandler wires the dependencies.
+func NewHandler(store *Store, fetcher *GUSFetcher, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if fetcher == nil {
+		fetcher = NewGUSFetcher()
+	}
+	return &Handler{store: store, fetcher: fetcher, logger: logger}
+}
+
+type cpiPoint struct {
+	Year            int     `json:"year"`
+	YoYRate         pyFloat `json:"yoy_rate"`
+	CumulativeIndex pyFloat `json:"cumulative_index"`
+}
+
+type seriesResponse struct {
+	Points     []cpiPoint `json:"points"`
+	BaseYear   *int       `json:"base_year"`
+	LatestYear *int       `json:"latest_year"`
+	Source     string     `json:"source"`
+}
+
+type adjustResponse struct {
+	OriginalAmount pyFloat `json:"original_amount"`
+	AdjustedAmount pyFloat `json:"adjusted_amount"`
+	Factor         pyFloat `json:"factor"`
+	FromDate       isoDate `json:"from_date"`
+	ToDate         isoDate `json:"to_date"`
+	AsOfYear       int     `json:"as_of_year"`
+}
+
+type refreshResponse struct {
+	RowsWritten int  `json:"rows_written"`
+	LatestYear  *int `json:"latest_year"`
+}
+
+// GetSeries serves GET /api/cpi/series.
+func (h *Handler) GetSeries(w http.ResponseWriter, r *http.Request) {
+	yoyMap, err := h.store.LoadYoYMap(r.Context())
+	if err != nil {
+		h.logger.Error("load cpi", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	indexMap := CumulativeIndex(yoyMap)
+	years := sortedYears(indexMap)
+	points := make([]cpiPoint, 0, len(years))
+	for _, y := range years {
+		yoy, _ := yoyMap[y].Float64()
+		idx, _ := indexMap[y].Float64()
+		points = append(points, cpiPoint{
+			Year:            y,
+			YoYRate:         pyFloat(yoy),
+			CumulativeIndex: pyFloat(idx),
+		})
+	}
+	out := seriesResponse{Points: points, Source: GUSSourceTag}
+	if len(points) > 0 {
+		base := points[0].Year
+		latest := points[len(points)-1].Year
+		out.BaseYear = &base
+		out.LatestYear = &latest
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Adjust serves POST /api/cpi/adjust.
+func (h *Handler) Adjust(w http.ResponseWriter, r *http.Request) {
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	amount, vErr := requireFloat(raw, "amount")
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	from, vErr := requireDate(raw, "from_date")
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	to, vErr := requireDate(raw, "to_date")
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+
+	yoyMap, err := h.store.LoadYoYMap(r.Context())
+	if err != nil {
+		h.logger.Error("load cpi", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	indexMap := CumulativeIndex(yoyMap)
+	adjusted, err := AdjustWithIndex(indexMap, amount, from, to)
+	if err != nil {
+		if errors.Is(err, ErrInflationDataMissing) {
+			writeDetailError(w, http.StatusServiceUnavailable, err.Error())
+			return
+		}
+		h.logger.Error("adjust", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	latest, ok, err := h.store.LatestKnownYear(r.Context())
+	if err != nil {
+		h.logger.Error("latest year", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	if !ok {
+		writeDetailError(w, http.StatusServiceUnavailable, "CPI table is empty")
+		return
+	}
+	factor := 0.0
+	if amount != 0 {
+		factor = adjusted / amount
+	}
+	writeJSON(w, http.StatusOK, adjustResponse{
+		OriginalAmount: pyFloat(amount),
+		AdjustedAmount: pyFloat(adjusted),
+		Factor:         pyFloat(factor),
+		FromDate:       isoDate(from),
+		ToDate:         isoDate(to),
+		AsOfYear:       latest,
+	})
+}
+
+// Refresh serves POST /api/cpi/refresh.
+func (h *Handler) Refresh(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.fetcher.Fetch(r.Context())
+	if err != nil {
+		writeDetailError(w, http.StatusBadGateway, "GUS BDL fetch failed: "+err.Error())
+		return
+	}
+	written, err := h.store.Upsert(r.Context(), GUSSourceTag, rows)
+	if err != nil {
+		h.logger.Error("upsert cpi", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	latest, ok, err := h.store.LatestKnownYear(r.Context())
+	if err != nil {
+		h.logger.Error("latest year", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := refreshResponse{RowsWritten: written}
+	if ok {
+		y := latest
+		out.LatestYear = &y
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// --- validation ---
+
+func requireFloat(raw map[string]json.RawMessage, key string) (float64, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return 0, &validationError{Field: key, Msg: "Field required"}
+	}
+	var f float64
+	if err := json.Unmarshal(v, &f); err != nil {
+		return 0, &validationError{Field: key, Msg: "must be a number"}
+	}
+	return f, nil
+}
+
+func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return time.Time{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be a string"}
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be YYYY-MM-DD"}
+	}
+	return t, nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}
+
+// --- wire types (copies — promote when shared helper lands) ---
+
+type isoDate time.Time
+
+const isoDateLayout = "2006-01-02"
+
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
+}
+
+func (d *isoDate) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	t, err := time.Parse(isoDateLayout, s)
+	if err != nil {
+		return err
+	}
+	*d = isoDate(t)
+	return nil
+}
+
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/cpi/inflation.go
+++ b/backend-go/internal/cpi/inflation.go
@@ -1,0 +1,106 @@
+// Package cpi implements /api/cpi — series, inflation adjust, refresh.
+//
+// Math (inflation.go) is a pure-functions port of
+// backend/app/services/inflation.py. yoy_rate is stored as published by GUS
+// (114.4 = +14.4% YoY). A fixed-base cumulative index is derived per call;
+// arbitrary dates linearly interpolate within a year.
+package cpi
+
+import (
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// ErrInflationDataMissing mirrors Python's InflationDataMissingError.
+var ErrInflationDataMissing = errors.New("CPI table is empty")
+
+// YearRate is a (year, yoy_rate) pair as published by GUS.
+type YearRate struct {
+	Year int
+	YoY  decimal.Decimal
+}
+
+// CumulativeIndex returns a fixed-base index map: index[Y] is the end-of-year-Y
+// price level, anchored at index[earliest] = 100 and compounded forward by
+// yoy_rate.
+func CumulativeIndex(yoyByYear map[int]decimal.Decimal) map[int]decimal.Decimal {
+	if len(yoyByYear) == 0 {
+		return map[int]decimal.Decimal{}
+	}
+	years := sortedYears(yoyByYear)
+	index := map[int]decimal.Decimal{years[0]: decimal.NewFromInt(100)}
+	hundred := decimal.NewFromInt(100)
+	for i := 1; i < len(years); i++ {
+		prev := years[i-1]
+		year := years[i]
+		index[year] = index[prev].Mul(yoyByYear[year]).Div(hundred)
+	}
+	return index
+}
+
+// IndexAtDate interpolates the fixed-base index at an arbitrary calendar date.
+// Outside the known range we clamp to the earliest or latest known year.
+func IndexAtDate(indexByYear map[int]decimal.Decimal, when time.Time) (decimal.Decimal, error) {
+	if len(indexByYear) == 0 {
+		return decimal.Zero, ErrInflationDataMissing
+	}
+	years := sortedYears(indexByYear)
+	if when.Year() < years[0] {
+		return indexByYear[years[0]], nil
+	}
+	if when.Year() > years[len(years)-1] {
+		return indexByYear[years[len(years)-1]], nil
+	}
+	startIdx, ok := indexByYear[when.Year()-1]
+	if !ok {
+		startIdx = indexByYear[years[0]]
+	}
+	endIdx := indexByYear[when.Year()]
+
+	yearStart := time.Date(when.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+	nextYearStart := time.Date(when.Year()+1, 1, 1, 0, 0, 0, 0, time.UTC)
+	spanDays := decimal.NewFromInt(int64(nextYearStart.Sub(yearStart).Hours() / 24))
+	when = time.Date(when.Year(), when.Month(), when.Day(), 0, 0, 0, 0, time.UTC)
+	elapsedDays := decimal.NewFromInt(int64(when.Sub(yearStart).Hours() / 24))
+	fraction := elapsedDays.Div(spanDays)
+	return startIdx.Add(endIdx.Sub(startIdx).Mul(fraction)), nil
+}
+
+// AdjustWithIndex inflates/deflates amount between two dates using a
+// pre-loaded fixed-base index.
+func AdjustWithIndex(
+	indexByYear map[int]decimal.Decimal,
+	amount float64,
+	from, to time.Time,
+) (float64, error) {
+	if len(indexByYear) == 0 {
+		return 0, ErrInflationDataMissing
+	}
+	fromIdx, err := IndexAtDate(indexByYear, from)
+	if err != nil {
+		return 0, err
+	}
+	toIdx, err := IndexAtDate(indexByYear, to)
+	if err != nil {
+		return 0, err
+	}
+	if fromIdx.IsZero() {
+		return 0, errors.New("source index is zero")
+	}
+	factor := toIdx.Div(fromIdx)
+	amountDec := decimal.NewFromFloat(amount)
+	result, _ := amountDec.Mul(factor).Float64()
+	return result, nil
+}
+
+func sortedYears(m map[int]decimal.Decimal) []int {
+	years := make([]int, 0, len(m))
+	for y := range m {
+		years = append(years, y)
+	}
+	sort.Ints(years)
+	return years
+}

--- a/backend-go/internal/cpi/inflation.go
+++ b/backend-go/internal/cpi/inflation.go
@@ -8,14 +8,31 @@ package cpi
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 	"time"
 
 	"github.com/shopspring/decimal"
 )
 
-// ErrInflationDataMissing mirrors Python's InflationDataMissingError.
+// ErrInflationDataMissing mirrors Python's InflationDataMissingError. Use
+// errors.Is to detect the family from the handler — both the
+// empty-table case and the zero-source-index case wrap it.
 var ErrInflationDataMissing = errors.New("CPI table is empty")
+
+// inflationDataError carries a specific message but answers errors.Is for
+// ErrInflationDataMissing so the handler routes both to 503 with the
+// specific message preserved (matches Python's raise InflationDataMissingError(msg)).
+type inflationDataError struct{ msg string }
+
+func (e *inflationDataError) Error() string { return e.msg }
+func (e *inflationDataError) Is(target error) bool {
+	return target == ErrInflationDataMissing
+}
+
+func newInflationErr(msg string) error {
+	return &inflationDataError{msg: msg}
+}
 
 // YearRate is a (year, yoy_rate) pair as published by GUS.
 type YearRate struct {
@@ -43,6 +60,8 @@ func CumulativeIndex(yoyByYear map[int]decimal.Decimal) map[int]decimal.Decimal 
 
 // IndexAtDate interpolates the fixed-base index at an arbitrary calendar date.
 // Outside the known range we clamp to the earliest or latest known year.
+// Inside the range, a missing year (gap in the series) is a hard error —
+// silently zeroing it would corrupt downstream math.
 func IndexAtDate(indexByYear map[int]decimal.Decimal, when time.Time) (decimal.Decimal, error) {
 	if len(indexByYear) == 0 {
 		return decimal.Zero, ErrInflationDataMissing
@@ -54,11 +73,14 @@ func IndexAtDate(indexByYear map[int]decimal.Decimal, when time.Time) (decimal.D
 	if when.Year() > years[len(years)-1] {
 		return indexByYear[years[len(years)-1]], nil
 	}
+	endIdx, ok := indexByYear[when.Year()]
+	if !ok {
+		return decimal.Zero, newInflationErr(fmt.Sprintf("CPI series missing year %d", when.Year()))
+	}
 	startIdx, ok := indexByYear[when.Year()-1]
 	if !ok {
 		startIdx = indexByYear[years[0]]
 	}
-	endIdx := indexByYear[when.Year()]
 
 	yearStart := time.Date(when.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
 	nextYearStart := time.Date(when.Year()+1, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -88,7 +110,7 @@ func AdjustWithIndex(
 		return 0, err
 	}
 	if fromIdx.IsZero() {
-		return 0, errors.New("source index is zero")
+		return 0, newInflationErr("Source index is zero")
 	}
 	factor := toIdx.Div(fromIdx)
 	amountDec := decimal.NewFromFloat(amount)

--- a/backend-go/internal/cpi/store.go
+++ b/backend-go/internal/cpi/store.go
@@ -11,14 +11,6 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// CpiIndex mirrors backend/app/models/cpi_index.CpiIndex.
-type CpiIndex struct {
-	Year      int
-	YoYRate   decimal.Decimal
-	Source    string
-	FetchedAt time.Time
-}
-
 // Store is the persistence boundary.
 type Store struct {
 	pool *pgxpool.Pool
@@ -68,39 +60,73 @@ func (s *Store) LatestKnownYear(ctx context.Context) (int, bool, error) {
 }
 
 // Upsert applies the (year, yoy_rate) batch as Python's refresh_cpi_sync does:
-// only updates the existing row when the value changed and inserts otherwise.
+// only writes rows whose yoy_rate actually changed. The whole batch is wrapped
+// in a transaction so concurrent refreshes can't leave the table partially
+// updated. Per-row uses INSERT ... ON CONFLICT (year) DO UPDATE so concurrent
+// inserts race-cleanly on the primary key.
+//
 // Returns the number of rows actually written.
 func (s *Store) Upsert(ctx context.Context, source string, rows []YearRate) (int, error) {
 	if len(rows) == 0 {
 		return 0, nil
 	}
-	existing, err := s.LoadYoYMap(ctx)
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("begin upsert tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	written, err := writeRows(ctx, tx, source, rows)
 	if err != nil {
 		return 0, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("commit upsert tx: %w", err)
+	}
+	committed = true
+	return written, nil
+}
+
+func writeRows(ctx context.Context, tx pgx.Tx, source string, rows []YearRate) (int, error) {
+	existing := map[int]decimal.Decimal{}
+	q, err := tx.Query(ctx, `SELECT year, yoy_rate FROM cpi_index FOR UPDATE`)
+	if err != nil {
+		return 0, fmt.Errorf("lock cpi_index: %w", err)
+	}
+	for q.Next() {
+		var y int
+		var rate decimal.Decimal
+		if err := q.Scan(&y, &rate); err != nil {
+			q.Close()
+			return 0, fmt.Errorf("scan existing cpi_index: %w", err)
+		}
+		existing[y] = rate
+	}
+	q.Close()
+	if err := q.Err(); err != nil {
+		return 0, fmt.Errorf("iterate cpi_index: %w", err)
 	}
 	written := 0
 	now := time.Now().UTC()
 	for _, r := range rows {
-		if current, ok := existing[r.Year]; ok {
-			if current.Equal(r.YoY) {
-				continue
-			}
-			if _, err := s.pool.Exec(ctx, `
-				UPDATE cpi_index SET yoy_rate = $1, source = $2, fetched_at = $3
-				WHERE year = $4`,
-				r.YoY, source, now, r.Year,
-			); err != nil {
-				return written, fmt.Errorf("update cpi_index year %d: %w", r.Year, err)
-			}
-			written++
+		if current, ok := existing[r.Year]; ok && current.Equal(r.YoY) {
 			continue
 		}
-		if _, err := s.pool.Exec(ctx, `
+		if _, err := tx.Exec(ctx, `
 			INSERT INTO cpi_index (year, yoy_rate, source, fetched_at)
-			VALUES ($1, $2, $3, $4)`,
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (year) DO UPDATE SET
+				yoy_rate = EXCLUDED.yoy_rate,
+				source = EXCLUDED.source,
+				fetched_at = EXCLUDED.fetched_at
+			WHERE cpi_index.yoy_rate IS DISTINCT FROM EXCLUDED.yoy_rate`,
 			r.Year, r.YoY, source, now,
 		); err != nil {
-			return written, fmt.Errorf("insert cpi_index year %d: %w", r.Year, err)
+			return written, fmt.Errorf("upsert cpi_index year %d: %w", r.Year, err)
 		}
 		written++
 	}

--- a/backend-go/internal/cpi/store.go
+++ b/backend-go/internal/cpi/store.go
@@ -1,0 +1,108 @@
+package cpi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// CpiIndex mirrors backend/app/models/cpi_index.CpiIndex.
+type CpiIndex struct {
+	Year      int
+	YoYRate   decimal.Decimal
+	Source    string
+	FetchedAt time.Time
+}
+
+// Store is the persistence boundary.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+// LoadYoYMap returns year → yoy_rate for every cpi_index row.
+func (s *Store) LoadYoYMap(ctx context.Context) (map[int]decimal.Decimal, error) {
+	rows, err := s.pool.Query(ctx, `SELECT year, yoy_rate FROM cpi_index`)
+	if err != nil {
+		return nil, fmt.Errorf("select cpi_index: %w", err)
+	}
+	defer rows.Close()
+	out := map[int]decimal.Decimal{}
+	for rows.Next() {
+		var y int
+		var rate decimal.Decimal
+		if err := rows.Scan(&y, &rate); err != nil {
+			return nil, fmt.Errorf("scan cpi_index: %w", err)
+		}
+		out[y] = rate
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate cpi_index: %w", err)
+	}
+	return out, nil
+}
+
+// LatestKnownYear returns the highest year present in cpi_index, or (0, false)
+// when the table is empty.
+func (s *Store) LatestKnownYear(ctx context.Context) (int, bool, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT year FROM cpi_index ORDER BY year DESC LIMIT 1`,
+	)
+	var y int
+	if err := row.Scan(&y); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("select latest cpi year: %w", err)
+	}
+	return y, true, nil
+}
+
+// Upsert applies the (year, yoy_rate) batch as Python's refresh_cpi_sync does:
+// only updates the existing row when the value changed and inserts otherwise.
+// Returns the number of rows actually written.
+func (s *Store) Upsert(ctx context.Context, source string, rows []YearRate) (int, error) {
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	existing, err := s.LoadYoYMap(ctx)
+	if err != nil {
+		return 0, err
+	}
+	written := 0
+	now := time.Now().UTC()
+	for _, r := range rows {
+		if current, ok := existing[r.Year]; ok {
+			if current.Equal(r.YoY) {
+				continue
+			}
+			if _, err := s.pool.Exec(ctx, `
+				UPDATE cpi_index SET yoy_rate = $1, source = $2, fetched_at = $3
+				WHERE year = $4`,
+				r.YoY, source, now, r.Year,
+			); err != nil {
+				return written, fmt.Errorf("update cpi_index year %d: %w", r.Year, err)
+			}
+			written++
+			continue
+		}
+		if _, err := s.pool.Exec(ctx, `
+			INSERT INTO cpi_index (year, yoy_rate, source, fetched_at)
+			VALUES ($1, $2, $3, $4)`,
+			r.Year, r.YoY, source, now,
+		); err != nil {
+			return written, fmt.Errorf("insert cpi_index year %d: %w", r.Year, err)
+		}
+		written++
+	}
+	return written, nil
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 	bonusevents "github.com/Automaat/finance-buddy/backend-go/internal/bonus_events"
 	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/config"
+	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 	equitygrants "github.com/Automaat/finance-buddy/backend-go/internal/equity_grants"
 	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
@@ -125,6 +126,13 @@ func New(cfg Config, logger *slog.Logger, deps Deps) http.Handler {
 			r.Get("/{id}", grantsHandler.Get)
 			r.Patch("/{id}", grantsHandler.Update)
 			r.Delete("/{id}", grantsHandler.Delete)
+		})
+
+		cpiHandler := cpi.NewHandler(cpi.NewStore(deps.Pool), cpi.NewGUSFetcher(), logger)
+		r.Route("/api/cpi", func(r chi.Router) {
+			r.Get("/series", cpiHandler.GetSeries)
+			r.Post("/adjust", cpiHandler.Adjust)
+			r.Post("/refresh", cpiHandler.Refresh)
 		})
 	}
 

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -82,3 +82,10 @@ rules:
   - method: DELETE
     path_prefix: /api/equity-grants
     upstream: http://backend-go:8000
+  # Group 5 — /api/cpi cut over to Go (GUS BDL fetch + inflation math).
+  - method: GET
+    path_prefix: /api/cpi
+    upstream: http://backend-go:8000
+  - method: POST
+    path_prefix: /api/cpi
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

Group 5 cutover — Polish CPI (GUS BDL variable 217230). Brings the inflation math + GUS fetcher to Go and frees Group 6 (salaries) which reads CPI when computing real wages.

Per the umbrella plan, the in-process APScheduler that auto-refreshes monthly is being tracked as a separate decision (#449). This PR ships the three HTTP endpoints; the scheduler stays on the Python side for now.

## Implementation information

### `internal/cpi/inflation.go`

Pure-functions port of `backend/app/services/inflation.py`. Math identical:

- `yoy_rate` is the value as published by GUS (e.g. 114.4 means +14.4% YoY).
- Cumulative index is derived at query time, anchored at the earliest year = 100 and compounded forward.
- Within a year the index interpolates linearly between `index[Y-1]` (start of year) and `index[Y]` (end of year) pro-rata by day-of-year. Outside the known range we clamp to the nearest known year.

All math in `decimal.Decimal` until the float64 result.

### `internal/cpi/store.go`

- `LoadYoYMap` for the read path.
- `LatestKnownYear` returns `(year, found, err)` — empty table → `(0, false, nil)`.
- `Upsert` mirrors Python's `refresh_cpi_sync`: only writes rows whose `yoy_rate` actually changed, leaves untouched rows alone. Returns the number of rows written.

### `internal/cpi/gus.go`

Single-shot fetcher hitting `https://bdl.stat.gov.pl/api/v1/data/by-variable/217230` with the same 15s timeout the Python backend uses. Sorted ascending by year. Non-2xx surfaces as error → 502.

### `internal/cpi/handler.go`

- `GET /api/cpi/series` — returns `{points: [...], base_year, latest_year, source}`. `base_year`/`latest_year` are `null` when the table is empty.
- `POST /api/cpi/adjust` — validates `amount` (required, number) + `from_date` + `to_date` (both YYYY-MM-DD), returns `{original_amount, adjusted_amount, factor, from_date, to_date, as_of_year}`. Empty CPI → 503 with `"CPI table is empty"`.
- `POST /api/cpi/refresh` — fetches GUS, upserts, returns `{rows_written, latest_year}`. GUS errors → 502.

### Lint config

Per the user preference established this session:

- Removed `unnamedResult` from gocritic.enabled-checks (was nudging me to add names to multi-return signatures).
- Added `nonamedreturns` linter to forbid named returns repo-wide.

### Parity proof against Go

```
============================= test session starts ==============================
tests/test_cpi.py::test_get_cpi_series_matches_golden  PASSED
tests/test_cpi.py::test_get_cpi_series_shape           PASSED
tests/test_cpi.py::test_post_cpi_adjust_happy_path     PASSED
tests/test_cpi.py::test_post_cpi_adjust_validation_error PASSED
tests/test_cpi.py::test_post_cpi_refresh_skipped_external_call SKIPPED
========================= 4 passed, 1 skipped in 0.11s =========================
```

The `golden` snapshot for `/api/cpi/series` matches byte-for-byte — the full 2003-2025 CPI history serializes identically out of Python and Go.

`refresh` is skipped because it hits the real GUS API; manual smoke against prod will validate the upsert path.

### `routes.yaml`

GET + POST rules for `/api/cpi/`. Both methods cover the three endpoints.

## Supporting documentation

- Umbrella: #435
- Subissue: #440
- Scheduler decision: #449 (separate)
- Procedure: `migration/CUTOVER.md`

> Changelog: skip