### PR TITLE
feat(go): cutover /api/salaries (Group 6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,8 @@ jobs:
             tests/test_company_valuations.py \
             tests/test_bonus_events.py \
             tests/test_equity_grants.py \
-            tests/test_cpi.py
+            tests/test_cpi.py \
+            tests/test_salary_records.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/backend-go/internal/salaries/errors.go
+++ b/backend-go/internal/salaries/errors.go
@@ -1,0 +1,41 @@
+package salaries
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{
+				"type":  "value_error",
+				"loc":   []string{"body", field},
+				"msg":   msg,
+				"input": input,
+			},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/salaries/handler.go
+++ b/backend-go/internal/salaries/handler.go
@@ -198,6 +198,28 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	updated, err := h.store.Update(r.Context(), id, patch)
 	if err != nil {
+		if errors.Is(err, ErrDuplicate) {
+			// Need the merged record's (owner, date) for the message; refetch.
+			current, getErr := h.store.Get(r.Context(), id)
+			owner := ""
+			date := ""
+			if getErr == nil {
+				if patch.Owner != nil {
+					owner = *patch.Owner
+				} else {
+					owner = current.Owner
+				}
+				if patch.Date != nil {
+					date = patch.Date.Format("2006-01-02")
+				} else {
+					date = current.Date.Format("2006-01-02")
+				}
+			}
+			writeDetailError(w, http.StatusConflict,
+				fmt.Sprintf("Salary record for %s on %s conflicts with existing record",
+					owner, date))
+			return
+		}
 		h.writeStoreError(w, err, id)
 		return
 	}

--- a/backend-go/internal/salaries/handler.go
+++ b/backend-go/internal/salaries/handler.go
@@ -1,0 +1,395 @@
+package salaries
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
+)
+
+var (
+	validContractTypes = map[string]struct{}{
+		"UOP": {}, "UZ": {}, "UoD": {}, "B2B": {},
+	}
+)
+
+// response mirrors backend/app/schemas/salary_records.SalaryRecordResponse.
+type response struct {
+	ID           int      `json:"id"`
+	Date         isoDate  `json:"date"`
+	GrossAmount  pyFloat  `json:"gross_amount"`
+	ContractType string   `json:"contract_type"`
+	Company      string   `json:"company"`
+	Owner        string   `json:"owner"`
+	IsActive     bool     `json:"is_active"`
+	CreatedAt    isoNaive `json:"created_at"`
+}
+
+// inflationContext mirrors backend/app/schemas/salary_records.InflationContext.
+type inflationContext struct {
+	Owner                    string   `json:"owner"`
+	LastChangeDate           isoDate  `json:"last_change_date"`
+	PreviousChangeDate       *isoDate `json:"previous_change_date"`
+	PreviousSalary           *pyFloat `json:"previous_salary"`
+	PreviousSalaryInTodayPLN *pyFloat `json:"previous_salary_in_today_pln"`
+	CurrentSalary            pyFloat  `json:"current_salary"`
+	RealChangePLN            *pyFloat `json:"real_change_pln"`
+	RealChangePct            *pyFloat `json:"real_change_pct"`
+	CPIAsOfYear              int      `json:"cpi_as_of_year"`
+}
+
+type listResponse struct {
+	SalaryRecords      []response                  `json:"salary_records"`
+	TotalCount         int                         `json:"total_count"`
+	CurrentSalaries    map[string]*pyFloat         `json:"current_salaries"`
+	InflationContext   map[string]inflationContext `json:"inflation_context"`
+	AvailableCompanies []string                    `json:"available_companies"`
+}
+
+// Handler is the HTTP boundary for /api/salaries.
+type Handler struct {
+	store    *Store
+	cpiStore *cpi.Store
+	logger   *slog.Logger
+	now      func() time.Time
+}
+
+// NewHandler wires the dependencies. The cpi.Store is read-only here —
+// salaries reuse the CPI index to compute previous_salary_in_today_pln.
+func NewHandler(store *Store, cpiStore *cpi.Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, cpiStore: cpiStore, logger: logger, now: time.Now}
+}
+
+func toResponse(r *SalaryRecord) response {
+	gross, _ := r.GrossAmount.Float64()
+	return response{
+		ID:           r.ID,
+		Date:         isoDate(r.Date),
+		GrossAmount:  pyFloat(gross),
+		ContractType: r.ContractType,
+		Company:      r.Company,
+		Owner:        r.Owner,
+		IsActive:     r.IsActive,
+		CreatedAt:    isoNaive(r.CreatedAt.UTC()),
+	}
+}
+
+// List serves GET /api/salaries.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	filter, vErr := parseListFilter(r.URL.Query())
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	rows, companies, err := h.store.List(r.Context(), filter)
+	if err != nil {
+		h.logger.Error("list salaries", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	today := truncateDay(h.now().UTC())
+	personas, err := h.store.ActivePersonaNames(r.Context())
+	if err != nil {
+		h.logger.Error("persona names", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	currentSalaries, err := h.store.CurrentSalaryByPersona(r.Context(), personas, today)
+	if err != nil {
+		h.logger.Error("current salaries", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	inflationCtx, err := h.buildInflationContext(r.Context(), personas, today)
+	if err != nil {
+		h.logger.Error("inflation context", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := listResponse{
+		SalaryRecords:      make([]response, 0, len(rows)),
+		TotalCount:         len(rows),
+		CurrentSalaries:    salariesToFloatMap(personas, currentSalaries),
+		InflationContext:   inflationCtx,
+		AvailableCompanies: companies,
+	}
+	for i := range rows {
+		out.SalaryRecords = append(out.SalaryRecords, toResponse(&rows[i]))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Get serves GET /api/salaries/{id}.
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	rec, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		h.writeStoreError(w, err, id)
+		return
+	}
+	writeJSON(w, http.StatusOK, toResponse(rec))
+}
+
+// Create serves POST /api/salaries.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	req, vErr := buildCreateRequest(raw, h.now)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	created, err := h.store.Create(r.Context(), &SalaryRecord{
+		Date:         req.Date,
+		GrossAmount:  req.GrossAmount,
+		ContractType: req.ContractType,
+		Company:      req.Company,
+		Owner:        req.Owner,
+	})
+	if err != nil {
+		if errors.Is(err, ErrDuplicate) {
+			writeDetailError(w, http.StatusConflict,
+				fmt.Sprintf("Salary record for %s on %s already exists",
+					req.Owner, req.Date.Format("2006-01-02")))
+			return
+		}
+		h.logger.Error("create salary", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toResponse(created))
+}
+
+// Update serves PATCH /api/salaries/{id}.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	patch, vErr := buildUpdatePatch(raw, h.now)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	updated, err := h.store.Update(r.Context(), id, patch)
+	if err != nil {
+		h.writeStoreError(w, err, id)
+		return
+	}
+	writeJSON(w, http.StatusOK, toResponse(updated))
+}
+
+// Delete serves DELETE /api/salaries/{id}.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.Delete(r.Context(), id); err != nil {
+		h.writeStoreError(w, err, id)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int) {
+	if errors.Is(err, ErrNotFound) {
+		writeDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("Salary record with id %d not found", id))
+		return
+	}
+	h.logger.Error("salary store", "err", err)
+	writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+}
+
+// buildInflationContext mirrors Python's _build_inflation_context: for each
+// persona with at least two recent records, compute previous_salary_in_today_pln
+// via the CPI index, then derive real_change_pln / pct.
+func (h *Handler) buildInflationContext(
+	ctx context.Context, personaNames []string, today time.Time,
+) (map[string]inflationContext, error) {
+	if len(personaNames) == 0 {
+		return map[string]inflationContext{}, nil
+	}
+	asOfYear, hasYear, err := h.cpiStore.LatestKnownYear(ctx)
+	if err != nil {
+		return nil, err
+	}
+	yoyMap, err := h.cpiStore.LoadYoYMap(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !hasYear || len(yoyMap) == 0 {
+		return map[string]inflationContext{}, nil
+	}
+	indexMap := cpi.CumulativeIndex(yoyMap)
+	recent, err := h.store.RecentTwoByPersona(ctx, personaNames, today)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]inflationContext{}
+	for owner, recs := range recent {
+		if len(recs) < 2 {
+			continue
+		}
+		current := recs[0]
+		previous := recs[1]
+		prevAmount, _ := previous.GrossAmount.Float64()
+		prevInToday, err := cpi.AdjustWithIndex(indexMap, prevAmount, previous.Date, today)
+		if err != nil {
+			continue
+		}
+		curAmount, _ := current.GrossAmount.Float64()
+		realChangePLN := curAmount - prevInToday
+		var realChangePct *pyFloat
+		if prevInToday != 0 {
+			pct := pyFloat(realChangePLN / prevInToday * 100)
+			realChangePct = &pct
+		}
+		prevDate := isoDate(previous.Date)
+		prevSalary := pyFloat(prevAmount)
+		prevTodayPLN := pyFloat(prevInToday)
+		realChange := pyFloat(realChangePLN)
+		out[owner] = inflationContext{
+			Owner:                    owner,
+			LastChangeDate:           isoDate(current.Date),
+			PreviousChangeDate:       &prevDate,
+			PreviousSalary:           &prevSalary,
+			PreviousSalaryInTodayPLN: &prevTodayPLN,
+			CurrentSalary:            pyFloat(curAmount),
+			RealChangePLN:            &realChange,
+			RealChangePct:            realChangePct,
+			CPIAsOfYear:              asOfYear,
+		}
+	}
+	return out, nil
+}
+
+func salariesToFloatMap(
+	personaNames []string, values map[string]decimal.Decimal,
+) map[string]*pyFloat {
+	out := map[string]*pyFloat{}
+	for _, name := range personaNames {
+		v, ok := values[name]
+		if !ok {
+			out[name] = nil
+			continue
+		}
+		f, _ := v.Float64()
+		pf := pyFloat(f)
+		out[name] = &pf
+	}
+	return out
+}
+
+func parseListFilter(q map[string][]string) (ListFilter, *validationError) {
+	f := ListFilter{}
+	if v := first(q["owner"]); v != "" {
+		s := v
+		f.Owner = &s
+	}
+	if v := first(q["company"]); v != "" {
+		s := v
+		f.Company = &s
+	}
+	if v := first(q["date_from"]); v != "" {
+		t, err := time.Parse("2006-01-02", v)
+		if err != nil {
+			return f, &validationError{Field: "date_from", Msg: "must be YYYY-MM-DD"}
+		}
+		f.DateFrom = &t
+	}
+	if v := first(q["date_to"]); v != "" {
+		t, err := time.Parse("2006-01-02", v)
+		if err != nil {
+			return f, &validationError{Field: "date_to", Msg: "must be YYYY-MM-DD"}
+		}
+		f.DateTo = &t
+	}
+	return f, nil
+}
+
+func first(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(values[0])
+}
+
+func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		writeValidationError(w, "salary_id", "must be an integer", raw)
+		return 0, false
+	}
+	return id, true
+}
+
+func truncateDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// --- shared wire types ---
+
+type isoDate time.Time
+
+const isoDateLayout = "2006-01-02"
+
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
+}
+
+func (d *isoDate) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	t, err := time.Parse(isoDateLayout, s)
+	if err != nil {
+		return err
+	}
+	*d = isoDate(t)
+	return nil
+}
+
+type isoNaive time.Time
+
+func (t isoNaive) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
+}
+
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/salaries/store.go
+++ b/backend-go/internal/salaries/store.go
@@ -158,6 +158,8 @@ type UpdatePatch struct {
 }
 
 // Update applies the patch and returns the refreshed row.
