### PR TITLE
feat(go): cutover /api/accounts (Group 9a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,8 @@ jobs:
             tests/test_equity_grants.py \
             tests/test_cpi.py \
             tests/test_salary_records.py \
-            tests/test_zus.py
+            tests/test_zus.py \
+            tests/test_accounts.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/backend-go/internal/accounts/errors.go
+++ b/backend-go/internal/accounts/errors.go
@@ -1,0 +1,41 @@
+package accounts
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{
+				"type":  "value_error",
+				"loc":   []string{"body", field},
+				"msg":   msg,
+				"input": input,
+			},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/accounts/handler.go
+++ b/backend-go/internal/accounts/handler.go
@@ -1,0 +1,247 @@
+package accounts
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+)
+
+var (
+	validAccountTypes = map[string]struct{}{"asset": {}, "liability": {}}
+	validCategories   = map[string]struct{}{
+		"bank": {}, "saving_account": {}, "stock": {}, "bond": {}, "gold": {},
+		"real_estate": {}, "ppk": {}, "fund": {}, "etf": {}, "vehicle": {},
+		"mortgage": {}, "installment": {},
+	}
+	validPurposes = map[string]struct{}{
+		"retirement": {}, "emergency_fund": {}, "general": {},
+	}
+	validWrappers = map[string]struct{}{
+		"IKE": {}, "IKZE": {}, "PPK": {},
+	}
+)
+
+type response struct {
+	ID                    int      `json:"id"`
+	Name                  string   `json:"name"`
+	Type                  string   `json:"type"`
+	Category              string   `json:"category"`
+	Owner                 string   `json:"owner"`
+	Currency              string   `json:"currency"`
+	AccountWrapper        *string  `json:"account_wrapper"`
+	Purpose               string   `json:"purpose"`
+	SquareMeters          *pyFloat `json:"square_meters"`
+	IsActive              bool     `json:"is_active"`
+	ReceivesContributions bool     `json:"receives_contributions"`
+	CreatedAt             isoNaive `json:"created_at"`
+	CurrentValue          pyFloat  `json:"current_value"`
+}
+
+type listResponse struct {
+	Assets      []response `json:"assets"`
+	Liabilities []response `json:"liabilities"`
+}
+
+// Handler is the HTTP boundary for /api/accounts.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewHandler wires the store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger}
+}
+
+func toResponse(a *Account, currentValue decimal.Decimal) response {
+	cv, _ := currentValue.Float64()
+	out := response{
+		ID:                    a.ID,
+		Name:                  a.Name,
+		Type:                  a.Type,
+		Category:              a.Category,
+		Owner:                 a.Owner,
+		Currency:              a.Currency,
+		AccountWrapper:        a.AccountWrapper,
+		Purpose:               a.Purpose,
+		IsActive:              a.IsActive,
+		ReceivesContributions: a.ReceivesContributions,
+		CreatedAt:             isoNaive(a.CreatedAt.UTC()),
+		CurrentValue:          pyFloat(cv),
+	}
+	if a.SquareMeters != nil {
+		f, _ := a.SquareMeters.Float64()
+		pf := pyFloat(f)
+		out.SquareMeters = &pf
+	}
+	return out
+}
+
+// List serves GET /api/accounts.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	accounts, err := h.store.List(r.Context())
+	if err != nil {
+		h.logger.Error("list accounts", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	ids := make([]int, 0, len(accounts))
+	for i := range accounts {
+		ids = append(ids, accounts[i].ID)
+	}
+	values, err := h.store.LatestValuesByAccount(r.Context(), ids)
+	if err != nil {
+		h.logger.Error("latest values", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := listResponse{Assets: []response{}, Liabilities: []response{}}
+	for i := range accounts {
+		a := &accounts[i]
+		cv := values[a.ID]
+		resp := toResponse(a, cv)
+		if a.Type == "asset" {
+			out.Assets = append(out.Assets, resp)
+		} else {
+			out.Liabilities = append(out.Liabilities, resp)
+		}
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Create serves POST /api/accounts.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	req, vErr := buildCreateRequest(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	created, err := h.store.Create(r.Context(), &Account{
+		Name:                  req.Name,
+		Type:                  req.Type,
+		Category:              req.Category,
+		Owner:                 req.Owner,
+		Currency:              req.Currency,
+		AccountWrapper:        req.AccountWrapper,
+		Purpose:               req.Purpose,
+		SquareMeters:          req.SquareMeters,
+		ReceivesContributions: req.ReceivesContributions,
+	})
+	if err != nil {
+		if errors.Is(err, ErrDuplicateName) {
+			writeDetailError(w, http.StatusConflict,
+				fmt.Sprintf("Account with name '%s' already exists", req.Name))
+			return
+		}
+		h.logger.Error("create account", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toResponse(created, decimal.Zero))
+}
+
+// Update serves PUT /api/accounts/{id}.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	patch, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	updated, err := h.store.Update(r.Context(), id, patch)
+	if err != nil {
+		h.writeStoreError(w, err, id, patch.Name)
+		return
+	}
+	cv, err := h.store.LatestValueForAccount(r.Context(), id)
+	if err != nil {
+		h.logger.Error("latest value", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusOK, toResponse(updated, cv))
+}
+
+// Delete serves DELETE /api/accounts/{id}.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.Delete(r.Context(), id); err != nil {
+		h.writeStoreError(w, err, id, nil)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int, name *string) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		writeDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("Account with id %d not found", id))
+	case errors.Is(err, ErrDuplicateName):
+		n := ""
+		if name != nil {
+			n = *name
+		}
+		writeDetailError(w, http.StatusConflict,
+			fmt.Sprintf("Account with name '%s' already exists", n))
+	default:
+		h.logger.Error("account store", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+	}
+}
+
+func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		writeValidationError(w, "account_id", "must be an integer", raw)
+		return 0, false
+	}
+	return id, true
+}
+
+// --- shared wire types ---
+
+type isoNaive time.Time
+
+func (t isoNaive) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
+}
+
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/accounts/store.go
+++ b/backend-go/internal/accounts/store.go
@@ -77,7 +77,9 @@ func (s *Store) List(ctx context.Context) ([]Account, error) {
 	return out, nil
 }
 
