### PR TITLE
feat(go): cutover /api/zus (Group 7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,8 @@ jobs:
             tests/test_bonus_events.py \
             tests/test_equity_grants.py \
             tests/test_cpi.py \
-            tests/test_salary_records.py
+            tests/test_salary_records.py \
+            tests/test_zus.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/personas"
 	"github.com/Automaat/finance-buddy/backend-go/internal/salaries"
+	"github.com/Automaat/finance-buddy/backend-go/internal/zus"
 )
 
 // Config holds the runtime knobs the server reads at startup.
@@ -69,85 +70,89 @@ func New(cfg Config, logger *slog.Logger, deps Deps) http.Handler {
 	r.Get("/health", healthHandler(logger))
 
 	if deps.Pool != nil {
-		cfgHandler := config.NewHandler(config.NewStore(deps.Pool), logger)
-		r.Route("/api/config", func(r chi.Router) {
-			r.Get("/", cfgHandler.Get)
-			r.Put("/", cfgHandler.Put)
-		})
-
-		personasHandler := personas.NewHandler(personas.NewStore(deps.Pool), logger)
-		r.Route("/api/personas", func(r chi.Router) {
-			r.Get("/", personasHandler.List)
-			r.Post("/", personasHandler.Create)
-			r.Put("/{id}", personasHandler.Update)
-			r.Delete("/{id}", personasHandler.Delete)
-		})
-
-		goalsHandler := goals.NewHandler(goals.NewStore(deps.Pool), logger)
-		r.Route("/api/goals", func(r chi.Router) {
-			r.Get("/", goalsHandler.List)
-			r.Post("/", goalsHandler.Create)
-			r.Get("/{id}", goalsHandler.Get)
-			r.Put("/{id}", goalsHandler.Update)
-			r.Delete("/{id}", goalsHandler.Delete)
-		})
-
-		valuationsHandler := companyvaluations.NewHandler(
-			companyvaluations.NewStore(deps.Pool), logger,
-		)
-		r.Route("/api/company-valuations", func(r chi.Router) {
-			r.Get("/", valuationsHandler.List)
-			r.Post("/", valuationsHandler.Create)
-			r.Get("/{id}", valuationsHandler.Get)
-			r.Patch("/{id}", valuationsHandler.Update)
-			r.Delete("/{id}", valuationsHandler.Delete)
-		})
-
-		fxSvc := fx.NewService(deps.Pool, logger)
-		bonusesHandler := bonusevents.NewHandler(
-			bonusevents.NewStore(deps.Pool), fxSvc, logger,
-		)
-		r.Route("/api/bonuses", func(r chi.Router) {
-			r.Get("/", bonusesHandler.List)
-			r.Post("/", bonusesHandler.Create)
-			r.Get("/{id}", bonusesHandler.Get)
-			r.Patch("/{id}", bonusesHandler.Update)
-			r.Delete("/{id}", bonusesHandler.Delete)
-		})
-
-		grantsHandler := equitygrants.NewHandler(
-			equitygrants.NewStore(deps.Pool),
-			companyvaluations.NewStore(deps.Pool),
-			fxSvc,
-			logger,
-		)
-		r.Route("/api/equity-grants", func(r chi.Router) {
-			r.Get("/", grantsHandler.List)
-			r.Post("/", grantsHandler.Create)
-			r.Get("/{id}", grantsHandler.Get)
-			r.Patch("/{id}", grantsHandler.Update)
-			r.Delete("/{id}", grantsHandler.Delete)
-		})
-
-		cpiStore := cpi.NewStore(deps.Pool)
-		cpiHandler := cpi.NewHandler(cpiStore, cpi.NewGUSFetcher(), logger)
-		r.Route("/api/cpi", func(r chi.Router) {
-			r.Get("/series", cpiHandler.GetSeries)
-			r.Post("/adjust", cpiHandler.Adjust)
-			r.Post("/refresh", cpiHandler.Refresh)
-		})
-
-		salariesHandler := salaries.NewHandler(salaries.NewStore(deps.Pool), cpiStore, logger)
-		r.Route("/api/salaries", func(r chi.Router) {
-			r.Get("/", salariesHandler.List)
-			r.Post("/", salariesHandler.Create)
-			r.Get("/{id}", salariesHandler.Get)
-			r.Patch("/{id}", salariesHandler.Update)
-			r.Delete("/{id}", salariesHandler.Delete)
-		})
+		registerAPIRoutes(r, deps.Pool, logger)
 	}
 
 	return r
+}
+
+func registerAPIRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
+	cfgHandler := config.NewHandler(config.NewStore(pool), logger)
+	r.Route("/api/config", func(r chi.Router) {
+		r.Get("/", cfgHandler.Get)
+		r.Put("/", cfgHandler.Put)
+	})
+
+	personasHandler := personas.NewHandler(personas.NewStore(pool), logger)
+	r.Route("/api/personas", func(r chi.Router) {
+		r.Get("/", personasHandler.List)
+		r.Post("/", personasHandler.Create)
+		r.Put("/{id}", personasHandler.Update)
+		r.Delete("/{id}", personasHandler.Delete)
+	})
+
+	goalsHandler := goals.NewHandler(goals.NewStore(pool), logger)
+	r.Route("/api/goals", func(r chi.Router) {
+		r.Get("/", goalsHandler.List)
+		r.Post("/", goalsHandler.Create)
+		r.Get("/{id}", goalsHandler.Get)
+		r.Put("/{id}", goalsHandler.Update)
+		r.Delete("/{id}", goalsHandler.Delete)
+	})
+
+	valuationsStore := companyvaluations.NewStore(pool)
+	valuationsHandler := companyvaluations.NewHandler(valuationsStore, logger)
+	r.Route("/api/company-valuations", func(r chi.Router) {
+		r.Get("/", valuationsHandler.List)
+		r.Post("/", valuationsHandler.Create)
+		r.Get("/{id}", valuationsHandler.Get)
+		r.Patch("/{id}", valuationsHandler.Update)
+		r.Delete("/{id}", valuationsHandler.Delete)
+	})
+
+	fxSvc := fx.NewService(pool, logger)
+	bonusesHandler := bonusevents.NewHandler(bonusevents.NewStore(pool), fxSvc, logger)
+	r.Route("/api/bonuses", func(r chi.Router) {
+		r.Get("/", bonusesHandler.List)
+		r.Post("/", bonusesHandler.Create)
+		r.Get("/{id}", bonusesHandler.Get)
+		r.Patch("/{id}", bonusesHandler.Update)
+		r.Delete("/{id}", bonusesHandler.Delete)
+	})
+
+	grantsHandler := equitygrants.NewHandler(
+		equitygrants.NewStore(pool), valuationsStore, fxSvc, logger,
+	)
+	r.Route("/api/equity-grants", func(r chi.Router) {
+		r.Get("/", grantsHandler.List)
+		r.Post("/", grantsHandler.Create)
+		r.Get("/{id}", grantsHandler.Get)
+		r.Patch("/{id}", grantsHandler.Update)
+		r.Delete("/{id}", grantsHandler.Delete)
+	})
+
+	cpiStore := cpi.NewStore(pool)
+	cpiHandler := cpi.NewHandler(cpiStore, cpi.NewGUSFetcher(), logger)
+	r.Route("/api/cpi", func(r chi.Router) {
+		r.Get("/series", cpiHandler.GetSeries)
+		r.Post("/adjust", cpiHandler.Adjust)
+		r.Post("/refresh", cpiHandler.Refresh)
+	})
+
+	salariesHandler := salaries.NewHandler(salaries.NewStore(pool), cpiStore, logger)
+	r.Route("/api/salaries", func(r chi.Router) {
+		r.Get("/", salariesHandler.List)
+		r.Post("/", salariesHandler.Create)
+		r.Get("/{id}", salariesHandler.Get)
+		r.Patch("/{id}", salariesHandler.Update)
+		r.Delete("/{id}", salariesHandler.Delete)
+	})
+
+	zusHandler := zus.NewHandler(zus.NewStore(pool), logger)
+	r.Route("/api/zus", func(r chi.Router) {
+		r.Post("/calculate", zusHandler.Calculate)
+		r.Get("/prefill", zusHandler.Prefill)
+	})
 }
 
 func healthHandler(logger *slog.Logger) http.HandlerFunc {

--- a/backend-go/internal/zus/calculator.go
+++ b/backend-go/internal/zus/calculator.go
@@ -1,0 +1,305 @@
+// Package zus implements /api/zus — pension projection + prefill.
+//
+// calculator.go is a pure-functions port of
+// backend/app/services/zus_calculator.py. Math intentionally uses float64
+// throughout to match Python's behavior byte-for-byte (every round is the
+// same round(x, 2)).
+package zus
+
+import (
+	"math"
+)
+
+// ZUS contribution rates (% of gross salary).
+const (
+	contributionRateKonto         = 0.1222
+	contributionRateSubkontoNoOFE = 0.0730
+	contributionRateSubkontoOFE   = 0.0438
+)
+
+// 30x average salary cap — annual limit on contribution base (2026 estimate).
+const (
+	cap30x2026     = 282_600.0
+	capGrowthRate  = 0.05
+	pitRate        = 0.12
+	healthRate     = 0.09
+	annualFreeThr  = 30_000.0
+	baseCapYear    = 2026
+	monthsPerYear  = 12.0
+	suwakLookahead = 10
+)
+
+// lifeExpectancyMonths — GUS 2025 dalsze trwanie życia at retirement age.
+var lifeExpectancyMonths = map[int]float64{
+	55: 318.0, 56: 312.0, 57: 306.0, 58: 300.0, 59: 294.0,
+	60: 266.4, 61: 260.4, 62: 254.4, 63: 248.4, 64: 234.6,
+	65: 220.8, 66: 214.8, 67: 208.8, 68: 202.8, 69: 196.8,
+	70: 190.8,
+}
+
+// Inputs mirrors the Pydantic ZusCalculatorInputs after validation.
+type Inputs struct {
+	Owner                     string
+	BirthYear                 int
+	Gender                    string
+	RetirementAge             int
+	CurrentGrossMonthlySalary float64
+	SalaryGrowthRate          float64
+	InflationRate             float64
+	ValorizationRateKonto     float64
+	ValorizationRateSubkonto  float64
+	HasOFE                    bool
+	KapitalPoczatkowy         float64
+	WorkStartYear             int
+	SalaryHistory             map[int]float64
+}
+
+// YearlyProjection mirrors ZusYearlyProjection.
+type YearlyProjection struct {
+	Year                 int
+	Age                  int
+	AnnualGrossSalary    float64
+	SalaryCapped         bool
+	ContributionKonto    float64
+	ContributionSubkonto float64
+	KontoBalance         float64
+	SubkontoBalance      float64
+	TotalBalance         float64
+}
+
+// SensitivityScenario mirrors ZusSensitivityScenario.
+type SensitivityScenario struct {
+	Label                string
+	ValorizationKonto    float64
+	ValorizationSubkonto float64
+	MonthlyPensionGross  float64
+	MonthlyPensionNet    float64
+	ReplacementRate      float64
+}
+
+// Result mirrors ZusCalculatorResponse minus the echoed inputs (handler
+// re-attaches them).
+type Result struct {
+	YearlyProjections          []YearlyProjection
+	LifeExpectancyMonths       float64
+	KontoAtRetirement          float64
+	SubkontoAtRetirement       float64
+	KapitalPoczatkowyValorized float64
+	TotalCapital               float64
+	MonthlyPensionGross        float64
+	MonthlyPensionNet          float64
+	ReplacementRate            float64
+	LastGrossSalary            float64
+	Sensitivity                []SensitivityScenario
+}
+
+// Calculate runs the ZUS projection. Pure function — no I/O.
+func Calculate(in Inputs, currentYear int) Result {
+	retirementYear := in.BirthYear + in.RetirementAge
+	subkontoRate := contributionRateSubkontoNoOFE
+	if in.HasOFE {
+		subkontoRate = contributionRateSubkontoOFE
+	}
+
+	state := projectionState{
+		kapitalValorized: in.KapitalPoczatkowy,
+		lastSalary:       in.CurrentGrossMonthlySalary * monthsPerYear,
+	}
+	projections := make([]YearlyProjection, 0, retirementYear-in.WorkStartYear)
+	for year := in.WorkStartYear; year < retirementYear; year++ {
+		p := state.step(in, subkontoRate, year, currentYear, retirementYear)
+		projections = append(projections, p)
+	}
+
+	life := lifeExpectancy(in.RetirementAge)
+	totalCapital := state.kapitalValorized + state.konto + state.subkonto
+	monthlyGross := totalCapital / life
+	monthlyNet := applyPensionTax(monthlyGross)
+	replacementRate := 0.0
+	if state.lastSalary > 0 {
+		replacementRate = monthlyGross / (state.lastSalary / monthsPerYear) * 100
+	}
+	sensitivity := buildSensitivity(in, retirementYear, currentYear, life)
+
+	return Result{
+		YearlyProjections:          projections,
+		LifeExpectancyMonths:       life,
+		KontoAtRetirement:          round2(state.konto),
+		SubkontoAtRetirement:       round2(state.subkonto),
+		KapitalPoczatkowyValorized: round2(state.kapitalValorized),
+		TotalCapital:               round2(totalCapital),
+		MonthlyPensionGross:        round2(monthlyGross),
+		MonthlyPensionNet:          round2(monthlyNet),
+		ReplacementRate:            round2(replacementRate),
+		LastGrossSalary:            round2(state.lastSalary / monthsPerYear),
+		Sensitivity:                sensitivity,
+	}
+}
+
+type projectionState struct {
+	konto            float64
+	subkonto         float64
+	kapitalValorized float64
+	lastSalary       float64
+}
+
+func (s *projectionState) step(
+	in Inputs, subkontoRate float64,
+	year, currentYear, retirementYear int,
+) YearlyProjection {
+	annualSalary := salaryForYear(in, year, currentYear)
+	s.lastSalary = annualSalary
+
+	yearsFromBase := max(0, year-baseCapYear)
+	yearCap := cap30x2026 * math.Pow(1+capGrowthRate, float64(yearsFromBase))
+	capped := math.Min(annualSalary, yearCap)
+	salaryCapped := annualSalary > yearCap
+
+	cKonto := capped * contributionRateKonto
+	cSubkonto := capped * subkontoRate
+	if retirementYear-year <= suwakLookahead {
+		cKonto += cSubkonto
+		cSubkonto = 0
+	}
+
+	s.konto *= 1 + in.ValorizationRateKonto/100
+	s.subkonto *= 1 + in.ValorizationRateSubkonto/100
+	s.kapitalValorized *= 1 + in.ValorizationRateKonto/100
+
+	s.konto += cKonto
+	s.subkonto += cSubkonto
+
+	return YearlyProjection{
+		Year:                 year,
+		Age:                  year - in.BirthYear,
+		AnnualGrossSalary:    round2(annualSalary),
+		SalaryCapped:         salaryCapped,
+		ContributionKonto:    round2(cKonto),
+		ContributionSubkonto: round2(cSubkonto),
+		KontoBalance:         round2(s.konto),
+		SubkontoBalance:      round2(s.subkonto),
+		TotalBalance:         round2(s.konto + s.subkonto + s.kapitalValorized),
+	}
+}
+
+func salaryForYear(in Inputs, year, currentYear int) float64 {
+	if v, ok := in.SalaryHistory[year]; ok {
+		return v
+	}
+	if year <= currentYear {
+		return in.CurrentGrossMonthlySalary * monthsPerYear
+	}
+	yearsAhead := float64(year - currentYear)
+	return in.CurrentGrossMonthlySalary * monthsPerYear * math.Pow(1+in.SalaryGrowthRate/100, yearsAhead)
+}
+
+func buildSensitivity(in Inputs, retirementYear, currentYear int, life float64) []SensitivityScenario {
+	deltas := []struct {
+		label string
+		delta float64
+	}{
+		{"Pesymistyczny", -2.0},
+		{"Bazowy", 0.0},
+		{"Optymistyczny", 2.0},
+	}
+	results := make([]SensitivityScenario, 0, len(deltas))
+	for _, d := range deltas {
+		valKonto := in.ValorizationRateKonto + d.delta
+		valSubkonto := in.ValorizationRateSubkonto + d.delta
+		total := quickCalculate(in, retirementYear, currentYear, valKonto, valSubkonto)
+		gross := total / life
+		net := applyPensionTax(gross)
+		lastSalary := projectedLastSalary(in, retirementYear, currentYear)
+		rr := 0.0
+		if lastSalary > 0 {
+			rr = gross / lastSalary * 100
+		}
+		results = append(results, SensitivityScenario{
+			Label:                d.label,
+			ValorizationKonto:    valKonto,
+			ValorizationSubkonto: valSubkonto,
+			MonthlyPensionGross:  round2(gross),
+			MonthlyPensionNet:    round2(net),
+			ReplacementRate:      round2(rr),
+		})
+	}
+	return results
+}
+
+func quickCalculate(in Inputs, retirementYear, currentYear int, valKonto, valSubkonto float64) float64 {
+	subkontoRate := contributionRateSubkontoNoOFE
+	if in.HasOFE {
+		subkontoRate = contributionRateSubkontoOFE
+	}
+	konto := 0.0
+	subkonto := 0.0
+	kapital := in.KapitalPoczatkowy
+	for year := in.WorkStartYear; year < retirementYear; year++ {
+		annualSalary := salaryForYear(in, year, currentYear)
+		yearsFromBase := max(0, year-baseCapYear)
+		yearCap := cap30x2026 * math.Pow(1+capGrowthRate, float64(yearsFromBase))
+		capped := math.Min(annualSalary, yearCap)
+		cKonto := capped * contributionRateKonto
+		cSubkonto := capped * subkontoRate
+		if retirementYear-year <= suwakLookahead {
+			cKonto += cSubkonto
+			cSubkonto = 0
+		}
+		konto *= 1 + valKonto/100
+		subkonto *= 1 + valSubkonto/100
+		kapital *= 1 + valKonto/100
+		konto += cKonto
+		subkonto += cSubkonto
+	}
+	return kapital + konto + subkonto
+}
+
+func projectedLastSalary(in Inputs, retirementYear, currentYear int) float64 {
+	yearsAhead := retirementYear - 1 - currentYear
+	if yearsAhead <= 0 {
+		return in.CurrentGrossMonthlySalary
+	}
+	return in.CurrentGrossMonthlySalary * math.Pow(1+in.SalaryGrowthRate/100, float64(yearsAhead))
+}
+
+func lifeExpectancy(retirementAge int) float64 {
+	if v, ok := lifeExpectancyMonths[retirementAge]; ok {
+		return v
+	}
+	if retirementAge < 55 {
+		return lifeExpectancyMonths[55]
+	}
+	if retirementAge > 70 {
+		return lifeExpectancyMonths[70]
+	}
+	// Linear interpolation between two nearest ages.
+	lower, upper := retirementAge, retirementAge
+	for k := range lifeExpectancyMonths {
+		if k <= retirementAge && k > lower {
+			lower = k
+		}
+		if k >= retirementAge && k < upper {
+			upper = k
+		}
+	}
+	if lower == upper {
+		return lifeExpectancyMonths[lower]
+	}
+	frac := float64(retirementAge-lower) / float64(upper-lower)
+	return lifeExpectancyMonths[lower] + frac*(lifeExpectancyMonths[upper]-lifeExpectancyMonths[lower])
+}
+
+// applyPensionTax mirrors Python's apply_pension_tax (12% PIT with 30k free
+// threshold + 9% health insurance).
+func applyPensionTax(monthlyGross float64) float64 {
+	annualGross := monthlyGross * monthsPerYear
+	annualHealth := annualGross * healthRate
+	taxable := math.Max(0, annualGross-annualFreeThr)
+	annualPIT := taxable * pitRate
+	annualNet := annualGross - annualHealth - annualPIT
+	return math.Max(0, annualNet/monthsPerYear)
+}
+
+func round2(v float64) float64 {
+	return math.Round(v*100) / 100
+}

--- a/backend-go/internal/zus/calculator.go
+++ b/backend-go/internal/zus/calculator.go
@@ -272,8 +272,11 @@ func lifeExpectancy(retirementAge int) float64 {
 	if retirementAge > 70 {
 		return lifeExpectancyMonths[70]
 	}
-	// Linear interpolation between two nearest ages.
-	lower, upper := retirementAge, retirementAge
+	// Linear interpolation between the two nearest known ages.
+	// Initialize lower below the floor and upper above the ceiling so any
+	// matching key in the table will displace the sentinel.
+	lower := -1
+	upper := 1 << 30
 	for k := range lifeExpectancyMonths {
 		if k <= retirementAge && k > lower {
 			lower = k

--- a/backend-go/internal/zus/errors.go
+++ b/backend-go/internal/zus/errors.go
@@ -1,0 +1,41 @@
+package zus
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{
+				"type":  "value_error",
+				"loc":   []string{"body", field},
+				"msg":   msg,
+				"input": input,
+			},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/zus/handler.go
+++ b/backend-go/internal/zus/handler.go
@@ -166,10 +166,15 @@ func (h *Handler) Calculate(w http.ResponseWriter, r *http.Request) {
 
 // Prefill serves GET /api/zus/prefill.
 func (h *Handler) Prefill(w http.ResponseWriter, r *http.Request) {
+	// Mirror Python's `if not owner` semantics: empty string from the query
+	// param falls through to the first-persona fallback exactly like Python's
+	// `Query(None)` default. Don't TrimSpace — Python doesn't.
 	var ownerHint *string
-	if v := strings.TrimSpace(r.URL.Query().Get("owner")); v != "" {
-		o := v
-		ownerHint = &o
+	if r.URL.Query().Has("owner") {
+		v := r.URL.Query().Get("owner")
+		if v != "" {
+			ownerHint = &v
+		}
 	}
 	data, err := h.store.LoadPrefill(r.Context(), ownerHint)
 	if err != nil {

--- a/backend-go/internal/zus/handler.go
+++ b/backend-go/internal/zus/handler.go
@@ -1,0 +1,248 @@
+package zus
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Handler is the HTTP boundary for /api/zus.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+	now    func() time.Time
+}
+
+// NewHandler wires the store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger, now: time.Now}
+}
+
+// --- wire types ---
+
+type salaryHistoryEntry struct {
+	Year        int     `json:"year"`
+	AnnualGross pyFloat `json:"annual_gross"`
+}
+
+type inputsResponse struct {
+	Owner                     string               `json:"owner"`
+	BirthDate                 isoDate              `json:"birth_date"`
+	Gender                    string               `json:"gender"`
+	RetirementAge             int                  `json:"retirement_age"`
+	CurrentGrossMonthlySalary pyFloat              `json:"current_gross_monthly_salary"`
+	SalaryGrowthRate          pyFloat              `json:"salary_growth_rate"`
+	InflationRate             pyFloat              `json:"inflation_rate"`
+	ValorizationRateKonto     pyFloat              `json:"valorization_rate_konto"`
+	ValorizationRateSubkonto  pyFloat              `json:"valorization_rate_subkonto"`
+	HasOFE                    bool                 `json:"has_ofe"`
+	KapitalPoczatkowy         pyFloat              `json:"kapital_poczatkowy"`
+	WorkStartYear             int                  `json:"work_start_year"`
+	SalaryHistory             []salaryHistoryEntry `json:"salary_history"`
+}
+
+type projectionResponse struct {
+	Year                 int     `json:"year"`
+	Age                  int     `json:"age"`
+	AnnualGrossSalary    pyFloat `json:"annual_gross_salary"`
+	SalaryCapped         bool    `json:"salary_capped"`
+	ContributionKonto    pyFloat `json:"contribution_konto"`
+	ContributionSubkonto pyFloat `json:"contribution_subkonto"`
+	KontoBalance         pyFloat `json:"konto_balance"`
+	SubkontoBalance      pyFloat `json:"subkonto_balance"`
+	TotalBalance         pyFloat `json:"total_balance"`
+}
+
+type sensitivityResponse struct {
+	Label                string  `json:"label"`
+	ValorizationKonto    pyFloat `json:"valorization_konto"`
+	ValorizationSubkonto pyFloat `json:"valorization_subkonto"`
+	MonthlyPensionGross  pyFloat `json:"monthly_pension_gross"`
+	MonthlyPensionNet    pyFloat `json:"monthly_pension_net"`
+	ReplacementRate      pyFloat `json:"replacement_rate"`
+}
+
+type calculateResponse struct {
+	Inputs                     inputsResponse        `json:"inputs"`
+	YearlyProjections          []projectionResponse  `json:"yearly_projections"`
+	LifeExpectancyMonths       pyFloat               `json:"life_expectancy_months"`
+	KontoAtRetirement          pyFloat               `json:"konto_at_retirement"`
+	SubkontoAtRetirement       pyFloat               `json:"subkonto_at_retirement"`
+	KapitalPoczatkowyValorized pyFloat               `json:"kapital_poczatkowy_valorized"`
+	TotalCapital               pyFloat               `json:"total_capital"`
+	MonthlyPensionGross        pyFloat               `json:"monthly_pension_gross"`
+	MonthlyPensionNet          pyFloat               `json:"monthly_pension_net"`
+	ReplacementRate            pyFloat               `json:"replacement_rate"`
+	LastGrossSalary            pyFloat               `json:"last_gross_salary"`
+	Sensitivity                []sensitivityResponse `json:"sensitivity"`
+}
+
+type prefillResponse struct {
+	BirthDate                 *isoDate             `json:"birth_date"`
+	RetirementAge             int                  `json:"retirement_age"`
+	Gender                    string               `json:"gender"`
+	CurrentGrossMonthlySalary *pyFloat             `json:"current_gross_monthly_salary"`
+	Owner                     *string              `json:"owner"`
+	SalaryHistory             []salaryHistoryEntry `json:"salary_history"`
+	WorkStartYear             *int                 `json:"work_start_year"`
+}
+
+// Calculate serves POST /api/zus/calculate.
+func (h *Handler) Calculate(w http.ResponseWriter, r *http.Request) {
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	req, vErr := buildInputs(raw, h.now)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	currentYear := h.now().UTC().Year()
+	result := Calculate(req.Inputs, currentYear)
+
+	hist := historyAsList(req.Inputs.SalaryHistory)
+	resp := calculateResponse{
+		Inputs: inputsResponse{
+			Owner:                     req.Inputs.Owner,
+			BirthDate:                 isoDate(req.BirthDate),
+			Gender:                    req.Inputs.Gender,
+			RetirementAge:             req.Inputs.RetirementAge,
+			CurrentGrossMonthlySalary: pyFloat(req.Inputs.CurrentGrossMonthlySalary),
+			SalaryGrowthRate:          pyFloat(req.Inputs.SalaryGrowthRate),
+			InflationRate:             pyFloat(req.Inputs.InflationRate),
+			ValorizationRateKonto:     pyFloat(req.Inputs.ValorizationRateKonto),
+			ValorizationRateSubkonto:  pyFloat(req.Inputs.ValorizationRateSubkonto),
+			HasOFE:                    req.Inputs.HasOFE,
+			KapitalPoczatkowy:         pyFloat(req.Inputs.KapitalPoczatkowy),
+			WorkStartYear:             req.Inputs.WorkStartYear,
+			SalaryHistory:             hist,
+		},
+		LifeExpectancyMonths:       pyFloat(result.LifeExpectancyMonths),
+		KontoAtRetirement:          pyFloat(result.KontoAtRetirement),
+		SubkontoAtRetirement:       pyFloat(result.SubkontoAtRetirement),
+		KapitalPoczatkowyValorized: pyFloat(result.KapitalPoczatkowyValorized),
+		TotalCapital:               pyFloat(result.TotalCapital),
+		MonthlyPensionGross:        pyFloat(result.MonthlyPensionGross),
+		MonthlyPensionNet:          pyFloat(result.MonthlyPensionNet),
+		ReplacementRate:            pyFloat(result.ReplacementRate),
+		LastGrossSalary:            pyFloat(result.LastGrossSalary),
+	}
+	resp.YearlyProjections = make([]projectionResponse, 0, len(result.YearlyProjections))
+	for _, p := range result.YearlyProjections {
+		resp.YearlyProjections = append(resp.YearlyProjections, projectionResponse{
+			Year: p.Year, Age: p.Age,
+			AnnualGrossSalary:    pyFloat(p.AnnualGrossSalary),
+			SalaryCapped:         p.SalaryCapped,
+			ContributionKonto:    pyFloat(p.ContributionKonto),
+			ContributionSubkonto: pyFloat(p.ContributionSubkonto),
+			KontoBalance:         pyFloat(p.KontoBalance),
+			SubkontoBalance:      pyFloat(p.SubkontoBalance),
+			TotalBalance:         pyFloat(p.TotalBalance),
+		})
+	}
+	resp.Sensitivity = make([]sensitivityResponse, 0, len(result.Sensitivity))
+	for _, s := range result.Sensitivity {
+		resp.Sensitivity = append(resp.Sensitivity, sensitivityResponse{
+			Label:                s.Label,
+			ValorizationKonto:    pyFloat(s.ValorizationKonto),
+			ValorizationSubkonto: pyFloat(s.ValorizationSubkonto),
+			MonthlyPensionGross:  pyFloat(s.MonthlyPensionGross),
+			MonthlyPensionNet:    pyFloat(s.MonthlyPensionNet),
+			ReplacementRate:      pyFloat(s.ReplacementRate),
+		})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// Prefill serves GET /api/zus/prefill.
+func (h *Handler) Prefill(w http.ResponseWriter, r *http.Request) {
+	var ownerHint *string
+	if v := strings.TrimSpace(r.URL.Query().Get("owner")); v != "" {
+		o := v
+		ownerHint = &o
+	}
+	data, err := h.store.LoadPrefill(r.Context(), ownerHint)
+	if err != nil {
+		h.logger.Error("zus prefill", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	resp := prefillResponse{
+		RetirementAge: data.RetirementAge,
+		Gender:        "M",
+	}
+	if data.BirthDate != nil {
+		d := isoDate(*data.BirthDate)
+		resp.BirthDate = &d
+	}
+	if data.Owner != nil {
+		o := *data.Owner
+		resp.Owner = &o
+	}
+	if data.CurrentGrossMonthlySalary != nil {
+		v := pyFloat(*data.CurrentGrossMonthlySalary)
+		resp.CurrentGrossMonthlySalary = &v
+	}
+	if data.WorkStartYear != nil {
+		w := *data.WorkStartYear
+		resp.WorkStartYear = &w
+	}
+	resp.SalaryHistory = historyAsList(data.YearlySalaryHistory)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func historyAsList(yearly map[int]float64) []salaryHistoryEntry {
+	years := make([]int, 0, len(yearly))
+	for y := range yearly {
+		years = append(years, y)
+	}
+	sort.Ints(years)
+	out := make([]salaryHistoryEntry, 0, len(years))
+	for _, y := range years {
+		out = append(out, salaryHistoryEntry{Year: y, AnnualGross: pyFloat(yearly[y])})
+	}
+	return out
+}
+
+// --- wire types (shared) ---
+
+type isoDate time.Time
+
+const isoDateLayout = "2006-01-02"
+
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
+}
+
+func (d *isoDate) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	t, err := time.Parse(isoDateLayout, s)
+	if err != nil {
+		return err
+	}
+	*d = isoDate(t)
+	return nil
+}
+
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/zus/store.go
+++ b/backend-go/internal/zus/store.go
@@ -10,9 +10,10 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// ErrNoSalary marks the absence of any active salary record for a given
+// errNoSalary marks the absence of any active salary record for a given
 // owner. Lets latestSalary return a sentinel error instead of (nil, nil)
-// which the nilnil lint forbids.
+// which the nilnil lint forbids. Unexported — internal package signal,
+// not part of the package API.
 var errNoSalary = errors.New("no salary record for owner")
 
 // Store reads salary records + persona + app_config for prefill.

--- a/backend-go/internal/zus/store.go
+++ b/backend-go/internal/zus/store.go
@@ -1,0 +1,173 @@
+package zus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ErrNoSalary marks the absence of any active salary record for a given
+// owner. Lets latestSalary return a sentinel error instead of (nil, nil)
+// which the nilnil lint forbids.
+var errNoSalary = errors.New("no salary record for owner")
+
+// Store reads salary records + persona + app_config for prefill.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+// PrefillData bundles everything prefill needs in a single struct so the
+// handler can compose the response without per-field branching.
+type PrefillData struct {
+	Owner                     *string
+	BirthDate                 *time.Time
+	RetirementAge             int
+	CurrentGrossMonthlySalary *float64
+	WorkStartYear             *int
+	YearlySalaryHistory       map[int]float64
+}
+
+// LoadPrefill fetches the data Python's get_zus_prefill assembles:
+// - config (birth_date + retirement_age)
+// - resolved owner (passed-in or first persona alphabetically)
+// - latest active salary for owner -> current_gross_monthly_salary
+// - all active salaries for owner -> yearly history (latest record per year)
+func (s *Store) LoadPrefill(ctx context.Context, ownerHint *string) (PrefillData, error) {
+	data := PrefillData{RetirementAge: 65, YearlySalaryHistory: map[int]float64{}}
+
+	birth, ra, err := s.loadConfig(ctx)
+	if err != nil {
+		return data, err
+	}
+	if birth != nil {
+		data.BirthDate = birth
+	}
+	if ra != 0 {
+		data.RetirementAge = ra
+	}
+
+	owner := ""
+	if ownerHint != nil && *ownerHint != "" {
+		owner = *ownerHint
+	} else {
+		first, err := s.firstPersona(ctx)
+		if err != nil {
+			return data, err
+		}
+		owner = first
+	}
+	if owner == "" {
+		return data, nil
+	}
+	data.Owner = &owner
+
+	current, err := s.latestSalary(ctx, owner)
+	if err != nil && !errors.Is(err, errNoSalary) {
+		return data, err
+	}
+	if current != nil {
+		data.CurrentGrossMonthlySalary = current
+	}
+
+	yearly, workStart, err := s.yearlyHistory(ctx, owner)
+	if err != nil {
+		return data, err
+	}
+	data.YearlySalaryHistory = yearly
+	if workStart != nil {
+		data.WorkStartYear = workStart
+	}
+	return data, nil
+}
+
+func (s *Store) loadConfig(ctx context.Context) (*time.Time, int, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT birth_date, retirement_age FROM app_config LIMIT 1`,
+	)
+	var birth *time.Time
+	var ra int
+	if err := row.Scan(&birth, &ra); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, 0, nil
+		}
+		return nil, 0, fmt.Errorf("select app_config: %w", err)
+	}
+	return birth, ra, nil
+}
+
+func (s *Store) firstPersona(ctx context.Context) (string, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT name FROM personas ORDER BY name LIMIT 1`,
+	)
+	var n string
+	if err := row.Scan(&n); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("select first persona: %w", err)
+	}
+	return n, nil
+}
+
+func (s *Store) latestSalary(ctx context.Context, owner string) (*float64, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT gross_amount FROM salary_records
+		WHERE owner = $1 AND is_active = true
+		ORDER BY date DESC LIMIT 1`,
+		owner,
+	)
+	var v float64
+	if err := row.Scan(&v); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, errNoSalary
+		}
+		return nil, fmt.Errorf("select latest salary: %w", err)
+	}
+	return &v, nil
+}
+
+func (s *Store) yearlyHistory(ctx context.Context, owner string) (map[int]float64, *int, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT date, gross_amount FROM salary_records
+		WHERE owner = $1 AND is_active = true
+		ORDER BY date`,
+		owner,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("select salary history: %w", err)
+	}
+	defer rows.Close()
+	yearly := map[int]float64{}
+	for rows.Next() {
+		var d time.Time
+		var gross float64
+		if err := rows.Scan(&d, &gross); err != nil {
+			return nil, nil, fmt.Errorf("scan salary history: %w", err)
+		}
+		// "latest record per year" — keep overwriting; we ORDER BY date so
+		// the last write wins (matches Python's dict assignment loop).
+		yearly[d.Year()] = gross * 12
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate salary history: %w", err)
+	}
+	if len(yearly) == 0 {
+		return yearly, nil, nil
+	}
+	minYear := 0
+	for y := range yearly {
+		if minYear == 0 || y < minYear {
+			minYear = y
+		}
+	}
+	return yearly, &minYear, nil
+}

--- a/backend-go/internal/zus/validation.go
+++ b/backend-go/internal/zus/validation.go
@@ -1,0 +1,282 @@
+package zus
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type calculateInputs struct {
+	Inputs    Inputs
+	BirthDate time.Time
+}
+
+// buildInputs validates the calculate POST body. Mirrors the Pydantic
+// validators on ZusCalculatorInputs (gender M/F, retirement_age 55..70,
+// non-negative salaries, rates 0..20, work_start_year 1970..2030,
+// retirement_age strictly greater than current age).
+func buildInputs(raw map[string]json.RawMessage, now func() time.Time) (calculateInputs, *validationError) {
+	var c calculateInputs
+	var err *validationError
+	c.Inputs.Owner, err = requireString(raw, "owner", "Owner cannot be empty")
+	if err != nil {
+		return c, err
+	}
+	c.BirthDate, err = requireDate(raw, "birth_date")
+	if err != nil {
+		return c, err
+	}
+	c.Inputs.BirthYear = c.BirthDate.Year()
+
+	c.Inputs.Gender, err = requireEnumString(raw, "gender", map[string]struct{}{"M": {}, "F": {}})
+	if err != nil {
+		return c, err
+	}
+
+	c.Inputs.RetirementAge, err = optionalIntRange(raw, "retirement_age", 65, 55, 70, "Retirement age must be between 55 and 70")
+	if err != nil {
+		return c, err
+	}
+	c.Inputs.CurrentGrossMonthlySalary, err = requireNonNegativeFloat(raw, "current_gross_monthly_salary", "Salary cannot be negative")
+	if err != nil {
+		return c, err
+	}
+	if vErr := readRates(raw, &c.Inputs); vErr != nil {
+		return c, vErr
+	}
+	if vErr := readMisc(raw, &c.Inputs); vErr != nil {
+		return c, vErr
+	}
+	if vErr := readSalaryHistory(raw, &c.Inputs); vErr != nil {
+		return c, vErr
+	}
+	if vErr := validateAgeRelationship(c.BirthDate, c.Inputs.RetirementAge, now); vErr != nil {
+		return c, vErr
+	}
+	return c, nil
+}
+
+func readRates(raw map[string]json.RawMessage, in *Inputs) *validationError {
+	rates := []struct {
+		key      string
+		dest     *float64
+		fallback float64
+	}{
+		{"salary_growth_rate", &in.SalaryGrowthRate, 3.0},
+		{"inflation_rate", &in.InflationRate, 3.0},
+		{"valorization_rate_konto", &in.ValorizationRateKonto, 5.0},
+		{"valorization_rate_subkonto", &in.ValorizationRateSubkonto, 4.0},
+	}
+	for _, r := range rates {
+		v, err := optionalFloatRange(raw, r.key, r.fallback, 0, 20, "Rate must be between 0% and 20%")
+		if err != nil {
+			return err
+		}
+		*r.dest = v
+	}
+	return nil
+}
+
+func readMisc(raw map[string]json.RawMessage, in *Inputs) *validationError {
+	hasOFE, err := optionalBool(raw, "has_ofe", false)
+	if err != nil {
+		return err
+	}
+	in.HasOFE = hasOFE
+	kapital, err := optionalNonNegativeFloat(raw, "kapital_poczatkowy", 0.0, "Kapitał początkowy cannot be negative")
+	if err != nil {
+		return err
+	}
+	in.KapitalPoczatkowy = kapital
+	work, err := requireIntRange(raw, "work_start_year", 1970, 2030, "Work start year must be between 1970 and 2030")
+	if err != nil {
+		return err
+	}
+	in.WorkStartYear = work
+	return nil
+}
+
+func readSalaryHistory(raw map[string]json.RawMessage, in *Inputs) *validationError {
+	in.SalaryHistory = map[int]float64{}
+	v, ok := raw["salary_history"]
+	if !ok || isNull(v) {
+		return nil
+	}
+	var entries []map[string]any
+	if err := json.Unmarshal(v, &entries); err != nil {
+		return &validationError{Field: "salary_history", Msg: "must be an array"}
+	}
+	for _, e := range entries {
+		yVal, hasYear := e["year"]
+		gVal, hasGross := e["annual_gross"]
+		if !hasYear || !hasGross {
+			return &validationError{Field: "salary_history", Msg: "entries require 'year' and 'annual_gross'"}
+		}
+		yf, ok := yVal.(float64)
+		if !ok {
+			return &validationError{Field: "salary_history", Msg: "year must be a number"}
+		}
+		gf, ok := gVal.(float64)
+		if !ok {
+			return &validationError{Field: "salary_history", Msg: "annual_gross must be a number"}
+		}
+		in.SalaryHistory[int(yf)] = gf
+	}
+	return nil
+}
+
+func validateAgeRelationship(birth time.Time, retirementAge int, now func() time.Time) *validationError {
+	today := now().UTC()
+	currentAge := today.Year() - birth.Year()
+	if today.Month() < birth.Month() ||
+		(today.Month() == birth.Month() && today.Day() < birth.Day()) {
+		currentAge--
+	}
+	if retirementAge <= currentAge {
+		return &validationError{
+			Field: "retirement_age",
+			Msg:   "Retirement age must be greater than current age",
+		}
+	}
+	return nil
+}
+
+// --- helpers ---
+
+func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	if s == "" {
+		return "", &validationError{Field: key, Msg: emptyMsg}
+	}
+	return s, nil
+}
+
+func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return time.Time{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be a string"}
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be YYYY-MM-DD"}
+	}
+	return t, nil
+}
+
+func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return "", &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	return s, nil
+}
+
+func requireNonNegativeFloat(raw map[string]json.RawMessage, key, msg string) (float64, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return 0, &validationError{Field: key, Msg: "Field required"}
+	}
+	var f float64
+	if err := json.Unmarshal(v, &f); err != nil {
+		return 0, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if f < 0 {
+		return 0, &validationError{Field: key, Msg: msg}
+	}
+	return f, nil
+}
+
+func optionalNonNegativeFloat(raw map[string]json.RawMessage, key string, fallback float64, msg string) (float64, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return fallback, nil
+	}
+	var f float64
+	if err := json.Unmarshal(v, &f); err != nil {
+		return 0, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if f < 0 {
+		return 0, &validationError{Field: key, Msg: msg}
+	}
+	return f, nil
+}
+
+func optionalFloatRange(raw map[string]json.RawMessage, key string, fallback, lo, hi float64, msg string) (float64, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return fallback, nil
+	}
+	var f float64
+	if err := json.Unmarshal(v, &f); err != nil {
+		return 0, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if f < lo || f > hi {
+		return 0, &validationError{Field: key, Msg: msg}
+	}
+	return f, nil
+}
+
+func optionalIntRange(raw map[string]json.RawMessage, key string, fallback, lo, hi int, msg string) (int, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return fallback, nil
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return 0, &validationError{Field: key, Msg: "must be an integer"}
+	}
+	if n < lo || n > hi {
+		return 0, &validationError{Field: key, Msg: msg}
+	}
+	return n, nil
+}
+
+func requireIntRange(raw map[string]json.RawMessage, key string, lo, hi int, msg string) (int, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return 0, &validationError{Field: key, Msg: "Field required"}
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return 0, &validationError{Field: key, Msg: "must be an integer"}
+	}
+	if n < lo || n > hi {
+		return 0, &validationError{Field: key, Msg: msg}
+	}
+	return n, nil
+}
+
+func optionalBool(raw map[string]json.RawMessage, key string, fallback bool) (bool, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return fallback, nil
+	}
+	var b bool
+	if err := json.Unmarshal(v, &b); err != nil {
+		return false, &validationError{Field: key, Msg: "must be a boolean"}
+	}
+	return b, nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}