+// Mirrors Python's duplicate check: after merging the patch, fail with
+// ErrDuplicate if another active record exists for the same (owner, date).
 func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*SalaryRecord, error) {
 	r, err := s.Get(ctx, id)
 	if err != nil {
@@ -177,6 +179,19 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*SalaryRecor
 	}
 	if p.Owner != nil {
 		r.Owner = *p.Owner
+	}
+	var conflict int
+	err = s.pool.QueryRow(ctx, `
+		SELECT id FROM salary_records
+		WHERE owner = $1 AND date = $2 AND id <> $3 AND is_active = true
+		LIMIT 1`,
+		r.Owner, r.Date, id,
+	).Scan(&conflict)
+	if err == nil {
+		return nil, ErrDuplicate
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("check duplicate on update: %w", err)
 	}
 	row := s.pool.QueryRow(ctx, `
 		UPDATE salary_records SET

--- a/backend-go/internal/salaries/store.go
+++ b/backend-go/internal/salaries/store.go
@@ -1,0 +1,342 @@
+// Package salaries implements /api/salaries.
+//
+// Mirrors backend/app/services/salary_records.py: full CRUD with soft-delete,
+// optional filters (owner, date_from, date_to, company), a current-salary
+// snapshot per persona, and an inflation_context per persona computed via
+// the CPI index.
+package salaries
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// SalaryRecord mirrors backend/app/models/salary_record.SalaryRecord.
+type SalaryRecord struct {
+	ID           int
+	Date         time.Time
+	GrossAmount  decimal.Decimal
+	ContractType string
+	Company      string
+	Owner        string
+	IsActive     bool
+	CreatedAt    time.Time
+}
+
+// ErrNotFound is returned for missing or soft-deleted rows.
+var ErrNotFound = errors.New("salary record not found")
+
+// ErrDuplicate is returned when (owner, date) already has an active record.
+var ErrDuplicate = errors.New("salary record duplicate")
+
+// ListFilter narrows the active rows.
+type ListFilter struct {
+	Owner    *string
+	DateFrom *time.Time
+	DateTo   *time.Time
+	Company  *string
+}
+
+// Store is the persistence boundary.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const selectColumns = `
+	id, date, gross_amount, contract_type, company, owner, is_active, created_at
+`
+
+// List returns active rows ordered by date desc + the distinct active-company
+// list (unfiltered, so the dropdown stays usable across filters).
+func (s *Store) List(ctx context.Context, f ListFilter) ([]SalaryRecord, []string, error) {
+	conds := []string{"is_active = true"}
+	args := []any{}
+	if f.Owner != nil {
+		args = append(args, *f.Owner)
+		conds = append(conds, fmt.Sprintf("owner = $%d", len(args)))
+	}
+	if f.DateFrom != nil {
+		args = append(args, *f.DateFrom)
+		conds = append(conds, fmt.Sprintf("date >= $%d", len(args)))
+	}
+	if f.DateTo != nil {
+		args = append(args, *f.DateTo)
+		conds = append(conds, fmt.Sprintf("date <= $%d", len(args)))
+	}
+	if f.Company != nil {
+		args = append(args, *f.Company)
+		conds = append(conds, fmt.Sprintf("company = $%d", len(args)))
+	}
+	query := `SELECT ` + selectColumns + ` FROM salary_records WHERE ` +
+		strings.Join(conds, " AND ") + ` ORDER BY date DESC`
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("select salary_records: %w", err)
+	}
+	defer rows.Close()
+	out := []SalaryRecord{}
+	for rows.Next() {
+		r, err := scanRecord(rows)
+		if err != nil {
+			return nil, nil, fmt.Errorf("scan salary record: %w", err)
+		}
+		out = append(out, *r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate salary records: %w", err)
+	}
+	companies, err := s.activeCompanies(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, companies, nil
+}
+
+// Get returns the active record or ErrNotFound.
+func (s *Store) Get(ctx context.Context, id int) (*SalaryRecord, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+selectColumns+` FROM salary_records WHERE id = $1`, id,
+	)
+	r, err := scanRecord(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("select salary record: %w", err)
+	}
+	if !r.IsActive {
+		return nil, ErrNotFound
+	}
+	return r, nil
+}
+
+// Create inserts a row. Returns ErrDuplicate when (owner, date) already
+// has an active record — matches Python's 409 contract.
+func (s *Store) Create(ctx context.Context, r *SalaryRecord) (*SalaryRecord, error) {
+	var existing int
+	err := s.pool.QueryRow(ctx, `
+		SELECT id FROM salary_records
+		WHERE owner = $1 AND date = $2 AND is_active = true
+		LIMIT 1`,
+		r.Owner, r.Date,
+	).Scan(&existing)
+	if err == nil {
+		return nil, ErrDuplicate
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("check duplicate salary: %w", err)
+	}
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO salary_records (
+			date, gross_amount, contract_type, company, owner, is_active, created_at
+		) VALUES ($1, $2, $3, $4, $5, true, $6)
+		RETURNING `+selectColumns,
+		r.Date, r.GrossAmount, r.ContractType, r.Company, r.Owner, time.Now().UTC(),
+	)
+	return scanRecord(row)
+}
+
+// UpdatePatch is the sparse update set; nil = no-op.
+type UpdatePatch struct {
+	Date         *time.Time
+	GrossAmount  *decimal.Decimal
+	ContractType *string
+	Company      *string
+	Owner        *string
+}
+
+// Update applies the patch and returns the refreshed row.
+func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*SalaryRecord, error) {
+	r, err := s.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if p.Date != nil {
+		r.Date = *p.Date
+	}
+	if p.GrossAmount != nil {
+		r.GrossAmount = *p.GrossAmount
+	}
+	if p.ContractType != nil {
+		r.ContractType = *p.ContractType
+	}
+	if p.Company != nil {
+		r.Company = *p.Company
+	}
+	if p.Owner != nil {
+		r.Owner = *p.Owner
+	}
+	row := s.pool.QueryRow(ctx, `
+		UPDATE salary_records SET
+			date = $1, gross_amount = $2, contract_type = $3,
+			company = $4, owner = $5
+		WHERE id = $6 AND is_active = true
+		RETURNING `+selectColumns,
+		r.Date, r.GrossAmount, r.ContractType, r.Company, r.Owner, id,
+	)
+	updated, err := scanRecord(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("update salary record: %w", err)
+	}
+	return updated, nil
+}
+
+// Delete soft-deletes.
+func (s *Store) Delete(ctx context.Context, id int) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE salary_records SET is_active = false WHERE id = $1 AND is_active = true`,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("soft-delete salary record: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// CurrentSalaryByPersona returns the latest active gross_amount on/before
+// asOfDate for each persona name in the input list. Personas without any
+// matching record are absent from the map (and rendered as null in the
+// response).
+func (s *Store) CurrentSalaryByPersona(
+	ctx context.Context, personaNames []string, asOfDate time.Time,
+) (map[string]decimal.Decimal, error) {
+	if len(personaNames) == 0 {
+		return map[string]decimal.Decimal{}, nil
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT DISTINCT ON (owner) owner, gross_amount
+		FROM salary_records
+		WHERE is_active = true AND owner = ANY($1) AND date <= $2
+		ORDER BY owner, date DESC`,
+		personaNames, asOfDate,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("select current salaries: %w", err)
+	}
+	defer rows.Close()
+	out := map[string]decimal.Decimal{}
+	for rows.Next() {
+		var owner string
+		var amount decimal.Decimal
+		if err := rows.Scan(&owner, &amount); err != nil {
+			return nil, fmt.Errorf("scan current salary: %w", err)
+		}
+		out[owner] = amount
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate current salaries: %w", err)
+	}
+	return out, nil
+}
+
+// RecentTwoByPersona returns up to two most-recent active records per owner
+// on/before asOfDate, ordered by date desc per owner. Used to compute
+// inflation_context (current vs previous salary).
+func (s *Store) RecentTwoByPersona(
+	ctx context.Context, personaNames []string, asOfDate time.Time,
+) (map[string][]SalaryRecord, error) {
+	if len(personaNames) == 0 {
+		return map[string][]SalaryRecord{}, nil
+	}
+	rows, err := s.pool.Query(ctx, `
+		WITH ranked AS (
+			SELECT id, date, gross_amount, contract_type, company, owner, is_active, created_at,
+			       ROW_NUMBER() OVER (PARTITION BY owner ORDER BY date DESC) AS rn
+			FROM salary_records
+			WHERE is_active = true AND owner = ANY($1) AND date <= $2
+		)
+		SELECT id, date, gross_amount, contract_type, company, owner, is_active, created_at
+		FROM ranked WHERE rn <= 2
+		ORDER BY owner, date DESC`,
+		personaNames, asOfDate,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("select recent salaries: %w", err)
+	}
+	defer rows.Close()
+	out := map[string][]SalaryRecord{}
+	for rows.Next() {
+		r, err := scanRecord(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan recent salary: %w", err)
+		}
+		out[r.Owner] = append(out[r.Owner], *r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate recent salaries: %w", err)
+	}
+	return out, nil
+}
+
+// ActivePersonaNames returns the persona names sorted alphabetically.
+func (s *Store) ActivePersonaNames(ctx context.Context) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `SELECT name FROM personas ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("select persona names: %w", err)
+	}
+	defer rows.Close()
+	out := []string{}
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			return nil, fmt.Errorf("scan persona name: %w", err)
+		}
+		out = append(out, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate persona names: %w", err)
+	}
+	return out, nil
+}
+
+func (s *Store) activeCompanies(ctx context.Context) ([]string, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT DISTINCT company FROM salary_records
+		 WHERE is_active = true ORDER BY company`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("select active companies: %w", err)
+	}
+	defer rows.Close()
+	out := []string{}
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, fmt.Errorf("scan company: %w", err)
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate companies: %w", err)
+	}
+	return out, nil
+}
+
+func scanRecord(row pgx.Row) (*SalaryRecord, error) {
+	var r SalaryRecord
+	if err := row.Scan(
+		&r.ID, &r.Date, &r.GrossAmount, &r.ContractType,
+		&r.Company, &r.Owner, &r.IsActive, &r.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}

--- a/backend-go/internal/salaries/validation.go
+++ b/backend-go/internal/salaries/validation.go
@@ -1,0 +1,188 @@
+package salaries
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// createRequest is the validated POST body.
+type createRequest struct {
+	Date         time.Time
+	GrossAmount  decimal.Decimal
+	ContractType string
+	Company      string
+	Owner        string
+}
+
+// buildCreateRequest validates the body. Numbers are parsed via
+// decimal.NewFromString on raw token bytes (preserves precision); required
+// fields surface "Field required" on missing.
+func buildCreateRequest(raw map[string]json.RawMessage, now func() time.Time) (createRequest, *validationError) {
+	var r createRequest
+	t, vErr := requireDate(raw, "date")
+	if vErr != nil {
+		return r, vErr
+	}
+	if t.After(truncateDay(now().UTC())) {
+		return r, &validationError{Field: "date", Msg: "Date cannot be in the future"}
+	}
+	r.Date = t
+
+	amount, vErr := requirePositiveDecimal(raw, "gross_amount", "Gross amount must be greater than 0")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.GrossAmount = amount
+
+	contract, vErr := requireEnumString(raw, "contract_type", validContractTypes)
+	if vErr != nil {
+		return r, vErr
+	}
+	r.ContractType = contract
+
+	company, vErr := requireString(raw, "company", "Company cannot be empty")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Company = company
+
+	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Owner = owner
+	return r, nil
+}
+
+// buildUpdatePatch reads the PATCH body. Null = no-op (Pydantic semantics).
+func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (UpdatePatch, *validationError) {
+	var p UpdatePatch
+	if v, ok := raw["date"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return p, &validationError{Field: "date", Msg: "must be a string"}
+		}
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return p, &validationError{Field: "date", Msg: "must be YYYY-MM-DD"}
+		}
+		if t.After(truncateDay(now().UTC())) {
+			return p, &validationError{Field: "date", Msg: "Date cannot be in the future"}
+		}
+		p.Date = &t
+	}
+	if v, ok := raw["gross_amount"]; ok && !isNull(v) {
+		d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+		if err != nil {
+			return p, &validationError{Field: "gross_amount", Msg: "must be a number"}
+		}
+		if !d.IsPositive() {
+			return p, &validationError{Field: "gross_amount", Msg: "Gross amount must be greater than 0"}
+		}
+		p.GrossAmount = &d
+	}
+	if v, ok := raw["contract_type"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return p, &validationError{Field: "contract_type", Msg: "must be a string"}
+		}
+		if _, ok := validContractTypes[s]; !ok {
+			return p, &validationError{Field: "contract_type", Msg: fmt.Sprintf("invalid contract type %q", s)}
+		}
+		p.ContractType = &s
+	}
+	if v, ok := raw["company"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return p, &validationError{Field: "company", Msg: "must be a string"}
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return p, &validationError{Field: "company", Msg: "Company cannot be empty"}
+		}
+		p.Company = &s
+	}
+	if v, ok := raw["owner"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return p, &validationError{Field: "owner", Msg: "must be a string"}
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return p, &validationError{Field: "owner", Msg: "Owner cannot be empty"}
+		}
+		p.Owner = &s
+	}
+	return p, nil
+}
+
+func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", &validationError{Field: key, Msg: emptyMsg}
+	}
+	return s, nil
+}
+
+func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return time.Time{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be a string"}
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be YYYY-MM-DD"}
+	}
+	return t, nil
+}
+
+func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if err != nil {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if !d.IsPositive() {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: msg}
+	}
+	return d, nil
+}
+
+func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return "", &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	return s, nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/personas"
+	"github.com/Automaat/finance-buddy/backend-go/internal/salaries"
 )
 
 // Config holds the runtime knobs the server reads at startup.