-// Get returns one active account or ErrNotFound.
+// Get returns the account regardless of is_active, mirroring Python's
+// get_or_404 helper. Returns ErrNotFound when the row doesn't exist; callers
+// that need an active row check IsActive themselves.
 func (s *Store) Get(ctx context.Context, id int) (*Account, error) {
 	row := s.pool.QueryRow(ctx,
 		`SELECT `+selectColumns+` FROM accounts WHERE id = $1`, id,
@@ -248,7 +250,14 @@ func (s *Store) Delete(ctx context.Context, id int) error {
 		return err
 	}
 	if !current.IsActive {
-		return tx.Commit(ctx) // Idempotent — matches Python's `if not is_active: return`.
+		// Idempotent — matches Python's `if not is_active: return`.
+		// Commit the empty tx so the FOR UPDATE row lock releases promptly,
+		// and mark committed so the deferred rollback is a no-op.
+		if err := tx.Commit(ctx); err != nil {
+			return fmt.Errorf("commit idempotent delete: %w", err)
+		}
+		committed = true
+		return nil
 	}
 	if _, err := tx.Exec(ctx,
 		`UPDATE accounts SET is_active = false WHERE id = $1`, id,

--- a/backend-go/internal/accounts/store.go
+++ b/backend-go/internal/accounts/store.go
@@ -1,0 +1,389 @@
+// Package accounts implements /api/accounts — CRUD with cascade-on-edit:
+// owner/category changes trigger snapshot_aggregates recompute for every
+// snapshot that references this account.
+package accounts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/aggregates"
+)
+
+// Account mirrors backend/app/models/account.Account.
+type Account struct {
+	ID                    int
+	Name                  string
+	Type                  string
+	Category              string
+	Owner                 string
+	Currency              string
+	AccountWrapper        *string
+	Purpose               string
+	SquareMeters          *decimal.Decimal
+	IsActive              bool
+	ReceivesContributions bool
+	CreatedAt             time.Time
+}
+
+// Sentinel errors mapped to HTTP status codes by the handler.
+var (
+	ErrNotFound      = errors.New("account not found")
+	ErrDuplicateName = errors.New("account name already exists")
+)
+
+// Store is the persistence boundary.
+type Store struct {
+	pool       *pgxpool.Pool
+	aggregates *aggregates.Store
+}
+
+// NewStore wires the pool + aggregates store (used for cascade-on-edit).
+func NewStore(pool *pgxpool.Pool, aggs *aggregates.Store) *Store {
+	return &Store{pool: pool, aggregates: aggs}
+}
+
+const selectColumns = `
+	id, name, type, category, owner, currency, account_wrapper, purpose,
+	square_meters, is_active, receives_contributions, created_at
+`
+
+// List returns active accounts.
+func (s *Store) List(ctx context.Context) ([]Account, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+selectColumns+` FROM accounts WHERE is_active = true ORDER BY id`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list accounts: %w", err)
+	}
+	defer rows.Close()
+	out := []Account{}
+	for rows.Next() {
+		a, err := scanAccount(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan account: %w", err)
+		}
+		out = append(out, *a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate accounts: %w", err)
+	}
+	return out, nil
+}
+
+// Get returns one active account or ErrNotFound.
+func (s *Store) Get(ctx context.Context, id int) (*Account, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+selectColumns+` FROM accounts WHERE id = $1`, id,
+	)
+	a, err := scanAccount(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get account: %w", err)
+	}
+	return a, nil
+}
+
+// LatestValuesByAccount returns the most recent active snapshot value per
+// account in one query — used to fill AccountResponse.current_value.
+func (s *Store) LatestValuesByAccount(ctx context.Context, accountIDs []int) (map[int]decimal.Decimal, error) {
+	if len(accountIDs) == 0 {
+		return map[int]decimal.Decimal{}, nil
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT DISTINCT ON (sv.account_id) sv.account_id, sv.value
+		FROM snapshot_values sv
+		JOIN snapshots s ON s.id = sv.snapshot_id
+		WHERE sv.account_id = ANY($1)
+		ORDER BY sv.account_id, s.date DESC`,
+		accountIDs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("latest values: %w", err)
+	}
+	defer rows.Close()
+	out := map[int]decimal.Decimal{}
+	for rows.Next() {
+		var id int
+		var v decimal.Decimal
+		if err := rows.Scan(&id, &v); err != nil {
+			return nil, fmt.Errorf("scan latest value: %w", err)
+		}
+		out[id] = v
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate latest values: %w", err)
+	}
+	return out, nil
+}
+
+// LatestValueForAccount returns the most recent active snapshot value for
+// one account, or zero when none exists (matches Python's 0.0 fallback).
+func (s *Store) LatestValueForAccount(ctx context.Context, accountID int) (decimal.Decimal, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT sv.value
+		FROM snapshot_values sv
+		JOIN snapshots s ON s.id = sv.snapshot_id
+		WHERE sv.account_id = $1
+		ORDER BY s.date DESC LIMIT 1`,
+		accountID,
+	)
+	var v decimal.Decimal
+	if err := row.Scan(&v); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return decimal.Zero, nil
+		}
+		return decimal.Zero, fmt.Errorf("latest value: %w", err)
+	}
+	return v, nil
+}
+
+// Create inserts an account. Returns ErrDuplicateName for a name collision.
+func (s *Store) Create(ctx context.Context, a *Account) (*Account, error) {
+	if err := s.checkDuplicateName(ctx, a.Name, 0); err != nil {
+		return nil, err
+	}
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO accounts (
+			name, type, category, owner, currency, account_wrapper, purpose,
+			square_meters, is_active, receives_contributions, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, true, $9, $10)
+		RETURNING `+selectColumns,
+		a.Name, a.Type, a.Category, a.Owner, a.Currency, a.AccountWrapper, a.Purpose,
+		a.SquareMeters, a.ReceivesContributions, time.Now().UTC(),
+	)
+	return scanAccount(row)
+}
+
+// UpdatePatch is the sparse update set with explicit "field was set" booleans
+// for the two nullable fields whose null-vs-omit semantics differ.
+type UpdatePatch struct {
+	Name                  *string
+	Category              *string
+	Owner                 *string
+	Currency              *string
+	AccountWrapperSet     bool
+	AccountWrapper        *string
+	Purpose               *string
+	SquareMetersSet       bool
+	SquareMeters          *decimal.Decimal
+	ReceivesContributions *bool
+}
+
+// Update applies the patch. Owner/category changes cascade into a
+// snapshot_aggregates recompute for every snapshot referencing the account.
+// The whole op runs in one transaction.
+func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Account, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin update tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	current, err := lockAccount(ctx, tx, id)
+	if err != nil {
+		return nil, err
+	}
+	if p.Name != nil && *p.Name != current.Name {
+		if err := s.checkDuplicateNameTx(ctx, tx, *p.Name, id); err != nil {
+			return nil, err
+		}
+	}
+	// Capture pre-patch values to decide whether the request meaningfully
+	// changed owner or category — matches Python's old_owner/old_category.
+	oldOwner := current.Owner
+	oldCategory := current.Category
+	applyPatch(current, p)
+	needsRecompute := (p.Owner != nil && *p.Owner != oldOwner) ||
+		(p.Category != nil && *p.Category != oldCategory)
+	if err := s.updateRow(ctx, tx, id, current); err != nil {
+		return nil, err
+	}
+	if needsRecompute {
+		ids, err := s.aggregates.AffectedSnapshotIDsForAccount(ctx, tx, id)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.aggregates.RecomputeForSnapshots(ctx, tx, ids); err != nil {
+			return nil, err
+		}
+	}
+	updated, err := loadAccount(ctx, tx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit update tx: %w", err)
+	}
+	committed = true
+	return updated, nil
+}
+
+// Delete soft-deletes + cascades into aggregate recompute.
+func (s *Store) Delete(ctx context.Context, id int) error {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin delete tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	current, err := lockAccount(ctx, tx, id)
+	if err != nil {
+		return err
+	}
+	if !current.IsActive {
+		return tx.Commit(ctx) // Idempotent — matches Python's `if not is_active: return`.
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE accounts SET is_active = false WHERE id = $1`, id,
+	); err != nil {
+		return fmt.Errorf("soft-delete account: %w", err)
+	}
+	ids, err := s.aggregates.AffectedSnapshotIDsForAccount(ctx, tx, id)
+	if err != nil {
+		return err
+	}
+	if err := s.aggregates.RecomputeForSnapshots(ctx, tx, ids); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit delete tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *Store) checkDuplicateName(ctx context.Context, name string, excludeID int) error {
+	var existing int
+	args := []any{name}
+	q := `SELECT id FROM accounts WHERE name = $1 AND is_active = true`
+	if excludeID > 0 {
+		q += ` AND id <> $2`
+		args = append(args, excludeID)
+	}
+	err := s.pool.QueryRow(ctx, q+` LIMIT 1`, args...).Scan(&existing)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("check duplicate name: %w", err)
+	}
+	return ErrDuplicateName
+}
+
+func (s *Store) checkDuplicateNameTx(ctx context.Context, tx pgx.Tx, name string, excludeID int) error {
+	var existing int
+	err := tx.QueryRow(ctx, `
+		SELECT id FROM accounts
+		WHERE name = $1 AND is_active = true AND id <> $2
+		LIMIT 1`,
+		name, excludeID,
+	).Scan(&existing)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("check duplicate name (tx): %w", err)
+	}
+	return ErrDuplicateName
+}
+
+func (s *Store) updateRow(ctx context.Context, tx pgx.Tx, id int, a *Account) error {
+	_, err := tx.Exec(ctx, `
+		UPDATE accounts SET
+			name = $1, type = $2, category = $3, owner = $4, currency = $5,
+			account_wrapper = $6, purpose = $7, square_meters = $8,
+			receives_contributions = $9
+		WHERE id = $10`,
+		a.Name, a.Type, a.Category, a.Owner, a.Currency,
+		a.AccountWrapper, a.Purpose, a.SquareMeters,
+		a.ReceivesContributions, id,
+	)
+	if err != nil {
+		return fmt.Errorf("update account: %w", err)
+	}
+	return nil
+}
+
+func lockAccount(ctx context.Context, tx pgx.Tx, id int) (*Account, error) {
+	row := tx.QueryRow(ctx,
+		`SELECT `+selectColumns+` FROM accounts WHERE id = $1 FOR UPDATE`, id,
+	)
+	a, err := scanAccount(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("lock account: %w", err)
+	}
+	return a, nil
+}
+
+func loadAccount(ctx context.Context, tx pgx.Tx, id int) (*Account, error) {
+	row := tx.QueryRow(ctx,
+		`SELECT `+selectColumns+` FROM accounts WHERE id = $1`, id,
+	)
+	a, err := scanAccount(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("load account: %w", err)
+	}
+	return a, nil
+}
+
+func applyPatch(a *Account, p UpdatePatch) {
+	if p.Name != nil {
+		a.Name = *p.Name
+	}
+	if p.Category != nil {
+		a.Category = *p.Category
+	}
+	if p.Owner != nil {
+		a.Owner = *p.Owner
+	}
+	if p.Currency != nil {
+		a.Currency = *p.Currency
+	}
+	if p.Purpose != nil {
+		a.Purpose = *p.Purpose
+	}
+	if p.ReceivesContributions != nil {
+		a.ReceivesContributions = *p.ReceivesContributions
+	}
+	if p.AccountWrapperSet {
+		a.AccountWrapper = p.AccountWrapper
+	}
+	if p.SquareMetersSet {
+		a.SquareMeters = p.SquareMeters
+	}
+}
+
+func scanAccount(row pgx.Row) (*Account, error) {
+	var a Account
+	if err := row.Scan(
+		&a.ID, &a.Name, &a.Type, &a.Category, &a.Owner, &a.Currency,
+		&a.AccountWrapper, &a.Purpose, &a.SquareMeters,
+		&a.IsActive, &a.ReceivesContributions, &a.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	return &a, nil
+}

--- a/backend-go/internal/accounts/validation.go
+++ b/backend-go/internal/accounts/validation.go
@@ -83,9 +83,10 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *validat
 // buildUpdatePatch reads PUT body.
 //
 // Field semantics mirror Pydantic's AccountUpdate (all fields Optional):
-// - absent  -> no change
-// - explicit null on nullable fields (account_wrapper, square_meters) -> set to NULL
-// - explicit null on other fields -> validation error
+//   - absent OR explicit null on non-nullable fields -> no change
+//     (Python's service uses `if data.X is not None` and skips Nones)
+//   - explicit null on account_wrapper or square_meters -> set to NULL
+//     (Pydantic's `Wrapper | None` lets None through and the service writes it)
 func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *validationError) {
 	var p UpdatePatch
 	if v, ok := raw["name"]; ok && !isNull(v) {

--- a/backend-go/internal/accounts/validation.go
+++ b/backend-go/internal/accounts/validation.go
@@ -1,0 +1,280 @@
+package accounts
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+)
+
+type createRequest struct {
+	Name                  string
+	Type                  string
+	Category              string
+	Owner                 string
+	Currency              string
+	AccountWrapper        *string
+	Purpose               string
+	SquareMeters          *decimal.Decimal
+	ReceivesContributions bool
+}
+
+// buildCreateRequest validates the POST body.
+func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *validationError) {
+	var r createRequest
+	name, vErr := requireString(raw, "name", "Name cannot be empty")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Name = name
+
+	t, vErr := requireEnumString(raw, "type", validAccountTypes)
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Type = t
+
+	cat, vErr := requireEnumString(raw, "category", validCategories)
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Category = cat
+
+	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Owner = owner
+
+	cur, vErr := optionalString(raw, "currency", "PLN")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Currency = cur
+
+	wrap, vErr := optionalEnumOrNull(raw, "account_wrapper", validWrappers)
+	if vErr != nil {
+		return r, vErr
+	}
+	r.AccountWrapper = wrap
+
+	purpose, vErr := requireEnumString(raw, "purpose", validPurposes)
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Purpose = purpose
+
+	sq, vErr := optionalDecimal(raw, "square_meters")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.SquareMeters = sq
+
+	recv, vErr := optionalBool(raw, "receives_contributions", true)
+	if vErr != nil {
+		return r, vErr
+	}
+	r.ReceivesContributions = recv
+	return r, nil
+}
+
+// buildUpdatePatch reads PUT body.
+//
+// Field semantics mirror Pydantic's AccountUpdate (all fields Optional):
+// - absent  -> no change
+// - explicit null on nullable fields (account_wrapper, square_meters) -> set to NULL
+// - explicit null on other fields -> validation error
+func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *validationError) {
+	var p UpdatePatch
+	if v, ok := raw["name"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return p, &validationError{Field: "name", Msg: "must be a string"}
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return p, &validationError{Field: "name", Msg: "Name cannot be empty"}
+		}
+		p.Name = &s
+	}
+	if vErr := patchEnumString(raw, "category", validCategories, &p.Category); vErr != nil {
+		return p, vErr
+	}
+	if v, ok := raw["owner"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return p, &validationError{Field: "owner", Msg: "must be a string"}
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return p, &validationError{Field: "owner", Msg: "Owner cannot be empty"}
+		}
+		p.Owner = &s
+	}
+	if vErr := patchPlainString(raw, "currency", &p.Currency); vErr != nil {
+		return p, vErr
+	}
+	if vErr := patchEnumString(raw, "purpose", validPurposes, &p.Purpose); vErr != nil {
+		return p, vErr
+	}
+	if v, ok := raw["account_wrapper"]; ok {
+		p.AccountWrapperSet = true
+		if isNull(v) {
+			p.AccountWrapper = nil
+		} else {
+			var s string
+			if err := json.Unmarshal(v, &s); err != nil {
+				return p, &validationError{Field: "account_wrapper", Msg: "must be a string"}
+			}
+			if _, ok := validWrappers[s]; !ok {
+				return p, &validationError{Field: "account_wrapper", Msg: fmt.Sprintf("invalid wrapper %q", s)}
+			}
+			p.AccountWrapper = &s
+		}
+	}
+	if v, ok := raw["square_meters"]; ok {
+		p.SquareMetersSet = true
+		if isNull(v) {
+			p.SquareMeters = nil
+		} else {
+			d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+			if err != nil {
+				return p, &validationError{Field: "square_meters", Msg: "must be a number"}
+			}
+			p.SquareMeters = &d
+		}
+	}
+	if v, ok := raw["receives_contributions"]; ok && !isNull(v) {
+		var b bool
+		if err := json.Unmarshal(v, &b); err != nil {
+			return p, &validationError{Field: "receives_contributions", Msg: "must be a boolean"}
+		}
+		p.ReceivesContributions = &b
+	}
+	return p, nil
+}
+
+// --- helpers ---
+
+func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", &validationError{Field: key, Msg: emptyMsg}
+	}
+	return s, nil
+}
+
+func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return "", &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	return s, nil
+}
+
+func optionalString(raw map[string]json.RawMessage, key, fallback string) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok {
+		return fallback, nil
+	}
+	if isNull(v) {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	return s, nil
+}
+
+func optionalEnumOrNull(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (*string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return nil, nil
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return nil, &validationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return nil, &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	return &s, nil
+}
+
+func optionalDecimal(raw map[string]json.RawMessage, key string) (*decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return nil, nil
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if err != nil {
+		return nil, &validationError{Field: key, Msg: "must be a number"}
+	}
+	return &d, nil
+}
+
+func optionalBool(raw map[string]json.RawMessage, key string, fallback bool) (bool, *validationError) {
+	v, ok := raw[key]
+	if !ok {
+		return fallback, nil
+	}
+	if isNull(v) {
+		return false, &validationError{Field: key, Msg: "must be a boolean"}
+	}
+	var b bool
+	if err := json.Unmarshal(v, &b); err != nil {
+		return false, &validationError{Field: key, Msg: "must be a boolean"}
+	}
+	return b, nil
+}
+
+func patchEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}, dest **string) *validationError {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return &validationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	*dest = &s
+	return nil
+}
+
+func patchPlainString(raw map[string]json.RawMessage, key string, dest **string) *validationError {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return &validationError{Field: key, Msg: "must be a string"}
+	}
+	*dest = &s
+	return nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}

