### PR TITLE
feat(go): cutover investment stats (Group 11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,8 @@ jobs:
             tests/test_transactions.py \
             tests/test_debt_payments.py \
             tests/test_debts.py \
-            tests/test_retirement.py
+            tests/test_retirement.py \
+            tests/test_investment.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/backend-go/internal/investment/handler.go
+++ b/backend-go/internal/investment/handler.go
@@ -1,0 +1,91 @@
+package investment
+
+import (
+	"encoding/json"
+	"log/slog"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type response struct {
+	Category         string  `json:"category"`
+	TotalValue       pyFloat `json:"total_value"`
+	TotalContributed pyFloat `json:"total_contributed"`
+	Returns          pyFloat `json:"returns"`
+	ROIPercentage    pyFloat `json:"roi_percentage"`
+}
+
+// Handler is the HTTP boundary for /api/investment.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewHandler wires the store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger}
+}
+
+// StockStats serves GET /api/investment/stock-stats.
+func (h *Handler) StockStats(w http.ResponseWriter, r *http.Request) {
+	h.categoryStats(w, r, "stock")
+}
+
+// BondStats serves GET /api/investment/bond-stats.
+func (h *Handler) BondStats(w http.ResponseWriter, r *http.Request) {
+	h.categoryStats(w, r, "bond")
+}
+
+func (h *Handler) categoryStats(w http.ResponseWriter, r *http.Request, category string) {
+	stats, err := h.store.StatsForCategory(r.Context(), category)
+	if err != nil {
+		h.logger.Error("category stats", "category", category, "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	if !stats.HasAccounts {
+		writeJSON(w, http.StatusOK, response{Category: category})
+		return
+	}
+	value, _ := stats.TotalValue.Float64()
+	contributed, _ := stats.TotalContributed.Float64()
+	returns := value - contributed
+	roi := 0.0
+	if contributed > 0 {
+		roi = returns / contributed * 100
+	}
+	writeJSON(w, http.StatusOK, response{
+		Category:         category,
+		TotalValue:       pyFloat(value),
+		TotalContributed: pyFloat(contributed),
+		Returns:          pyFloat(returns),
+		ROIPercentage:    pyFloat(math.Round(roi*100) / 100),
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/investment/store.go
+++ b/backend-go/internal/investment/store.go
@@ -29,24 +29,14 @@ type CategoryStats struct {
 //     exist (uncapped otherwise).
 //   - total_value: sum of snapshot_values at that latest snapshot date.
 //
-// Returns HasAccounts=false when the category has no active accounts so the
-// handler can emit the all-zero response Python produces.
+// Single round-trip: the cat_accounts CTE drives the has-accounts flag, the
+// transactions sum and the value sum. HasAccounts=false makes the handler
+// emit the all-zero response Python produces for an empty category.
+//
+// The "uncapped when no snapshot" behavior is the `latest.d IS NULL OR
+// t.date <= latest.d` predicate — when no snapshot row exists, latest.d is
+// NULL and the date bound drops out.
 func (s *Store) StatsForCategory(ctx context.Context, category string) (CategoryStats, error) {
-	var accountCount int
-	if err := s.pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM accounts WHERE category = $1 AND is_active = true`,
-		category,
-	).Scan(&accountCount); err != nil {
-		return CategoryStats{}, fmt.Errorf("count category accounts: %w", err)
-	}
-	if accountCount == 0 {
-		return CategoryStats{HasAccounts: false}, nil
-	}
-
-	// total_contributed + total_value in a single query. The latest snapshot
-	// date is the MAX(s.date) over snapshots that hold a value for any active
-	// account in this category; when no snapshot exists the date subquery is
-	// NULL and the transactions sum is left uncapped (COALESCE on the bound).
 	row := s.pool.QueryRow(ctx, `
 		WITH cat_accounts AS (
 			SELECT id FROM accounts WHERE category = $1 AND is_active = true
@@ -58,6 +48,7 @@ func (s *Store) StatsForCategory(ctx context.Context, category string) (Category
 			WHERE sv.account_id IN (SELECT id FROM cat_accounts)
 		)
 		SELECT
+			EXISTS (SELECT 1 FROM cat_accounts) AS has_accounts,
 			(SELECT COALESCE(SUM(t.amount), 0)
 			 FROM transactions t, latest
 			 WHERE t.account_id IN (SELECT id FROM cat_accounts)
@@ -74,8 +65,7 @@ func (s *Store) StatsForCategory(ctx context.Context, category string) (Category
 		category,
 	)
 	var stats CategoryStats
-	stats.HasAccounts = true
-	if err := row.Scan(&stats.TotalContributed, &stats.TotalValue); err != nil {
+	if err := row.Scan(&stats.HasAccounts, &stats.TotalContributed, &stats.TotalValue); err != nil {
 		return CategoryStats{}, fmt.Errorf("category stats: %w", err)
 	}
 	return stats, nil

--- a/backend-go/internal/investment/store.go
+++ b/backend-go/internal/investment/store.go
@@ -1,0 +1,82 @@
+// Package investment implements /api/investment — stock + bond ROI
+// aggregates computed across snapshots.
+package investment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Store is the persistence boundary.
+type Store struct{ pool *pgxpool.Pool }
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
+
+// CategoryStats is the computed aggregate for one investment category.
+type CategoryStats struct {
+	TotalValue       decimal.Decimal
+	TotalContributed decimal.Decimal
+	HasAccounts      bool
+}
+
+// StatsForCategory replicates backend/app/services/investment.get_category_stats:
+//   - total_contributed: sum of active transactions for the category's
+//     active accounts, capped at the latest snapshot date when snapshots
+//     exist (uncapped otherwise).
+//   - total_value: sum of snapshot_values at that latest snapshot date.
+//
+// Returns HasAccounts=false when the category has no active accounts so the
+// handler can emit the all-zero response Python produces.
+func (s *Store) StatsForCategory(ctx context.Context, category string) (CategoryStats, error) {
+	var accountCount int
+	if err := s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM accounts WHERE category = $1 AND is_active = true`,
+		category,
+	).Scan(&accountCount); err != nil {
+		return CategoryStats{}, fmt.Errorf("count category accounts: %w", err)
+	}
+	if accountCount == 0 {
+		return CategoryStats{HasAccounts: false}, nil
+	}
+
+	// total_contributed + total_value in a single query. The latest snapshot
+	// date is the MAX(s.date) over snapshots that hold a value for any active
+	// account in this category; when no snapshot exists the date subquery is
+	// NULL and the transactions sum is left uncapped (COALESCE on the bound).
+	row := s.pool.QueryRow(ctx, `
+		WITH cat_accounts AS (
+			SELECT id FROM accounts WHERE category = $1 AND is_active = true
+		),
+		latest AS (
+			SELECT MAX(s.date) AS d
+			FROM snapshots s
+			JOIN snapshot_values sv ON sv.snapshot_id = s.id
+			WHERE sv.account_id IN (SELECT id FROM cat_accounts)
+		)
+		SELECT
+			(SELECT COALESCE(SUM(t.amount), 0)
+			 FROM transactions t, latest
+			 WHERE t.account_id IN (SELECT id FROM cat_accounts)
+			   AND t.is_active = true
+			   AND (latest.d IS NULL OR t.date <= latest.d)
+			) AS total_contributed,
+			(SELECT COALESCE(SUM(sv.value), 0)
+			 FROM snapshot_values sv
+			 JOIN snapshots s ON s.id = sv.snapshot_id, latest
+			 WHERE sv.account_id IN (SELECT id FROM cat_accounts)
+			   AND latest.d IS NOT NULL
+			   AND s.date = latest.d
+			) AS total_value`,
+		category,
+	)
+	var stats CategoryStats
+	stats.HasAccounts = true
+	if err := row.Scan(&stats.TotalContributed, &stats.TotalValue); err != nil {
+		return CategoryStats{}, fmt.Errorf("category stats: %w", err)
+	}
+	return stats, nil
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -28,6 +28,7 @@ import (
 	equitygrants "github.com/Automaat/finance-buddy/backend-go/internal/equity_grants"
 	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
+	"github.com/Automaat/finance-buddy/backend-go/internal/investment"
 	"github.com/Automaat/finance-buddy/backend-go/internal/personas"
 	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
 	"github.com/Automaat/finance-buddy/backend-go/internal/salaries"
@@ -123,6 +124,10 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	r.Post("/api/retirement/ppk-contributions/generate", retHandler.GeneratePPKContributions)
 	r.Get("/api/retirement/limits/{year}", retHandler.LimitsForYear)
 	r.Put("/api/retirement/limits/{year}/{wrapper}/{owner}", retHandler.UpsertLimit)
+
+	invHandler := investment.NewHandler(investment.NewStore(pool), logger)
+	r.Get("/api/investment/stock-stats", invHandler.StockStats)
+	r.Get("/api/investment/bond-stats", invHandler.BondStats)
 }
 
 func registerCoreRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -178,3 +178,7 @@ rules:
   - method: PUT
     path_prefix: /api/retirement
     upstream: http://backend-go:8000
+  # Group 11 — /api/investment cut over to Go (stock + bond ROI aggregates).
+  - method: GET
+    path_prefix: /api/investment
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

Group 11 cutover — investment ROI aggregates (`/api/investment/stock-stats`, `/bond-stats`). Closes #446. Depends on Group 9 (snapshots + accounts).

## Implementation information

### `internal/investment/store.go`

`StatsForCategory` ports `backend/app/services/investment.get_category_stats` into a single query with two CTEs:

- `cat_accounts` — active accounts in the category
- `latest` — `MAX(s.date)` over snapshots that hold a value for any of those accounts

Then:
- `total_contributed` = sum of active transactions for those accounts, capped at the latest snapshot date *when one exists*. Python only adds the `<= max_date` filter when `has_snapshots`; the CTE's `latest.d IS NULL OR t.date <= latest.d` reproduces that exactly.
- `total_value` = sum of `snapshot_values` at the latest snapshot date.

`HasAccounts=false` short-circuits to the all-zero response Python emits when the category has no active accounts.

### `internal/investment/handler.go`

`returns = value - contributed`; `roi = returns / contributed * 100` (0 when contributed ≤ 0), rounded with `math.Round(x*100)/100` to match Python's `round(x, 2)`.

### Parity proof against Go

```
tests/test_investment.py::test_get_stock_stats_matches_golden  PASSED
tests/test_investment.py::test_get_stock_stats_shape           PASSED
tests/test_investment.py::test_get_bond_stats_matches_golden   PASSED
tests/test_investment.py::test_get_bond_stats_shape            PASSED
4 passed
```

Both golden snapshots match byte-for-byte.

### `routes.yaml`

GET rule for `/api/investment`.

## Supporting documentation

- Umbrella: #435
- Subissue: #446
- Procedure: `migration/CUTOVER.md`

> Changelog: skip