### PR TITLE
feat(go): cutover ledger (Group 8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,10 @@ jobs:
             tests/test_zus.py \
             tests/test_accounts.py \
             tests/test_assets.py \
-            tests/test_snapshots.py
+            tests/test_snapshots.py \
+            tests/test_transactions.py \
+            tests/test_debt_payments.py \
+            tests/test_debts.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/backend-go/internal/debt_payments/errors.go
+++ b/backend-go/internal/debt_payments/errors.go
@@ -1,0 +1,36 @@
+package debtpayments
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{"type": "value_error", "loc": []string{"body", field}, "msg": msg, "input": input},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/debt_payments/handler.go
+++ b/backend-go/internal/debt_payments/handler.go
@@ -1,0 +1,356 @@
+package debtpayments
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+)
+
+type response struct {
+	ID          int      `json:"id"`
+	AccountID   int      `json:"account_id"`
+	AccountName string   `json:"account_name"`
+	Amount      pyFloat  `json:"amount"`
+	Date        isoDate  `json:"date"`
+	Owner       string   `json:"owner"`
+	CreatedAt   isoNaive `json:"created_at"`
+}
+
+type listResponse struct {
+	Payments     []response `json:"payments"`
+	TotalPaid    pyFloat    `json:"total_paid"`
+	PaymentCount int        `json:"payment_count"`
+}
+
+// Handler is the HTTP boundary.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewHandler wires the store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger}
+}
+
+func toResponse(p DebtPayment, name string) response {
+	amt, _ := p.Amount.Float64()
+	return response{
+		ID: p.ID, AccountID: p.AccountID, AccountName: name,
+		Amount: pyFloat(amt), Date: isoDate(p.Date), Owner: p.Owner,
+		CreatedAt: isoNaive(p.CreatedAt.UTC()),
+	}
+}
+
+// ListForAccount serves GET /api/accounts/{id}/payments.
+func (h *Handler) ListForAccount(w http.ResponseWriter, r *http.Request) {
+	accountID, ok := parseAccountID(w, r)
+	if !ok {
+		return
+	}
+	account, err := h.store.LoadAccount(r.Context(), accountID)
+	if err != nil {
+		name := ""
+		if account != nil {
+			name = account.Name
+		}
+		h.writeAccountError(w, err, accountID, name)
+		return
+	}
+	rows, err := h.store.ListForAccount(r.Context(), accountID)
+	if err != nil {
+		h.logger.Error("list account payments", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := listResponse{Payments: make([]response, 0, len(rows))}
+	total := decimal.Zero
+	for _, p := range rows {
+		out.Payments = append(out.Payments, toResponse(p, account.Name))
+		total = total.Add(p.Amount)
+	}
+	out.PaymentCount = len(out.Payments)
+	f, _ := total.Float64()
+	out.TotalPaid = pyFloat(f)
+	writeJSON(w, http.StatusOK, out)
+}
+
+// ListAll serves GET /api/payments.
+func (h *Handler) ListAll(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	f := ListFilter{}
+	if v := q.Get("account_id"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			writeValidationError(w, "account_id", "must be an integer", v)
+			return
+		}
+		f.AccountID = &n
+	}
+	if v := q.Get("owner"); v != "" {
+		s := v
+		f.Owner = &s
+	}
+	for _, p := range []struct {
+		key  string
+		dest **time.Time
+	}{
+		{"date_from", &f.DateFrom},
+		{"date_to", &f.DateTo},
+	} {
+		if v := q.Get(p.key); v != "" {
+			t, err := time.Parse("2006-01-02", v)
+			if err != nil {
+				writeValidationError(w, p.key, "must be YYYY-MM-DD", v)
+				return
+			}
+			*p.dest = &t
+		}
+	}
+	rows, err := h.store.ListAll(r.Context(), f)
+	if err != nil {
+		h.logger.Error("list all payments", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := listResponse{Payments: make([]response, 0, len(rows))}
+	total := decimal.Zero
+	for _, p := range rows {
+		out.Payments = append(out.Payments, toResponse(p.Payment, p.AccountName))
+		total = total.Add(p.Payment.Amount)
+	}
+	out.PaymentCount = len(out.Payments)
+	f64, _ := total.Float64()
+	out.TotalPaid = pyFloat(f64)
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Create serves POST /api/accounts/{id}/payments.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	accountID, ok := parseAccountID(w, r)
+	if !ok {
+		return
+	}
+	account, err := h.store.LoadAccount(r.Context(), accountID)
+	if err != nil {
+		name := ""
+		if account != nil {
+			name = account.Name
+		}
+		h.writeAccountError(w, err, accountID, name)
+		return
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	req, vErr := buildCreateRequest(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	created, err := h.store.Create(r.Context(), &DebtPayment{
+		AccountID: accountID, Amount: req.Amount, Date: req.Date, Owner: req.Owner,
+	})
+	if err != nil {
+		if errors.Is(err, ErrDuplicate) {
+			writeDetailError(w, http.StatusConflict,
+				fmt.Sprintf("Payment for account %d on %s already exists",
+					accountID, req.Date.Format("2006-01-02")))
+			return
+		}
+		h.logger.Error("create payment", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toResponse(*created, account.Name))
+}
+
+// Delete serves DELETE /api/accounts/{id}/payments/{payment_id}.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	accountID, ok := parseAccountID(w, r)
+	if !ok {
+		return
+	}
+	paymentID, err := strconv.Atoi(chi.URLParam(r, "payment_id"))
+	if err != nil {
+		writeValidationError(w, "payment_id", "must be an integer", chi.URLParam(r, "payment_id"))
+		return
+	}
+	if err := h.store.SoftDelete(r.Context(), accountID, paymentID); err != nil {
+		switch {
+		case errors.Is(err, ErrNotFound):
+			writeDetailError(w, http.StatusNotFound,
+				fmt.Sprintf("Payment with id %d not found", paymentID))
+		case errors.Is(err, ErrCrossAccount):
+			writeDetailError(w, http.StatusForbidden,
+				fmt.Sprintf("Payment %d does not belong to account %d", paymentID, accountID))
+		default:
+			h.logger.Error("delete payment", "err", err)
+			writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Counts serves GET /api/payments/counts.
+func (h *Handler) Counts(w http.ResponseWriter, r *http.Request) {
+	counts, err := h.store.CountsByAccount(r.Context())
+	if err != nil {
+		h.logger.Error("payment counts", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := make(map[string]int, len(counts))
+	for k, v := range counts {
+		out[strconv.Itoa(k)] = v
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) writeAccountError(w http.ResponseWriter, err error, id int, name string) {
+	switch {
+	case errors.Is(err, ErrAccountNotFound):
+		writeDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("Account with id %d not found", id))
+	case errors.Is(err, ErrAccountNotLiability):
+		writeDetailError(w, http.StatusBadRequest,
+			fmt.Sprintf("Account '%s' is not a liability account. "+
+				"Only liability accounts can have debt payments.", name))
+	default:
+		h.logger.Error("account check", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+	}
+}
+
+func parseAccountID(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "account_id")
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		writeValidationError(w, "account_id", "must be an integer", raw)
+		return 0, false
+	}
+	return id, true
+}
+
+type createRequest struct {
+	Amount decimal.Decimal
+	Date   time.Time
+	Owner  string
+}
+
+func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *validationError) {
+	var r createRequest
+	amount, vErr := requirePositiveDecimal(raw, "amount", "Amount must be greater than 0")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Amount = amount
+
+	t, vErr := requireDateNotFuture(raw, "date")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Date = t
+
+	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Owner = owner
+	return r, nil
+}
+
+func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", &validationError{Field: key, Msg: emptyMsg}
+	}
+	return s, nil
+}
+
+func requireDateNotFuture(raw map[string]json.RawMessage, key string) (time.Time, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return time.Time{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be a string"}
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be YYYY-MM-DD"}
+	}
+	today := time.Now().UTC()
+	today = time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)
+	if t.After(today) {
+		return time.Time{}, &validationError{Field: key, Msg: "Date cannot be in the future"}
+	}
+	return t, nil
+}
+
+func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if err != nil {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if !d.IsPositive() {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: msg}
+	}
+	return d, nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}
+
+// wire types
+type isoDate time.Time
+
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format("2006-01-02") + `"`), nil
+}
+
+type isoNaive time.Time
+
+func (t isoNaive) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
+}
+
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/debt_payments/store.go
+++ b/backend-go/internal/debt_payments/store.go
@@ -1,0 +1,248 @@
+// Package debtpayments implements /api/accounts/{id}/payments + /api/payments.
+package debtpayments
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// DebtPayment mirrors backend/app/models/debt_payment.DebtPayment.
+type DebtPayment struct {
+	ID        int
+	AccountID int
+	Amount    decimal.Decimal
+	Date      time.Time
+	Owner     string
+	IsActive  bool
+	CreatedAt time.Time
+}
+
+// AccountInfo carries the subset of the parent account we need.
+type AccountInfo struct {
+	ID       int
+	Name     string
+	Type     string
+	IsActive bool
+}
+
+// Sentinel errors mapped to HTTP statuses.
+var (
+	ErrAccountNotFound     = errors.New("account not found")
+	ErrAccountNotLiability = errors.New("account is not a liability")
+	ErrNotFound            = errors.New("payment not found")
+	ErrDuplicate           = errors.New("payment for date already exists")
+	ErrCrossAccount        = errors.New("payment does not belong to account")
+)
+
+// Store is the persistence boundary.
+type Store struct{ pool *pgxpool.Pool }
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
+
+const paymentCols = `id, account_id, amount, date, owner, is_active, created_at`
+
+// LoadAccount mirrors Python's validation: active account that is type=liability.
+// Returns the account along with ErrAccountNotLiability so the handler can use
+// its name in the 400 detail.
+func (s *Store) LoadAccount(ctx context.Context, id int) (*AccountInfo, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT id, name, type, is_active FROM accounts WHERE id = $1`, id,
+	)
+	var a AccountInfo
+	if err := row.Scan(&a.ID, &a.Name, &a.Type, &a.IsActive); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrAccountNotFound
+		}
+		return nil, fmt.Errorf("load account: %w", err)
+	}
+	if !a.IsActive {
+		return nil, ErrAccountNotFound
+	}
+	if a.Type != "liability" {
+		return &a, ErrAccountNotLiability
+	}
+	return &a, nil
+}
+
+// ListForAccount returns active payments for one account.
+func (s *Store) ListForAccount(ctx context.Context, accountID int) ([]DebtPayment, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+paymentCols+` FROM debt_payments
+		 WHERE account_id = $1 AND is_active = true
+		 ORDER BY date DESC, id DESC`,
+		accountID,
+	)
+	return scanPayments(rows, err)
+}
+
+// ListFilter narrows the all-payments view.
+type ListFilter struct {
+	AccountID *int
+	Owner     *string
+	DateFrom  *time.Time
+	DateTo    *time.Time
+}
+
+// PaymentWithAccount is one payment with its account name joined in.
+type PaymentWithAccount struct {
+	Payment     DebtPayment
+	AccountName string
+}
+
+// ListAll joins debt_payments to active accounts and applies optional filters.
+func (s *Store) ListAll(ctx context.Context, f ListFilter) ([]PaymentWithAccount, error) {
+	conds := []string{"p.is_active = true", "a.is_active = true"}
+	args := []any{}
+	if f.AccountID != nil {
+		args = append(args, *f.AccountID)
+		conds = append(conds, fmt.Sprintf("p.account_id = $%d", len(args)))
+	}
+	if f.Owner != nil {
+		args = append(args, *f.Owner)
+		conds = append(conds, fmt.Sprintf("p.owner = $%d", len(args)))
+	}
+	if f.DateFrom != nil {
+		args = append(args, *f.DateFrom)
+		conds = append(conds, fmt.Sprintf("p.date >= $%d", len(args)))
+	}
+	if f.DateTo != nil {
+		args = append(args, *f.DateTo)
+		conds = append(conds, fmt.Sprintf("p.date <= $%d", len(args)))
+	}
+	q := `SELECT p.id, p.account_id, p.amount, p.date, p.owner, p.is_active, p.created_at, a.name
+	      FROM debt_payments p
+	      JOIN accounts a ON a.id = p.account_id
+	      WHERE ` + strings.Join(conds, " AND ") + `
+	      ORDER BY p.date DESC, p.id DESC`
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list payments: %w", err)
+	}
+	defer rows.Close()
+	out := []PaymentWithAccount{}
+	for rows.Next() {
+		var p DebtPayment
+		var name string
+		if err := rows.Scan(&p.ID, &p.AccountID, &p.Amount, &p.Date, &p.Owner, &p.IsActive, &p.CreatedAt, &name); err != nil {
+			return nil, fmt.Errorf("scan payment join: %w", err)
+		}
+		out = append(out, PaymentWithAccount{Payment: p, AccountName: name})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate payments: %w", err)
+	}
+	return out, nil
+}
+
+// Create inserts a payment. ErrDuplicate on same (account_id, date) for an
+// active row.
+func (s *Store) Create(ctx context.Context, p *DebtPayment) (*DebtPayment, error) {
+	var existing int
+	err := s.pool.QueryRow(ctx, `
+		SELECT id FROM debt_payments
+		WHERE account_id = $1 AND date = $2 AND is_active = true
+		LIMIT 1`,
+		p.AccountID, p.Date,
+	).Scan(&existing)
+	if err == nil {
+		return nil, ErrDuplicate
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("check duplicate payment: %w", err)
+	}
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO debt_payments (account_id, amount, date, owner, is_active, created_at)
+		VALUES ($1, $2, $3, $4, true, $5)
+		RETURNING `+paymentCols,
+		p.AccountID, p.Amount, p.Date, p.Owner, time.Now().UTC(),
+	)
+	out, err := scanPayment(row)
+	if err != nil {
+		return nil, fmt.Errorf("insert payment: %w", err)
+	}
+	return out, nil
+}
+
+// SoftDelete soft-deletes the payment, enforcing account ownership.
+func (s *Store) SoftDelete(ctx context.Context, accountID, paymentID int) error {
+	var owned bool
+	err := s.pool.QueryRow(ctx, `
+		SELECT account_id = $1 FROM debt_payments WHERE id = $2`,
+		accountID, paymentID,
+	).Scan(&owned)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("check payment ownership: %w", err)
+	}
+	if !owned {
+		return ErrCrossAccount
+	}
+	if _, err := s.pool.Exec(ctx,
+		`UPDATE debt_payments SET is_active = false WHERE id = $1`, paymentID,
+	); err != nil {
+		return fmt.Errorf("soft-delete payment: %w", err)
+	}
+	return nil
+}
+
+// CountsByAccount returns the per-account count of active payments.
+func (s *Store) CountsByAccount(ctx context.Context) (map[int]int, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT account_id, COUNT(*)
+		FROM debt_payments WHERE is_active = true
+		GROUP BY account_id`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("payment counts: %w", err)
+	}
+	defer rows.Close()
+	out := map[int]int{}
+	for rows.Next() {
+		var id, n int
+		if err := rows.Scan(&id, &n); err != nil {
+			return nil, fmt.Errorf("scan count: %w", err)
+		}
+		out[id] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate counts: %w", err)
+	}
+	return out, nil
+}
+
+func scanPayments(rows pgx.Rows, err error) ([]DebtPayment, error) {
+	if err != nil {
+		return nil, fmt.Errorf("query payments: %w", err)
+	}
+	defer rows.Close()
+	out := []DebtPayment{}
+	for rows.Next() {
+		p, err := scanPayment(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan payment: %w", err)
+		}
+		out = append(out, *p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate payments: %w", err)
+	}
+	return out, nil
+}
+
+func scanPayment(row pgx.Row) (*DebtPayment, error) {
+	var p DebtPayment
+	if err := row.Scan(&p.ID, &p.AccountID, &p.Amount, &p.Date, &p.Owner, &p.IsActive, &p.CreatedAt); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}

--- a/backend-go/internal/debt_payments/store.go
+++ b/backend-go/internal/debt_payments/store.go
@@ -80,7 +80,22 @@ func (s *Store) ListForAccount(ctx context.Context, accountID int) ([]DebtPaymen
 		 ORDER BY date DESC, id DESC`,
 		accountID,
 	)
