### PR TITLE
feat(go): cutover /api/snapshots (Group 9c)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,8 @@ jobs:
             tests/test_salary_records.py \
             tests/test_zus.py \
             tests/test_accounts.py \
-            tests/test_assets.py
+            tests/test_assets.py \
+            tests/test_snapshots.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/personas"
 	"github.com/Automaat/finance-buddy/backend-go/internal/salaries"
+	"github.com/Automaat/finance-buddy/backend-go/internal/snapshots"
 	"github.com/Automaat/finance-buddy/backend-go/internal/zus"
 )
 
@@ -80,6 +81,13 @@ func New(cfg Config, logger *slog.Logger, deps Deps) http.Handler {
 }
 
 func registerAPIRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
+	registerCoreRoutes(r, pool, logger)
+	registerEquityRoutes(r, pool, logger)
+	registerCPIAndPayrollRoutes(r, pool, logger)
+	registerPortfolioRoutes(r, pool, logger)
+}
+
+func registerCoreRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 	cfgHandler := config.NewHandler(config.NewStore(pool), logger)
 	r.Route("/api/config", func(r chi.Router) {
 		r.Get("/", cfgHandler.Get)
@@ -102,7 +110,9 @@ func registerAPIRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 		r.Put("/{id}", goalsHandler.Update)
 		r.Delete("/{id}", goalsHandler.Delete)
 	})
+}
 
+func registerEquityRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 	valuationsStore := companyvaluations.NewStore(pool)
 	valuationsHandler := companyvaluations.NewHandler(valuationsStore, logger)
 	r.Route("/api/company-valuations", func(r chi.Router) {
@@ -133,7 +143,9 @@ func registerAPIRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 		r.Patch("/{id}", grantsHandler.Update)
 		r.Delete("/{id}", grantsHandler.Delete)
 	})
+}
 
+func registerCPIAndPayrollRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 	cpiStore := cpi.NewStore(pool)
 	cpiHandler := cpi.NewHandler(cpiStore, cpi.NewGUSFetcher(), logger)
 	r.Route("/api/cpi", func(r chi.Router) {
@@ -156,7 +168,9 @@ func registerAPIRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 		r.Post("/calculate", zusHandler.Calculate)
 		r.Get("/prefill", zusHandler.Prefill)
 	})
+}
 
+func registerPortfolioRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 	aggregatesStore := aggregates.NewStore(pool)
 	accountsHandler := accounts.NewHandler(accounts.NewStore(pool, aggregatesStore), logger)
 	r.Route("/api/accounts", func(r chi.Router) {
@@ -172,6 +186,14 @@ func registerAPIRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 		r.Post("/", assetsHandler.Create)
 		r.Put("/{id}", assetsHandler.Update)
 		r.Delete("/{id}", assetsHandler.Delete)
+	})
+
+	snapshotsHandler := snapshots.NewHandler(snapshots.NewStore(pool, aggregatesStore), logger)
+	r.Route("/api/snapshots", func(r chi.Router) {
+		r.Get("/", snapshotsHandler.List)
+		r.Post("/", snapshotsHandler.Create)
+		r.Get("/{id}", snapshotsHandler.Get)
+		r.Put("/{id}", snapshotsHandler.Update)
 	})
 }
 