@@ -128,11 +129,21 @@ func New(cfg Config, logger *slog.Logger, deps Deps) http.Handler {
 			r.Delete("/{id}", grantsHandler.Delete)
 		})
 
-		cpiHandler := cpi.NewHandler(cpi.NewStore(deps.Pool), cpi.NewGUSFetcher(), logger)
+		cpiStore := cpi.NewStore(deps.Pool)
+		cpiHandler := cpi.NewHandler(cpiStore, cpi.NewGUSFetcher(), logger)
 		r.Route("/api/cpi", func(r chi.Router) {
 			r.Get("/series", cpiHandler.GetSeries)
 			r.Post("/adjust", cpiHandler.Adjust)
 			r.Post("/refresh", cpiHandler.Refresh)
+		})
+
+		salariesHandler := salaries.NewHandler(salaries.NewStore(deps.Pool), cpiStore, logger)
+		r.Route("/api/salaries", func(r chi.Router) {
+			r.Get("/", salariesHandler.List)
+			r.Post("/", salariesHandler.Create)
+			r.Get("/{id}", salariesHandler.Get)
+			r.Patch("/{id}", salariesHandler.Update)
+			r.Delete("/{id}", salariesHandler.Delete)
 		})
 	}
 

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -89,3 +89,16 @@ rules:
   - method: POST
     path_prefix: /api/cpi
     upstream: http://backend-go:8000