-	return scanPayments(rows, err)
+	if err != nil {
+		return nil, fmt.Errorf("query payments: %w", err)
+	}
+	defer rows.Close()
+	out := []DebtPayment{}
+	for rows.Next() {
+		p, err := scanPayment(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan payment: %w", err)
+		}
+		out = append(out, *p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate payments: %w", err)
+	}
+	return out, nil
 }
 
 // ListFilter narrows the all-payments view.
@@ -216,25 +231,6 @@ func (s *Store) CountsByAccount(ctx context.Context) (map[int]int, error) {
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate counts: %w", err)
-	}
-	return out, nil
-}
-
-func scanPayments(rows pgx.Rows, err error) ([]DebtPayment, error) {
-	if err != nil {
-		return nil, fmt.Errorf("query payments: %w", err)
-	}
-	defer rows.Close()
-	out := []DebtPayment{}
-	for rows.Next() {
-		p, err := scanPayment(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scan payment: %w", err)
-		}
-		out = append(out, *p)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate payments: %w", err)
 	}
 	return out, nil
 }

--- a/backend-go/internal/debts/errors.go
+++ b/backend-go/internal/debts/errors.go
@@ -1,0 +1,36 @@
+package debts
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{"type": "value_error", "loc": []string{"body", field}, "msg": msg, "input": input},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/debts/handler.go
+++ b/backend-go/internal/debts/handler.go
@@ -1,0 +1,599 @@
+package debts
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+)
+
+var validDebtTypes = map[string]struct{}{
+	"mortgage": {}, "installment_0percent": {},
+}
+
+type response struct {
+	ID                int      `json:"id"`
+	AccountID         int      `json:"account_id"`
+	AccountName       string   `json:"account_name"`
+	AccountOwner      string   `json:"account_owner"`
+	Name              string   `json:"name"`
+	DebtType          string   `json:"debt_type"`
+	StartDate         isoDate  `json:"start_date"`
+	InitialAmount     pyFloat  `json:"initial_amount"`
+	InterestRate      pyFloat  `json:"interest_rate"`
+	Currency          string   `json:"currency"`
+	Notes             *string  `json:"notes"`
+	IsActive          bool     `json:"is_active"`
+	CreatedAt         isoNaive `json:"created_at"`
+	LatestBalance     *pyFloat `json:"latest_balance"`
+	LatestBalanceDate *isoDate `json:"latest_balance_date"`
+	TotalPaid         pyFloat  `json:"total_paid"`
+	InterestPaid      pyFloat  `json:"interest_paid"`
+}
+
+type listResponse struct {
+	Debts              []response `json:"debts"`
+	TotalCount         int        `json:"total_count"`
+	TotalInitialAmount pyFloat    `json:"total_initial_amount"`
+	ActiveDebtsCount   int        `json:"active_debts_count"`
+}
+
+// Handler is the HTTP boundary.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewHandler wires the store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger}
+}
+
+type debtMetrics struct {
+	latestBalance     *decimal.Decimal
+	latestBalanceDate *time.Time
+	totalPaid         decimal.Decimal
+}
+
+func computeMetrics(initial decimal.Decimal, balance *decimal.Decimal, totalPaid decimal.Decimal) (decimal.Decimal, decimal.Decimal) {
+	if balance == nil {
+		return decimal.Zero, decimal.Zero
+	}
+	principalPaid := initial.Sub(*balance)
+	return principalPaid, totalPaid.Sub(principalPaid)
+}
+
+func toResponse(d Debt, a AccountInfo, m debtMetrics) response {
+	initial, _ := d.InitialAmount.Float64()
+	rate, _ := d.InterestRate.Float64()
+	totalPaid, _ := m.totalPaid.Float64()
+	_, interestPaid := computeMetrics(d.InitialAmount, m.latestBalance, m.totalPaid)
+	ip, _ := interestPaid.Float64()
+	out := response{
+		ID: d.ID, AccountID: d.AccountID, AccountName: a.Name, AccountOwner: a.Owner,
+		Name: d.Name, DebtType: d.DebtType, StartDate: isoDate(d.StartDate),
+		InitialAmount: pyFloat(initial), InterestRate: pyFloat(rate),
+		Currency: d.Currency, Notes: d.Notes, IsActive: d.IsActive,
+		CreatedAt: isoNaive(d.CreatedAt.UTC()),
+		TotalPaid: pyFloat(totalPaid), InterestPaid: pyFloat(ip),
+	}
+	if m.latestBalance != nil {
+		f, _ := m.latestBalance.Float64()
+		pf := pyFloat(f)
+		out.LatestBalance = &pf
+	}
+	if m.latestBalanceDate != nil {
+		d := isoDate(*m.latestBalanceDate)
+		out.LatestBalanceDate = &d
+	}
+	return out
+}
+
+// List serves GET /api/debts.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	f := ListFilter{}
+	if v := q.Get("account_id"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			writeValidationError(w, "account_id", "must be an integer", v)
+			return
+		}
+		f.AccountID = &n
+	}
+	if v := q.Get("debt_type"); v != "" {
+		s := v
+		f.DebtType = &s
+	}
+	rows, err := h.store.ListAll(r.Context(), f)
+	if err != nil {
+		h.logger.Error("list debts", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	ids := make([]int, 0, len(rows))
+	for i := range rows {
+		ids = append(ids, rows[i].Debt.AccountID)
+	}
+	balances, err := h.store.LatestBalancesByAccount(r.Context(), ids)
+	if err != nil {
+		h.logger.Error("latest balances", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	totals, err := h.store.TotalPaidByAccount(r.Context(), ids)
+	if err != nil {
+		h.logger.Error("total paid", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := listResponse{Debts: make([]response, 0, len(rows))}
+	totalInitial := decimal.Zero
+	for i := range rows {
+		dwa := &rows[i]
+		m := metricsFor(dwa.Debt.AccountID, balances, totals)
+		out.Debts = append(out.Debts, toResponse(dwa.Debt, dwa.Account, m))
+		totalInitial = totalInitial.Add(dwa.Debt.InitialAmount)
+	}
+	out.TotalCount = len(out.Debts)
+	out.ActiveDebtsCount = len(out.Debts)
+	f64, _ := totalInitial.Float64()
+	out.TotalInitialAmount = pyFloat(f64)
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Get serves GET /api/debts/{id}.
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r, "id", "debt_id")
+	if !ok {
+		return
+	}
+	dwa, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		h.writeDebtError(w, err, id)
+		return
+	}
+	m, err := h.metricsForDebt(r.Context(), dwa.Debt.AccountID)
+	if err != nil {
+		h.logger.Error("debt metrics", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusOK, toResponse(dwa.Debt, dwa.Account, m))
+}
+
+// Create serves POST /api/accounts/{account_id}/debts.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	accountID, err := strconv.Atoi(chi.URLParam(r, "account_id"))
+	if err != nil {
+		writeValidationError(w, "account_id", "must be an integer", chi.URLParam(r, "account_id"))
+		return
+	}
+	account, err := h.store.LoadAccount(r.Context(), accountID)
+	if err != nil {
+		name := ""
+		if account != nil {
+			name = account.Name
+		}
+		h.writeAccountError(w, err, accountID, name)
+		return
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	req, vErr := buildCreateRequest(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	created, err := h.store.Create(r.Context(), &Debt{
+		AccountID: accountID,
+		Name:      req.Name, DebtType: req.DebtType, StartDate: req.StartDate,
+		InitialAmount: req.InitialAmount, InterestRate: req.InterestRate,
+		Currency: req.Currency, Notes: req.Notes,
+	})
+	if err != nil {
+		if errors.Is(err, ErrDuplicateForAccount) {
+			writeDetailError(w, http.StatusConflict,
+				fmt.Sprintf("Debt already exists for account '%s'", account.Name))
+			return
+		}
+		h.logger.Error("create debt", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	m, err := h.metricsForDebt(r.Context(), accountID)
+	if err != nil {
+		h.logger.Error("debt metrics", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toResponse(*created, *account, m))
+}
+
+// Update serves PUT /api/debts/{id}.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r, "id", "debt_id")
+	if !ok {
+		return
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	patch, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	dwa, err := h.store.Update(r.Context(), id, patch)
+	if err != nil {
+		h.writeDebtError(w, err, id)
+		return
+	}
+	m, err := h.metricsForDebt(r.Context(), dwa.Debt.AccountID)
+	if err != nil {
+		h.logger.Error("debt metrics", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusOK, toResponse(dwa.Debt, dwa.Account, m))
+}
+
+// Delete serves DELETE /api/debts/{id}.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r, "id", "debt_id")
+	if !ok {
+		return
+	}
+	if err := h.store.Delete(r.Context(), id); err != nil {
+		h.writeDebtError(w, err, id)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) metricsForDebt(ctx context.Context, accountID int) (debtMetrics, error) {
+	lb, found, err := h.store.LatestBalanceForAccount(ctx, accountID)
+	if err != nil {
+		return debtMetrics{}, err
+	}
+	totals, err := h.store.TotalPaidByAccount(ctx, []int{accountID})
+	if err != nil {
+		return debtMetrics{}, err
+	}
+	m := debtMetrics{totalPaid: totals[accountID]}
+	if found {
+		balance := lb.Value
+		date := lb.Date
+		m.latestBalance = &balance
+		m.latestBalanceDate = &date
+	}
+	return m, nil
+}
+
+func metricsFor(accountID int, balances map[int]LatestBalance, totals map[int]decimal.Decimal) debtMetrics {
+	m := debtMetrics{totalPaid: totals[accountID]}
+	if lb, ok := balances[accountID]; ok {
+		balance := lb.Value
+		date := lb.Date
+		m.latestBalance = &balance
+		m.latestBalanceDate = &date
+	}
+	return m
+}
+
+func (h *Handler) writeAccountError(w http.ResponseWriter, err error, id int, name string) {
+	switch {
+	case errors.Is(err, ErrAccountNotFound):
+		writeDetailError(w, http.StatusNotFound, "Account not found")
+	case errors.Is(err, ErrAccountNotLiability):
+		writeDetailError(w, http.StatusBadRequest,
+			fmt.Sprintf("Account '%s' is not a liability account. "+
+				"Only liability accounts can have debts.", name))
+	default:
+		h.logger.Error("account check", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+	}
+}
+
+func (h *Handler) writeDebtError(w http.ResponseWriter, err error, id int) {
+	if errors.Is(err, ErrNotFound) {
+		writeDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("Debt with id %d not found", id))
+		return
+	}
+	h.logger.Error("debt store", "err", err)
+	writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+}
+
+func parseIDParam(w http.ResponseWriter, r *http.Request, urlKey, errField string) (int, bool) {
+	raw := chi.URLParam(r, urlKey)
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		writeValidationError(w, errField, "must be an integer", raw)
+		return 0, false
+	}
+	return id, true
+}
+
+// --- request parsing ---
+
+type createRequest struct {
+	Name          string
+	DebtType      string
+	StartDate     time.Time
+	InitialAmount decimal.Decimal
+	InterestRate  decimal.Decimal
+	Currency      string
+	Notes         *string
+}
+
+func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *validationError) {
+	var r createRequest
+	name, vErr := requireString(raw, "name", "Name cannot be empty")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Name = name
+
+	dt, vErr := requireEnumString(raw, "debt_type", validDebtTypes)
+	if vErr != nil {
+		return r, vErr
+	}
+	r.DebtType = dt
+
+	sd, vErr := requireDateNotFuture(raw, "start_date", "Start date cannot be in the future")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.StartDate = sd
+
+	ia, vErr := requirePositiveDecimal(raw, "initial_amount", "Initial amount must be greater than 0")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.InitialAmount = ia
+
+	ir, vErr := requireNonNegativeDecimal(raw, "interest_rate", "Interest rate must be greater than or equal to 0")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.InterestRate = ir
+
+	cur, vErr := optionalCurrencyPLN(raw)
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Currency = cur
+
+	if v, ok := raw["notes"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return r, &validationError{Field: "notes", Msg: "must be a string"}
+		}
+		r.Notes = &s
+	}
+	return r, nil
+}
+
+func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *validationError) {
+	var p UpdatePatch
+	if v, ok := raw["name"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return p, &validationError{Field: "name", Msg: "must be a string"}
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return p, &validationError{Field: "name", Msg: "Name cannot be empty"}
+		}
+		p.Name = &s
+	}
+	if v, ok := raw["debt_type"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return p, &validationError{Field: "debt_type", Msg: "must be a string"}
+		}
+		if _, ok := validDebtTypes[s]; !ok {
+			return p, &validationError{Field: "debt_type", Msg: fmt.Sprintf("invalid value %q", s)}
+		}
+		p.DebtType = &s
+	}
+	if v, ok := raw["start_date"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return p, &validationError{Field: "start_date", Msg: "must be a string"}
+		}
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return p, &validationError{Field: "start_date", Msg: "must be YYYY-MM-DD"}
+		}
+		if t.After(today()) {
+			return p, &validationError{Field: "start_date", Msg: "Start date cannot be in the future"}
+		}
+		p.StartDate = &t
+	}
+	if v, ok := raw["initial_amount"]; ok && !isNull(v) {
+		d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+		if err != nil {
+			return p, &validationError{Field: "initial_amount", Msg: "must be a number"}
+		}
+		if !d.IsPositive() {
+			return p, &validationError{Field: "initial_amount", Msg: "Initial amount must be greater than 0"}
+		}
+		p.InitialAmount = &d
+	}
+	if v, ok := raw["interest_rate"]; ok && !isNull(v) {
+		d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+		if err != nil {
+			return p, &validationError{Field: "interest_rate", Msg: "must be a number"}
+		}
+		if d.IsNegative() {
+			return p, &validationError{Field: "interest_rate", Msg: "Interest rate must be greater than or equal to 0"}
+		}
+		p.InterestRate = &d
+	}
+	if v, ok := raw["currency"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return p, &validationError{Field: "currency", Msg: "must be a string"}
+		}
+		if s != "PLN" {
+			return p, &validationError{Field: "currency", Msg: "Currency must be 'PLN'"}
+		}
+		p.Currency = &s
+	}
+	if v, ok := raw["notes"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return p, &validationError{Field: "notes", Msg: "must be a string"}
+		}
+		p.NotesSet = true
+		p.Notes = &s
+	}
+	return p, nil
+}
+
+func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", &validationError{Field: key, Msg: emptyMsg}
+	}
+	return s, nil
+}
+
+func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return "", &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	return s, nil
+}
+
+func requireDateNotFuture(raw map[string]json.RawMessage, key, msg string) (time.Time, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return time.Time{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be a string"}
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be YYYY-MM-DD"}
+	}
+	if t.After(today()) {
+		return time.Time{}, &validationError{Field: key, Msg: msg}
+	}
+	return t, nil
+}
+
+func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if err != nil {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if !d.IsPositive() {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: msg}
+	}
+	return d, nil
+}
+
+func requireNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if err != nil {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if d.IsNegative() {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: msg}
+	}
+	return d, nil
+}
+
+func optionalCurrencyPLN(raw map[string]json.RawMessage) (string, *validationError) {
+	v, ok := raw["currency"]
+	if !ok || isNull(v) {
+		return "PLN", nil
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: "currency", Msg: "must be a string"}
+	}
+	if s != "PLN" {
+		return "", &validationError{Field: "currency", Msg: "Currency must be 'PLN'"}
+	}
+	return s, nil
+}
+
+func today() time.Time {
+	t := time.Now().UTC()
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}
+
+// wire types
+type isoDate time.Time
+
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format("2006-01-02") + `"`), nil
+}
+
+type isoNaive time.Time
+
+func (t isoNaive) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
+}
+
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/debts/handler.go
+++ b/backend-go/internal/debts/handler.go
@@ -302,6 +302,9 @@ func metricsFor(accountID int, balances map[int]LatestBalance, totals map[int]de
 func (h *Handler) writeAccountError(w http.ResponseWriter, err error, id int, name string) {
 	switch {
 	case errors.Is(err, ErrAccountNotFound):
+		writeDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("Account with id %d not found", id))
+	case errors.Is(err, ErrAccountInactive):
 		writeDetailError(w, http.StatusNotFound, "Account not found")
 	case errors.Is(err, ErrAccountNotLiability):
 		writeDetailError(w, http.StatusBadRequest,

--- a/backend-go/internal/debts/store.go
+++ b/backend-go/internal/debts/store.go
@@ -1,0 +1,397 @@
+// Package debts implements /api/debts and /api/accounts/{id}/debts.
+package debts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Debt mirrors backend/app/models/debt.Debt.
+type Debt struct {
+	ID            int
+	AccountID     int
+	Name          string
+	DebtType      string
+	StartDate     time.Time
+	InitialAmount decimal.Decimal
+	InterestRate  decimal.Decimal
+	Currency      string
+	Notes         *string
+	IsActive      bool
+	CreatedAt     time.Time
+}
+
+// AccountInfo is the subset of Account columns we need.
+type AccountInfo struct {
+	ID       int
+	Name     string
+	Owner    string
+	Type     string
+	IsActive bool
+}
+
+// LatestBalance is one row's most-recent snapshot value.
+type LatestBalance struct {
+	AccountID int
+	Value     decimal.Decimal
+	Date      time.Time
+}
+
+// Sentinel errors.
+var (
+	ErrAccountNotFound     = errors.New("account not found")
+	ErrAccountNotLiability = errors.New("account is not a liability")
+	ErrNotFound            = errors.New("debt not found")
+	ErrDuplicateForAccount = errors.New("debt already exists for account")
+)
+
+// Store is the persistence boundary.
+type Store struct{ pool *pgxpool.Pool }
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
+
+const debtCols = `
+	id, account_id, name, debt_type, start_date, initial_amount,
+	interest_rate, currency, notes, is_active, created_at
+`
+
+// debtColsQualified is debtCols with `d.` prefix on every column — used in
+// queries that JOIN accounts (which also has `id`).
+const debtColsQualified = `
+	d.id, d.account_id, d.name, d.debt_type, d.start_date, d.initial_amount,
+	d.interest_rate, d.currency, d.notes, d.is_active, d.created_at
+`
+
+// LoadAccount mirrors Python's create-debt validation.
+func (s *Store) LoadAccount(ctx context.Context, id int) (*AccountInfo, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT id, name, owner, type, is_active FROM accounts WHERE id = $1`, id,
+	)
+	var a AccountInfo
+	if err := row.Scan(&a.ID, &a.Name, &a.Owner, &a.Type, &a.IsActive); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrAccountNotFound
+		}
+		return nil, fmt.Errorf("load account: %w", err)
+	}
+	if !a.IsActive {
+		return nil, ErrAccountNotFound
+	}
+	if a.Type != "liability" {
+		return &a, ErrAccountNotLiability
+	}
+	return &a, nil
+}
+
+// DebtWithAccount carries a debt with its account info joined in.
+type DebtWithAccount struct {
+	Debt    Debt
+	Account AccountInfo
+}
+
+// ListFilter narrows the all-debts view.
+type ListFilter struct {
+	AccountID *int
+	DebtType  *string
+}
+
+// ListAll returns active debts + active-account names/owners.
+func (s *Store) ListAll(ctx context.Context, f ListFilter) ([]DebtWithAccount, error) {
+	conds := []string{"d.is_active = true", "a.is_active = true"}
+	args := []any{}
+	if f.AccountID != nil {
+		args = append(args, *f.AccountID)
+		conds = append(conds, fmt.Sprintf("d.account_id = $%d", len(args)))
+	}
+	if f.DebtType != nil {
+		args = append(args, *f.DebtType)
+		conds = append(conds, fmt.Sprintf("d.debt_type = $%d", len(args)))
+	}
+	q := `SELECT ` + debtColsQualified + `, a.name, a.owner
+	      FROM debts d
+	      JOIN accounts a ON a.id = d.account_id
+	      WHERE ` + strings.Join(conds, " AND ") + `
+	      ORDER BY d.start_date DESC, d.id DESC`
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list debts: %w", err)
+	}
+	defer rows.Close()
+	out := []DebtWithAccount{}
+	for rows.Next() {
+		var d Debt
+		var a AccountInfo
+		if err := rows.Scan(
+			&d.ID, &d.AccountID, &d.Name, &d.DebtType, &d.StartDate,
+			&d.InitialAmount, &d.InterestRate, &d.Currency, &d.Notes,
+			&d.IsActive, &d.CreatedAt, &a.Name, &a.Owner,
+		); err != nil {
+			return nil, fmt.Errorf("scan debt: %w", err)
+		}
+		a.ID = d.AccountID
+		out = append(out, DebtWithAccount{Debt: d, Account: a})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate debts: %w", err)
+	}
+	return out, nil
+}
+
+// LatestBalanceForAccount returns the most recent snapshot value for an account.
+// Returns (false, ...) when no snapshot value exists.
+func (s *Store) LatestBalanceForAccount(ctx context.Context, accountID int) (LatestBalance, bool, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT s.date, sv.value
+		FROM snapshot_values sv
+		JOIN snapshots s ON s.id = sv.snapshot_id
+		WHERE sv.account_id = $1
+		ORDER BY s.date DESC LIMIT 1`,
+		accountID,
+	)
+	var lb LatestBalance
+	lb.AccountID = accountID
+	if err := row.Scan(&lb.Date, &lb.Value); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return LatestBalance{}, false, nil
+		}
+		return LatestBalance{}, false, fmt.Errorf("latest balance: %w", err)
+	}
+	return lb, true, nil
+}
+
+// LatestBalancesByAccount batches LatestBalanceForAccount across many accounts.
+func (s *Store) LatestBalancesByAccount(ctx context.Context, ids []int) (map[int]LatestBalance, error) {
+	if len(ids) == 0 {
+		return map[int]LatestBalance{}, nil
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT DISTINCT ON (sv.account_id) sv.account_id, s.date, sv.value
+		FROM snapshot_values sv
+		JOIN snapshots s ON s.id = sv.snapshot_id
+		WHERE sv.account_id = ANY($1)
+		ORDER BY sv.account_id, s.date DESC`,
+		ids,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("batch latest balances: %w", err)
+	}
+	defer rows.Close()
+	out := map[int]LatestBalance{}
+	for rows.Next() {
+		var lb LatestBalance
+		if err := rows.Scan(&lb.AccountID, &lb.Date, &lb.Value); err != nil {
+			return nil, fmt.Errorf("scan latest balance: %w", err)
+		}
+		out[lb.AccountID] = lb
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate balances: %w", err)
+	}
+	return out, nil
+}
+
+// TotalPaidByAccount returns the sum of active debt_payments per account.
+func (s *Store) TotalPaidByAccount(ctx context.Context, ids []int) (map[int]decimal.Decimal, error) {
+	if len(ids) == 0 {
+		return map[int]decimal.Decimal{}, nil
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT account_id, COALESCE(SUM(amount), 0)
+		FROM debt_payments WHERE account_id = ANY($1) AND is_active = true
+		GROUP BY account_id`,
+		ids,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("total paid: %w", err)
+	}
+	defer rows.Close()
+	out := map[int]decimal.Decimal{}
+	for rows.Next() {
+		var id int
+		var total decimal.Decimal
+		if err := rows.Scan(&id, &total); err != nil {
+			return nil, fmt.Errorf("scan total paid: %w", err)
+		}
+		out[id] = total
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate total paid: %w", err)
+	}
+	return out, nil
+}
+
+// Get returns one active debt + its account info.
+func (s *Store) Get(ctx context.Context, debtID int) (*DebtWithAccount, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT `+debtColsQualified+`, a.name, a.owner
+		FROM debts d
+		JOIN accounts a ON a.id = d.account_id
+		WHERE d.id = $1 AND d.is_active = true`,
+		debtID,
+	)
+	var d Debt
+	var a AccountInfo
+	if err := row.Scan(
+		&d.ID, &d.AccountID, &d.Name, &d.DebtType, &d.StartDate,
+		&d.InitialAmount, &d.InterestRate, &d.Currency, &d.Notes,
+		&d.IsActive, &d.CreatedAt, &a.Name, &a.Owner,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get debt: %w", err)
+	}
+	a.ID = d.AccountID
+	return &DebtWithAccount{Debt: d, Account: a}, nil
+}
+
+// Create inserts a debt. Returns ErrDuplicateForAccount if the
+// uq_debt_account constraint trips (one debt per account in Python).
+func (s *Store) Create(ctx context.Context, d *Debt) (*Debt, error) {
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO debts (
+			account_id, name, debt_type, start_date, initial_amount,
+			interest_rate, currency, notes, is_active, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, true, $9)
+		RETURNING `+debtCols,
+		d.AccountID, d.Name, d.DebtType, d.StartDate, d.InitialAmount,
+		d.InterestRate, d.Currency, d.Notes, time.Now().UTC(),
+	)
+	out, err := scanDebt(row)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return nil, ErrDuplicateForAccount
+		}
+		return nil, fmt.Errorf("insert debt: %w", err)
+	}
+	return out, nil
+}
+
+// UpdatePatch is the sparse update set.
+type UpdatePatch struct {
+	Name          *string
+	DebtType      *string
+	StartDate     *time.Time
+	InitialAmount *decimal.Decimal
+	InterestRate  *decimal.Decimal
+	Currency      *string
+	NotesSet      bool
+	Notes         *string
+}
+
+// Update applies the patch.
+func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*DebtWithAccount, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin update tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	row := tx.QueryRow(ctx,
+		`SELECT `+debtCols+` FROM debts WHERE id = $1 AND is_active = true FOR UPDATE`, id,
+	)
+	current, err := scanDebt(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("lock debt: %w", err)
+	}
+	applyPatch(current, p)
+	if _, err := tx.Exec(ctx, `
+		UPDATE debts SET
+			name = $1, debt_type = $2, start_date = $3, initial_amount = $4,
+			interest_rate = $5, currency = $6, notes = $7
+		WHERE id = $8`,
+		current.Name, current.DebtType, current.StartDate, current.InitialAmount,
+		current.InterestRate, current.Currency, current.Notes, id,
+	); err != nil {
+		return nil, fmt.Errorf("update debt: %w", err)
+	}
+	row = tx.QueryRow(ctx,
+		`SELECT name, owner FROM accounts WHERE id = $1`, current.AccountID,
+	)
+	var a AccountInfo
+	a.ID = current.AccountID
+	if err := row.Scan(&a.Name, &a.Owner); err != nil {
+		return nil, fmt.Errorf("load account for debt: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit update: %w", err)
+	}
+	committed = true
+	return &DebtWithAccount{Debt: *current, Account: a}, nil
+}
+
+// Delete soft-deletes a debt.
+func (s *Store) Delete(ctx context.Context, id int) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE debts SET is_active = false WHERE id = $1 AND is_active = true`,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("soft-delete debt: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func applyPatch(d *Debt, p UpdatePatch) {
+	if p.Name != nil {
+		d.Name = *p.Name
+	}
+	if p.DebtType != nil {
+		d.DebtType = *p.DebtType
+	}
+	if p.StartDate != nil {
+		d.StartDate = *p.StartDate
+	}
+	if p.InitialAmount != nil {
+		d.InitialAmount = *p.InitialAmount
+	}
+	if p.InterestRate != nil {
+		d.InterestRate = *p.InterestRate
+	}
+	if p.Currency != nil {
+		d.Currency = *p.Currency
+	}
+	if p.NotesSet {
+		d.Notes = p.Notes
+	}
+}
+
+func scanDebt(row pgx.Row) (*Debt, error) {
+	var d Debt
+	if err := row.Scan(
+		&d.ID, &d.AccountID, &d.Name, &d.DebtType, &d.StartDate,
+		&d.InitialAmount, &d.InterestRate, &d.Currency, &d.Notes,
+		&d.IsActive, &d.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr == nil {
+		return false
+	}
+	return pgErr.Code == pgerrcode.UniqueViolation
+}

--- a/backend-go/internal/debts/store.go
+++ b/backend-go/internal/debts/store.go
@@ -49,6 +49,7 @@ type LatestBalance struct {
 // Sentinel errors.
 var (
 	ErrAccountNotFound     = errors.New("account not found")
+	ErrAccountInactive     = errors.New("account is inactive")
 	ErrAccountNotLiability = errors.New("account is not a liability")
 	ErrNotFound            = errors.New("debt not found")
 	ErrDuplicateForAccount = errors.New("debt already exists for account")
@@ -72,7 +73,10 @@ const debtColsQualified = `
 	d.interest_rate, d.currency, d.notes, d.is_active, d.created_at
 `
 
-// LoadAccount mirrors Python's create-debt validation.
+// LoadAccount mirrors Python's create-debt validation. Distinguishes the
+// missing-row case ("Account with id {id} not found") from the
+// soft-deleted-row case ("Account not found") by returning the account
+// alongside ErrAccountInactive.
 func (s *Store) LoadAccount(ctx context.Context, id int) (*AccountInfo, error) {
 	row := s.pool.QueryRow(ctx,
 		`SELECT id, name, owner, type, is_active FROM accounts WHERE id = $1`, id,
@@ -85,7 +89,7 @@ func (s *Store) LoadAccount(ctx context.Context, id int) (*AccountInfo, error) {
 		return nil, fmt.Errorf("load account: %w", err)
 	}
 	if !a.IsActive {
-		return nil, ErrAccountNotFound
+		return &a, ErrAccountInactive
 	}
 	if a.Type != "liability" {
 		return &a, ErrAccountNotLiability

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -23,12 +23,15 @@ import (
 	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/config"
 	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
+	debtpayments "github.com/Automaat/finance-buddy/backend-go/internal/debt_payments"
+	"github.com/Automaat/finance-buddy/backend-go/internal/debts"
 	equitygrants "github.com/Automaat/finance-buddy/backend-go/internal/equity_grants"
 	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/personas"
 	"github.com/Automaat/finance-buddy/backend-go/internal/salaries"
 	"github.com/Automaat/finance-buddy/backend-go/internal/snapshots"
+	"github.com/Automaat/finance-buddy/backend-go/internal/transactions"
 	"github.com/Automaat/finance-buddy/backend-go/internal/zus"
 )
 
@@ -85,6 +88,33 @@ func registerAPIRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 	registerEquityRoutes(r, pool, logger)
 	registerCPIAndPayrollRoutes(r, pool, logger)
 	registerPortfolioRoutes(r, pool, logger)
+	registerLedgerRoutes(r, pool, logger)
+}
+
+func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
+	txStore := transactions.NewStore(pool)
+	txHandler := transactions.NewHandler(txStore, logger)
+	r.Get("/api/accounts/{account_id}/transactions", txHandler.ListForAccount)
+	r.Post("/api/accounts/{account_id}/transactions", txHandler.Create)
+	r.Delete("/api/accounts/{account_id}/transactions/{transaction_id}", txHandler.Delete)
+	r.Get("/api/transactions", txHandler.ListAll)
+	r.Get("/api/transactions/counts", txHandler.Counts)
+
+	dpStore := debtpayments.NewStore(pool)
+	dpHandler := debtpayments.NewHandler(dpStore, logger)
+	r.Get("/api/accounts/{account_id}/payments", dpHandler.ListForAccount)
+	r.Post("/api/accounts/{account_id}/payments", dpHandler.Create)
+	r.Delete("/api/accounts/{account_id}/payments/{payment_id}", dpHandler.Delete)
+	r.Get("/api/payments", dpHandler.ListAll)
+	r.Get("/api/payments/counts", dpHandler.Counts)
+
+	debtsStore := debts.NewStore(pool)
+	debtsHandler := debts.NewHandler(debtsStore, logger)
+	r.Get("/api/debts", debtsHandler.List)
+	r.Post("/api/accounts/{account_id}/debts", debtsHandler.Create)
+	r.Get("/api/debts/{id}", debtsHandler.Get)
+	r.Put("/api/debts/{id}", debtsHandler.Update)
+	r.Delete("/api/debts/{id}", debtsHandler.Delete)
 }
 
 func registerCoreRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {

--- a/backend-go/internal/transactions/errors.go
+++ b/backend-go/internal/transactions/errors.go
@@ -1,0 +1,36 @@
+package transactions
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{"type": "value_error", "loc": []string{"body", field}, "msg": msg, "input": input},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/transactions/handler.go
+++ b/backend-go/internal/transactions/handler.go
@@ -1,0 +1,401 @@
+package transactions
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+)
+
+var validTransactionTypes = map[string]struct{}{
+	"employee": {}, "employer": {}, "withdrawal": {}, "government": {},
+}
+
+type response struct {
+	ID              int      `json:"id"`
+	AccountID       int      `json:"account_id"`
+	AccountName     string   `json:"account_name"`
+	Amount          pyFloat  `json:"amount"`
+	Date            isoDate  `json:"date"`
+	Owner           string   `json:"owner"`
+	TransactionType *string  `json:"transaction_type"`
+	CreatedAt       isoNaive `json:"created_at"`
+}
+
+type listResponse struct {
+	Transactions     []response `json:"transactions"`
+	TotalInvested    pyFloat    `json:"total_invested"`
+	TransactionCount int        `json:"transaction_count"`
+}
+
+// Handler is the HTTP boundary.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewHandler wires the store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger}
+}
+
+func toResponse(t Transaction, accountName string) response {
+	amt, _ := t.Amount.Float64()
+	return response{
+		ID:              t.ID,
+		AccountID:       t.AccountID,
+		AccountName:     accountName,
+		Amount:          pyFloat(amt),
+		Date:            isoDate(t.Date),
+		Owner:           t.Owner,
+		TransactionType: t.TransactionType,
+		CreatedAt:       isoNaive(t.CreatedAt.UTC()),
+	}
+}
+
+// ListForAccount serves GET /api/accounts/{id}/transactions.
+func (h *Handler) ListForAccount(w http.ResponseWriter, r *http.Request) {
+	accountID, ok := parseAccountID(w, r)
+	if !ok {
+		return
+	}
+	account, err := h.store.LoadAccount(r.Context(), accountID)
+	if err != nil {
+		name := ""
+		if account != nil {
+			name = account.Name
+		}
+		h.writeAccountError(w, err, accountID, name)
+		return
+	}
+	rows, err := h.store.ListForAccount(r.Context(), accountID)
+	if err != nil {
+		h.logger.Error("list account transactions", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	h.writeList(w, rows, func(t Transaction) string { return account.Name })
+}
+
+// ListAll serves GET /api/transactions.
+func (h *Handler) ListAll(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	f := ListFilter{}
+	if v := q.Get("account_id"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			writeValidationError(w, "account_id", "must be an integer", v)
+			return
+		}
+		f.AccountID = &n
+	}
+	if v := q.Get("owner"); v != "" {
+		s := v
+		f.Owner = &s
+	}
+	for _, p := range []struct {
+		key  string
+		dest **time.Time
+	}{
+		{"date_from", &f.DateFrom},
+		{"date_to", &f.DateTo},
+	} {
+		if v := q.Get(p.key); v != "" {
+			t, err := time.Parse("2006-01-02", v)
+			if err != nil {
+				writeValidationError(w, p.key, "must be YYYY-MM-DD", v)
+				return
+			}
+			*p.dest = &t
+		}
+	}
+	rows, err := h.store.ListAll(r.Context(), f)
+	if err != nil {
+		h.logger.Error("list all transactions", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := listResponse{Transactions: make([]response, 0, len(rows))}
+	totalCents := decimal.Zero
+	for i := range rows {
+		tr := &rows[i]
+		out.Transactions = append(out.Transactions, toResponse(tr.Transaction, tr.AccountName))
+		if tr.Transaction.TransactionType != nil && *tr.Transaction.TransactionType == "withdrawal" {
+			totalCents = totalCents.Sub(tr.Transaction.Amount)
+		} else {
+			totalCents = totalCents.Add(tr.Transaction.Amount)
+		}
+	}
+	out.TransactionCount = len(out.Transactions)
+	total, _ := totalCents.Float64()
+	out.TotalInvested = pyFloat(total)
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Create serves POST /api/accounts/{id}/transactions.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	accountID, ok := parseAccountID(w, r)
+	if !ok {
+		return
+	}
+	account, err := h.store.LoadAccount(r.Context(), accountID)
+	if err != nil {
+		name := ""
+		if account != nil {
+			name = account.Name
+		}
+		h.writeAccountError(w, err, accountID, name)
+		return
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	req, vErr := buildCreateRequest(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	created, err := h.store.Create(r.Context(), &Transaction{
+		AccountID:       accountID,
+		Amount:          req.Amount,
+		Date:            req.Date,
+		Owner:           req.Owner,
+		TransactionType: req.TransactionType,
+	})
+	if err != nil {
+		if errors.Is(err, ErrDuplicate) {
+			writeDetailError(w, http.StatusConflict,
+				fmt.Sprintf("Transaction for account %d on %s already exists",
+					accountID, req.Date.Format("2006-01-02")))
+			return
+		}
+		h.logger.Error("create transaction", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toResponse(*created, account.Name))
+}
+
+// Delete serves DELETE /api/accounts/{id}/transactions/{transaction_id}.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	accountID, ok := parseAccountID(w, r)
+	if !ok {
+		return
+	}
+	transactionID, err := strconv.Atoi(chi.URLParam(r, "transaction_id"))
+	if err != nil {
+		writeValidationError(w, "transaction_id", "must be an integer", chi.URLParam(r, "transaction_id"))
+		return
+	}
+	if err := h.store.SoftDelete(r.Context(), accountID, transactionID); err != nil {
+		switch {
+		case errors.Is(err, ErrNotFound):
+			writeDetailError(w, http.StatusNotFound,
+				fmt.Sprintf("Transaction with id %d not found", transactionID))
+		case errors.Is(err, ErrCrossAccount):
+			writeDetailError(w, http.StatusForbidden,
+				fmt.Sprintf("Transaction %d does not belong to account %d", transactionID, accountID))
+		default:
+			h.logger.Error("delete transaction", "err", err)
+			writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Counts serves GET /api/transactions/counts.
+func (h *Handler) Counts(w http.ResponseWriter, r *http.Request) {
+	counts, err := h.store.CountsByAccount(r.Context())
+	if err != nil {
+		h.logger.Error("transaction counts", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	// Pydantic dict[int, int] serializes int keys as JSON strings.
+	out := make(map[string]int, len(counts))
+	for k, v := range counts {
+		out[strconv.Itoa(k)] = v
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) writeList(w http.ResponseWriter, rows []Transaction, name func(Transaction) string) {
+	out := listResponse{Transactions: make([]response, 0, len(rows))}
+	total := decimal.Zero
+	for _, t := range rows {
+		out.Transactions = append(out.Transactions, toResponse(t, name(t)))
+		if t.TransactionType != nil && *t.TransactionType == "withdrawal" {
+			total = total.Sub(t.Amount)
+		} else {
+			total = total.Add(t.Amount)
+		}
+	}
+	out.TransactionCount = len(out.Transactions)
+	f, _ := total.Float64()
+	out.TotalInvested = pyFloat(f)
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) writeAccountError(w http.ResponseWriter, err error, id int, name string) {
+	switch {
+	case errors.Is(err, ErrAccountNotFound):
+		writeDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("Account with id %d not found", id))
+	case errors.Is(err, ErrAccountNotInvestment):
+		writeDetailError(w, http.StatusBadRequest,
+			fmt.Sprintf("Account '%s' cannot have transactions. "+
+				"Only investment or retirement accounts (IKE/IKZE/PPK) can track transactions.", name))
+	default:
+		h.logger.Error("account check", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+	}
+}
+
+func parseAccountID(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "account_id")
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		writeValidationError(w, "account_id", "must be an integer", raw)
+		return 0, false
+	}
+	return id, true
+}
+
+// --- request parsing ---
+
+type createRequest struct {
+	Amount          decimal.Decimal
+	Date            time.Time
+	Owner           string
+	TransactionType *string
+}
+
+func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *validationError) {
+	var r createRequest
+	amount, vErr := requirePositiveDecimal(raw, "amount", "Amount must be greater than 0")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Amount = amount
+
+	t, vErr := requireDateNotFuture(raw, "date")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Date = t
+
+	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Owner = owner
+
+	if v, ok := raw["transaction_type"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return r, &validationError{Field: "transaction_type", Msg: "must be a string"}
+		}
+		if _, ok := validTransactionTypes[s]; !ok {
+			return r, &validationError{Field: "transaction_type", Msg: fmt.Sprintf("invalid value %q", s)}
+		}
+		r.TransactionType = &s
+	}
+	return r, nil
+}
+
+func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", &validationError{Field: key, Msg: emptyMsg}
+	}
+	return s, nil
+}
+
+func requireDateNotFuture(raw map[string]json.RawMessage, key string) (time.Time, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return time.Time{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be a string"}
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be YYYY-MM-DD"}
+	}
+	today := time.Now().UTC()
+	today = time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)
+	if t.After(today) {
+		return time.Time{}, &validationError{Field: key, Msg: "Date cannot be in the future"}
+	}
+	return t, nil
+}
+
+func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if err != nil {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if !d.IsPositive() {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: msg}
+	}
+	return d, nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}
+
+// --- wire types ---
+
+type isoDate time.Time
+
+const isoDateLayout = "2006-01-02"
+
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
+}
+
+type isoNaive time.Time
+
+func (t isoNaive) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
+}
+
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/transactions/store.go
+++ b/backend-go/internal/transactions/store.go
@@ -1,0 +1,282 @@
+// Package transactions implements transaction endpoints for investment +
+// retirement accounts. Soft-delete is the only delete; create enforces
+// one-per-day per account.
+package transactions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Transaction mirrors backend/app/models/transaction.Transaction.
+type Transaction struct {
+	ID              int
+	AccountID       int
+	Amount          decimal.Decimal
+	Date            time.Time
+	Owner           string
+	TransactionType *string
+	IsActive        bool
+	CreatedAt       time.Time
+}
+
+// AccountInfo is the subset of Account columns we need for response building
+// + parent-account validation.
+type AccountInfo struct {
+	ID             int
+	Name           string
+	Type           string
+	Category       string
+	AccountWrapper *string
+	IsActive       bool
+}
+
+// Investment categories that may have transactions; retirement wrappers
+// (IKE/IKZE/PPK) are also allowed regardless of category.
+var investmentCategories = map[string]struct{}{
+	"stock": {}, "bond": {}, "fund": {}, "etf": {},
+}
+
+// Sentinel errors mapped to HTTP statuses by the handler.
+var (
+	ErrAccountNotFound      = errors.New("account not found")
+	ErrAccountNotInvestment = errors.New("account is not investment/retirement")
+	ErrNotFound             = errors.New("transaction not found")
+	ErrDuplicate            = errors.New("transaction for date already exists")
+	ErrCrossAccount         = errors.New("transaction does not belong to account")
+)
+
+// Store is the persistence boundary.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const accountCols = `id, name, type, category, account_wrapper, is_active`
+
+const txCols = `
+	id, account_id, amount, date, owner, transaction_type, is_active, created_at
+`
+
+// LoadAccount returns the parent-account info; on ErrAccountNotInvestment the
+// account is still returned so the handler can render the account name in
+// the 400 detail. ErrAccountNotFound for missing or inactive rows.
+func (s *Store) LoadAccount(ctx context.Context, id int) (*AccountInfo, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+accountCols+` FROM accounts WHERE id = $1`, id,
+	)
+	a, err := scanAccount(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrAccountNotFound
+		}
+		return nil, fmt.Errorf("load account: %w", err)
+	}
+	if !a.IsActive {
+		return nil, ErrAccountNotFound
+	}
+	if _, ok := investmentCategories[a.Category]; !ok && (a.AccountWrapper == nil || *a.AccountWrapper == "") {
+		return a, ErrAccountNotInvestment
+	}
+	return a, nil
+}
+
+// ListForAccount returns active transactions for one account, ordered by
+// date desc.
+func (s *Store) ListForAccount(ctx context.Context, accountID int) ([]Transaction, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+txCols+` FROM transactions
+		 WHERE account_id = $1 AND is_active = true
+		 ORDER BY date DESC, id DESC`,
+		accountID,
+	)
+	return scanTransactions(rows, err)
+}
+
+// ListFilter narrows the all-transactions view.
+type ListFilter struct {
+	AccountID *int
+	Owner     *string
+	DateFrom  *time.Time
+	DateTo    *time.Time
+}
+
+// TxnWithAccount carries one transaction with its account name joined in.
+type TxnWithAccount struct {
+	Transaction Transaction
+	AccountName string
+}
+
+// ListAll joins transactions to active accounts and applies optional filters.
+func (s *Store) ListAll(ctx context.Context, f ListFilter) ([]TxnWithAccount, error) {
+	conds := []string{"t.is_active = true", "a.is_active = true"}
+	args := []any{}
+	if f.AccountID != nil {
+		args = append(args, *f.AccountID)
+		conds = append(conds, fmt.Sprintf("t.account_id = $%d", len(args)))
+	}
+	if f.Owner != nil {
+		args = append(args, *f.Owner)
+		conds = append(conds, fmt.Sprintf("t.owner = $%d", len(args)))
+	}
+	if f.DateFrom != nil {
+		args = append(args, *f.DateFrom)
+		conds = append(conds, fmt.Sprintf("t.date >= $%d", len(args)))
+	}
+	if f.DateTo != nil {
+		args = append(args, *f.DateTo)
+		conds = append(conds, fmt.Sprintf("t.date <= $%d", len(args)))
+	}
+	q := `SELECT t.id, t.account_id, t.amount, t.date, t.owner, t.transaction_type,
+	             t.is_active, t.created_at, a.name
+	      FROM transactions t
+	      JOIN accounts a ON a.id = t.account_id
+	      WHERE ` + strings.Join(conds, " AND ") + `
+	      ORDER BY t.date DESC, t.id DESC`
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list transactions: %w", err)
+	}
+	defer rows.Close()
+	out := []TxnWithAccount{}
+	for rows.Next() {
+		var t Transaction
+		var name string
+		if err := rows.Scan(
+			&t.ID, &t.AccountID, &t.Amount, &t.Date, &t.Owner,
+			&t.TransactionType, &t.IsActive, &t.CreatedAt, &name,
+		); err != nil {
+			return nil, fmt.Errorf("scan transaction join: %w", err)
+		}
+		out = append(out, TxnWithAccount{Transaction: t, AccountName: name})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate transactions: %w", err)
+	}
+	return out, nil
+}
+
+// Create inserts a transaction. ErrDuplicate on same (account_id, date) for
+// an active row.
+func (s *Store) Create(ctx context.Context, t *Transaction) (*Transaction, error) {
+	var existing int
+	err := s.pool.QueryRow(ctx, `
+		SELECT id FROM transactions
+		WHERE account_id = $1 AND date = $2 AND is_active = true
+		LIMIT 1`,
+		t.AccountID, t.Date,
+	).Scan(&existing)
+	if err == nil {
+		return nil, ErrDuplicate
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("check duplicate transaction: %w", err)
+	}
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO transactions (account_id, amount, date, owner, transaction_type, is_active, created_at)
+		VALUES ($1, $2, $3, $4, $5, true, $6)
+		RETURNING `+txCols,
+		t.AccountID, t.Amount, t.Date, t.Owner, t.TransactionType, time.Now().UTC(),
+	)
+	return scanTransaction(row)
+}
+
+// SoftDelete soft-deletes a transaction. Enforces account ownership.
+func (s *Store) SoftDelete(ctx context.Context, accountID, transactionID int) error {
+	var owned bool
+	err := s.pool.QueryRow(ctx, `
+		SELECT account_id = $1
+		FROM transactions WHERE id = $2`,
+		accountID, transactionID,
+	).Scan(&owned)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("check transaction ownership: %w", err)
+	}
+	if !owned {
+		return ErrCrossAccount
+	}
+	if _, err := s.pool.Exec(ctx,
+		`UPDATE transactions SET is_active = false WHERE id = $1`,
+		transactionID,
+	); err != nil {
+		return fmt.Errorf("soft-delete transaction: %w", err)
+	}
+	return nil
+}
+
+// CountsByAccount returns the per-account count of active transactions.
+func (s *Store) CountsByAccount(ctx context.Context) (map[int]int, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT account_id, COUNT(*)
+		FROM transactions WHERE is_active = true
+		GROUP BY account_id`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("transaction counts: %w", err)
+	}
+	defer rows.Close()
+	out := map[int]int{}
+	for rows.Next() {
+		var id, n int
+		if err := rows.Scan(&id, &n); err != nil {
+			return nil, fmt.Errorf("scan count: %w", err)
+		}
+		out[id] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate counts: %w", err)
+	}
+	return out, nil
+}
+
+func scanTransactions(rows pgx.Rows, err error) ([]Transaction, error) {
+	if err != nil {
+		return nil, fmt.Errorf("list transactions: %w", err)
+	}
+	defer rows.Close()
+	out := []Transaction{}
+	for rows.Next() {
+		t, err := scanTransaction(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan transaction: %w", err)
+		}
+		out = append(out, *t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate transactions: %w", err)
+	}
+	return out, nil
+}
+
+func scanTransaction(row pgx.Row) (*Transaction, error) {
+	var t Transaction
+	if err := row.Scan(
+		&t.ID, &t.AccountID, &t.Amount, &t.Date, &t.Owner,
+		&t.TransactionType, &t.IsActive, &t.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func scanAccount(row pgx.Row) (*AccountInfo, error) {
+	var a AccountInfo
+	if err := row.Scan(&a.ID, &a.Name, &a.Type, &a.Category, &a.AccountWrapper, &a.IsActive); err != nil {
+		return nil, err
+	}
+	return &a, nil
+}

--- a/backend-go/internal/transactions/store.go
+++ b/backend-go/internal/transactions/store.go
@@ -101,7 +101,22 @@ func (s *Store) ListForAccount(ctx context.Context, accountID int) ([]Transactio
 		 ORDER BY date DESC, id DESC`,
 		accountID,
 	)
