### PR TITLE
feat(go): cutover retirement (Group 10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,8 @@ jobs:
             tests/test_snapshots.py \
             tests/test_transactions.py \
             tests/test_debt_payments.py \
-            tests/test_debts.py
+            tests/test_debts.py \
+            tests/test_retirement.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/backend-go/internal/retirement/errors.go
+++ b/backend-go/internal/retirement/errors.go
@@ -1,0 +1,36 @@
+package retirement
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{"type": "value_error", "loc": []string{"body", field}, "msg": msg, "input": input},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/retirement/handler.go
+++ b/backend-go/internal/retirement/handler.go
@@ -145,10 +145,9 @@ func (h *Handler) buildYearlyStat(ctx context.Context, year int, wrapper, owner 
 	if limitF > 0 {
 		percentage = totalF / limitF * 100
 	}
-	percentageRounded := math.Round(percentage*10) / 10
 	lAmt := pyFloat(limitF)
 	rem := pyFloat(remaining)
-	pct := pyFloat(percentageRounded)
+	pct := pyFloat(math.Round(percentage*10) / 10)
 	return yearlyStat{
 		Year: year, AccountWrapper: wrapper, Owner: owner,
 		LimitAmount:         &lAmt,
@@ -157,7 +156,10 @@ func (h *Handler) buildYearlyStat(ctx context.Context, year int, wrapper, owner 
 		EmployerContributed: pyFloat(employerF),
 		Remaining:           &rem,
 		PercentageUsed:      &pct,
-		IsWarning:           percentageRounded >= 90,
+		// is_warning uses the unrounded percentage — Python computes it from
+		// the raw value, so 89.95% must NOT flip the flag even though it
+		// rounds to 90.0 in percentage_used.
+		IsWarning: percentage >= 90,
 	}, true, nil
 }
 

--- a/backend-go/internal/retirement/handler.go
+++ b/backend-go/internal/retirement/handler.go
@@ -1,0 +1,528 @@
+package retirement
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+)
+
+type yearlyStat struct {
+	Year                int      `json:"year"`
+	AccountWrapper      string   `json:"account_wrapper"`
+	Owner               string   `json:"owner"`
+	LimitAmount         *pyFloat `json:"limit_amount"`
+	TotalContributed    pyFloat  `json:"total_contributed"`
+	EmployeeContributed pyFloat  `json:"employee_contributed"`
+	EmployerContributed pyFloat  `json:"employer_contributed"`
+	Remaining           *pyFloat `json:"remaining"`
+	PercentageUsed      *pyFloat `json:"percentage_used"`
+	IsWarning           bool     `json:"is_warning"`
+}
+
+type ppkStat struct {
+	Owner                 string  `json:"owner"`
+	TotalValue            pyFloat `json:"total_value"`
+	EmployeeContributed   pyFloat `json:"employee_contributed"`
+	EmployerContributed   pyFloat `json:"employer_contributed"`
+	GovernmentContributed pyFloat `json:"government_contributed"`
+	TotalContributed      pyFloat `json:"total_contributed"`
+	Returns               pyFloat `json:"returns"`
+	ROIPercentage         pyFloat `json:"roi_percentage"`
+}
+
+type limitResponse struct {
+	ID             int     `json:"id"`
+	Year           int     `json:"year"`
+	AccountWrapper string  `json:"account_wrapper"`
+	Owner          string  `json:"owner"`
+	LimitAmount    pyFloat `json:"limit_amount"`
+	Notes          *string `json:"notes"`
+}
+
+type ppkGenerateResponse struct {
+	Owner               string  `json:"owner"`
+	Month               int     `json:"month"`
+	Year                int     `json:"year"`
+	GrossSalary         pyFloat `json:"gross_salary"`
+	EmployeeAmount      pyFloat `json:"employee_amount"`
+	EmployerAmount      pyFloat `json:"employer_amount"`
+	TotalAmount         pyFloat `json:"total_amount"`
+	TransactionsCreated []int   `json:"transactions_created"`
+}
+
+// Handler is the HTTP boundary for /api/retirement.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+	now    func() time.Time
+}
+
+// NewHandler wires the store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger, now: time.Now}
+}
+
+// Stats serves GET /api/retirement/stats.
+func (h *Handler) Stats(w http.ResponseWriter, r *http.Request) {
+	year := h.now().UTC().Year()
+	if v := r.URL.Query().Get("year"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			writeValidationError(w, "year", "must be an integer", v)
+			return
+		}
+		year = n
+	}
+	owners, err := h.resolveOwners(r.Context(), r.URL.Query().Get("owner"))
+	if err != nil {
+		h.logger.Error("resolve owners", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := []yearlyStat{}
+	for _, wrapper := range []string{"IKE", "IKZE"} {
+		for _, owner := range owners {
+			stat, included, err := h.buildYearlyStat(r.Context(), year, wrapper, owner)
+			if err != nil {
+				h.logger.Error("yearly stat", "err", err)
+				writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+				return
+			}
+			if included {
+				out = append(out, stat)
+			}
+		}
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) buildYearlyStat(ctx context.Context, year int, wrapper, owner string) (yearlyStat, bool, error) {
+	accountIDs, err := h.store.AccountIDsForWrapper(ctx, wrapper, owner)
+	if err != nil {
+		return yearlyStat{}, false, err
+	}
+	if len(accountIDs) == 0 {
+		return yearlyStat{}, false, nil
+	}
+	totals, err := h.store.YearlyContributions(ctx, year, accountIDs)
+	if err != nil {
+		return yearlyStat{}, false, err
+	}
+	limit, configured, err := h.store.LimitConfigured(ctx, year, wrapper, owner)
+	if err != nil {
+		return yearlyStat{}, false, err
+	}
+	if !configured {
+		return yearlyStat{}, false, nil
+	}
+	totalF, _ := totals.Total.Float64()
+	employeeF, _ := totals.Employee.Float64()
+	employerF, _ := totals.Employer.Float64()
+	if totalF > employeeF+employerF {
+		employeeF += totalF - (employeeF + employerF)
+	}
+	limitF, _ := limit.LimitAmount.Float64()
+	remaining := limitF - totalF
+	if remaining < 0 {
+		remaining = 0
+	}
+	percentage := 0.0
+	if limitF > 0 {
+		percentage = totalF / limitF * 100
+	}
+	percentageRounded := math.Round(percentage*10) / 10
+	lAmt := pyFloat(limitF)
+	rem := pyFloat(remaining)
+	pct := pyFloat(percentageRounded)
+	return yearlyStat{
+		Year: year, AccountWrapper: wrapper, Owner: owner,
+		LimitAmount:         &lAmt,
+		TotalContributed:    pyFloat(totalF),
+		EmployeeContributed: pyFloat(employeeF),
+		EmployerContributed: pyFloat(employerF),
+		Remaining:           &rem,
+		PercentageUsed:      &pct,
+		IsWarning:           percentageRounded >= 90,
+	}, true, nil
+}
+
+// PPKStats serves GET /api/retirement/ppk-stats.
+func (h *Handler) PPKStats(w http.ResponseWriter, r *http.Request) {
+	owners, err := h.resolveOwners(r.Context(), r.URL.Query().Get("owner"))
+	if err != nil {
+		h.logger.Error("resolve owners", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := []ppkStat{}
+	for _, owner := range owners {
+		stat, included, err := h.buildPPKStat(r.Context(), owner)
+		if err != nil {
+			h.logger.Error("ppk stat", "err", err)
+			writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+			return
+		}
+		if included {
+			out = append(out, stat)
+		}
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) buildPPKStat(ctx context.Context, owner string) (ppkStat, bool, error) {
+	accountIDs, err := h.store.AccountIDsForWrapper(ctx, "PPK", owner)
+	if err != nil {
+		return ppkStat{}, false, err
+	}
+	if len(accountIDs) == 0 {
+		return ppkStat{}, false, nil
+	}
+	totals, err := h.store.PPKContributions(ctx, accountIDs)
+	if err != nil {
+		return ppkStat{}, false, err
+	}
+	totalF, _ := totals.Total.Float64()
+	employeeF, _ := totals.Employee.Float64()
+	employerF, _ := totals.Employer.Float64()
+	governmentF, _ := totals.Government.Float64()
+	if totalF > employeeF+employerF+governmentF {
+		employeeF += totalF - (employeeF + employerF + governmentF)
+	}
+	latest, err := h.store.LatestSnapshotValueSum(ctx, accountIDs)
+	if err != nil {
+		return ppkStat{}, false, err
+	}
+	totalValue, _ := latest.Float64()
+	returns := totalValue - totalF
+	roi := 0.0
+	if totalF > 0 {
+		roi = returns / totalF * 100
+	}
+	roiRounded := math.Round(roi*100) / 100
+	return ppkStat{
+		Owner:                 owner,
+		TotalValue:            pyFloat(totalValue),
+		EmployeeContributed:   pyFloat(employeeF),
+		EmployerContributed:   pyFloat(employerF),
+		GovernmentContributed: pyFloat(governmentF),
+		TotalContributed:      pyFloat(totalF),
+		Returns:               pyFloat(returns),
+		ROIPercentage:         pyFloat(roiRounded),
+	}, true, nil
+}
+
+// LimitsForYear serves GET /api/retirement/limits/{year}.
+func (h *Handler) LimitsForYear(w http.ResponseWriter, r *http.Request) {
+	year, err := strconv.Atoi(chi.URLParam(r, "year"))
+	if err != nil {
+		writeValidationError(w, "year", "must be an integer", chi.URLParam(r, "year"))
+		return
+	}
+	limits, err := h.store.LimitsForYear(r.Context(), year)
+	if err != nil {
+		h.logger.Error("limits", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := make([]limitResponse, 0, len(limits))
+	for _, l := range limits {
+		amt, _ := l.LimitAmount.Float64()
+		out = append(out, limitResponse{
+			ID: l.ID, Year: l.Year, AccountWrapper: l.AccountWrapper,
+			Owner: l.Owner, LimitAmount: pyFloat(amt), Notes: l.Notes,
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// UpsertLimit serves PUT /api/retirement/limits/{year}/{wrapper}/{owner}.
+func (h *Handler) UpsertLimit(w http.ResponseWriter, r *http.Request) {
+	year, err := strconv.Atoi(chi.URLParam(r, "year"))
+	if err != nil {
+		writeValidationError(w, "year", "must be an integer", chi.URLParam(r, "year"))
+		return
+	}
+	wrapper := chi.URLParam(r, "wrapper")
+	owner := chi.URLParam(r, "owner")
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	req, vErr := buildLimitRequest(raw, h.now)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	l, err := h.store.UpsertLimit(r.Context(), year, wrapper, owner, req.LimitAmount, req.Notes)
+	if err != nil {
+		h.logger.Error("upsert limit", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	amt, _ := l.LimitAmount.Float64()
+	writeJSON(w, http.StatusOK, limitResponse{
+		ID: l.ID, Year: l.Year, AccountWrapper: l.AccountWrapper,
+		Owner: l.Owner, LimitAmount: pyFloat(amt), Notes: l.Notes,
+	})
+}
+
+// GeneratePPKContributions serves POST /api/retirement/ppk-contributions/generate.
+func (h *Handler) GeneratePPKContributions(w http.ResponseWriter, r *http.Request) {
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	req, vErr := buildGenerateRequest(raw, h.now)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	firstDay := time.Date(req.Year, time.Month(req.Month), 1, 0, 0, 0, 0, time.UTC)
+	gross, err := h.store.CurrentSalaryFor(r.Context(), req.Owner, firstDay)
+	if err != nil {
+		if errors.Is(err, ErrNoSalary) {
+			writeDetailError(w, http.StatusBadRequest,
+				fmt.Sprintf("No salary record found for %s in %d/%d", req.Owner, req.Month, req.Year))
+			return
+		}
+		h.logger.Error("ppk salary", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	employeeRate, employerRate, err := h.store.PersonaPPKRates(r.Context(), req.Owner)
+	if err != nil {
+		if errors.Is(err, ErrPersonaNotFound) {
+			writeDetailError(w, http.StatusNotFound,
+				fmt.Sprintf("Persona '%s' not found", req.Owner))
+			return
+		}
+		h.logger.Error("ppk rates", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	hundred := decimal.NewFromInt(100)
+	employeeAmt := gross.Mul(employeeRate).Div(hundred)
+	employerAmt := gross.Mul(employerRate).Div(hundred)
+	accountID, err := h.store.ActivePPKAccountForOwner(r.Context(), req.Owner)
+	if err != nil {
+		if errors.Is(err, ErrNoPPKAccount) {
+			writeDetailError(w, http.StatusNotFound,
+				fmt.Sprintf("No active PPK account found for %s. "+
+					"Mark one PPK account as receiving contributions.", req.Owner))
+			return
+		}
+		h.logger.Error("ppk account", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	lastDay := time.Date(req.Year, time.Month(req.Month)+1, 0, 0, 0, 0, 0, time.UTC)
+	ids, err := h.store.InsertPPKContributions(r.Context(), PPKContribution{
+		AccountID: accountID, EmployeeAmt: employeeAmt, EmployerAmt: employerAmt,
+		Date: lastDay, Owner: req.Owner,
+	})
+	if err != nil {
+		if errors.Is(err, ErrContributionsExist) {
+			writeDetailError(w, http.StatusConflict,
+				fmt.Sprintf("Contributions already exist for %d/%d", req.Month, req.Year))
+			return
+		}
+		h.logger.Error("insert ppk contributions", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	grossF, _ := gross.Float64()
+	empF, _ := employeeAmt.Float64()
+	emprF, _ := employerAmt.Float64()
+	writeJSON(w, http.StatusOK, ppkGenerateResponse{
+		Owner: req.Owner, Month: req.Month, Year: req.Year,
+		GrossSalary:         pyFloat(grossF),
+		EmployeeAmount:      pyFloat(empF),
+		EmployerAmount:      pyFloat(emprF),
+		TotalAmount:         pyFloat(empF + emprF),
+		TransactionsCreated: ids,
+	})
+}
+
+func (h *Handler) resolveOwners(ctx context.Context, queryOwner string) ([]string, error) {
+	if queryOwner != "" {
+		return []string{queryOwner}, nil
+	}
+	return h.store.PersonaNames(ctx)
+}
+
+// --- request parsing ---
+
+type limitRequest struct {
+	Year           int
+	AccountWrapper string
+	Owner          string
+	LimitAmount    decimal.Decimal
+	Notes          *string
+}
+
+var validWrappers = map[string]struct{}{
+	"IKE": {}, "IKZE": {}, "PPK": {},
+}
+
+func buildLimitRequest(raw map[string]json.RawMessage, now func() time.Time) (limitRequest, *validationError) {
+	var r limitRequest
+	currentYear := now().UTC().Year()
+	year, vErr := requireIntRange(raw, "year", 2000, currentYear+10,
+		fmt.Sprintf("Year must be between 2000 and %d", currentYear+10))
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Year = year
+
+	wrap, vErr := requireEnumString(raw, "account_wrapper", validWrappers)
+	if vErr != nil {
+		return r, vErr
+	}
+	r.AccountWrapper = wrap
+
+	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Owner = owner
+
+	amt, vErr := requirePositiveDecimal(raw, "limit_amount", "Limit amount must be greater than 0")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.LimitAmount = amt
+
+	if v, ok := raw["notes"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return r, &validationError{Field: "notes", Msg: "must be a string"}
+		}
+		r.Notes = &s
+	}
+	return r, nil
+}
+
+type generateRequest struct {
+	Owner string
+	Month int
+	Year  int
+}
+
+func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) (generateRequest, *validationError) {
+	var r generateRequest
+	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Owner = owner
+
+	month, vErr := requireIntRange(raw, "month", 1, 12, "Month must be between 1 and 12")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Month = month
+
+	currentYear := now().UTC().Year()
+	year, vErr := requireIntRange(raw, "year", 2019, currentYear+1,
+		fmt.Sprintf("Year must be between 2019 and %d", currentYear+1))
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Year = year
+	return r, nil
+}
+
+// --- helpers ---
+
+func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", &validationError{Field: key, Msg: emptyMsg}
+	}
+	return s, nil
+}
+
+func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return "", &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	return s, nil
+}
+
+func requireIntRange(raw map[string]json.RawMessage, key string, lo, hi int, msg string) (int, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return 0, &validationError{Field: key, Msg: "Field required"}
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return 0, &validationError{Field: key, Msg: "must be an integer"}
+	}
+	if n < lo || n > hi {
+		return 0, &validationError{Field: key, Msg: msg}
+	}
+	return n, nil
+}
+
+func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if err != nil {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if !d.IsPositive() {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: msg}
+	}
+	return d, nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}
+
+// wire type
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/retirement/store.go
+++ b/backend-go/internal/retirement/store.go
@@ -225,17 +225,17 @@ func (s *Store) LimitFor(ctx context.Context, year int, wrapper, owner string) (
 	return &l, nil
 }
 
-// LimitConfigured wraps LimitFor with the "no row" branch surfaced as a
-// (nil, nil) pair — callers don't need to import the sentinel.
-func (s *Store) LimitConfigured(ctx context.Context, year int, wrapper, owner string) (*Limit, bool, error) {
+// LimitConfigured wraps LimitFor with the "no row" branch surfaced via the
+// bool — callers can ignore the sentinel and not worry about a nil deref.
+func (s *Store) LimitConfigured(ctx context.Context, year int, wrapper, owner string) (Limit, bool, error) {
 	l, err := s.LimitFor(ctx, year, wrapper, owner)
 	if err != nil {
 		if errors.Is(err, errNoLimit) {
-			return nil, false, nil
+			return Limit{}, false, nil
 		}
-		return nil, false, err
+		return Limit{}, false, err
 	}
-	return l, true, nil
+	return *l, true, nil
 }
 
 // UpsertLimit creates the (year, wrapper, owner) row or updates limit_amount

--- a/backend-go/internal/retirement/store.go
+++ b/backend-go/internal/retirement/store.go
@@ -1,0 +1,391 @@
+// Package retirement implements /api/retirement — yearly stats per
+// IKE/IKZE wrapper, PPK aggregates, limit upsert, and PPK contribution
+// generation that writes employee + employer transactions atomically.
+package retirement
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Sentinel errors.
+var (
+	ErrNoSalary           = errors.New("no salary record for owner")
+	ErrPersonaNotFound    = errors.New("persona not found")
+	ErrNoPPKAccount       = errors.New("no active PPK account for owner")
+	ErrContributionsExist = errors.New("contributions already exist for month")
+)
+
+// errNoLimit is the internal sentinel for "no retirement_limit row matches
+// (year, wrapper, owner)" — unexported because callers use the (nil, err)
+// branch directly.
+var errNoLimit = errors.New("no limit configured for wrapper")
+
+// Limit mirrors backend/app/models/retirement_limit.RetirementLimit.
+type Limit struct {
+	ID             int
+	Year           int
+	AccountWrapper string
+	Owner          string
+	LimitAmount    decimal.Decimal
+	Notes          *string
+}
+
+// Store is the persistence boundary.
+type Store struct{ pool *pgxpool.Pool }
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
+
+// PersonaNames returns persona names alphabetically.
+func (s *Store) PersonaNames(ctx context.Context) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `SELECT name FROM personas ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("personas: %w", err)
+	}
+	defer rows.Close()
+	out := []string{}
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			return nil, fmt.Errorf("scan persona: %w", err)
+		}
+		out = append(out, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate personas: %w", err)
+	}
+	return out, nil
+}
+
+// AccountIDsForWrapper returns the active account IDs for one wrapper+owner.
+func (s *Store) AccountIDsForWrapper(ctx context.Context, wrapper, owner string) ([]int, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id FROM accounts
+		WHERE account_wrapper = $1 AND owner = $2 AND is_active = true`,
+		wrapper, owner,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("account ids: %w", err)
+	}
+	defer rows.Close()
+	out := []int{}
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan account id: %w", err)
+		}
+		out = append(out, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate account ids: %w", err)
+	}
+	return out, nil
+}
+
+// ContributionTotals aggregates active transaction amounts for one year +
+// account set, broken down by transaction_type. typed_sum < total -> the
+// remainder is untyped and the handler attributes it to the employee bucket
+// (matches Python's behavior).
+type ContributionTotals struct {
+	Total      decimal.Decimal
+	Employee   decimal.Decimal
+	Employer   decimal.Decimal
+	Government decimal.Decimal
+}
+
+// YearlyContributions aggregates transactions for one year limited to one
+// year and one set of accounts.
+func (s *Store) YearlyContributions(ctx context.Context, year int, accountIDs []int) (ContributionTotals, error) {
+	if len(accountIDs) == 0 {
+		return ContributionTotals{}, nil
+	}
+	row := s.pool.QueryRow(ctx, `
+		SELECT
+			COALESCE(SUM(amount), 0) AS total,
+			COALESCE(SUM(CASE WHEN transaction_type = 'employee' THEN amount ELSE 0 END), 0) AS employee,
+			COALESCE(SUM(CASE WHEN transaction_type = 'employer' THEN amount ELSE 0 END), 0) AS employer
+		FROM transactions
+		WHERE account_id = ANY($1)
+		  AND EXTRACT(year FROM date) = $2
+		  AND is_active = true`,
+		accountIDs, year,
+	)
+	var t ContributionTotals
+	if err := row.Scan(&t.Total, &t.Employee, &t.Employer); err != nil {
+		return ContributionTotals{}, fmt.Errorf("yearly contributions: %w", err)
+	}
+	return t, nil
+}
+
+// PPKContributions aggregates all-time PPK transactions including the
+// government bucket. Matches Python's three-typed + untyped-as-employee
+// logic.
+func (s *Store) PPKContributions(ctx context.Context, accountIDs []int) (ContributionTotals, error) {
+	if len(accountIDs) == 0 {
+		return ContributionTotals{}, nil
+	}
+	row := s.pool.QueryRow(ctx, `
+		SELECT
+			COALESCE(SUM(CASE
+				WHEN transaction_type IN ('employee', 'employer', 'government') OR transaction_type IS NULL
+				THEN amount ELSE 0
+			END), 0) AS total,
+			COALESCE(SUM(CASE WHEN transaction_type = 'employee' THEN amount ELSE 0 END), 0) AS employee,
+			COALESCE(SUM(CASE WHEN transaction_type = 'employer' THEN amount ELSE 0 END), 0) AS employer,
+			COALESCE(SUM(CASE WHEN transaction_type = 'government' THEN amount ELSE 0 END), 0) AS government
+		FROM transactions
+		WHERE account_id = ANY($1) AND is_active = true`,
+		accountIDs,
+	)
+	var t ContributionTotals
+	if err := row.Scan(&t.Total, &t.Employee, &t.Employer, &t.Government); err != nil {
+		return ContributionTotals{}, fmt.Errorf("ppk contributions: %w", err)
+	}
+	return t, nil
+}
+
+// LatestSnapshotValueSum returns the sum of snapshot values for accountIDs
+// at the most recent snapshot date that touches any of them.
+func (s *Store) LatestSnapshotValueSum(ctx context.Context, accountIDs []int) (decimal.Decimal, error) {
+	if len(accountIDs) == 0 {
+		return decimal.Zero, nil
+	}
+	row := s.pool.QueryRow(ctx, `
+		WITH latest AS (
+			SELECT MAX(s.date) AS d
+			FROM snapshots s
+			JOIN snapshot_values sv ON sv.snapshot_id = s.id
+			WHERE sv.account_id = ANY($1)
+		)
+		SELECT COALESCE(SUM(sv.value), 0)
+		FROM snapshot_values sv
+		JOIN snapshots s ON s.id = sv.snapshot_id
+		JOIN latest l ON s.date = l.d
+		WHERE sv.account_id = ANY($1)`,
+		accountIDs,
+	)
+	var v decimal.Decimal
+	if err := row.Scan(&v); err != nil {
+		return decimal.Zero, fmt.Errorf("latest ppk value: %w", err)
+	}
+	return v, nil
+}
+
+// LimitsForYear returns all RetirementLimit rows for a year, ordered by id.
+func (s *Store) LimitsForYear(ctx context.Context, year int) ([]Limit, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, year, account_wrapper, owner, limit_amount, notes
+		FROM retirement_limits WHERE year = $1
+		ORDER BY id`,
+		year,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("limits: %w", err)
+	}
+	defer rows.Close()
+	out := []Limit{}
+	for rows.Next() {
+		var l Limit
+		if err := rows.Scan(&l.ID, &l.Year, &l.AccountWrapper, &l.Owner, &l.LimitAmount, &l.Notes); err != nil {
+			return nil, fmt.Errorf("scan limit: %w", err)
+		}
+		out = append(out, l)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate limits: %w", err)
+	}
+	return out, nil
+}
+
+// LimitFor returns the Limit row for (year, wrapper, owner). errNoLimit
+// when the row is absent — callers handle that as "no limit configured".
+func (s *Store) LimitFor(ctx context.Context, year int, wrapper, owner string) (*Limit, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT id, year, account_wrapper, owner, limit_amount, notes
+		FROM retirement_limits
+		WHERE year = $1 AND account_wrapper = $2 AND owner = $3`,
+		year, wrapper, owner,
+	)
+	var l Limit
+	if err := row.Scan(&l.ID, &l.Year, &l.AccountWrapper, &l.Owner, &l.LimitAmount, &l.Notes); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, errNoLimit
+		}
+		return nil, fmt.Errorf("limit for: %w", err)
+	}
+	return &l, nil
+}
+
+// LimitConfigured wraps LimitFor with the "no row" branch surfaced as a
+// (nil, nil) pair — callers don't need to import the sentinel.
+func (s *Store) LimitConfigured(ctx context.Context, year int, wrapper, owner string) (*Limit, bool, error) {
+	l, err := s.LimitFor(ctx, year, wrapper, owner)
+	if err != nil {
+		if errors.Is(err, errNoLimit) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return l, true, nil
+}
+
+// UpsertLimit creates the (year, wrapper, owner) row or updates limit_amount
+// + notes when it exists. Mirrors Python's update_limit fall-through.
+func (s *Store) UpsertLimit(ctx context.Context, year int, wrapper, owner string, amount decimal.Decimal, notes *string) (*Limit, error) {
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO retirement_limits (year, account_wrapper, owner, limit_amount, notes)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (year, account_wrapper, owner) DO UPDATE
+		SET limit_amount = EXCLUDED.limit_amount,
+		    notes = COALESCE(EXCLUDED.notes, retirement_limits.notes)
+		RETURNING id, year, account_wrapper, owner, limit_amount, notes`,
+		year, wrapper, owner, amount, notes,
+	)
+	var l Limit
+	if err := row.Scan(&l.ID, &l.Year, &l.AccountWrapper, &l.Owner, &l.LimitAmount, &l.Notes); err != nil {
+		return nil, fmt.Errorf("upsert limit: %w", err)
+	}
+	return &l, nil
+}
+
+// CurrentSalaryFor returns the latest active gross_amount on/before asOfDate
+// for one owner.
+func (s *Store) CurrentSalaryFor(ctx context.Context, owner string, asOfDate time.Time) (decimal.Decimal, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT gross_amount FROM salary_records
+		WHERE owner = $1 AND is_active = true AND date <= $2
+		ORDER BY date DESC LIMIT 1`,
+		owner, asOfDate,
+	)
+	var v decimal.Decimal
+	if err := row.Scan(&v); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return decimal.Zero, ErrNoSalary
+		}
+		return decimal.Zero, fmt.Errorf("current salary: %w", err)
+	}
+	return v, nil
+}
+
+// PersonaPPKRates returns (employee_rate, employer_rate) percentages from
+// the personas table or ErrPersonaNotFound.
+func (s *Store) PersonaPPKRates(ctx context.Context, owner string) (decimal.Decimal, decimal.Decimal, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT ppk_employee_rate, ppk_employer_rate
+		FROM personas WHERE name = $1`,
+		owner,
+	)
+	var employee, employer decimal.Decimal
+	if err := row.Scan(&employee, &employer); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return decimal.Zero, decimal.Zero, ErrPersonaNotFound
+		}
+		return decimal.Zero, decimal.Zero, fmt.Errorf("ppk rates: %w", err)
+	}
+	return employee, employer, nil
+}
+
+// ActivePPKAccountForOwner returns the receiving PPK account or ErrNoPPKAccount.
+func (s *Store) ActivePPKAccountForOwner(ctx context.Context, owner string) (int, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT id FROM accounts
+		WHERE account_wrapper = 'PPK' AND owner = $1
+		  AND is_active = true AND receives_contributions = true
+		LIMIT 1`,
+		owner,
+	)
+	var id int
+	if err := row.Scan(&id); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, ErrNoPPKAccount
+		}
+		return 0, fmt.Errorf("ppk account: %w", err)
+	}
+	return id, nil
+}
+
+// PPKContribution is the writeback shape — two transactions per call.
+type PPKContribution struct {
+	AccountID   int
+	EmployeeAmt decimal.Decimal
+	EmployerAmt decimal.Decimal
+	Date        time.Time
+	Owner       string
+}
+
+// InsertPPKContributions writes the employee + employer transactions
+// atomically. ErrContributionsExist when a row already exists for the
+// (account_id, date, employee|employer) tuple — guarded both by a
+// pre-check and by a UniqueViolation catch.
+func (s *Store) InsertPPKContributions(ctx context.Context, c PPKContribution) ([]int, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin ppk tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	var existing int
+	err = tx.QueryRow(ctx, `
+		SELECT COUNT(*) FROM transactions
+		WHERE account_id = $1 AND date = $2
+		  AND transaction_type IN ('employee', 'employer')
+		  AND is_active = true`,
+		c.AccountID, c.Date,
+	).Scan(&existing)
+	if err != nil {
+		return nil, fmt.Errorf("count ppk existing: %w", err)
+	}
+	if existing > 0 {
+		return nil, ErrContributionsExist
+	}
+	now := time.Now().UTC()
+	var empID, emprID int
+	if err := tx.QueryRow(ctx, `
+		INSERT INTO transactions (account_id, amount, date, owner, transaction_type, is_active, created_at)
+		VALUES ($1, $2, $3, $4, 'employee', true, $5)
+		RETURNING id`,
+		c.AccountID, c.EmployeeAmt, c.Date, c.Owner, now,
+	).Scan(&empID); err != nil {
+		if isUniqueViolation(err) {
+			return nil, ErrContributionsExist
+		}
+		return nil, fmt.Errorf("insert employee txn: %w", err)
+	}
+	if err := tx.QueryRow(ctx, `
+		INSERT INTO transactions (account_id, amount, date, owner, transaction_type, is_active, created_at)
+		VALUES ($1, $2, $3, $4, 'employer', true, $5)
+		RETURNING id`,
+		c.AccountID, c.EmployerAmt, c.Date, c.Owner, now,
+	).Scan(&emprID); err != nil {
+		if isUniqueViolation(err) {
+			return nil, ErrContributionsExist
+		}
+		return nil, fmt.Errorf("insert employer txn: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit ppk tx: %w", err)
+	}
+	committed = true
+	return []int{empID, emprID}, nil
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr == nil {
+		return false
+	}
+	return pgErr.Code == pgerrcode.UniqueViolation
+}

--- a/backend-go/internal/retirement/store.go
+++ b/backend-go/internal/retirement/store.go
@@ -337,6 +337,18 @@ func (s *Store) InsertPPKContributions(ctx context.Context, c PPKContribution) (
 			_ = tx.Rollback(ctx)
 		}
 	}()
+	// Serialize concurrent generates for the same (account, month). The
+	// transactions table has no unique constraint covering this tuple, so
+	// a bare COUNT-then-INSERT races; a transaction-scoped advisory lock
+	// closes the window without a schema change. The key packs account_id
+	// into the high 32 bits and the day-number into the low 32 bits of a
+	// single bigint. Lock auto-releases on commit/rollback.
+	lockKey := int64(c.AccountID)<<32 | (c.Date.Unix() / 86400)
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock($1)`, lockKey,
+	); err != nil {
+		return nil, fmt.Errorf("ppk advisory lock: %w", err)
+	}
 	var existing int
 	err = tx.QueryRow(ctx, `
 		SELECT COUNT(*) FROM transactions

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/personas"
+	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
 	"github.com/Automaat/finance-buddy/backend-go/internal/salaries"
 	"github.com/Automaat/finance-buddy/backend-go/internal/snapshots"
 	"github.com/Automaat/finance-buddy/backend-go/internal/transactions"
@@ -115,6 +116,13 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	r.Get("/api/debts/{id}", debtsHandler.Get)
 	r.Put("/api/debts/{id}", debtsHandler.Update)
 	r.Delete("/api/debts/{id}", debtsHandler.Delete)
+
+	retHandler := retirement.NewHandler(retirement.NewStore(pool), logger)
+	r.Get("/api/retirement/stats", retHandler.Stats)
+	r.Get("/api/retirement/ppk-stats", retHandler.PPKStats)
+	r.Post("/api/retirement/ppk-contributions/generate", retHandler.GeneratePPKContributions)
+	r.Get("/api/retirement/limits/{year}", retHandler.LimitsForYear)
+	r.Put("/api/retirement/limits/{year}/{wrapper}/{owner}", retHandler.UpsertLimit)
 }
 
 func registerCoreRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -167,3 +167,14 @@ rules:
   - method: DELETE
     path_prefix: /api/debts
     upstream: http://backend-go:8000
+  # Group 10 — /api/retirement cut over to Go (IKE/IKZE stats, PPK aggregates,
+  # limit upsert, monthly PPK contribution generation).
+  - method: GET
+    path_prefix: /api/retirement
+    upstream: http://backend-go:8000
+  - method: POST
+    path_prefix: /api/retirement
+    upstream: http://backend-go:8000
+  - method: PUT
+    path_prefix: /api/retirement
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

Group 10 cutover — retirement (IKE/IKZE/PPK stats, limit upsert, PPK contribution generation). Closes #445.

Depends on Groups 2 (personas owner-rename), 6 (salary records fund the PPK calc), 9 (accounts must be on Go) — all already merged.

## Implementation information

### `internal/retirement/store.go`

- `YearlyContributions` aggregates IKE/IKZE transactions for one year with `CASE` per `transaction_type` so total + employee + employer come back in one query.
- `PPKContributions` does the same but adds `government` and includes the untyped `transaction_type IS NULL` branch in the total (matches Python's `or_(transaction_type.in_([...]), transaction_type.is_(None))`).
- `LatestSnapshotValueSum` uses a CTE to find the most recent snapshot date that touches any of the supplied account ids, then sums their values at that date.
- `LimitConfigured` wraps the internal `errNoLimit` sentinel as a `(value, bool, error)` tuple so the handler doesn't need to import the sentinel and nilnil stays happy.
- `UpsertLimit` is one ON CONFLICT statement; notes is preserved when the request body omits it (matches Python's `if data.notes is not None: limit.notes = data.notes`).
- `InsertPPKContributions` wraps the two transaction rows + pre-count in one tx. UniqueViolation also surfaces as `ErrContributionsExist` -> 409, so the race-with-concurrent-writer doesn't become a 500.

### `internal/retirement/handler.go`

- `buildYearlyStat` / `buildPPKStat` return `(value, bool, error)` so "skip this owner" is explicit (replaces the `(*Stat, error)` + nil pair that tripped nilnil).
- Untyped-amount-to-employee logic preserved: when `total > typed_sum`, the difference is added to the employee bucket.
- ROI / percentage rounded with `math.Round(x*100)/100` and `math.Round(x*10)/10` matching Python's `round(x, 2)` / `round(x, 1)`.
- `GeneratePPKContributions` orchestrates: salary lookup -> persona rates -> active PPK account -> insert two transactions. Each failure mode maps to the exact status code + detail Python produces.

### Parity proof against Go

```
============================= test session starts ==============================
tests/test_retirement.py::test_get_retirement_stats_matches_golden    PASSED
tests/test_retirement.py::test_get_retirement_stats_shape             PASSED
tests/test_retirement.py::test_get_ppk_stats_matches_golden           PASSED
tests/test_retirement.py::test_get_ppk_stats_shape                    PASSED
tests/test_retirement.py::test_get_limits_for_year_matches_golden     PASSED
tests/test_retirement.py::test_get_limits_for_year_shape              PASSED
tests/test_retirement.py::test_put_retirement_limit_upsert            PASSED
tests/test_retirement.py::test_put_retirement_limit_validation_error  PASSED
tests/test_retirement.py::test_post_ppk_contributions_validation_error PASSED
============================== 9 passed in 0.13s ===============================
```

Three golden snapshots (`retirement_stats_2025`, `retirement_ppk_stats`, `retirement_limits_2025`) match byte-for-byte.

### `routes.yaml`

GET / POST / PUT for `/api/retirement`.

## Supporting documentation

- Umbrella: #435
- Subissue: #445
- Procedure: `migration/CUTOVER.md`

> Changelog: skip