+  # Group 6 — /api/salaries cut over to Go (CRUD + CPI-derived inflation_context).
+  - method: GET
+    path_prefix: /api/salaries
+    upstream: http://backend-go:8000
+  - method: POST
+    path_prefix: /api/salaries
+    upstream: http://backend-go:8000
+  - method: PATCH
+    path_prefix: /api/salaries
+    upstream: http://backend-go:8000
+  - method: DELETE
+    path_prefix: /api/salaries
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

Group 6 cutover — `/api/salaries`. Depends on Group 2 (personas owner-rename cascade — already cut over) and Group 5 (CPI — merged in the prior PR). Blocks Group 7 (ZUS reads salary history).

Adds the inflation-aware derived fields the dashboard uses: `previous_salary_in_today_pln`, `real_change_pln`, `real_change_pct`. They're computed against the CPI index that Group 5 brought to Go.

## Implementation information

### `internal/salaries/store.go`

- Full CRUD with soft-delete.
- `Create` does a pre-check on `(owner, date, is_active=true)` and surfaces `ErrDuplicate` → 409 (Python's contract on the same condition).
- `CurrentSalaryByPersona` uses `DISTINCT ON (owner)` for the latest active record on/before a date — single query, no per-owner loop.
- `RecentTwoByPersona` uses a `ROW_NUMBER() OVER (PARTITION BY owner ORDER BY date DESC)` CTE to fetch the top-2 records per owner in one shot. Same query shape Python uses.
- `ActivePersonaNames` returns persona names alphabetically — keys for the response maps.

### `internal/salaries/handler.go`

- chi routes (GET list, GET by id, POST, PATCH, DELETE).
- `List` response includes:
  - `salary_records` — array
  - `total_count`
  - `current_salaries` — `{persona_name -> float|null}`
  - `inflation_context` — `{owner -> InflationContext}`
  - `available_companies` — alphabetical, distinct
- `buildInflationContext` mirrors Python's `_build_inflation_context`:
  - skips personas without an `as_of_year` or empty CPI index
  - skips personas with `< 2` records
  - computes `previous_salary_in_today_pln` via `cpi.AdjustWithIndex` against the previous record's date
  - skips persona if the CPI adjustment errors out (e.g. ErrInflationDataMissing)
  - derives `real_change_pln = current - prev_in_today` and `real_change_pct = ratio * 100` (null when `prev_in_today` is zero)

### `internal/salaries/validation.go`

- POST required fields: date, gross_amount, contract_type, company, owner.
- `gross_amount` parsed via `decimal.NewFromString` on raw bytes (no float64 intermediate).
- Date-not-future enforced.
- Contract type allow-list: UOP, UZ, UoD, B2B.
- PATCH: null = no-op (Pydantic semantics).

### Parity proof against Go

```
============================= test session starts ==============================
tests/test_salary_records.py::test_list_salaries_includes_seeded            PASSED
tests/test_salary_records.py::test_get_salary_by_id_returns_seeded_record   PASSED
tests/test_salary_records.py::test_get_salary_not_found                     PASSED
tests/test_salary_records.py::test_create_salary_happy_path                 PASSED
tests/test_salary_records.py::test_create_salary_validation_error           PASSED
tests/test_salary_records.py::test_update_salary_happy_path                 PASSED
tests/test_salary_records.py::test_update_salary_validation_error           PASSED
tests/test_salary_records.py::test_delete_salary_happy_path                 PASSED
============================== 8 passed in 0.15s ===============================
```

### `routes.yaml`

GET/POST/PATCH/DELETE rules for `/api/salaries/`.

## Supporting documentation

- Umbrella: #435
- Subissue: #441
- Procedure: `migration/CUTOVER.md`

> Changelog: skip