--- a/backend-go/internal/aggregates/spec.go
+++ b/backend-go/internal/aggregates/spec.go
@@ -116,7 +116,10 @@ func ComputeAggregates(
 	sort.Strings(owners)
 	out := make([]AggregateRow, 0, len(owners))
 	for _, owner := range owners {
-		b := totals[owner]
+		b, ok := totals[owner]
+		if !ok || b == nil {
+			continue
+		}
 		cats := make([]string, 0, len(b.alloc))
 		for c := range b.alloc {
 			cats = append(cats, c)

--- a/backend-go/internal/aggregates/spec.go
+++ b/backend-go/internal/aggregates/spec.go
@@ -1,0 +1,144 @@
+// Package aggregates ports backend/app/services/aggregate_spec.py +
+// snapshot_aggregates.py — pure aggregation math and the DB writeback that
+// recomputes snapshot_aggregates from snapshot_values + accounts + assets.
+package aggregates
+
+import (
+	"sort"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// AccountInput is the subset of Account columns the spec consumes.
+type AccountInput struct {
+	ID       int
+	Owner    string
+	Type     string
+	Category string
+}
+
+// SnapshotValueInput is one row from snapshot_values.
+type SnapshotValueInput struct {
+	AccountID *int
+	AssetID   *int
+	Value     decimal.Decimal
+}
+
+// SnapshotInput identifies the snapshot whose aggregates are being computed.
+type SnapshotInput struct {
+	ID   int
+	Date time.Time
+}
+
+// AllocationEntry is one row of the allocation_json array.
+type AllocationEntry struct {
+	Category string
+	Value    decimal.Decimal
+}
+
+// AggregateRow is one precomputed row per (snapshot_id, owner).
+type AggregateRow struct {
+	SnapshotID       int
+	Month            time.Time
+	Owner            string
+	TotalAssets      decimal.Decimal
+	TotalLiabilities decimal.Decimal
+	NetWorth         decimal.Decimal
+	Allocation       []AllocationEntry
+}
+
+// ComputeAggregates is the pure-math port of aggregate_spec.compute_aggregates.
+// Caller must filter accounts/assets to is_active=true rows before calling.
+func ComputeAggregates(
+	snap SnapshotInput,
+	values []SnapshotValueInput,
+	accounts []AccountInput,
+	activeAssetIDs map[int]struct{},
+) []AggregateRow {
+	accountMap := map[int]AccountInput{}
+	for _, a := range accounts {
+		accountMap[a.ID] = a
+	}
+
+	type bucket struct {
+		assets      decimal.Decimal
+		liabilities decimal.Decimal
+		alloc       map[string]decimal.Decimal
+	}
+	totals := map[string]*bucket{}
+	getBucket := func(owner string) *bucket {
+		if b, ok := totals[owner]; ok {
+			return b
+		}
+		b := &bucket{alloc: map[string]decimal.Decimal{}}
+		totals[owner] = b
+		return b
+	}
+
+	for _, sv := range values {
+		v := sv.Value
+		switch {
+		case sv.AssetID != nil:
+			if _, active := activeAssetIDs[*sv.AssetID]; active {
+				b := getBucket("Shared")
+				b.assets = b.assets.Add(v)
+			}
+		case sv.AccountID != nil:
+			acc, ok := accountMap[*sv.AccountID]
+			if !ok {
+				continue
+			}
+			b := getBucket(acc.Owner)
+			if acc.Type == "asset" {
+				b.assets = b.assets.Add(v)
+				b.alloc[acc.Category] = b.alloc[acc.Category].Add(v)
+			} else {
+				b.liabilities = b.liabilities.Add(v)
+			}
+		}
+	}
+
+	month := firstOfMonth(snap.Date)
+	if len(totals) == 0 {
+		return []AggregateRow{{
+			SnapshotID: snap.ID,
+			Month:      month,
+			Owner:      "Shared",
+			Allocation: []AllocationEntry{},
+		}}
+	}
+
+	owners := make([]string, 0, len(totals))
+	for o := range totals {
+		owners = append(owners, o)
+	}
+	sort.Strings(owners)
+	out := make([]AggregateRow, 0, len(owners))
+	for _, owner := range owners {
+		b := totals[owner]
+		cats := make([]string, 0, len(b.alloc))
+		for c := range b.alloc {
+			cats = append(cats, c)
+		}
+		sort.Strings(cats)
+		alloc := make([]AllocationEntry, 0, len(cats))
+		for _, c := range cats {
+			alloc = append(alloc, AllocationEntry{Category: c, Value: b.alloc[c]})
+		}
+		out = append(out, AggregateRow{
+			SnapshotID:       snap.ID,
+			Month:            month,
+			Owner:            owner,
+			TotalAssets:      b.assets,
+			TotalLiabilities: b.liabilities,
+			NetWorth:         b.assets.Sub(b.liabilities),
+			Allocation:       alloc,
+		})
+	}
+	return out
+}
+
+func firstOfMonth(d time.Time) time.Time {
+	return time.Date(d.Year(), d.Month(), 1, 0, 0, 0, 0, time.UTC)
+}

--- a/backend-go/internal/aggregates/store.go
+++ b/backend-go/internal/aggregates/store.go
@@ -1,0 +1,254 @@
+package aggregates
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// errSnapshotGone signals "snapshot row no longer exists" — callers treat
+// that as a successful no-op (matches Python's `if snapshot is None: return`).
+// Unexported sentinel so we don't return (nil, nil).
+var errSnapshotGone = errors.New("snapshot no longer exists")
+
+// Store does the recompute_for_snapshot[s] writeback against snapshot_aggregates.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+// RecomputeForSnapshot deletes and reinserts aggregate rows for one snapshot.
+// Idempotent. Runs in the caller's transaction so accounts.Update can chain
+// account writes + aggregate recompute atomically.
+//
+// When the snapshot has already been deleted (e.g. concurrent delete + edit),
+// returns nil and writes nothing.
+func (s *Store) RecomputeForSnapshot(ctx context.Context, tx pgx.Tx, snapshotID int) error {
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM snapshot_aggregates WHERE snapshot_id = $1`, snapshotID,
+	); err != nil {
+		return fmt.Errorf("delete snapshot_aggregates: %w", err)
+	}
+	snap, err := loadSnapshot(ctx, tx, snapshotID)
+	if err != nil {
+		if errors.Is(err, errSnapshotGone) {
+			return nil
+		}
+		return err
+	}
+	values, err := loadSnapshotValues(ctx, tx, snapshotID)
+	if err != nil {
+		return err
+	}
+	accountIDs := []int{}
+	assetIDs := []int{}
+	for _, v := range values {
+		if v.AccountID != nil {
+			accountIDs = append(accountIDs, *v.AccountID)
+		}
+		if v.AssetID != nil {
+			assetIDs = append(assetIDs, *v.AssetID)
+		}
+	}
+	accounts, err := loadActiveAccounts(ctx, tx, accountIDs)
+	if err != nil {
+		return err
+	}
+	activeAssets, err := loadActiveAssetIDs(ctx, tx, assetIDs)
+	if err != nil {
+		return err
+	}
+	rows := ComputeAggregates(snap, values, accounts, activeAssets)
+	now := time.Now().UTC()
+	for _, r := range rows {
+		alloc := make([]map[string]any, 0, len(r.Allocation))
+		for _, a := range r.Allocation {
+			f, _ := a.Value.Float64()
+			alloc = append(alloc, map[string]any{"category": a.Category, "value": f})
+		}
+		allocJSON, err := json.Marshal(alloc)
+		if err != nil {
+			return fmt.Errorf("encode allocation_json: %w", err)
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO snapshot_aggregates (
+				snapshot_id, month, owner, total_assets, total_liabilities,
+				net_worth, allocation_json, computed_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+			r.SnapshotID, r.Month, r.Owner,
+			r.TotalAssets, r.TotalLiabilities, r.NetWorth, allocJSON, now,
+		); err != nil {
+			return fmt.Errorf("insert snapshot_aggregates: %w", err)
+		}
+	}
+	return nil
+}
+
+// RecomputeForSnapshots loops over a set of snapshot IDs.
+func (s *Store) RecomputeForSnapshots(ctx context.Context, tx pgx.Tx, snapshotIDs []int) error {
+	for _, sid := range snapshotIDs {
+		if err := s.RecomputeForSnapshot(ctx, tx, sid); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AffectedSnapshotIDsForAccount returns the snapshot IDs that hold a value
+// for this account — accounts.Update calls this before deciding to recompute.
+func (s *Store) AffectedSnapshotIDsForAccount(ctx context.Context, tx pgx.Tx, accountID int) ([]int, error) {
+	rows, err := tx.Query(ctx,
+		`SELECT DISTINCT snapshot_id FROM snapshot_values WHERE account_id = $1`,
+		accountID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("affected snapshots for account: %w", err)
+	}
+	defer rows.Close()
+	out := []int{}
+	for rows.Next() {
+		var sid int
+		if err := rows.Scan(&sid); err != nil {
+			return nil, fmt.Errorf("scan snapshot id: %w", err)
+		}
+		out = append(out, sid)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshot ids: %w", err)
+	}
+	return out, nil
+}
+
+// AffectedSnapshotIDsForAsset returns the snapshot IDs that hold a value
+// for this asset.
+func (s *Store) AffectedSnapshotIDsForAsset(ctx context.Context, tx pgx.Tx, assetID int) ([]int, error) {
+	rows, err := tx.Query(ctx,
+		`SELECT DISTINCT snapshot_id FROM snapshot_values WHERE asset_id = $1`,
+		assetID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("affected snapshots for asset: %w", err)
+	}
+	defer rows.Close()
+	out := []int{}
+	for rows.Next() {
+		var sid int
+		if err := rows.Scan(&sid); err != nil {
+			return nil, fmt.Errorf("scan snapshot id: %w", err)
+		}
+		out = append(out, sid)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshot ids: %w", err)
+	}
+	return out, nil
+}
+
+func loadSnapshot(ctx context.Context, tx pgx.Tx, id int) (SnapshotInput, error) {
+	row := tx.QueryRow(ctx, `SELECT id, date FROM snapshots WHERE id = $1`, id)
+	var s SnapshotInput
+	if err := row.Scan(&s.ID, &s.Date); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return SnapshotInput{}, errSnapshotGone
+		}
+		return SnapshotInput{}, fmt.Errorf("load snapshot: %w", err)
+	}
+	return s, nil
+}
+
+func loadSnapshotValues(ctx context.Context, tx pgx.Tx, snapshotID int) ([]SnapshotValueInput, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT account_id, asset_id, value
+		FROM snapshot_values WHERE snapshot_id = $1`,
+		snapshotID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load snapshot_values: %w", err)
+	}
+	defer rows.Close()
+	out := []SnapshotValueInput{}
+	for rows.Next() {
+		var v SnapshotValueInput
+		var account, asset *int
+		var value decimal.Decimal
+		if err := rows.Scan(&account, &asset, &value); err != nil {
+			return nil, fmt.Errorf("scan snapshot_value: %w", err)
+		}
+		v.AccountID = account
+		v.AssetID = asset
+		v.Value = value
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshot_values: %w", err)
+	}
+	return out, nil
+}
+
+func loadActiveAccounts(ctx context.Context, tx pgx.Tx, ids []int) ([]AccountInput, error) {
+	if len(ids) == 0 {
+		return []AccountInput{}, nil
+	}
+	rows, err := tx.Query(ctx, `
+		SELECT id, owner, type, category
+		FROM accounts WHERE id = ANY($1) AND is_active = true`,
+		ids,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load active accounts: %w", err)
+	}
+	defer rows.Close()
+	out := []AccountInput{}
+	for rows.Next() {
+		var a AccountInput
+		if err := rows.Scan(&a.ID, &a.Owner, &a.Type, &a.Category); err != nil {
+			return nil, fmt.Errorf("scan account: %w", err)
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate accounts: %w", err)
+	}
+	return out, nil
+}
+
+func loadActiveAssetIDs(ctx context.Context, tx pgx.Tx, ids []int) (map[int]struct{}, error) {
+	if len(ids) == 0 {
+		return map[int]struct{}{}, nil
+	}
+	rows, err := tx.Query(ctx, `
+		SELECT id FROM assets WHERE id = ANY($1) AND is_active = true`,
+		ids,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load active assets: %w", err)
+	}
+	defer rows.Close()
+	out := map[int]struct{}{}
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan asset id: %w", err)
+		}
+		out[id] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate asset ids: %w", err)
+	}
+	return out, nil
+}
+
+// Pool exposes the pgx pool for callers that need to BeginTx outside the
+// aggregates package (accounts/assets/snapshots use this to wrap their
+// mutations + recompute in one tx).
+func (s *Store) Pool() *pgxpool.Pool { return s.pool }

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -16,6 +16,8 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Automaat/finance-buddy/backend-go/internal/accounts"
+	"github.com/Automaat/finance-buddy/backend-go/internal/aggregates"
 	bonusevents "github.com/Automaat/finance-buddy/backend-go/internal/bonus_events"
 	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/config"
@@ -152,6 +154,15 @@ func registerAPIRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 	r.Route("/api/zus", func(r chi.Router) {
 		r.Post("/calculate", zusHandler.Calculate)
 		r.Get("/prefill", zusHandler.Prefill)
+	})
+
+	aggregatesStore := aggregates.NewStore(pool)
+	accountsHandler := accounts.NewHandler(accounts.NewStore(pool, aggregatesStore), logger)
+	r.Route("/api/accounts", func(r chi.Router) {
+		r.Get("/", accountsHandler.List)
+		r.Post("/", accountsHandler.Create)
+		r.Put("/{id}", accountsHandler.Update)
+		r.Delete("/{id}", accountsHandler.Delete)
 	})
 }
 

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -109,3 +109,16 @@ rules:
   - method: POST
     path_prefix: /api/zus
     upstream: http://backend-go:8000
+  # Group 9a — /api/accounts cut over to Go (incl. cascade aggregate recompute on owner/category change).
+  - method: GET
+    path_prefix: /api/accounts
+    upstream: http://backend-go:8000
+  - method: POST
+    path_prefix: /api/accounts
+    upstream: http://backend-go:8000
+  - method: PUT
+    path_prefix: /api/accounts
+    upstream: http://backend-go:8000
+  - method: DELETE
+    path_prefix: /api/accounts
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

First slice of Group 9 (#444) — accounts CRUD + the snapshot_aggregates math that 9b (assets) and 9c (snapshots) will also consume.

Group 9 is the largest cutover so far so I'm splitting it into three sub-PRs to keep each slice reviewable:

- **9a (this PR):** snapshot_aggregates package + accounts CRUD with cascade-on-edit
- **9b (next):** assets CRUD (depends on aggregates)
- **9c (final):** snapshots CRUD with the create/update/delete that triggers full recompute

The aggregates package is foundational — every subsequent slice consumes it. Landing the math first lets the parity surface progressively.

## Implementation information

### `internal/aggregates/spec.go`

Pure-functions port of `backend/app/services/aggregate_spec.py`:

- Decimal everywhere (no float intermediate)
- Signed-value rules unchanged: asset-table value -> Shared bucket; account `type='asset'` -> bucket's assets + allocation[category]; account `type='liability'` -> bucket's liabilities
- Owners sorted alphabetically in the output to match Python's `for owner, data in totals.items()` after sorted-categories step
- Empty totals produce one zero row for owner='Shared' so the month isn't a gap in the chart (matches Python)

### `internal/aggregates/store.go`

- `RecomputeForSnapshot(ctx, tx, snapshotID)` — DELETE the existing aggregate rows, load snapshot + values + active accounts + active assets, compute via spec, INSERT each row. Runs in the caller's tx so callers can atomically chain mutation + recompute.
- `RecomputeForSnapshots(ctx, tx, ids)` — bulk variant.
- `AffectedSnapshotIDsForAccount` / `ForAsset` — used by accounts/assets to decide which snapshots to recompute.
- `errSnapshotGone` sentinel for the concurrent-delete branch (snapshot disappeared mid-tx) — recompute returns nil instead of erroring, matching Python's `if snapshot is None: return`.

### `internal/accounts/store.go`

Full CRUD with soft-delete + cascade:

- `Update` does FOR UPDATE row lock, applies the patch, captures pre-patch `oldOwner` / `oldCategory`, and triggers `RecomputeForSnapshots` only when the request meaningfully changed either field (matches Python's `needs_recompute` decision exactly).
- `Delete` (soft) cascades the recompute too — inactive account contributes 0 in the new aggregates.
- Duplicate name check on create + update with a tx-aware path that holds the row lock through the dup check.

### `internal/accounts/handler.go`

- GET /api/accounts -> `{assets: [...], liabilities: [...]}` bucketed by `type`
- POST / PUT / DELETE wired to chi
- `current_value` filled via a single DISTINCT ON query (no N+1)

### `internal/accounts/validation.go`

- All enums (type, category, purpose, wrapper) enforced with allow-list maps
- PATCH (PUT in this domain since Python uses PUT) honors the null-vs-omit distinction: omit -> no change; explicit null on `account_wrapper` or `square_meters` -> set to NULL; explicit null on other fields -> 422

### Parity proof against Go

```
============================= test session starts ==============================
tests/test_accounts.py::test_get_accounts_matches_golden                       PASSED
tests/test_accounts.py::test_get_accounts_buckets_assets_and_liabilities       PASSED
tests/test_accounts.py::test_create_account_happy_path                         PASSED
tests/test_accounts.py::test_create_account_validation_error                   PASSED
tests/test_accounts.py::test_update_account_happy_path                         PASSED
tests/test_accounts.py::test_update_account_validation_error                   PASSED
tests/test_accounts.py::test_delete_account_happy_path                         PASSED
============================== 7 passed in 0.14s ===============================
```

Golden snapshot reproduces byte-for-byte. Aggregate recompute covered indirectly by the update path; full snapshot-level parity gates 9c.

### `routes.yaml`

GET / POST / PUT / DELETE rules for `/api/accounts/`. Group 9b (assets) and 9c (snapshots) will add their own rules.

## Supporting documentation

- Umbrella: #435
- Subissue: #444
- Procedure: `migration/CUTOVER.md`

> Changelog: skip