--- a/backend-go/internal/zus/validation.go
+++ b/backend-go/internal/zus/validation.go
@@ -100,8 +100,11 @@ func readMisc(raw map[string]json.RawMessage, in *Inputs) *validationError {
 func readSalaryHistory(raw map[string]json.RawMessage, in *Inputs) *validationError {
 	in.SalaryHistory = map[int]float64{}
 	v, ok := raw["salary_history"]
-	if !ok || isNull(v) {
+	if !ok {
 		return nil
+	}
+	if isNull(v) {
+		return &validationError{Field: "salary_history", Msg: "must be an array"}
 	}
 	var entries []map[string]any
 	if err := json.Unmarshal(v, &entries); err != nil {
@@ -205,10 +208,15 @@ func requireNonNegativeFloat(raw map[string]json.RawMessage, key, msg string) (f
 	return f, nil
 }
 
+// optionalNonNegativeFloat: omitted -> fallback. Present-as-null -> 422
+// (Pydantic rejects null on non-Optional typed defaults).
 func optionalNonNegativeFloat(raw map[string]json.RawMessage, key string, fallback float64, msg string) (float64, *validationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok {
 		return fallback, nil
+	}
+	if isNull(v) {
+		return 0, &validationError{Field: key, Msg: "must be a number"}
 	}
 	var f float64
 	if err := json.Unmarshal(v, &f); err != nil {
@@ -222,8 +230,11 @@ func optionalNonNegativeFloat(raw map[string]json.RawMessage, key string, fallba
 
 func optionalFloatRange(raw map[string]json.RawMessage, key string, fallback, lo, hi float64, msg string) (float64, *validationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok {
 		return fallback, nil
+	}
+	if isNull(v) {
+		return 0, &validationError{Field: key, Msg: "must be a number"}
 	}
 	var f float64
 	if err := json.Unmarshal(v, &f); err != nil {
@@ -237,8 +248,11 @@ func optionalFloatRange(raw map[string]json.RawMessage, key string, fallback, lo
 
 func optionalIntRange(raw map[string]json.RawMessage, key string, fallback, lo, hi int, msg string) (int, *validationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok {
 		return fallback, nil
+	}
+	if isNull(v) {
+		return 0, &validationError{Field: key, Msg: "must be an integer"}
 	}
 	var n int
 	if err := json.Unmarshal(v, &n); err != nil {
@@ -267,8 +281,11 @@ func requireIntRange(raw map[string]json.RawMessage, key string, lo, hi int, msg
 
 func optionalBool(raw map[string]json.RawMessage, key string, fallback bool) (bool, *validationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok {
 		return fallback, nil
+	}
+	if isNull(v) {
+		return false, &validationError{Field: key, Msg: "must be a boolean"}
 	}
 	var b bool
 	if err := json.Unmarshal(v, &b); err != nil {

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -102,3 +102,10 @@ rules:
   - method: DELETE
     path_prefix: /api/salaries
     upstream: http://backend-go:8000
+  # Group 7 — /api/zus cut over to Go (pension projection + salary-history prefill).
+  - method: GET
+    path_prefix: /api/zus
+    upstream: http://backend-go:8000
+  - method: POST
+    path_prefix: /api/zus
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

Group 7 cutover — ZUS pension calculator + prefill. Depends on Group 6 (salaries). Pure compute on the `calculate` side; prefill reads salary history + app_config + persona.

Risk-L per the umbrella plan — pension math is the most numerically sensitive endpoint so far. The bb-tests carry two `@pytest.mark.golden` snapshots specifically to catch numeric drift, and both pass byte-for-byte against the Go implementation.

## Implementation information

### `internal/zus/calculator.go`

Pure-functions port of `backend/app/services/zus_calculator.py`. Deliberately keeps everything in `float64` (no `decimal.Decimal`) because:

- The Python service computes in `float` everywhere
- Every persisted/projected value goes through `round(x, 2)` which is `math.Round(v*100)/100` in Go
- A `Decimal` rewrite would diverge on `round(.5)` semantics (banker's vs half-away-from-zero) and miss the bb-test golden

Logic mirrors Python exactly:

- Annual loop from `work_start_year` to `retirement_year-1` (inclusive end excluded, matching `range`)
- 30x salary cap grows ~5%/year from the 2026 base of 282,600 PLN
- Suwak bezpieczeństwa: 10 years before retirement, subkonto contributions reroute to konto
- Valorization applied before adding the current year's contributions
- Kapitał początkowy valorized with the konto rate
- `apply_pension_tax`: 12% PIT on (gross - 30k free threshold) + 9% health insurance
- Sensitivity scenarios: -2% / 0 / +2% on both valorization rates, in `Pesymistyczny / Bazowy / Optymistyczny` order

### `internal/zus/store.go`

Read-only:

- `loadConfig` — birth_date + retirement_age from `app_config`
- `firstPersona` — alphabetical fallback when no owner specified
- `latestSalary` — most-recent active salary for owner (returns `errNoSalary` sentinel on absent, avoids nilnil)
- `yearlyHistory` — all active salaries for owner grouped by `date.Year`, value = `gross * 12` (matches Python's `dict[year] = gross * 12` loop)

### `internal/zus/validation.go`

Pydantic-shape validators ported one-for-one. All of Python's `@field_validator` and the `@model_validator(mode="after")` retirement-age-greater-than-current-age check are reproduced.

### `internal/server/server.go`

Extracted `registerAPIRoutes(r, pool, logger)` so the route count growth no longer trips the funlen=100 budget on `server.New`.

### Parity proof against Go

```
============================= test session starts ==============================
tests/test_zus.py::test_get_zus_prefill_matches_golden     PASSED   [ 20%]
tests/test_zus.py::test_get_zus_prefill_shape              PASSED   [ 40%]
tests/test_zus.py::test_post_zus_calculate_matches_golden  PASSED   [ 60%]
tests/test_zus.py::test_post_zus_calculate_happy_path      PASSED   [ 80%]
tests/test_zus.py::test_post_zus_calculate_validation_error PASSED  [100%]
============================== 5 passed in 0.10s ===============================
```

Both golden snapshots match — the full yearly_projections array (~50 years × 9 fields) is byte-identical.

### `routes.yaml`

GET + POST rules for `/api/zus/`. Covers `/calculate` (POST) and `/prefill` (GET).

## Supporting documentation

- Umbrella: #435
- Subissue: #442
- Procedure: `migration/CUTOVER.md`

> Changelog: skip