### PR TITLE
feat(go): cutover /api/assets (Group 9b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,8 @@ jobs:
             tests/test_cpi.py \
             tests/test_salary_records.py \
             tests/test_zus.py \
-            tests/test_accounts.py
+            tests/test_accounts.py \
+            tests/test_assets.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/backend-go/internal/assets/errors.go
+++ b/backend-go/internal/assets/errors.go
@@ -1,0 +1,41 @@
+package assets
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{
+				"type":  "value_error",
+				"loc":   []string{"body", field},
+				"msg":   msg,
+				"input": input,
+			},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/assets/handler.go
+++ b/backend-go/internal/assets/handler.go
@@ -1,0 +1,194 @@
+package assets
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+)
+
+type response struct {
+	ID           int      `json:"id"`
+	Name         string   `json:"name"`
+	IsActive     bool     `json:"is_active"`
+	CreatedAt    isoNaive `json:"created_at"`
+	CurrentValue pyFloat  `json:"current_value"`
+}
+
+type listResponse struct {
+	Assets []response `json:"assets"`
+}
+
+// Handler is the HTTP boundary for /api/assets.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewHandler wires the store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger}
+}
+
+func toResponse(a *Asset, current decimal.Decimal) response {
+	cv, _ := current.Float64()
+	return response{
+		ID:           a.ID,
+		Name:         a.Name,
+		IsActive:     a.IsActive,
+		CreatedAt:    isoNaive(a.CreatedAt.UTC()),
+		CurrentValue: pyFloat(cv),
+	}
+}
+
+// List serves GET /api/assets.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.store.List(r.Context())
+	if err != nil {
+		h.logger.Error("list assets", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	ids := make([]int, 0, len(rows))
+	for i := range rows {
+		ids = append(ids, rows[i].ID)
+	}
+	values, err := h.store.LatestValuesByAsset(r.Context(), ids)
+	if err != nil {
+		h.logger.Error("latest asset values", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := listResponse{Assets: make([]response, 0, len(rows))}
+	for i := range rows {
+		a := &rows[i]
+		out.Assets = append(out.Assets, toResponse(a, values[a.ID]))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Create serves POST /api/assets.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	name, vErr := requireName(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	created, err := h.store.Create(r.Context(), name)
+	if err != nil {
+		if errors.Is(err, ErrDuplicateName) {
+			writeDetailError(w, http.StatusConflict,
+				fmt.Sprintf("Asset with name '%s' already exists", name))
+			return
+		}
+		h.logger.Error("create asset", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toResponse(created, decimal.Zero))
+}
+
+// Update serves PUT /api/assets/{id}.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	namePtr, vErr := optionalName(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	updated, err := h.store.Update(r.Context(), id, namePtr)
+	if err != nil {
+		h.writeStoreError(w, err, id, namePtr)
+		return
+	}
+	cv, err := h.store.LatestValueForAsset(r.Context(), id)
+	if err != nil {
+		h.logger.Error("latest asset value", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusOK, toResponse(updated, cv))
+}
+
+// Delete serves DELETE /api/assets/{id}.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.Delete(r.Context(), id); err != nil {
+		h.writeStoreError(w, err, id, nil)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int, name *string) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		writeDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("Asset with id %d not found", id))
+	case errors.Is(err, ErrDuplicateName):
+		n := ""
+		if name != nil {
+			n = *name
+		}
+		writeDetailError(w, http.StatusConflict,
+			fmt.Sprintf("Asset with name '%s' already exists", n))
+	default:
+		h.logger.Error("asset store", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+	}
+}
+
+func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		writeValidationError(w, "asset_id", "must be an integer", raw)
+		return 0, false
+	}
+	return id, true
+}
+
+// --- wire types (shared) ---
+
+type isoNaive time.Time
+
+func (t isoNaive) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
+}
+
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/assets/store.go
+++ b/backend-go/internal/assets/store.go
@@ -1,0 +1,266 @@
+// Package assets implements /api/assets — CRUD with cascade-on-delete:
+// soft-delete triggers snapshot_aggregates recompute for snapshots that
+// reference the asset (inactive asset contributes 0).
+package assets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/aggregates"
+)
+
+// Asset mirrors backend/app/models/asset.Asset.
+type Asset struct {
+	ID        int
+	Name      string
+	IsActive  bool
+	CreatedAt time.Time
+}
+
+// Sentinel errors mapped to HTTP status codes.
+var (
+	ErrNotFound      = errors.New("asset not found")
+	ErrDuplicateName = errors.New("asset name already exists")
+)
+
+// Store is the persistence boundary.
+type Store struct {
+	pool       *pgxpool.Pool
+	aggregates *aggregates.Store
+}
+
+// NewStore wires the pool + aggregates store (cascade-on-delete uses it).
+func NewStore(pool *pgxpool.Pool, aggs *aggregates.Store) *Store {
+	return &Store{pool: pool, aggregates: aggs}
+}
+
+const selectColumns = `id, name, is_active, created_at`
+
+// List returns active assets.
+func (s *Store) List(ctx context.Context) ([]Asset, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+selectColumns+` FROM assets WHERE is_active = true ORDER BY id`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list assets: %w", err)
+	}
+	defer rows.Close()
+	out := []Asset{}
+	for rows.Next() {
+		a, err := scanAsset(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan asset: %w", err)
+		}
+		out = append(out, *a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate assets: %w", err)
+	}
+	return out, nil
+}
+
+// LatestValuesByAsset returns the most recent snapshot value per asset.
+func (s *Store) LatestValuesByAsset(ctx context.Context, assetIDs []int) (map[int]decimal.Decimal, error) {
+	if len(assetIDs) == 0 {
+		return map[int]decimal.Decimal{}, nil
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT DISTINCT ON (sv.asset_id) sv.asset_id, sv.value
+		FROM snapshot_values sv
+		JOIN snapshots s ON s.id = sv.snapshot_id
+		WHERE sv.asset_id = ANY($1)
+		ORDER BY sv.asset_id, s.date DESC`,
+		assetIDs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("latest asset values: %w", err)
+	}
+	defer rows.Close()
+	out := map[int]decimal.Decimal{}
+	for rows.Next() {
+		var id int
+		var v decimal.Decimal
+		if err := rows.Scan(&id, &v); err != nil {
+			return nil, fmt.Errorf("scan latest asset value: %w", err)
+		}
+		out[id] = v
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate latest asset values: %w", err)
+	}
+	return out, nil
+}
+
+// LatestValueForAsset returns the asset's value in the latest snapshot, or
+// zero. Mirrors Python: take the most recent snapshot by date, then the
+// matching SnapshotValue.
+func (s *Store) LatestValueForAsset(ctx context.Context, assetID int) (decimal.Decimal, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT sv.value
+		FROM snapshot_values sv
+		JOIN snapshots s ON s.id = sv.snapshot_id
+		WHERE sv.asset_id = $1
+		  AND s.id = (SELECT id FROM snapshots ORDER BY date DESC LIMIT 1)
+		LIMIT 1`,
+		assetID,
+	)
+	var v decimal.Decimal
+	if err := row.Scan(&v); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return decimal.Zero, nil
+		}
+		return decimal.Zero, fmt.Errorf("latest asset value: %w", err)
+	}
+	return v, nil
+}
+
+// Create inserts an asset row. Duplicate name -> ErrDuplicateName.
+func (s *Store) Create(ctx context.Context, name string) (*Asset, error) {
+	if err := s.checkDuplicateName(ctx, name, 0); err != nil {
+		return nil, err
+	}
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO assets (name, is_active, created_at)
+		VALUES ($1, true, $2)
+		RETURNING `+selectColumns,
+		name, time.Now().UTC(),
+	)
+	return scanAsset(row)
+}
+
+// Update applies the (only) field: name. No cascade — assets don't carry
+// owner/category, so aggregates are unaffected by a rename.
+func (s *Store) Update(ctx context.Context, id int, name *string) (*Asset, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin update tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	current, err := lockAsset(ctx, tx, id)
+	if err != nil {
+		return nil, err
+	}
+	if name != nil && *name != current.Name {
+		if err := s.checkDuplicateNameTx(ctx, tx, *name, id); err != nil {
+			return nil, err
+		}
+		if _, err := tx.Exec(ctx, `UPDATE assets SET name = $1 WHERE id = $2`, *name, id); err != nil {
+			return nil, fmt.Errorf("update asset: %w", err)
+		}
+		current.Name = *name
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit update tx: %w", err)
+	}
+	committed = true
+	return current, nil
+}
+
+// Delete soft-deletes and cascades into aggregate recompute.
+func (s *Store) Delete(ctx context.Context, id int) error {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin delete tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	current, err := lockAsset(ctx, tx, id)
+	if err != nil {
+		return err
+	}
+	if !current.IsActive {
+		if err := tx.Commit(ctx); err != nil {
+			return fmt.Errorf("commit idempotent delete: %w", err)
+		}
+		committed = true
+		return nil
+	}
+	if _, err := tx.Exec(ctx, `UPDATE assets SET is_active = false WHERE id = $1`, id); err != nil {
+		return fmt.Errorf("soft-delete asset: %w", err)
+	}
+	ids, err := s.aggregates.AffectedSnapshotIDsForAsset(ctx, tx, id)
+	if err != nil {
+		return err
+	}
+	if err := s.aggregates.RecomputeForSnapshots(ctx, tx, ids); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit delete tx: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (s *Store) checkDuplicateName(ctx context.Context, name string, excludeID int) error {
+	q := `SELECT id FROM assets WHERE name = $1 AND is_active = true`
+	args := []any{name}
+	if excludeID > 0 {
+		q += ` AND id <> $2`
+		args = append(args, excludeID)
+	}
+	var existing int
+	err := s.pool.QueryRow(ctx, q+` LIMIT 1`, args...).Scan(&existing)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("check duplicate asset name: %w", err)
+	}
+	return ErrDuplicateName
+}
+
+func (s *Store) checkDuplicateNameTx(ctx context.Context, tx pgx.Tx, name string, excludeID int) error {
+	var existing int
+	err := tx.QueryRow(ctx, `
+		SELECT id FROM assets
+		WHERE name = $1 AND is_active = true AND id <> $2
+		LIMIT 1`,
+		name, excludeID,
+	).Scan(&existing)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("check duplicate asset name (tx): %w", err)
+	}
+	return ErrDuplicateName
+}
+
+func lockAsset(ctx context.Context, tx pgx.Tx, id int) (*Asset, error) {
+	row := tx.QueryRow(ctx,
+		`SELECT `+selectColumns+` FROM assets WHERE id = $1 FOR UPDATE`, id,
+	)
+	a, err := scanAsset(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("lock asset: %w", err)
+	}
+	return a, nil
+}
+
+func scanAsset(row pgx.Row) (*Asset, error) {
+	var a Asset
+	if err := row.Scan(&a.ID, &a.Name, &a.IsActive, &a.CreatedAt); err != nil {
+		return nil, err
+	}
+	return &a, nil
+}

--- a/backend-go/internal/assets/validation.go
+++ b/backend-go/internal/assets/validation.go
@@ -1,0 +1,44 @@
+package assets
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+func requireName(raw map[string]json.RawMessage) (string, *validationError) {
+	v, ok := raw["name"]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: "name", Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: "name", Msg: "must be a string"}
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", &validationError{Field: "name", Msg: "Name cannot be empty"}
+	}
+	return s, nil
+}
+
+// optionalName: absent / explicit null -> no change. Empty string -> 422.
+func optionalName(raw map[string]json.RawMessage) (*string, *validationError) {
+	v, ok := raw["name"]
+	if !ok || isNull(v) {
+		return nil, nil
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return nil, &validationError{Field: "name", Msg: "must be a string"}
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, &validationError{Field: "name", Msg: "Name cannot be empty"}
+	}
+	return &s, nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/accounts"
 	"github.com/Automaat/finance-buddy/backend-go/internal/aggregates"
+	"github.com/Automaat/finance-buddy/backend-go/internal/assets"
 	bonusevents "github.com/Automaat/finance-buddy/backend-go/internal/bonus_events"
 	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/config"
@@ -163,6 +164,14 @@ func registerAPIRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 		r.Post("/", accountsHandler.Create)
 		r.Put("/{id}", accountsHandler.Update)
 		r.Delete("/{id}", accountsHandler.Delete)
+	})
+
+	assetsHandler := assets.NewHandler(assets.NewStore(pool, aggregatesStore), logger)
+	r.Route("/api/assets", func(r chi.Router) {
+		r.Get("/", assetsHandler.List)
+		r.Post("/", assetsHandler.Create)
+		r.Put("/{id}", assetsHandler.Update)
+		r.Delete("/{id}", assetsHandler.Delete)
 	})
 }
 

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -122,3 +122,16 @@ rules:
   - method: DELETE
     path_prefix: /api/accounts
     upstream: http://backend-go:8000
+  # Group 9b — /api/assets cut over to Go (cascade recompute on soft-delete).
+  - method: GET
+    path_prefix: /api/assets
+    upstream: http://backend-go:8000
+  - method: POST
+    path_prefix: /api/assets
+    upstream: http://backend-go:8000
+  - method: PUT
+    path_prefix: /api/assets
+    upstream: http://backend-go:8000
+  - method: DELETE
+    path_prefix: /api/assets
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

Second slice of Group 9 (#444) — assets CRUD. Builds on the aggregates package landed in 9a (#468); next is 9c (snapshots, the largest piece).

Assets are simpler than accounts:
- Only \`name\` is mutable
- No owner/category so renames don't trigger aggregate recompute
- Soft-delete still cascades (an inactive asset contributes 0 to the spec)

## Implementation information

### \`internal/assets/store.go\`

- Full CRUD. Create does a pre-INSERT duplicate-name SELECT, same shape as Python (a race exists between SELECT and INSERT but it's outside scope; if it becomes a problem we add a unique index in a separate PR).
- Update + Delete wrap their work in a transaction with a FOR UPDATE row lock so the duplicate-name check on rename or the cascade aggregate recompute on soft-delete runs against a stable view.
- \`Delete\` (soft) calls \`aggregates.AffectedSnapshotIDsForAsset\` + \`RecomputeForSnapshots\` in the same transaction so an inactive asset removes its old contribution from every snapshot atomically.
- \`LatestValuesByAsset\` uses a single DISTINCT ON query to fill response.current_value without an N+1 over assets.
- \`LatestValueForAsset\` (used on PUT) follows Python's two-step shape: pick the latest snapshot by date, then read its value for the asset.

### \`internal/assets/handler.go\` / \`validation.go\` / \`errors.go\`

- chi routes, Pydantic-shape POST/PUT validators (name required on POST; null/absent on PUT = no-op).
- Same \`pyFloat\` + \`isoNaive\` wire types as the other Go-served domains.

### Parity proof against Go

\`\`\`
============================= test session starts ==============================
tests/test_assets.py::test_get_assets_matches_golden        PASSED
tests/test_assets.py::test_get_assets_includes_seeded       PASSED
tests/test_assets.py::test_create_asset_happy_path          PASSED
tests/test_assets.py::test_create_asset_validation_error    PASSED
tests/test_assets.py::test_update_asset_happy_path          PASSED
tests/test_assets.py::test_update_asset_validation_error    PASSED
tests/test_assets.py::test_delete_asset_happy_path          PASSED
============================== 7 passed in 0.15s ===============================
\`\`\`

Golden snapshot matches byte-for-byte.

### \`routes.yaml\`

GET / POST / PUT / DELETE rules for \`/api/assets/\`. Group 9c (snapshots) will be the last slice — it owns the create/update path that triggers full recompute.

## Supporting documentation

- Umbrella: #435
- Subissue: #444
- Slice 9a: #468 (merged)
- Procedure: \`migration/CUTOVER.md\`

> Changelog: skip