-	return scanTransactions(rows, err)
+	if err != nil {
+		return nil, fmt.Errorf("list transactions: %w", err)
+	}
+	defer rows.Close()
+	out := []Transaction{}
+	for rows.Next() {
+		t, err := scanTransaction(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan transaction: %w", err)
+		}
+		out = append(out, *t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate transactions: %w", err)
+	}
+	return out, nil
 }
 
 // ListFilter narrows the all-transactions view.
@@ -239,25 +254,6 @@ func (s *Store) CountsByAccount(ctx context.Context) (map[int]int, error) {
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate counts: %w", err)
-	}
-	return out, nil
-}
-
-func scanTransactions(rows pgx.Rows, err error) ([]Transaction, error) {
-	if err != nil {
-		return nil, fmt.Errorf("list transactions: %w", err)
-	}
-	defer rows.Close()
-	out := []Transaction{}
-	for rows.Next() {
-		t, err := scanTransaction(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scan transaction: %w", err)
-		}
-		out = append(out, *t)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate transactions: %w", err)
 	}
 	return out, nil
 }

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -145,3 +145,25 @@ rules:
   - method: PUT
     path_prefix: /api/snapshots
     upstream: http://backend-go:8000
+  # Group 8 — transactions / debt_payments / debts cut over to Go.
+  # Sub-routes under /api/accounts/{id}/(transactions|payments|debts) already
+  # match the /api/accounts prefix above; landing these here also covers the
+  # top-level /api/transactions, /api/payments, /api/debts collections.
+  - method: GET
+    path_prefix: /api/transactions
+    upstream: http://backend-go:8000
+  - method: GET
+    path_prefix: /api/payments
+    upstream: http://backend-go:8000
+  - method: GET
+    path_prefix: /api/debts
+    upstream: http://backend-go:8000
+  - method: POST
+    path_prefix: /api/debts
+    upstream: http://backend-go:8000
+  - method: PUT
+    path_prefix: /api/debts
+    upstream: http://backend-go:8000
+  - method: DELETE
+    path_prefix: /api/debts
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