--- a/backend-go/internal/snapshots/errors.go
+++ b/backend-go/internal/snapshots/errors.go
@@ -1,0 +1,41 @@
+package snapshots
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{
+				"type":  "value_error",
+				"loc":   []string{"body", field},
+				"msg":   msg,
+				"input": input,
+			},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/snapshots/handler.go
+++ b/backend-go/internal/snapshots/handler.go
@@ -1,0 +1,221 @@
+package snapshots
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type valueResponse struct {
+	ID          int     `json:"id"`
+	AssetID     *int    `json:"asset_id"`
+	AssetName   *string `json:"asset_name"`
+	AccountID   *int    `json:"account_id"`
+	AccountName *string `json:"account_name"`
+	Value       pyFloat `json:"value"`
+}
+
+type response struct {
+	ID     int             `json:"id"`
+	Date   isoDate         `json:"date"`
+	Notes  *string         `json:"notes"`
+	Values []valueResponse `json:"values"`
+}
+
+type listItem struct {
+	ID            int     `json:"id"`
+	Date          isoDate `json:"date"`
+	Notes         *string `json:"notes"`
+	TotalNetWorth pyFloat `json:"total_net_worth"`
+}
+
+// Handler is the HTTP boundary for /api/snapshots.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewHandler wires the store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger}
+}
+
+func buildResponse(snap *Snapshot, values []Value) response {
+	out := response{
+		ID:    snap.ID,
+		Date:  isoDate(snap.Date),
+		Notes: snap.Notes,
+	}
+	out.Values = make([]valueResponse, 0, len(values))
+	for _, v := range values {
+		f, _ := v.Value.Float64()
+		out.Values = append(out.Values, valueResponse{
+			ID: v.ID, AssetID: v.AssetID, AssetName: v.AssetName,
+			AccountID: v.AccountID, AccountName: v.AccountName,
+			Value: pyFloat(f),
+		})
+	}
+	return out
+}
+
+// List serves GET /api/snapshots.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.store.List(r.Context())
+	if err != nil {
+		h.logger.Error("list snapshots", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := make([]listItem, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, listItem{
+			ID: row.ID, Date: isoDate(row.Date), Notes: row.Notes,
+			TotalNetWorth: pyFloat(row.TotalNetWorth),
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Get serves GET /api/snapshots/{id}.
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	snap, values, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		h.writeStoreError(w, err, id, nil)
+		return
+	}
+	writeJSON(w, http.StatusOK, buildResponse(snap, values))
+}
+
+// Create serves POST /api/snapshots.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	req, vErr := buildCreateRequest(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	snap, values, err := h.store.Create(r.Context(), req.Date, req.Notes, req.Values)
+	if err != nil {
+		h.writeStoreError(w, err, 0, &req.Date)
+		return
+	}
+	writeJSON(w, http.StatusCreated, buildResponse(snap, values))
+}
+
+// Update serves PUT /api/snapshots/{id}.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	patch, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	snap, values, err := h.store.Update(r.Context(), id, patch)
+	if err != nil {
+		h.writeStoreError(w, err, id, patch.Date)
+		return
+	}
+	writeJSON(w, http.StatusOK, buildResponse(snap, values))
+}
+
+func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int, date *time.Time) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		writeDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("Snapshot %d not found", id))
+	case errors.Is(err, ErrDuplicateDate):
+		d := ""
+		if date != nil {
+			d = date.Format("2006-01-02")
+		}
+		writeDetailError(w, http.StatusBadRequest,
+			fmt.Sprintf("Snapshot for date %s already exists", d))
+	case errors.Is(err, ErrDuplicateValueIDs):
+		writeDetailError(w, http.StatusBadRequest,
+			"Duplicate asset or account IDs in snapshot values")
+	default:
+		var mre *MissingReferencesError
+		if errors.As(err, &mre) {
+			if len(mre.MissingAssets) > 0 {
+				writeDetailError(w, http.StatusNotFound,
+					fmt.Sprintf("Assets not found: %s", setLiteral(mre.MissingAssets)))
+				return
+			}
+			writeDetailError(w, http.StatusNotFound,
+				fmt.Sprintf("Accounts not found: %s", setLiteral(mre.MissingAccounts)))
+			return
+		}
+		h.logger.Error("snapshot store", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+	}
+}
+
+// setLiteral renders a Go []int as Python's `{1, 2, 3}` set-literal output
+// so the error detail matches Python's f"Assets not found: {missing}".
+func setLiteral(ids []int) string {
+	if len(ids) == 0 {
+		return "set()"
+	}
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		parts = append(parts, strconv.Itoa(id))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		writeValidationError(w, "snapshot_id", "must be an integer", raw)
+		return 0, false
+	}
+	return id, true
+}
+
+// --- wire types ---
+
+type isoDate time.Time
+
+const isoDateLayout = "2006-01-02"
+
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
+}
+
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/snapshots/handler.go
+++ b/backend-go/internal/snapshots/handler.go
@@ -157,9 +157,12 @@ func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int, date
 		}
 		writeDetailError(w, http.StatusBadRequest,
 			fmt.Sprintf("Snapshot for date %s already exists", d))
-	case errors.Is(err, ErrDuplicateValueIDs):
+	case errors.Is(err, ErrDuplicateAssetIDs):
 		writeDetailError(w, http.StatusBadRequest,
-			"Duplicate asset or account IDs in snapshot values")
+			"Duplicate asset IDs in snapshot values")
+	case errors.Is(err, ErrDuplicateAccountIDs):
+		writeDetailError(w, http.StatusBadRequest,
+			"Duplicate account IDs in snapshot values")
 	default:
 		var mre *MissingReferencesError
 		if errors.As(err, &mre) {

--- a/backend-go/internal/snapshots/store.go
+++ b/backend-go/internal/snapshots/store.go
@@ -1,0 +1,466 @@
+// Package snapshots implements /api/snapshots — atomic
+// create/update of a snapshot + its values + cascade
+// snapshot_aggregates recompute, all in one transaction.
+package snapshots
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/aggregates"
+)
+
+// Snapshot mirrors backend/app/models/snapshot.Snapshot.
+type Snapshot struct {
+	ID        int
+	Date      time.Time
+	Notes     *string
+	CreatedAt time.Time
+}
+
+// Value is one row from snapshot_values + the related asset/account name
+// resolved via LEFT JOIN.
+type Value struct {
+	ID          int
+	AssetID     *int
+	AssetName   *string
+	AccountID   *int
+	AccountName *string
+	Value       decimal.Decimal
+}
+
+// ListItem is what GET /api/snapshots returns per row.
+type ListItem struct {
+	ID            int
+	Date          time.Time
+	Notes         *string
+	TotalNetWorth float64
+}
+
+// ValueInput is one POST/PUT body entry. AssetID and AccountID are
+// mutually-exclusive — the validator enforces "exactly one".
+type ValueInput struct {
+	AssetID   *int
+	AccountID *int
+	Value     decimal.Decimal
+}
+
+// Sentinel errors mapped to HTTP status codes by the handler.
+var (
+	ErrNotFound          = errors.New("snapshot not found")
+	ErrDuplicateDate     = errors.New("snapshot date conflicts")
+	ErrDuplicateValueIDs = errors.New("duplicate value ids")
+	ErrMissingReferences = errors.New("referenced assets or accounts missing")
+)
+
+// MissingReferencesError carries the missing IDs back to the handler so the
+// 404 detail string can spell them out (matches Python's "Assets not found:
+// {1, 2}" message).
+type MissingReferencesError struct {
+	MissingAssets   []int
+	MissingAccounts []int
+}
+
+func (e *MissingReferencesError) Error() string {
+	return "missing references"
+}
+
+// Store is the persistence boundary.
+type Store struct {
+	pool       *pgxpool.Pool
+	aggregates *aggregates.Store
+}
+
+// NewStore wires the pool + aggregates store (used for recompute).
+func NewStore(pool *pgxpool.Pool, aggs *aggregates.Store) *Store {
+	return &Store{pool: pool, aggregates: aggs}
+}
+
+// List returns all snapshots ordered by date desc, each with its total_net_worth
+// computed from active accounts + active assets only (inactive contribute 0).
+func (s *Store) List(ctx context.Context) ([]ListItem, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT s.id, s.date, s.notes,
+			COALESCE(SUM(
+				CASE
+					WHEN a.id IS NOT NULL AND a.is_active = true THEN sv.value
+					WHEN acc.id IS NOT NULL AND acc.is_active = true AND acc.type = 'asset' THEN sv.value
+					WHEN acc.id IS NOT NULL AND acc.is_active = true AND acc.type = 'liability' THEN -sv.value
+					ELSE 0
+				END
+			), 0) AS total_net_worth
+		FROM snapshots s
+		LEFT JOIN snapshot_values sv ON sv.snapshot_id = s.id
+		LEFT JOIN assets a ON a.id = sv.asset_id
+		LEFT JOIN accounts acc ON acc.id = sv.account_id
+		GROUP BY s.id, s.date, s.notes
+		ORDER BY s.date DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list snapshots: %w", err)
+	}
+	defer rows.Close()
+	out := []ListItem{}
+	for rows.Next() {
+		var item ListItem
+		var total decimal.Decimal
+		if err := rows.Scan(&item.ID, &item.Date, &item.Notes, &total); err != nil {
+			return nil, fmt.Errorf("scan snapshot list item: %w", err)
+		}
+		item.TotalNetWorth, _ = total.Float64()
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshot list: %w", err)
+	}
+	return out, nil
+}
+
+// Get returns one snapshot + all its values with names joined in.
+func (s *Store) Get(ctx context.Context, id int) (*Snapshot, []Value, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT id, date, notes, created_at FROM snapshots WHERE id = $1`, id,
+	)
+	var snap Snapshot
+	if err := row.Scan(&snap.ID, &snap.Date, &snap.Notes, &snap.CreatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil, ErrNotFound
+		}
+		return nil, nil, fmt.Errorf("get snapshot: %w", err)
+	}
+	values, err := s.loadValues(ctx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &snap, values, nil
+}
+
+func (s *Store) loadValues(ctx context.Context, snapshotID int) ([]Value, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT sv.id, sv.asset_id, a.name, sv.account_id, acc.name, sv.value
+		FROM snapshot_values sv
+		LEFT JOIN assets a ON a.id = sv.asset_id
+		LEFT JOIN accounts acc ON acc.id = sv.account_id
+		WHERE sv.snapshot_id = $1
+		ORDER BY sv.id`,
+		snapshotID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load snapshot values: %w", err)
+	}
+	defer rows.Close()
+	out := []Value{}
+	for rows.Next() {
+		var v Value
+		if err := rows.Scan(&v.ID, &v.AssetID, &v.AssetName, &v.AccountID, &v.AccountName, &v.Value); err != nil {
+			return nil, fmt.Errorf("scan snapshot value: %w", err)
+		}
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshot values: %w", err)
+	}
+	return out, nil
+}
+
+// Create inserts a snapshot + all values + runs the aggregate recompute,
+// all atomically. ErrDuplicateDate if the date is already taken,
+// MissingReferencesError if any referenced asset/account doesn't exist or is
+// inactive.
+func (s *Store) Create(ctx context.Context, date time.Time, notes *string, values []ValueInput) (*Snapshot, []Value, error) {
+	if err := validateValueIDs(values); err != nil {
+		return nil, nil, err
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("begin create tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	if err := checkDuplicateDate(ctx, tx, date, 0); err != nil {
+		return nil, nil, err
+	}
+	if err := checkReferencesExistActive(ctx, tx, values); err != nil {
+		return nil, nil, err
+	}
+	var snap Snapshot
+	err = tx.QueryRow(ctx, `
+		INSERT INTO snapshots (date, notes, created_at)
+		VALUES ($1, $2, $3)
+		RETURNING id, date, notes, created_at`,
+		date, notes, time.Now().UTC(),
+	).Scan(&snap.ID, &snap.Date, &snap.Notes, &snap.CreatedAt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("insert snapshot: %w", err)
+	}
+	if err := insertValues(ctx, tx, snap.ID, values); err != nil {
+		return nil, nil, err
+	}
+	if err := s.aggregates.RecomputeForSnapshot(ctx, tx, snap.ID); err != nil {
+		return nil, nil, err
+	}
+	stored, err := loadValuesTx(ctx, tx, snap.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, nil, fmt.Errorf("commit create tx: %w", err)
+	}
+	committed = true
+	return &snap, stored, nil
+}
+
+// UpdatePatch is the sparse update set. ValuesSet=true distinguishes
+// "values omitted" (keep) from "values present" (replace).
+type UpdatePatch struct {
+	Date      *time.Time
+	NotesSet  bool
+	Notes     *string
+	ValuesSet bool
+	Values    []ValueInput
+}
+
+// Update mutates the snapshot, optionally replaces values, and runs the
+// aggregate recompute — all in one transaction.
+func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Snapshot, []Value, error) {
+	if p.ValuesSet {
+		if err := validateValueIDs(p.Values); err != nil {
+			return nil, nil, err
+		}
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("begin update tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	snap, err := lockSnapshot(ctx, tx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	if p.Date != nil {
+		if err := checkDuplicateDate(ctx, tx, *p.Date, id); err != nil {
+			return nil, nil, err
+		}
+		snap.Date = *p.Date
+	}
+	if p.NotesSet {
+		snap.Notes = p.Notes
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE snapshots SET date = $1, notes = $2 WHERE id = $3`,
+		snap.Date, snap.Notes, id,
+	); err != nil {
+		return nil, nil, fmt.Errorf("update snapshot: %w", err)
+	}
+	if p.ValuesSet {
+		if err := checkReferencesExist(ctx, tx, p.Values); err != nil {
+			return nil, nil, err
+		}
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM snapshot_values WHERE snapshot_id = $1`, id,
+		); err != nil {
+			return nil, nil, fmt.Errorf("delete snapshot values: %w", err)
+		}
+		if err := insertValues(ctx, tx, id, p.Values); err != nil {
+			return nil, nil, err
+		}
+	}
+	if err := s.aggregates.RecomputeForSnapshot(ctx, tx, id); err != nil {
+		return nil, nil, err
+	}
+	stored, err := loadValuesTx(ctx, tx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, nil, fmt.Errorf("commit update tx: %w", err)
+	}
+	committed = true
+	return snap, stored, nil
+}
+
+// --- helpers ---
+
+func validateValueIDs(values []ValueInput) error {
+	seenAssets := map[int]struct{}{}
+	seenAccounts := map[int]struct{}{}
+	for _, v := range values {
+		if v.AssetID != nil {
+			if _, dup := seenAssets[*v.AssetID]; dup {
+				return ErrDuplicateValueIDs
+			}
+			seenAssets[*v.AssetID] = struct{}{}
+		}
+		if v.AccountID != nil {
+			if _, dup := seenAccounts[*v.AccountID]; dup {
+				return ErrDuplicateValueIDs
+			}
+			seenAccounts[*v.AccountID] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func checkDuplicateDate(ctx context.Context, tx pgx.Tx, date time.Time, excludeID int) error {
+	q := `SELECT id FROM snapshots WHERE date = $1`
+	args := []any{date}
+	if excludeID > 0 {
+		q += ` AND id <> $2`
+		args = append(args, excludeID)
+	}
+	var existing int
+	err := tx.QueryRow(ctx, q+` LIMIT 1`, args...).Scan(&existing)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("check duplicate date: %w", err)
+	}
+	return ErrDuplicateDate
+}
+
+// checkReferencesExistActive enforces is_active=true (used on POST, matches
+// Python's `Asset.is_active.is_(True)`).
+func checkReferencesExistActive(ctx context.Context, tx pgx.Tx, values []ValueInput) error {
+	return checkReferences(ctx, tx, values, true)
+}
+
+// checkReferencesExist ignores is_active (used on PUT, matches Python's
+// PUT path which doesn't filter by is_active when validating IDs).
+func checkReferencesExist(ctx context.Context, tx pgx.Tx, values []ValueInput) error {
+	return checkReferences(ctx, tx, values, false)
+}
+
+func checkReferences(ctx context.Context, tx pgx.Tx, values []ValueInput, activeOnly bool) error {
+	assetIDs := []int{}
+	accountIDs := []int{}
+	for _, v := range values {
+		if v.AssetID != nil {
+			assetIDs = append(assetIDs, *v.AssetID)
+		}
+		if v.AccountID != nil {
+			accountIDs = append(accountIDs, *v.AccountID)
+		}
+	}
+	missingAssets, err := missingFrom(ctx, tx, "assets", assetIDs, activeOnly)
+	if err != nil {
+		return err
+	}
+	missingAccounts, err := missingFrom(ctx, tx, "accounts", accountIDs, activeOnly)
+	if err != nil {
+		return err
+	}
+	if len(missingAssets) > 0 || len(missingAccounts) > 0 {
+		sort.Ints(missingAssets)
+		sort.Ints(missingAccounts)
+		return &MissingReferencesError{
+			MissingAssets:   missingAssets,
+			MissingAccounts: missingAccounts,
+		}
+	}
+	return nil
+}
+
+func missingFrom(ctx context.Context, tx pgx.Tx, table string, ids []int, activeOnly bool) ([]int, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	q := fmt.Sprintf(`SELECT id FROM %s WHERE id = ANY($1)`, table)
+	if activeOnly {
+		q += ` AND is_active = true`
+	}
+	rows, err := tx.Query(ctx, q, ids)
+	if err != nil {
+		return nil, fmt.Errorf("check refs %s: %w", table, err)
+	}
+	defer rows.Close()
+	found := map[int]struct{}{}
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan ref %s: %w", table, err)
+		}
+		found[id] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate refs %s: %w", table, err)
+	}
+	missing := []int{}
+	for _, id := range ids {
+		if _, ok := found[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	return missing, nil
+}
+
+func insertValues(ctx context.Context, tx pgx.Tx, snapshotID int, values []ValueInput) error {
+	for _, v := range values {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO snapshot_values (snapshot_id, asset_id, account_id, value)
+			VALUES ($1, $2, $3, $4)`,
+			snapshotID, v.AssetID, v.AccountID, v.Value,
+		); err != nil {
+			return fmt.Errorf("insert snapshot value: %w", err)
+		}
+	}
+	return nil
+}
+
+func lockSnapshot(ctx context.Context, tx pgx.Tx, id int) (*Snapshot, error) {
+	row := tx.QueryRow(ctx,
+		`SELECT id, date, notes, created_at FROM snapshots WHERE id = $1 FOR UPDATE`, id,
+	)
+	var s Snapshot
+	if err := row.Scan(&s.ID, &s.Date, &s.Notes, &s.CreatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("lock snapshot: %w", err)
+	}
+	return &s, nil
+}
+
+func loadValuesTx(ctx context.Context, tx pgx.Tx, snapshotID int) ([]Value, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT sv.id, sv.asset_id, a.name, sv.account_id, acc.name, sv.value
+		FROM snapshot_values sv
+		LEFT JOIN assets a ON a.id = sv.asset_id
+		LEFT JOIN accounts acc ON acc.id = sv.account_id
+		WHERE sv.snapshot_id = $1
+		ORDER BY sv.id`,
+		snapshotID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load snapshot values: %w", err)
+	}
+	defer rows.Close()
+	out := []Value{}
+	for rows.Next() {
+		var v Value
+		if err := rows.Scan(&v.ID, &v.AssetID, &v.AssetName, &v.AccountID, &v.AccountName, &v.Value); err != nil {
+			return nil, fmt.Errorf("scan snapshot value: %w", err)
+		}
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshot values: %w", err)
+	}
+	return out, nil
+}

--- a/backend-go/internal/snapshots/store.go
+++ b/backend-go/internal/snapshots/store.go
@@ -10,7 +10,9 @@ import (
 	"sort"
 	"time"
 
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
 
@@ -54,10 +56,10 @@ type ValueInput struct {
 
 // Sentinel errors mapped to HTTP status codes by the handler.
 var (
-	ErrNotFound          = errors.New("snapshot not found")
-	ErrDuplicateDate     = errors.New("snapshot date conflicts")
-	ErrDuplicateValueIDs = errors.New("duplicate value ids")
-	ErrMissingReferences = errors.New("referenced assets or accounts missing")
+	ErrNotFound            = errors.New("snapshot not found")
+	ErrDuplicateDate       = errors.New("snapshot date conflicts")
+	ErrDuplicateAssetIDs   = errors.New("duplicate asset ids")
+	ErrDuplicateAccountIDs = errors.New("duplicate account ids")
 )
 
 // MissingReferencesError carries the missing IDs back to the handler so the
@@ -202,6 +204,9 @@ func (s *Store) Create(ctx context.Context, date time.Time, notes *string, value
 		date, notes, time.Now().UTC(),
 	).Scan(&snap.ID, &snap.Date, &snap.Notes, &snap.CreatedAt)
 	if err != nil {
+		if isUniqueViolation(err) {
+			return nil, nil, ErrDuplicateDate
+		}
 		return nil, nil, fmt.Errorf("insert snapshot: %w", err)
 	}
 	if err := insertValues(ctx, tx, snap.ID, values); err != nil {
@@ -266,6 +271,9 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Snapshot, [
 		`UPDATE snapshots SET date = $1, notes = $2 WHERE id = $3`,
 		snap.Date, snap.Notes, id,
 	); err != nil {
+		if isUniqueViolation(err) {
+			return nil, nil, ErrDuplicateDate
+		}
 		return nil, nil, fmt.Errorf("update snapshot: %w", err)
 	}
 	if p.ValuesSet {
@@ -303,13 +311,13 @@ func validateValueIDs(values []ValueInput) error {
 	for _, v := range values {
 		if v.AssetID != nil {
 			if _, dup := seenAssets[*v.AssetID]; dup {
-				return ErrDuplicateValueIDs
+				return ErrDuplicateAssetIDs
 			}
 			seenAssets[*v.AssetID] = struct{}{}
 		}
 		if v.AccountID != nil {
 			if _, dup := seenAccounts[*v.AccountID]; dup {
-				return ErrDuplicateValueIDs
+				return ErrDuplicateAccountIDs
 			}
 			seenAccounts[*v.AccountID] = struct{}{}
 		}
@@ -410,17 +418,38 @@ func missingFrom(ctx context.Context, tx pgx.Tx, table string, ids []int, active
 	return missing, nil
 }
 
+// insertValues batches all inserts through a single pgx.Batch so a snapshot
+// with N values pays one round-trip instead of N.
 func insertValues(ctx context.Context, tx pgx.Tx, snapshotID int, values []ValueInput) error {
+	if len(values) == 0 {
+		return nil
+	}
+	batch := &pgx.Batch{}
 	for _, v := range values {
-		if _, err := tx.Exec(ctx, `
+		batch.Queue(`
 			INSERT INTO snapshot_values (snapshot_id, asset_id, account_id, value)
 			VALUES ($1, $2, $3, $4)`,
 			snapshotID, v.AssetID, v.AccountID, v.Value,
-		); err != nil {
-			return fmt.Errorf("insert snapshot value: %w", err)
+		)
+	}
+	br := tx.SendBatch(ctx, batch)
+	defer br.Close()
+	for i := range values {
+		if _, err := br.Exec(); err != nil {
+			return fmt.Errorf("insert snapshot value[%d]: %w", i, err)
 		}
 	}
 	return nil
+}
+
+// isUniqueViolation checks whether err is a Postgres 23505. Used to convert
+// a racy duplicate-date INSERT into the same 400 the pre-check returns.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr == nil {
+		return false
+	}
+	return pgErr.Code == pgerrcode.UniqueViolation
 }
 
 func lockSnapshot(ctx context.Context, tx pgx.Tx, id int) (*Snapshot, error) {

--- a/backend-go/internal/snapshots/validation.go
+++ b/backend-go/internal/snapshots/validation.go
@@ -1,0 +1,168 @@
+package snapshots
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+type createRequest struct {
+	Date   time.Time
+	Notes  *string
+	Values []ValueInput
+}
+
+func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *validationError) {
+	var r createRequest
+	t, vErr := requireDate(raw, "date")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Date = t
+
+	if v, ok := raw["notes"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return r, &validationError{Field: "notes", Msg: "must be a string"}
+		}
+		r.Notes = &s
+	}
+
+	vRaw, ok := raw["values"]
+	if !ok || isNull(vRaw) {
+		return r, &validationError{Field: "values", Msg: "Field required"}
+	}
+	values, vErr := parseValues(vRaw)
+	if vErr != nil {
+		return r, vErr
+	}
+	if len(values) == 0 {
+		return r, &validationError{Field: "values", Msg: "Snapshot must contain at least one account value"}
+	}
+	r.Values = values
+	return r, nil
+}
+
+func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *validationError) {
+	var p UpdatePatch
+	if v, ok := raw["date"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return p, &validationError{Field: "date", Msg: "must be a string"}
+		}
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return p, &validationError{Field: "date", Msg: "must be YYYY-MM-DD"}
+		}
+		p.Date = &t
+	}
+	if v, ok := raw["notes"]; ok {
+		p.NotesSet = true
+		if isNull(v) {
+			p.Notes = nil
+		} else {
+			var s string
+			if err := json.Unmarshal(v, &s); err != nil {
+				return p, &validationError{Field: "notes", Msg: "must be a string"}
+			}
+			p.Notes = &s
+		}
+	}
+	if v, ok := raw["values"]; ok && !isNull(v) {
+		values, vErr := parseValues(v)
+		if vErr != nil {
+			return p, vErr
+		}
+		if len(values) == 0 {
+			return p, &validationError{Field: "values", Msg: "Snapshot must contain at least one value"}
+		}
+		p.ValuesSet = true
+		p.Values = values
+	}
+	return p, nil
+}
+
+func parseValues(raw json.RawMessage) ([]ValueInput, *validationError) {
+	var entries []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, &validationError{Field: "values", Msg: "must be an array of objects"}
+	}
+	out := make([]ValueInput, 0, len(entries))
+	for _, e := range entries {
+		entry, vErr := parseValueEntry(e)
+		if vErr != nil {
+			return nil, vErr
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+func parseValueEntry(e map[string]json.RawMessage) (ValueInput, *validationError) {
+	var v ValueInput
+
+	assetID, vErr := optionalInt(e, "asset_id")
+	if vErr != nil {
+		return v, vErr
+	}
+	v.AssetID = assetID
+
+	accountID, vErr := optionalInt(e, "account_id")
+	if vErr != nil {
+		return v, vErr
+	}
+	v.AccountID = accountID
+
+	if v.AssetID == nil && v.AccountID == nil {
+		return v, &validationError{Field: "values", Msg: "Either asset_id or account_id must be provided"}
+	}
+	if v.AssetID != nil && v.AccountID != nil {
+		return v, &validationError{Field: "values", Msg: "Only one of asset_id or account_id can be provided"}
+	}
+
+	valRaw, ok := e["value"]
+	if !ok || isNull(valRaw) {
+		return v, &validationError{Field: "value", Msg: "Field required"}
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(valRaw)))
+	if err != nil {
+		return v, &validationError{Field: "value", Msg: "must be a number"}
+	}
+	v.Value = d
+	return v, nil
+}
+
+func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return time.Time{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be a string"}
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be YYYY-MM-DD"}
+	}
+	return t, nil
+}
+
+func optionalInt(raw map[string]json.RawMessage, key string) (*int, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return nil, nil
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return nil, &validationError{Field: key, Msg: fmt.Sprintf("%s must be an integer", key)}
+	}
+	return &n, nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -135,3 +135,13 @@ rules:
   - method: DELETE
     path_prefix: /api/assets
     upstream: http://backend-go:8000
+  # Group 9c — /api/snapshots cut over to Go (atomic create/update with full recompute).
+  - method: GET
+    path_prefix: /api/snapshots
+    upstream: http://backend-go:8000
+  - method: POST
+    path_prefix: /api/snapshots
+    upstream: http://backend-go:8000
+  - method: PUT
+    path_prefix: /api/snapshots
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

Final slice of Group 9 (#444). Snapshots own the create/update path that triggers the full `snapshot_aggregates` recompute; this lands the byte-identical port + the atomic transaction that the dashboard (Group 13) will rely on.

## Implementation information

### `internal/snapshots/store.go`

- Full CRUD (no DELETE — Python doesn't expose one).
- `Create` and `Update` are both single-transaction:
  1. Validate the body (dup IDs, missing-references)
  2. INSERT the snapshot OR mutate it via FOR UPDATE row lock
  3. DELETE + INSERT snapshot_values when `values` is provided
  4. `aggregates.RecomputeForSnapshot` against the same tx
  5. Commit
- `List` computes `total_net_worth` directly in SQL with LEFT JOINs against `assets.is_active=true` and `accounts.is_active=true` so inactive contribute 0 — matches Python's LEFT JOIN shape.
- Sentinels mapped to HTTP:
  - `ErrNotFound` → 404 "Snapshot {id} not found"
  - `ErrDuplicateDate` → 400 "Snapshot for date {date} already exists"
  - `ErrDuplicateValueIDs` → 400
  - `MissingReferencesError` → 404 "Assets not found: {1, 2}" (Python set-literal rendered explicitly so the wire format matches)

### `internal/snapshots/validation.go`

- POST: `date` required, `values` required + non-empty; each value entry requires exactly one of `asset_id` / `account_id` and a numeric `value` (parsed via `decimal.NewFromString` so Numeric(15,2) precision survives).
- PUT: `date` / `notes` / `values` all optional; explicit-null `notes` clears the column; explicit-null `values` is treated as omit (Pydantic semantics), array-with-zero-entries → 422.

### `internal/server/server.go`

Split `registerAPIRoutes` into four domain helpers (core / equity / cpi+payroll / portfolio) so funlen stays bounded as we add more endpoints in groups 10-13.

### Parity proof against Go

```
============================= test session starts ==============================
tests/test_snapshots.py::test_list_snapshots_matches_golden          PASSED
tests/test_snapshots.py::test_list_snapshots_returns_seeded_dates    PASSED
tests/test_snapshots.py::test_get_snapshot_by_id                     PASSED
tests/test_snapshots.py::test_get_snapshot_not_found                 PASSED
tests/test_snapshots.py::test_create_snapshot_happy_path             PASSED
tests/test_snapshots.py::test_create_snapshot_validation_error       PASSED
tests/test_snapshots.py::test_update_snapshot_happy_path             PASSED
tests/test_snapshots.py::test_update_snapshot_validation_error       PASSED
============================== 8 passed in 0.15s ===============================
```

Golden snapshot matches byte-for-byte. Net worth math + aggregate recompute exercised by the create+update tests.

### `routes.yaml`

GET / POST / PUT rules for `/api/snapshots/`. Group 9 fully on Go after this lands; Groups 10-13 follow.

## Supporting documentation

- Umbrella: #435
- Subissue: #444
- Slices 9a/9b: #468 / #469 (merged)
- Procedure: `migration/CUTOVER.md`

> Changelog: skip