**URGENT regression fix.** Group 9a/9b cut `/api/accounts/*` to Go via the proxy's prefix rule, but the sub-routes under `/api/accounts/{id}/(transactions|payments|debts)` weren't ported. The proxy correctly routed them to Go, where they 404'd. This has been broken in prod since v0.18.0 (Group 9a).

This PR ports the three coupled domains (transactions, debt_payments, debts) and restores all five Python endpoints per domain.

Closes Group 8 (#443).

## Implementation information

### `internal/transactions`

- ListForAccount / ListAll / Create / Delete / Counts.
- `LoadAccount` enforces Python's investment-category-OR-retirement-wrapper check (IKE/IKZE/PPK).
- Duplicate `(account_id, date)` for an active row -> ErrDuplicate -> 409.
- Cross-account delete -> ErrCrossAccount -> 403 with matching message.
- `total_invested` sums with `withdrawal` flipping sign.

### `internal/debt_payments`

- Same shape as transactions but parent must be `type='liability'`.
- ErrAccountNotLiability -> 400 with the account name in the detail.

### `internal/debts`

- List joins debts + active accounts, then batches `LatestBalancesByAccount` + `TotalPaidByAccount` so the response carries `latest_balance`, `latest_balance_date`, `total_paid`, `interest_paid` without N+1.
- Get / Update / Delete on `/api/debts/{id}`.
- Create on `/api/accounts/{account_id}/debts`. UniqueViolation on `uq_debt_account` -> 409 with Python's exact message.
- Update wraps in a tx with FOR UPDATE row lock; PUT semantics: null/absent on non-notes fields = no-op; null/absent on notes = no change.

### `server.go`

New `registerLedgerRoutes` helper mounts the sub-routes (and top-level collections) directly on the root router. chi handles them despite the `/api/accounts` overlap because route patterns are pattern-matched, not prefix-matched.

### `routes.yaml`

Top-level prefixes added: `/api/transactions`, `/api/payments`, `/api/debts`. The sub-routes under `/api/accounts/{id}/...` already match the existing `/api/accounts` prefix rule.

### Parity proof against Go

```
============================= test session starts ==============================
tests/test_transactions.py ........        7 passed
tests/test_debt_payments.py ........       7 passed
tests/test_debts.py .........             10 passed
============================== 24 passed in 0.19s ==============================
```

Golden snapshots for `list_all_transactions`, `transaction_counts`, `list_all_payments`, `payment_counts`, `list_debts` all match byte-for-byte.

## Supporting documentation

- Umbrella: #435
- Subissue: #443
- Procedure: `migration/CUTOVER.md`

> Changelog: skip