### PR TITLE
feat(go): cutover dashboard (Group 13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,8 @@ jobs:
             tests/test_debts.py \
             tests/test_retirement.py \
             tests/test_investment.py \
-            tests/test_simulations.py
+            tests/test_simulations.py \
+            tests/test_dashboard.py
         working-directory: backend-bb-tests
         env:
           BB_BASE_URL: http://127.0.0.1:8000

--- a/backend-go/internal/dashboard/compute.go
+++ b/backend-go/internal/dashboard/compute.go
@@ -1,0 +1,148 @@
+package dashboard
+
+import (
+	"sort"
+	"time"
+)
+
+// investmentCategories — used by time series + the has-investment check.
+var investmentCategories = map[string]struct{}{
+	"stock": {}, "bond": {}, "fund": {}, "etf": {}, "gold": {}, "ppk": {},
+}
+
+// mergedRow is a snapshot_value joined to its asset (name) and account
+// (type/category/owner/wrapper/purpose) plus the snapshot date — the Go
+// equivalent of the pandas merged DataFrame row.
+type mergedRow struct {
+	SnapshotID int
+	Date       time.Time
+	AccountID  *int
+	AssetID    *int
+	AssetName  *string // non-nil only when the asset join hit an active asset
+	Value      float64
+
+	// account columns (nil when account_id is nil or account inactive)
+	AccType  *string
+	Category *string
+	Owner    *string
+	Wrapper  *string
+	Purpose  *string
+}
+
+// signedValue mirrors the pandas vectorized sign rule:
+//   - account row (account_id + type present) -> +value if asset, -value if liability
+//   - else asset-table row (asset_id + joined name present) -> +value
+//   - else 0
+func (r mergedRow) signedValue() float64 {
+	if r.AccountID != nil && r.AccType != nil {
+		if *r.AccType == "asset" {
+			return r.Value
+		}
+		return -r.Value
+	}
+	if r.AssetID != nil && r.AssetName != nil {
+		return r.Value
+	}
+	return 0
+}
+
+// buildMergedRows joins snapshot_values to assets + accounts + snapshots,
+// mirroring _build_merged_df / the raw-path merge. Accounts are the active
+// set; an account_id pointing at an inactive account leaves the account
+// columns nil (LEFT JOIN miss).
+func buildMergedRows(
+	values []SnapshotValue,
+	snapshotDate map[int]time.Time,
+	accounts map[int]Account,
+	activeAssetIDs map[int]struct{},
+) []mergedRow {
+	out := make([]mergedRow, 0, len(values))
+	for _, v := range values {
+		d, ok := snapshotDate[v.SnapshotID]
+		if !ok {
+			continue // snapshot missing — pandas inner-merges snapshots, dropping it
+		}
+		val, _ := v.Value.Float64()
+		row := mergedRow{
+			SnapshotID: v.SnapshotID,
+			Date:       d,
+			AccountID:  v.AccountID,
+			AssetID:    v.AssetID,
+			Value:      val,
+		}
+		if v.AssetID != nil {
+			if _, active := activeAssetIDs[*v.AssetID]; active {
+				name := "asset" // any non-nil name marks "asset join hit"
+				row.AssetName = &name
+			}
+		}
+		if v.AccountID != nil {
+			if acc, ok := accounts[*v.AccountID]; ok {
+				t := acc.Type
+				c := acc.Category
+				o := acc.Owner
+				p := acc.Purpose
+				row.AccType = &t
+				row.Category = &c
+				row.Owner = &o
+				row.Purpose = &p
+				row.Wrapper = acc.AccountWrapper
+			}
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+// snapshotTotals is the per-snapshot (assets, liabilities, net_worth) row.
+type snapshotTotals struct {
+	SnapshotID  int
+	Date        time.Time
+	Assets      float64
+	Liabilities float64
+	NetWorth    float64
+}
+
+// perSnapshotTotals ports metrics._per_snapshot_totals — aggregate assets +
+// liabilities per snapshot, sorted by (date, snapshot_id).
+func perSnapshotTotals(rows []mergedRow) []snapshotTotals {
+	type acc struct {
+		date        time.Time
+		assets      float64
+		liabilities float64
+	}
+	bySnap := map[int]*acc{}
+	for _, r := range rows {
+		a, ok := bySnap[r.SnapshotID]
+		if !ok {
+			a = &acc{date: r.Date}
+			bySnap[r.SnapshotID] = a
+		}
+		assetTable := r.AssetID != nil && r.AssetName != nil
+		accountAsset := r.AccountID != nil && r.AccType != nil && *r.AccType == "asset"
+		accountLiab := r.AccountID != nil && r.AccType != nil && *r.AccType == "liability"
+		if assetTable || accountAsset {
+			a.assets += r.Value
+		}
+		if accountLiab {
+			a.liabilities += r.Value
+		}
+	}
+	out := make([]snapshotTotals, 0, len(bySnap))
+	for sid, a := range bySnap {
+		out = append(out, snapshotTotals{
+			SnapshotID:  sid,
+			Date:        a.date,
+			Assets:      a.assets,
+			Liabilities: a.liabilities,
+			NetWorth:    a.assets - a.liabilities,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].Date.Equal(out[j].Date) {
+			return out[i].Date.Before(out[j].Date)
+		}
+		return out[i].SnapshotID < out[j].SnapshotID
+	})
+	return out
+}

--- a/backend-go/internal/dashboard/dashboard.go
+++ b/backend-go/internal/dashboard/dashboard.go
@@ -1,0 +1,207 @@
+package dashboard
+
+import (
+	"context"
+	"sort"
+	"time"
+)
+
+// netWorthPoint mirrors NetWorthPoint.
+type netWorthPoint struct {
+	Date  time.Time
+	Value float64
+}
+
+// allocationItem mirrors AllocationItem.
+type allocationItem struct {
+	Category string
+	Owner    *string
+	Value    float64
+}
+
+// metricCards mirrors MetricCards. The four ratio fields are nil-able.
+type metricCards struct {
+	PropertySQM             float64
+	EmergencyFundMonths     float64
+	RetirementIncomeMonthly float64
+	MortgageRemaining       float64
+	MortgageMonthsLeft      int
+	MortgageYearsLeft       float64
+	RetirementTotal         float64
+	InvestmentContributions float64
+	InvestmentReturns       float64
+	SavingsRate             *float64
+	DebtToIncomeRatio       *float64
+	HourOfWorkCost          *float64
+	HourOfLifeCost          *float64
+}
+
+type allocationBreakdown struct {
+	Category          string
+	CurrentValue      float64
+	CurrentPercentage float64
+	TargetPercentage  float64
+	Difference        float64
+}
+
+type wrapperBreakdown struct {
+	Wrapper    string
+	Value      float64
+	Percentage float64
+}
+
+type rebalancingSuggestion struct {
+	Category string
+	Action   string
+	Amount   float64
+}
+
+type allocationAnalysis struct {
+	ByCategory           []allocationBreakdown
+	ByWrapper            []wrapperBreakdown
+	Rebalancing          []rebalancingSuggestion
+	TotalInvestmentValue float64
+}
+
+// result is the fully-computed dashboard, ready for the handler to serialize.
+type result struct {
+	NetWorthHistory        []netWorthPoint
+	CurrentNetWorth        float64
+	ChangeVsLastMonth      float64
+	TotalAssets            float64
+	TotalLiabilities       float64
+	Allocation             []allocationItem
+	RetirementAccountValue float64
+	MetricCards            metricCards
+	AllocationAnalysis     allocationAnalysis
+	InvestmentTimeSeries   []timeSeriesPoint
+	WrapperTimeSeries      map[string][]timeSeriesPoint
+	CategoryTimeSeries     map[string][]timeSeriesPoint
+	TileDeltas             tileDeltas
+}
+
+// Compute runs the dashboard. Aggregate-backed when snapshot_aggregates has
+// rows; raw fallback otherwise. Mirrors get_dashboard_data.
+func Compute(ctx context.Context, s *Store) (result, error) {
+	aggRows, err := s.LoadAggregateRows(ctx)
+	if err != nil {
+		return result{}, err
+	}
+	if len(aggRows) == 0 {
+		return computeRaw(ctx, s)
+	}
+	return computeFromAggregates(ctx, s, aggRows)
+}
+
+func emptyResult() result {
+	return result{
+		NetWorthHistory:      []netWorthPoint{},
+		Allocation:           []allocationItem{},
+		AllocationAnalysis:   allocationAnalysis{ByCategory: []allocationBreakdown{}, ByWrapper: []wrapperBreakdown{}, Rebalancing: []rebalancingSuggestion{}},
+		InvestmentTimeSeries: []timeSeriesPoint{},
+		WrapperTimeSeries:    map[string][]timeSeriesPoint{"IKE": {}, "IKZE": {}, "PPK": {}},
+		CategoryTimeSeries:   map[string][]timeSeriesPoint{"stock": {}, "bond": {}},
+	}
+}
+
+// sharedInputs bundles the tables both paths need.
+type sharedInputs struct {
+	accounts       map[int]Account
+	accountList    []Account
+	activeAssetIDs map[int]struct{}
+	snapshots      []SnapshotMeta
+	snapshotDate   map[int]time.Time
+	config         AppConfig
+	hasConfig      bool
+	txns           []txnWithAccount
+	salaries       []float64
+}
+
+func loadShared(ctx context.Context, s *Store) (sharedInputs, error) {
+	var in sharedInputs
+	accList, err := s.ActiveAccounts(ctx)
+	if err != nil {
+		return in, err
+	}
+	in.accountList = accList
+	in.accounts = map[int]Account{}
+	for _, a := range accList {
+		in.accounts[a.ID] = a
+	}
+	in.activeAssetIDs, err = s.ActiveAssetIDs(ctx)
+	if err != nil {
+		return in, err
+	}
+	in.snapshots, err = s.AllSnapshots(ctx)
+	if err != nil {
+		return in, err
+	}
+	in.snapshotDate = map[int]time.Time{}
+	for _, m := range in.snapshots {
+		in.snapshotDate[m.ID] = m.Date
+	}
+	cfg, hasCfg, err := s.LoadAppConfig(ctx)
+	if err != nil {
+		return in, err
+	}
+	in.config = cfg
+	in.hasConfig = hasCfg
+	rawTxns, err := s.ActiveTransactions(ctx)
+	if err != nil {
+		return in, err
+	}
+	in.txns = buildTxnsWithAccounts(rawTxns, in.accounts)
+	salDec, err := s.RecentSalaries(ctx, 3)
+	if err != nil {
+		return in, err
+	}
+	for _, d := range salDec {
+		f, _ := d.Float64()
+		in.salaries = append(in.salaries, f)
+	}
+	return in, nil
+}
+
+// hasInvestment reports whether any active account is an investment category.
+func hasInvestment(accounts []Account) bool {
+	for _, a := range accounts {
+		if _, ok := investmentCategories[a.Category]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// latestSnapshotByDate returns the snapshot with the highest (date, id) among
+// those that have at least one merged row — the raw path's selection.
+func latestSnapshotByDate(rows []mergedRow) (int, time.Time, bool) {
+	found := false
+	var bestID int
+	var bestDate time.Time
+	for _, r := range rows {
+		if !found || r.Date.After(bestDate) ||
+			(r.Date.Equal(bestDate) && r.SnapshotID > bestID) {
+			found = true
+			bestID = r.SnapshotID
+			bestDate = r.Date
+		}
+	}
+	return bestID, bestDate, found
+}
+
+// sortAllocation orders allocation items by (category, owner).
+func sortAllocation(items []allocationItem) {
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Category != items[j].Category {
+			return items[i].Category < items[j].Category
+		}
+		oi, oj := "", ""
+		if items[i].Owner != nil {
+			oi = *items[i].Owner
+		}
+		if items[j].Owner != nil {
+			oj = *items[j].Owner
+		}
+		return oi < oj
+	})
+}

--- a/backend-go/internal/dashboard/handler.go
+++ b/backend-go/internal/dashboard/handler.go
@@ -1,0 +1,286 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Handler is the HTTP boundary for /api/dashboard.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewHandler wires the store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger}
+}
+
+// Get serves GET /api/dashboard.
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	res, err := Compute(r.Context(), h.store)
+	if err != nil {
+		h.logger.Error("dashboard", "err", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "Internal Server Error"})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(toWire(res)); err != nil {
+		h.logger.Error("encode dashboard", "err", err)
+	}
+}
+
+// --- wire types ---
+
+type isoDate time.Time
+
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format("2006-01-02") + `"`), nil
+}
+
+type pyFloat float64
+
+func (f pyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}
+
+type netWorthPointWire struct {
+	Date  isoDate `json:"date"`
+	Value pyFloat `json:"value"`
+}
+
+type allocationItemWire struct {
+	Category string  `json:"category"`
+	Owner    *string `json:"owner"`
+	Value    pyFloat `json:"value"`
+}
+
+type deltaValueWire struct {
+	Absolute   pyFloat  `json:"absolute"`
+	Percentage *pyFloat `json:"percentage"`
+}
+
+type tileDeltaWire struct {
+	MoM *deltaValueWire `json:"mom"`
+	YoY *deltaValueWire `json:"yoy"`
+}
+
+type tileDeltasWire struct {
+	NetWorth    tileDeltaWire `json:"net_worth"`
+	Assets      tileDeltaWire `json:"assets"`
+	Liabilities tileDeltaWire `json:"liabilities"`
+}
+
+type metricCardsWire struct {
+	PropertySQM             pyFloat  `json:"property_sqm"`
+	EmergencyFundMonths     pyFloat  `json:"emergency_fund_months"`
+	RetirementIncomeMonthly pyFloat  `json:"retirement_income_monthly"`
+	MortgageRemaining       pyFloat  `json:"mortgage_remaining"`
+	MortgageMonthsLeft      int      `json:"mortgage_months_left"`
+	MortgageYearsLeft       pyFloat  `json:"mortgage_years_left"`
+	RetirementTotal         pyFloat  `json:"retirement_total"`
+	InvestmentContributions pyFloat  `json:"investment_contributions"`
+	InvestmentReturns       pyFloat  `json:"investment_returns"`
+	SavingsRate             *pyFloat `json:"savings_rate"`
+	DebtToIncomeRatio       *pyFloat `json:"debt_to_income_ratio"`
+	HourOfWorkCost          *pyFloat `json:"hour_of_work_cost"`
+	HourOfLifeCost          *pyFloat `json:"hour_of_life_cost"`
+}
+
+type allocationBreakdownWire struct {
+	Category          string  `json:"category"`
+	CurrentValue      pyFloat `json:"current_value"`
+	CurrentPercentage pyFloat `json:"current_percentage"`
+	TargetPercentage  pyFloat `json:"target_percentage"`
+	Difference        pyFloat `json:"difference"`
+}
+
+type wrapperBreakdownWire struct {
+	Wrapper    string  `json:"wrapper"`
+	Value      pyFloat `json:"value"`
+	Percentage pyFloat `json:"percentage"`
+}
+
+type rebalancingWire struct {
+	Category string  `json:"category"`
+	Action   string  `json:"action"`
+	Amount   pyFloat `json:"amount"`
+}
+
+type allocationAnalysisWire struct {
+	ByCategory           []allocationBreakdownWire `json:"by_category"`
+	ByWrapper            []wrapperBreakdownWire    `json:"by_wrapper"`
+	Rebalancing          []rebalancingWire         `json:"rebalancing"`
+	TotalInvestmentValue pyFloat                   `json:"total_investment_value"`
+}
+
+type timeSeriesPointWire struct {
+	Date          isoDate `json:"date"`
+	Value         pyFloat `json:"value"`
+	Contributions pyFloat `json:"contributions"`
+	Returns       pyFloat `json:"returns"`
+}
+
+type wrapperTimeSeriesWire struct {
+	IKE  []timeSeriesPointWire `json:"ike"`
+	IKZE []timeSeriesPointWire `json:"ikze"`
+	PPK  []timeSeriesPointWire `json:"ppk"`
+}
+
+type categoryTimeSeriesWire struct {
+	Stock []timeSeriesPointWire `json:"stock"`
+	Bond  []timeSeriesPointWire `json:"bond"`
+}
+
+type dashboardWire struct {
+	NetWorthHistory        []netWorthPointWire    `json:"net_worth_history"`
+	CurrentNetWorth        pyFloat                `json:"current_net_worth"`
+	ChangeVsLastMonth      pyFloat                `json:"change_vs_last_month"`
+	TotalAssets            pyFloat                `json:"total_assets"`
+	TotalLiabilities       pyFloat                `json:"total_liabilities"`
+	Allocation             []allocationItemWire   `json:"allocation"`
+	RetirementAccountValue pyFloat                `json:"retirement_account_value"`
+	MetricCards            metricCardsWire        `json:"metric_cards"`
+	AllocationAnalysis     allocationAnalysisWire `json:"allocation_analysis"`
+	InvestmentTimeSeries   []timeSeriesPointWire  `json:"investment_time_series"`
+	WrapperTimeSeries      wrapperTimeSeriesWire  `json:"wrapper_time_series"`
+	CategoryTimeSeries     categoryTimeSeriesWire `json:"category_time_series"`
+	TileDeltas             tileDeltasWire         `json:"tile_deltas"`
+}
+
+func toWire(res result) dashboardWire {
+	w := dashboardWire{
+		CurrentNetWorth:        pyFloat(res.CurrentNetWorth),
+		ChangeVsLastMonth:      pyFloat(res.ChangeVsLastMonth),
+		TotalAssets:            pyFloat(res.TotalAssets),
+		TotalLiabilities:       pyFloat(res.TotalLiabilities),
+		RetirementAccountValue: pyFloat(res.RetirementAccountValue),
+		MetricCards:            metricCardsToWire(res.MetricCards),
+		AllocationAnalysis:     allocationAnalysisToWire(res.AllocationAnalysis),
+		TileDeltas:             tileDeltasToWire(res.TileDeltas),
+	}
+	w.NetWorthHistory = make([]netWorthPointWire, 0, len(res.NetWorthHistory))
+	for _, p := range res.NetWorthHistory {
+		w.NetWorthHistory = append(w.NetWorthHistory, netWorthPointWire{
+			Date: isoDate(p.Date), Value: pyFloat(p.Value),
+		})
+	}
+	w.Allocation = make([]allocationItemWire, 0, len(res.Allocation))
+	for _, a := range res.Allocation {
+		w.Allocation = append(w.Allocation, allocationItemWire{
+			Category: a.Category, Owner: a.Owner, Value: pyFloat(a.Value),
+		})
+	}
+	w.InvestmentTimeSeries = seriesToWire(res.InvestmentTimeSeries)
+	w.WrapperTimeSeries = wrapperTimeSeriesWire{
+		IKE:  seriesToWire(res.WrapperTimeSeries["IKE"]),
+		IKZE: seriesToWire(res.WrapperTimeSeries["IKZE"]),
+		PPK:  seriesToWire(res.WrapperTimeSeries["PPK"]),
+	}
+	w.CategoryTimeSeries = categoryTimeSeriesWire{
+		Stock: seriesToWire(res.CategoryTimeSeries["stock"]),
+		Bond:  seriesToWire(res.CategoryTimeSeries["bond"]),
+	}
+	return w
+}
+
+func seriesToWire(pts []timeSeriesPoint) []timeSeriesPointWire {
+	out := make([]timeSeriesPointWire, 0, len(pts))
+	for _, p := range pts {
+		out = append(out, timeSeriesPointWire{
+			Date:          isoDate(p.Date),
+			Value:         pyFloat(p.Value),
+			Contributions: pyFloat(p.Contributions),
+			Returns:       pyFloat(p.Returns),
+		})
+	}
+	return out
+}
+
+func metricCardsToWire(m metricCards) metricCardsWire {
+	return metricCardsWire{
+		PropertySQM:             pyFloat(m.PropertySQM),
+		EmergencyFundMonths:     pyFloat(m.EmergencyFundMonths),
+		RetirementIncomeMonthly: pyFloat(m.RetirementIncomeMonthly),
+		MortgageRemaining:       pyFloat(m.MortgageRemaining),
+		MortgageMonthsLeft:      m.MortgageMonthsLeft,
+		MortgageYearsLeft:       pyFloat(m.MortgageYearsLeft),
+		RetirementTotal:         pyFloat(m.RetirementTotal),
+		InvestmentContributions: pyFloat(m.InvestmentContributions),
+		InvestmentReturns:       pyFloat(m.InvestmentReturns),
+		SavingsRate:             floatPtr(m.SavingsRate),
+		DebtToIncomeRatio:       floatPtr(m.DebtToIncomeRatio),
+		HourOfWorkCost:          floatPtr(m.HourOfWorkCost),
+		HourOfLifeCost:          floatPtr(m.HourOfLifeCost),
+	}
+}
+
+func allocationAnalysisToWire(a allocationAnalysis) allocationAnalysisWire {
+	w := allocationAnalysisWire{
+		TotalInvestmentValue: pyFloat(a.TotalInvestmentValue),
+		ByCategory:           make([]allocationBreakdownWire, 0, len(a.ByCategory)),
+		ByWrapper:            make([]wrapperBreakdownWire, 0, len(a.ByWrapper)),
+		Rebalancing:          make([]rebalancingWire, 0, len(a.Rebalancing)),
+	}
+	for _, b := range a.ByCategory {
+		w.ByCategory = append(w.ByCategory, allocationBreakdownWire{
+			Category:          b.Category,
+			CurrentValue:      pyFloat(b.CurrentValue),
+			CurrentPercentage: pyFloat(b.CurrentPercentage),
+			TargetPercentage:  pyFloat(b.TargetPercentage),
+			Difference:        pyFloat(b.Difference),
+		})
+	}
+	for _, b := range a.ByWrapper {
+		w.ByWrapper = append(w.ByWrapper, wrapperBreakdownWire{
+			Wrapper: b.Wrapper, Value: pyFloat(b.Value), Percentage: pyFloat(b.Percentage),
+		})
+	}
+	for _, b := range a.Rebalancing {
+		w.Rebalancing = append(w.Rebalancing, rebalancingWire{
+			Category: b.Category, Action: b.Action, Amount: pyFloat(b.Amount),
+		})
+	}
+	return w
+}
+
+func tileDeltasToWire(t tileDeltas) tileDeltasWire {
+	return tileDeltasWire{
+		NetWorth:    tileDeltaToWire(t.NetWorth),
+		Assets:      tileDeltaToWire(t.Assets),
+		Liabilities: tileDeltaToWire(t.Liabilities),
+	}
+}
+
+func tileDeltaToWire(t tileDelta) tileDeltaWire {
+	return tileDeltaWire{MoM: deltaToWire(t.MoM), YoY: deltaToWire(t.YoY)}
+}
+
+func deltaToWire(d *deltaValue) *deltaValueWire {
+	if d == nil {
+		return nil
+	}
+	return &deltaValueWire{Absolute: pyFloat(d.Absolute), Percentage: floatPtr(d.Percentage)}
+}
+
+func floatPtr(f *float64) *pyFloat {
+	if f == nil {
+		return nil
+	}
+	pf := pyFloat(*f)
+	return &pf
+}

--- a/backend-go/internal/dashboard/metrics.go
+++ b/backend-go/internal/dashboard/metrics.go
@@ -1,0 +1,133 @@
+package dashboard
+
+import (
+	"sort"
+	"time"
+)
+
+const (
+	monthlyWorkHours = 160.0
+	monthlyLifeHours = 730.0
+)
+
+// deltaValue mirrors the schema's DeltaValue. Percentage is nil when the
+// baseline is 0.
+type deltaValue struct {
+	Absolute   float64
+	Percentage *float64
+}
+
+// tileDelta mirrors TileDelta.
+type tileDelta struct {
+	MoM *deltaValue
+	YoY *deltaValue
+}
+
+// tileDeltas mirrors TileDeltas.
+type tileDeltas struct {
+	NetWorth    tileDelta
+	Assets      tileDelta
+	Liabilities tileDelta
+}
+
+// computeTileDeltas ports metrics.compute_tile_deltas.
+//
+// MoM window = [latest-45d, latest-15d]; YoY = [latest-395d, latest-335d].
+// The latest snapshot is excluded from baseline candidates.
+func computeTileDeltas(totals []snapshotTotals) tileDeltas {
+	if len(totals) == 0 {
+		return tileDeltas{}
+	}
+	current := totals[len(totals)-1]
+	prior := totals[:len(totals)-1]
+	latest := current.Date
+
+	momBase := pickBaseline(prior, latest.AddDate(0, 0, -45), latest.AddDate(0, 0, -15))
+	yoyBase := pickBaseline(prior, latest.AddDate(0, 0, -395), latest.AddDate(0, 0, -335))
+
+	tile := func(get func(snapshotTotals) float64) tileDelta {
+		cur := get(current)
+		return tileDelta{
+			MoM: delta(cur, momBase, get),
+			YoY: delta(cur, yoyBase, get),
+		}
+	}
+	return tileDeltas{
+		NetWorth:    tile(func(t snapshotTotals) float64 { return t.NetWorth }),
+		Assets:      tile(func(t snapshotTotals) float64 { return t.Assets }),
+		Liabilities: tile(func(t snapshotTotals) float64 { return t.Liabilities }),
+	}
+}
+
+// pickBaseline returns the latest row with low <= date <= high; ties broken
+// by snapshot_id desc.
+func pickBaseline(totals []snapshotTotals, low, high time.Time) *snapshotTotals {
+	window := []snapshotTotals{}
+	for _, t := range totals {
+		if !t.Date.Before(low) && !t.Date.After(high) {
+			window = append(window, t)
+		}
+	}
+	if len(window) == 0 {
+		return nil
+	}
+	maxDate := window[0].Date
+	for _, t := range window {
+		if t.Date.After(maxDate) {
+			maxDate = t.Date
+		}
+	}
+	sameDay := []snapshotTotals{}
+	for _, t := range window {
+		if t.Date.Equal(maxDate) {
+			sameDay = append(sameDay, t)
+		}
+	}
+	sort.Slice(sameDay, func(i, j int) bool {
+		return sameDay[i].SnapshotID > sameDay[j].SnapshotID
+	})
+	out := sameDay[0]
+	return &out
+}
+
+func delta(current float64, baseline *snapshotTotals, get func(snapshotTotals) float64) *deltaValue {
+	if baseline == nil {
+		return nil
+	}
+	base := get(*baseline)
+	absChange := current - base
+	dv := deltaValue{Absolute: absChange}
+	if base != 0 {
+		pct := absChange / abs(base) * 100
+		dv.Percentage = &pct
+	}
+	return &dv
+}
+
+func abs(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// savingsRate ports _calculate_savings_rate / the aggregate variant: average
+// of the last 3 monthly net-worth deltas divided by the average of the last
+// 3 salaries, ×100. nil when there's insufficient data. netWorths must be in
+// the same chronological order Python uses (last 4 are the recent window).
+func savingsRate(netWorths, salaries []float64) *float64 {
+	if len(netWorths) < 4 {
+		return nil
+	}
+	last4 := netWorths[len(netWorths)-4:]
+	avgDelta := ((last4[1] - last4[0]) + (last4[2] - last4[1]) + (last4[3] - last4[2])) / 3
+	if len(salaries) < 3 {
+		return nil
+	}
+	avgSalary := (salaries[0] + salaries[1] + salaries[2]) / 3
+	if avgSalary == 0 {
+		return nil
+	}
+	rate := avgDelta / avgSalary * 100
+	return &rate
+}

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -1,0 +1,493 @@
+package dashboard
+
+import (
+	"context"
+	"sort"
+	"time"
+)
+
+var allocationGroupMap = map[string]string{
+	"stock": "stocks", "fund": "stocks", "etf": "stocks",
+	"bond": "bonds", "gold": "gold",
+}
+
+// computeFromAggregates ports _get_dashboard_data_from_aggregates.
+func computeFromAggregates(ctx context.Context, s *Store, aggRows []AggregateRow) (result, error) {
+	shared, err := loadShared(ctx, s)
+	if err != nil {
+		return result{}, err
+	}
+
+	// net worth per snapshot, sorted by date.
+	snapNW := map[int]float64{}
+	for _, r := range aggRows {
+		nw, _ := r.NetWorth.Float64()
+		snapNW[r.SnapshotID] += nw
+	}
+	type snapNWPoint struct {
+		id   int
+		date time.Time
+		nw   float64
+	}
+	points := make([]snapNWPoint, 0, len(snapNW))
+	for sid, nw := range snapNW {
+		points = append(points, snapNWPoint{id: sid, date: shared.snapshotDate[sid], nw: nw})
+	}
+	sort.Slice(points, func(i, j int) bool { return points[i].date.Before(points[j].date) })
+
+	res := emptyResult()
+	res.NetWorthHistory = make([]netWorthPoint, 0, len(points))
+	for _, p := range points {
+		res.NetWorthHistory = append(res.NetWorthHistory, netWorthPoint{Date: p.date, Value: p.nw})
+	}
+	if len(points) > 0 {
+		res.CurrentNetWorth = points[len(points)-1].nw
+	}
+	lastMonthNW := 0.0
+	if len(points) > 1 {
+		lastMonthNW = points[len(points)-2].nw
+	}
+	res.ChangeVsLastMonth = res.CurrentNetWorth - lastMonthNW
+
+	// latest snapshot = highest snapshot_id among aggregate rows.
+	latestSID := 0
+	for _, r := range aggRows {
+		if r.SnapshotID > latestSID {
+			latestSID = r.SnapshotID
+		}
+	}
+	for _, r := range aggRows {
+		if r.SnapshotID != latestSID {
+			continue
+		}
+		ta, _ := r.TotalAssets.Float64()
+		tl, _ := r.TotalLiabilities.Float64()
+		res.TotalAssets += ta
+		res.TotalLiabilities += tl
+		owner := r.Owner
+		for _, item := range r.Allocation {
+			o := owner
+			res.Allocation = append(res.Allocation, allocationItem{
+				Category: item.Category, Owner: &o, Value: item.Value,
+			})
+		}
+	}
+	sortAllocation(res.Allocation)
+
+	// latest snapshot's merged rows drive metric cards + allocation analysis.
+	latestValues, err := s.SnapshotValuesFor(ctx, latestSID)
+	if err != nil {
+		return result{}, err
+	}
+	latestRows := buildMergedRows(latestValues, shared.snapshotDate, shared.accounts, shared.activeAssetIDs)
+	res.RetirementAccountValue = retirementValueOf(latestRows)
+
+	if shared.hasConfig && len(latestRows) > 0 {
+		latestDate := shared.snapshotDate[latestSID]
+		nwForSavings := aggregateMonthlyNetWorths(aggRows, shared.snapshotDate)
+		res.MetricCards = buildMetricCards(latestRows, shared, res.RetirementAccountValue, latestDate, nwForSavings)
+		res.AllocationAnalysis = buildAllocationAnalysis(latestRows, shared.config)
+	}
+
+	// time series + tile deltas.
+	if hasInvestment(shared.accountList) {
+		allValues, err := s.AllSnapshotValues(ctx)
+		if err != nil {
+			return result{}, err
+		}
+		allRows := buildMergedRows(allValues, shared.snapshotDate, shared.accounts, shared.activeAssetIDs)
+		res.InvestmentTimeSeries = buildInvestmentTimeSeries(allRows, shared.snapshots, shared.txns)
+		res.WrapperTimeSeries = buildWrapperTimeSeries(allRows, shared.snapshots, shared.txns)
+		res.CategoryTimeSeries = buildCategoryTimeSeries(allRows, shared.snapshots, shared.txns)
+		res.TileDeltas = computeTileDeltas(perSnapshotTotals(allRows))
+	} else {
+		res.TileDeltas = computeTileDeltas(synthTotalsFromAggregates(aggRows, shared.snapshotDate))
+	}
+	return res, nil
+}
+
+// computeRaw ports _get_dashboard_data_raw.
+func computeRaw(ctx context.Context, s *Store) (result, error) {
+	shared, err := loadShared(ctx, s)
+	if err != nil {
+		return result{}, err
+	}
+	allValues, err := s.AllSnapshotValues(ctx)
+	if err != nil {
+		return result{}, err
+	}
+	rows := buildMergedRows(allValues, shared.snapshotDate, shared.accounts, shared.activeAssetIDs)
+	res := emptyResult()
+	if len(rows) == 0 {
+		return res, nil
+	}
+
+	// net worth grouped by date.
+	nwByDate := map[time.Time]float64{}
+	for _, r := range rows {
+		nwByDate[r.Date] += r.signedValue()
+	}
+	dates := make([]time.Time, 0, len(nwByDate))
+	for d := range nwByDate {
+		dates = append(dates, d)
+	}
+	sort.Slice(dates, func(i, j int) bool { return dates[i].Before(dates[j]) })
+	res.NetWorthHistory = make([]netWorthPoint, 0, len(dates))
+	for _, d := range dates {
+		res.NetWorthHistory = append(res.NetWorthHistory, netWorthPoint{Date: d, Value: nwByDate[d]})
+	}
+	if len(dates) > 0 {
+		res.CurrentNetWorth = nwByDate[dates[len(dates)-1]]
+	}
+	lastMonth := 0.0
+	if len(dates) > 1 {
+		lastMonth = nwByDate[dates[len(dates)-2]]
+	}
+	res.ChangeVsLastMonth = res.CurrentNetWorth - lastMonth
+
+	latestSID, latestDate, found := latestSnapshotByDate(rows)
+	if found {
+		var latestRows []mergedRow
+		for _, r := range rows {
+			if r.SnapshotID == latestSID {
+				latestRows = append(latestRows, r)
+			}
+		}
+		res.TotalAssets, res.TotalLiabilities = rawTotals(latestRows)
+		res.Allocation = rawAllocation(latestRows)
+		res.RetirementAccountValue = retirementValueOf(latestRows)
+		if shared.hasConfig {
+			nwForSavings := rawMonthlyNetWorths(rows, shared.snapshots)
+			res.MetricCards = buildMetricCards(latestRows, shared, res.RetirementAccountValue, latestDate, nwForSavings)
+			res.AllocationAnalysis = buildAllocationAnalysis(latestRows, shared.config)
+		}
+	}
+	res.InvestmentTimeSeries = buildInvestmentTimeSeries(rows, shared.snapshots, shared.txns)
+	res.WrapperTimeSeries = buildWrapperTimeSeries(rows, shared.snapshots, shared.txns)
+	res.CategoryTimeSeries = buildCategoryTimeSeries(rows, shared.snapshots, shared.txns)
+	res.TileDeltas = computeTileDeltas(perSnapshotTotals(rows))
+	return res, nil
+}
+
+// retirementValueOf sums latest-snapshot account-asset rows with purpose=retirement.
+func retirementValueOf(latestRows []mergedRow) float64 {
+	total := 0.0
+	for _, r := range latestRows {
+		if r.AccountID != nil && r.AccType != nil && *r.AccType == "asset" &&
+			r.Purpose != nil && *r.Purpose == "retirement" {
+			total += r.Value
+		}
+	}
+	return total
+}
+
+func rawTotals(latestRows []mergedRow) (float64, float64) {
+	assets := 0.0
+	liabilities := 0.0
+	for _, r := range latestRows {
+		switch {
+		case r.AssetID != nil:
+			assets += r.Value
+		case r.AccountID != nil && r.AccType != nil:
+			switch *r.AccType {
+			case "asset":
+				assets += r.Value
+			case "liability":
+				liabilities += r.Value
+			}
+		}
+	}
+	return assets, liabilities
+}
+
+func rawAllocation(latestRows []mergedRow) []allocationItem {
+	type key struct{ cat, owner string }
+	sums := map[key]float64{}
+	for _, r := range latestRows {
+		if r.AccountID == nil || r.AccType == nil || *r.AccType != "asset" {
+			continue
+		}
+		if r.Category == nil || r.Owner == nil {
+			continue
+		}
+		sums[key{*r.Category, *r.Owner}] += r.Value
+	}
+	out := make([]allocationItem, 0, len(sums))
+	for k, v := range sums {
+		o := k.owner
+		out = append(out, allocationItem{Category: k.cat, Owner: &o, Value: v})
+	}
+	sortAllocation(out)
+	return out
+}
+
+// aggregateMonthlyNetWorths ports _compute_savings_rate_from_aggregates'
+// month-bucketing: latest snapshot per month, sorted chronologically.
+func aggregateMonthlyNetWorths(aggRows []AggregateRow, snapshotDate map[int]time.Time) []float64 {
+	snapNW := map[int]float64{}
+	snapMonth := map[int]time.Time{}
+	for _, r := range aggRows {
+		nw, _ := r.NetWorth.Float64()
+		snapNW[r.SnapshotID] += nw
+		snapMonth[r.SnapshotID] = r.Month
+	}
+	monthLatestSID := map[time.Time]int{}
+	for sid, month := range snapMonth {
+		if cur, ok := monthLatestSID[month]; !ok || sid > cur {
+			monthLatestSID[month] = sid
+		}
+	}
+	months := make([]time.Time, 0, len(monthLatestSID))
+	for m := range monthLatestSID {
+		months = append(months, m)
+	}
+	sort.Slice(months, func(i, j int) bool { return months[i].Before(months[j]) })
+	out := make([]float64, 0, len(months))
+	for _, m := range months {
+		out = append(out, snapNW[monthLatestSID[m]])
+	}
+	return out
+}
+
+// rawMonthlyNetWorths ports the raw savings-rate input: net worth of the
+// last-4 snapshots (by the snapshots-ordered-by-date tail).
+func rawMonthlyNetWorths(rows []mergedRow, snapshots []SnapshotMeta) []float64 {
+	nwBySnap := map[int]float64{}
+	for _, r := range rows {
+		nwBySnap[r.SnapshotID] += r.signedValue()
+	}
+	out := make([]float64, 0, len(snapshots))
+	for _, s := range snapshots {
+		out = append(out, nwBySnap[s.ID])
+	}
+	return out
+}
+
+// synthTotalsFromAggregates ports the no-investment tile-delta branch — one
+// synthetic totals row per snapshot from the aggregate sums.
+func synthTotalsFromAggregates(aggRows []AggregateRow, snapshotDate map[int]time.Time) []snapshotTotals {
+	type acc struct{ assets, liabilities float64 }
+	bySnap := map[int]*acc{}
+	for _, r := range aggRows {
+		a, ok := bySnap[r.SnapshotID]
+		if !ok {
+			a = &acc{}
+			bySnap[r.SnapshotID] = a
+		}
+		ta, _ := r.TotalAssets.Float64()
+		tl, _ := r.TotalLiabilities.Float64()
+		a.assets += ta
+		a.liabilities += tl
+	}
+	out := make([]snapshotTotals, 0, len(bySnap))
+	for sid, a := range bySnap {
+		out = append(out, snapshotTotals{
+			SnapshotID:  sid,
+			Date:        snapshotDate[sid],
+			Assets:      a.assets,
+			Liabilities: a.liabilities,
+			NetWorth:    a.assets - a.liabilities,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].Date.Equal(out[j].Date) {
+			return out[i].Date.Before(out[j].Date)
+		}
+		return out[i].SnapshotID < out[j].SnapshotID
+	})
+	return out
+}
+
+// buildMetricCards is the shared metric-card computation for both paths.
+func buildMetricCards(
+	latestRows []mergedRow,
+	shared sharedInputs,
+	retirementValue float64,
+	latestDate time.Time,
+	netWorthsForSavings []float64,
+) metricCards {
+	cfg := shared.config
+
+	realEstateIDs := map[int]struct{}{}
+	totalPropertySQM := 0.0
+	for _, a := range shared.accountList {
+		if a.Category == "real_estate" && (a.Owner == "Marcin" || a.Owner == "Shared") {
+			realEstateIDs[a.ID] = struct{}{}
+			if a.SquareMeters != nil {
+				sqm, _ := a.SquareMeters.Float64()
+				totalPropertySQM += sqm
+			}
+		}
+	}
+	propertyValue := 0.0
+	mortgageRemaining := 0.0
+	emergencyFund := 0.0
+	for _, r := range latestRows {
+		if r.AccountID == nil || r.AccType == nil {
+			continue
+		}
+		if *r.AccType == "asset" {
+			if _, re := realEstateIDs[*r.AccountID]; re {
+				propertyValue += r.Value
+			}
+			if r.Purpose != nil && *r.Purpose == "emergency_fund" {
+				emergencyFund += r.Value
+			}
+		}
+		if *r.AccType == "liability" && r.Category != nil &&
+			(*r.Category == "housing" || *r.Category == "mortgage") {
+			mortgageRemaining += r.Value
+		}
+	}
+	propertySQM := 0.0
+	if propertyValue > 0 {
+		equity := (propertyValue - mortgageRemaining) / propertyValue
+		if equity < 0 {
+			equity = 0
+		}
+		propertySQM = totalPropertySQM * equity
+	}
+	monthlyExpenses, _ := cfg.MonthlyExpenses.Float64()
+	emergencyMonths := 0.0
+	if monthlyExpenses > 0 {
+		emergencyMonths = emergencyFund / monthlyExpenses
+	}
+	monthlyMortgage, _ := cfg.MonthlyMortgagePayment.Float64()
+	mortgageMonthsLeft := 0
+	if monthlyMortgage > 0 {
+		mortgageMonthsLeft = int(abs(mortgageRemaining) / monthlyMortgage)
+	}
+	investmentContributions := 0.0
+	for _, t := range shared.txns {
+		if t.Purpose != nil && *t.Purpose == "retirement" && !t.Date.After(latestDate) {
+			investmentContributions += t.SignedAmount
+		}
+	}
+
+	mc := metricCards{
+		PropertySQM:             propertySQM,
+		EmergencyFundMonths:     emergencyMonths,
+		RetirementIncomeMonthly: retirementValue * 0.04 / 12,
+		MortgageRemaining:       mortgageRemaining,
+		MortgageMonthsLeft:      mortgageMonthsLeft,
+		MortgageYearsLeft:       float64(mortgageMonthsLeft) / 12,
+		RetirementTotal:         retirementValue,
+		InvestmentContributions: investmentContributions,
+		InvestmentReturns:       retirementValue - investmentContributions,
+		SavingsRate:             savingsRate(netWorthsForSavings, shared.salaries),
+	}
+	if monthlyMortgage > 0 && len(shared.salaries) > 0 && shared.salaries[0] != 0 {
+		dti := monthlyMortgage / shared.salaries[0] * 100
+		mc.DebtToIncomeRatio = &dti
+	}
+	if len(shared.salaries) > 0 && shared.salaries[0] != 0 {
+		work := shared.salaries[0] / monthlyWorkHours
+		life := shared.salaries[0] / monthlyLifeHours
+		mc.HourOfWorkCost = &work
+		mc.HourOfLifeCost = &life
+	}
+	return mc
+}
+
+// buildAllocationAnalysis is the shared allocation-analysis computation.
+func buildAllocationAnalysis(latestRows []mergedRow, cfg AppConfig) allocationAnalysis {
+	out := allocationAnalysis{
+		ByCategory:  []allocationBreakdown{},
+		ByWrapper:   []wrapperBreakdown{},
+		Rebalancing: []rebalancingSuggestion{},
+	}
+	allocCategories := map[string]struct{}{"stock": {}, "bond": {}, "fund": {}, "etf": {}, "gold": {}}
+
+	totalInvestment := 0.0
+	byGroup := map[string]float64{}
+	for _, r := range latestRows {
+		if r.AccountID == nil || r.AccType == nil || *r.AccType != "asset" || r.Category == nil {
+			continue
+		}
+		if _, ok := allocCategories[*r.Category]; !ok {
+			continue
+		}
+		totalInvestment += r.Value
+		group := allocationGroupMap[*r.Category]
+		if group == "" {
+			group = "other"
+		}
+		byGroup[group] += r.Value
+	}
+	out.TotalInvestmentValue = totalInvestment
+
+	targets := []struct {
+		name   string
+		target float64
+	}{
+		{"stocks", float64(cfg.AllocationStocks)},
+		{"bonds", float64(cfg.AllocationBonds)},
+		{"gold", float64(cfg.AllocationGold)},
+	}
+	for _, t := range targets {
+		current := byGroup[t.name]
+		pct := 0.0
+		if totalInvestment > 0 {
+			pct = current / totalInvestment * 100
+		}
+		out.ByCategory = append(out.ByCategory, allocationBreakdown{
+			Category:          t.name,
+			CurrentValue:      current,
+			CurrentPercentage: pct,
+			TargetPercentage:  t.target,
+			Difference:        pct - t.target,
+		})
+	}
+
+	allInvCategories := map[string]struct{}{
+		"stock": {}, "bond": {}, "fund": {}, "etf": {}, "gold": {}, "ppk": {},
+	}
+	wrapperSums := map[string]float64{}
+	allInvTotal := 0.0
+	for _, r := range latestRows {
+		if r.AccountID == nil || r.AccType == nil || *r.AccType != "asset" || r.Category == nil {
+			continue
+		}
+		if _, ok := allInvCategories[*r.Category]; !ok {
+			continue
+		}
+		wrapper := "Regular"
+		if r.Wrapper != nil && *r.Wrapper != "" {
+			wrapper = *r.Wrapper
+		}
+		wrapperSums[wrapper] += r.Value
+		allInvTotal += r.Value
+	}
+	wrapperNames := make([]string, 0, len(wrapperSums))
+	for w := range wrapperSums {
+		wrapperNames = append(wrapperNames, w)
+	}
+	sort.Strings(wrapperNames)
+	for _, w := range wrapperNames {
+		pct := 0.0
+		if allInvTotal > 0 {
+			pct = wrapperSums[w] / allInvTotal * 100
+		}
+		out.ByWrapper = append(out.ByWrapper, wrapperBreakdown{
+			Wrapper: w, Value: wrapperSums[w], Percentage: pct,
+		})
+	}
+
+	for _, b := range out.ByCategory {
+		if b.Difference >= -1 {
+			continue
+		}
+		targetValue := totalInvestment * b.TargetPercentage / 100
+		targetPct := b.TargetPercentage / 100
+		if targetPct >= 1 {
+			continue
+		}
+		amountToAdd := (targetValue - b.CurrentValue) / (1 - targetPct)
+		if amountToAdd > 100 {
+			out.Rebalancing = append(out.Rebalancing, rebalancingSuggestion{
+				Category: b.Category, Action: "buy", Amount: amountToAdd,
+			})
+		}
+	}
+	return out
+}

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"time"
 )
@@ -31,7 +32,15 @@ func computeFromAggregates(ctx context.Context, s *Store, aggRows []AggregateRow
 	}
 	points := make([]snapNWPoint, 0, len(snapNW))
 	for sid, nw := range snapNW {
-		points = append(points, snapNWPoint{id: sid, date: shared.snapshotDate[sid], nw: nw})
+		date, ok := shared.snapshotDate[sid]
+		if !ok {
+			// A snapshot_aggregates row references a snapshot that doesn't
+			// exist — partial restore / corruption. Fail fast, as Python's
+			// snap_date[sid] KeyError does, rather than skewing the history
+			// with a zero date.
+			return result{}, fmt.Errorf("aggregate references missing snapshot %d", sid)
+		}
+		points = append(points, snapNWPoint{id: sid, date: date, nw: nw})
 	}
 	sort.Slice(points, func(i, j int) bool { return points[i].date.Before(points[j].date) })
 

--- a/backend-go/internal/dashboard/store.go
+++ b/backend-go/internal/dashboard/store.go
@@ -215,7 +215,11 @@ func (s *Store) SnapshotValuesFor(ctx context.Context, snapshotID int) ([]Snapsh
 		FROM snapshot_values WHERE snapshot_id = $1`,
 		snapshotID,
 	)
-	return scanSnapshotValues(rows, err)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot values: %w", err)
+	}
+	defer rows.Close()
+	return collectSnapshotValues(rows)
 }
 
 // AllSnapshotValues returns every snapshot_values row.
@@ -223,14 +227,14 @@ func (s *Store) AllSnapshotValues(ctx context.Context) ([]SnapshotValue, error) 
 	rows, err := s.pool.Query(ctx, `
 		SELECT snapshot_id, account_id, asset_id, value FROM snapshot_values`,
 	)
-	return scanSnapshotValues(rows, err)
-}
-
-func scanSnapshotValues(rows pgx.Rows, err error) ([]SnapshotValue, error) {
 	if err != nil {
 		return nil, fmt.Errorf("snapshot values: %w", err)
 	}
 	defer rows.Close()
+	return collectSnapshotValues(rows)
+}
+
+func collectSnapshotValues(rows pgx.Rows) ([]SnapshotValue, error) {
 	out := []SnapshotValue{}
 	for rows.Next() {
 		var v SnapshotValue

--- a/backend-go/internal/dashboard/store.go
+++ b/backend-go/internal/dashboard/store.go
@@ -1,0 +1,318 @@
+// Package dashboard implements GET /api/dashboard — the aggregate-backed
+// hot path with a raw-fallback, ported from backend/app/services/dashboard/.
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Store holds every DB read the dashboard needs.
+type Store struct{ pool *pgxpool.Pool }
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
+
+// AggregateRow mirrors a snapshot_aggregates row.
+type AggregateRow struct {
+	SnapshotID       int
+	Month            time.Time
+	Owner            string
+	TotalAssets      decimal.Decimal
+	TotalLiabilities decimal.Decimal
+	NetWorth         decimal.Decimal
+	Allocation       []AllocationJSONItem
+}
+
+// AllocationJSONItem is one entry of allocation_json.
+type AllocationJSONItem struct {
+	Category string  `json:"category"`
+	Value    float64 `json:"value"`
+}
+
+// Account mirrors the columns the dashboard reads from accounts.
+type Account struct {
+	ID             int
+	Name           string
+	Type           string
+	Category       string
+	Owner          string
+	AccountWrapper *string
+	Purpose        string
+	SquareMeters   *decimal.Decimal
+}
+
+// SnapshotValue is one snapshot_values row.
+type SnapshotValue struct {
+	SnapshotID int
+	AccountID  *int
+	AssetID    *int
+	Value      decimal.Decimal
+}
+
+// Transaction is the subset of transactions the dashboard reads.
+type Transaction struct {
+	AccountID       int
+	Amount          decimal.Decimal
+	Date            time.Time
+	TransactionType *string
+}
+
+// AppConfig mirrors the app_config row.
+type AppConfig struct {
+	MonthlyExpenses        decimal.Decimal
+	MonthlyMortgagePayment decimal.Decimal
+	AllocationStocks       int
+	AllocationBonds        int
+	AllocationGold         int
+}
+
+// SnapshotMeta is id+date.
+type SnapshotMeta struct {
+	ID   int
+	Date time.Time
+}
+
+// LoadAggregateRows returns every snapshot_aggregates row.
+func (s *Store) LoadAggregateRows(ctx context.Context) ([]AggregateRow, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT snapshot_id, month, owner, total_assets, total_liabilities,
+		       net_worth, allocation_json
+		FROM snapshot_aggregates`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load aggregates: %w", err)
+	}
+	defer rows.Close()
+	out := []AggregateRow{}
+	for rows.Next() {
+		var r AggregateRow
+		var allocJSON []byte
+		if err := rows.Scan(
+			&r.SnapshotID, &r.Month, &r.Owner,
+			&r.TotalAssets, &r.TotalLiabilities, &r.NetWorth, &allocJSON,
+		); err != nil {
+			return nil, fmt.Errorf("scan aggregate: %w", err)
+		}
+		if len(allocJSON) > 0 && string(allocJSON) != "null" {
+			if err := json.Unmarshal(allocJSON, &r.Allocation); err != nil {
+				return nil, fmt.Errorf("decode allocation_json: %w", err)
+			}
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate aggregates: %w", err)
+	}
+	return out, nil
+}
+
+// SnapshotDates returns a map of snapshot id -> date for the given ids.
+func (s *Store) SnapshotDates(ctx context.Context, ids []int) (map[int]time.Time, error) {
+	out := map[int]time.Time{}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	rows, err := s.pool.Query(ctx, `SELECT id, date FROM snapshots WHERE id = ANY($1)`, ids)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot dates: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int
+		var d time.Time
+		if err := rows.Scan(&id, &d); err != nil {
+			return nil, fmt.Errorf("scan snapshot date: %w", err)
+		}
+		out[id] = d
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshot dates: %w", err)
+	}
+	return out, nil
+}
+
+// AllSnapshots returns id+date for every snapshot ordered by date.
+func (s *Store) AllSnapshots(ctx context.Context) ([]SnapshotMeta, error) {
+	rows, err := s.pool.Query(ctx, `SELECT id, date FROM snapshots ORDER BY date`)
+	if err != nil {
+		return nil, fmt.Errorf("all snapshots: %w", err)
+	}
+	defer rows.Close()
+	out := []SnapshotMeta{}
+	for rows.Next() {
+		var m SnapshotMeta
+		if err := rows.Scan(&m.ID, &m.Date); err != nil {
+			return nil, fmt.Errorf("scan snapshot: %w", err)
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshots: %w", err)
+	}
+	return out, nil
+}
+
+// ActiveAccounts returns every active account.
+func (s *Store) ActiveAccounts(ctx context.Context) ([]Account, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, name, type, category, owner, account_wrapper, purpose, square_meters
+		FROM accounts WHERE is_active = true`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("active accounts: %w", err)
+	}
+	defer rows.Close()
+	out := []Account{}
+	for rows.Next() {
+		var a Account
+		if err := rows.Scan(
+			&a.ID, &a.Name, &a.Type, &a.Category, &a.Owner,
+			&a.AccountWrapper, &a.Purpose, &a.SquareMeters,
+		); err != nil {
+			return nil, fmt.Errorf("scan account: %w", err)
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate accounts: %w", err)
+	}
+	return out, nil
+}
+
+// ActiveAssetIDs returns the set of active asset ids.
+func (s *Store) ActiveAssetIDs(ctx context.Context) (map[int]struct{}, error) {
+	rows, err := s.pool.Query(ctx, `SELECT id FROM assets WHERE is_active = true`)
+	if err != nil {
+		return nil, fmt.Errorf("active assets: %w", err)
+	}
+	defer rows.Close()
+	out := map[int]struct{}{}
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan asset id: %w", err)
+		}
+		out[id] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate asset ids: %w", err)
+	}
+	return out, nil
+}
+
+// SnapshotValuesFor returns the snapshot_values for one snapshot.
+func (s *Store) SnapshotValuesFor(ctx context.Context, snapshotID int) ([]SnapshotValue, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT snapshot_id, account_id, asset_id, value
+		FROM snapshot_values WHERE snapshot_id = $1`,
+		snapshotID,
+	)
+	return scanSnapshotValues(rows, err)
+}
+
+// AllSnapshotValues returns every snapshot_values row.
+func (s *Store) AllSnapshotValues(ctx context.Context) ([]SnapshotValue, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT snapshot_id, account_id, asset_id, value FROM snapshot_values`,
+	)
+	return scanSnapshotValues(rows, err)
+}
+
+func scanSnapshotValues(rows pgx.Rows, err error) ([]SnapshotValue, error) {
+	if err != nil {
+		return nil, fmt.Errorf("snapshot values: %w", err)
+	}
+	defer rows.Close()
+	out := []SnapshotValue{}
+	for rows.Next() {
+		var v SnapshotValue
+		if err := rows.Scan(&v.SnapshotID, &v.AccountID, &v.AssetID, &v.Value); err != nil {
+			return nil, fmt.Errorf("scan snapshot value: %w", err)
+		}
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshot values: %w", err)
+	}
+	return out, nil
+}
+
+// ActiveTransactions returns every active transaction.
+func (s *Store) ActiveTransactions(ctx context.Context) ([]Transaction, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT account_id, amount, date, transaction_type
+		FROM transactions WHERE is_active = true`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("active transactions: %w", err)
+	}
+	defer rows.Close()
+	out := []Transaction{}
+	for rows.Next() {
+		var t Transaction
+		if err := rows.Scan(&t.AccountID, &t.Amount, &t.Date, &t.TransactionType); err != nil {
+			return nil, fmt.Errorf("scan transaction: %w", err)
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate transactions: %w", err)
+	}
+	return out, nil
+}
+
+// LoadAppConfig returns the app_config id=1 row. The bool is false when no
+// config row exists (a normal branch — the dashboard emits zeroed metric
+// cards in that case).
+func (s *Store) LoadAppConfig(ctx context.Context) (AppConfig, bool, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT monthly_expenses, monthly_mortgage_payment,
+		       allocation_stocks, allocation_bonds, allocation_gold
+		FROM app_config WHERE id = 1`,
+	)
+	var c AppConfig
+	if err := row.Scan(
+		&c.MonthlyExpenses, &c.MonthlyMortgagePayment,
+		&c.AllocationStocks, &c.AllocationBonds, &c.AllocationGold,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AppConfig{}, false, nil
+		}
+		return AppConfig{}, false, fmt.Errorf("app config: %w", err)
+	}
+	return c, true, nil
+}
+
+// RecentSalaries returns the gross_amount of the latest n active salary
+// records, most-recent first.
+func (s *Store) RecentSalaries(ctx context.Context, n int) ([]decimal.Decimal, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT gross_amount FROM salary_records
+		WHERE is_active = true ORDER BY date DESC LIMIT $1`,
+		n,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("recent salaries: %w", err)
+	}
+	defer rows.Close()
+	out := []decimal.Decimal{}
+	for rows.Next() {
+		var v decimal.Decimal
+		if err := rows.Scan(&v); err != nil {
+			return nil, fmt.Errorf("scan salary: %w", err)
+		}
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate salaries: %w", err)
+	}
+	return out, nil
+}

--- a/backend-go/internal/dashboard/timeseries.go
+++ b/backend-go/internal/dashboard/timeseries.go
@@ -1,0 +1,193 @@
+package dashboard
+
+import (
+	"sort"
+	"time"
+)
+
+// timeSeriesPoint mirrors InvestmentTimeSeriesPoint.
+type timeSeriesPoint struct {
+	Date          time.Time
+	Value         float64
+	Contributions float64
+	Returns       float64
+}
+
+// txnWithAccount is a transaction joined to its account — carries the
+// signed amount + the joined account's category/wrapper/purpose.
+type txnWithAccount struct {
+	Date         time.Time
+	SignedAmount float64
+	Category     *string
+	Wrapper      *string
+	Purpose      *string
+}
+
+// buildTxnsWithAccounts joins active transactions to accounts and computes
+// the signed amount (withdrawal -> negative). Mirrors the
+// transactions_with_accounts_df construction.
+func buildTxnsWithAccounts(txns []Transaction, accounts map[int]Account) []txnWithAccount {
+	out := make([]txnWithAccount, 0, len(txns))
+	for _, t := range txns {
+		amt, _ := t.Amount.Float64()
+		sign := 1.0
+		if t.TransactionType != nil && *t.TransactionType == "withdrawal" {
+			sign = -1.0
+		}
+		row := txnWithAccount{Date: t.Date, SignedAmount: amt * sign}
+		if acc, ok := accounts[t.AccountID]; ok {
+			c := acc.Category
+			p := acc.Purpose
+			row.Category = &c
+			row.Purpose = &p
+			row.Wrapper = acc.AccountWrapper
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+// cumContributions ports _cum_contributions_per_snapshot: for each snapshot
+// date, the cumulative signed_amount of transactions on/before it.
+func cumContributions(txns []txnWithAccount, snapDates []time.Time) []float64 {
+	out := make([]float64, len(snapDates))
+	if len(txns) == 0 {
+		return out
+	}
+	sorted := make([]txnWithAccount, len(txns))
+	copy(sorted, txns)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Date.Before(sorted[j].Date) })
+	cum := make([]float64, len(sorted))
+	running := 0.0
+	for i, t := range sorted {
+		running += t.SignedAmount
+		cum[i] = running
+	}
+	for i, d := range snapDates {
+		// number of transactions with date <= d, minus 1 (searchsorted right)
+		idx := sort.Search(len(sorted), func(k int) bool { return sorted[k].Date.After(d) }) - 1
+		if idx >= 0 {
+			out[i] = cum[idx]
+		}
+	}
+	return out
+}
+
+// buildSeries ports _build_series: per-snapshot summed value + cumulative
+// contributions for the rows/transactions matching the supplied predicates.
+func buildSeries(
+	rows []mergedRow,
+	snapshots []SnapshotMeta,
+	txns []txnWithAccount,
+	valueMatch func(mergedRow) bool,
+	txnMatch func(txnWithAccount) bool,
+) []timeSeriesPoint {
+	if len(rows) == 0 || len(snapshots) == 0 {
+		return []timeSeriesPoint{}
+	}
+	snaps := make([]SnapshotMeta, len(snapshots))
+	copy(snaps, snapshots)
+	sort.Slice(snaps, func(i, j int) bool { return snaps[i].Date.Before(snaps[j].Date) })
+
+	valBySnap := map[int]float64{}
+	for _, r := range rows {
+		if valueMatch(r) {
+			valBySnap[r.SnapshotID] += r.Value
+		}
+	}
+	snapDates := make([]time.Time, len(snaps))
+	for i, s := range snaps {
+		snapDates[i] = s.Date
+	}
+	var contributions []float64
+	if txnMatch != nil && len(txns) > 0 {
+		filtered := []txnWithAccount{}
+		for _, t := range txns {
+			if txnMatch(t) {
+				filtered = append(filtered, t)
+			}
+		}
+		contributions = cumContributions(filtered, snapDates)
+	} else {
+		contributions = make([]float64, len(snaps))
+	}
+	out := make([]timeSeriesPoint, 0, len(snaps))
+	for i, s := range snaps {
+		value := valBySnap[s.ID]
+		c := contributions[i]
+		out = append(out, timeSeriesPoint{
+			Date: s.Date, Value: value, Contributions: c, Returns: value - c,
+		})
+	}
+	return out
+}
+
+func isInvestmentCategory(c *string) bool {
+	if c == nil {
+		return false
+	}
+	_, ok := investmentCategories[*c]
+	return ok
+}
+
+// buildInvestmentTimeSeries ports build_investment_time_series.
+func buildInvestmentTimeSeries(rows []mergedRow, snaps []SnapshotMeta, txns []txnWithAccount) []timeSeriesPoint {
+	valueMatch := func(r mergedRow) bool {
+		return r.AccountID != nil && r.AccType != nil && *r.AccType == "asset" &&
+			isInvestmentCategory(r.Category)
+	}
+	var txnMatch func(txnWithAccount) bool
+	if len(txns) > 0 {
+		txnMatch = func(t txnWithAccount) bool { return isInvestmentCategory(t.Category) }
+	}
+	return buildSeries(rows, snaps, txns, valueMatch, txnMatch)
+}
+
+// buildWrapperTimeSeries ports build_wrapper_time_series — IKE/IKZE/PPK.
+func buildWrapperTimeSeries(rows []mergedRow, snaps []SnapshotMeta, txns []txnWithAccount) map[string][]timeSeriesPoint {
+	out := map[string][]timeSeriesPoint{}
+	for _, wrapper := range []string{"IKE", "IKZE", "PPK"} {
+		w := wrapper
+		valueMatch := func(r mergedRow) bool {
+			return r.AccountID != nil && r.AccType != nil && *r.AccType == "asset" &&
+				isInvestmentCategory(r.Category) &&
+				r.Wrapper != nil && *r.Wrapper == w
+		}
+		var txnMatch func(txnWithAccount) bool
+		if len(txns) > 0 {
+			txnMatch = func(t txnWithAccount) bool {
+				return isInvestmentCategory(t.Category) && t.Wrapper != nil && *t.Wrapper == w
+			}
+		}
+		out[wrapper] = buildSeries(rows, snaps, txns, valueMatch, txnMatch)
+	}
+	return out
+}
+
+// buildCategoryTimeSeries ports build_category_time_series — stock/bond groups.
+func buildCategoryTimeSeries(rows []mergedRow, snaps []SnapshotMeta, txns []txnWithAccount) map[string][]timeSeriesPoint {
+	groups := map[string]map[string]struct{}{
+		"stock": {"stock": {}, "fund": {}, "etf": {}},
+		"bond":  {"bond": {}},
+	}
+	out := map[string][]timeSeriesPoint{}
+	for group, cats := range groups {
+		c := cats
+		inGroup := func(cat *string) bool {
+			if cat == nil {
+				return false
+			}
+			_, ok := c[*cat]
+			return ok
+		}
+		valueMatch := func(r mergedRow) bool {
+			return r.AccountID != nil && r.AccType != nil && *r.AccType == "asset" && inGroup(r.Category)
+		}
+		var txnMatch func(txnWithAccount) bool
+		if len(txns) > 0 {
+			txnMatch = func(t txnWithAccount) bool { return inGroup(t.Category) }
+		}
+		out[group] = buildSeries(rows, snaps, txns, valueMatch, txnMatch)
+	}
+	return out
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/config"
 	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
+	"github.com/Automaat/finance-buddy/backend-go/internal/dashboard"
 	debtpayments "github.com/Automaat/finance-buddy/backend-go/internal/debt_payments"
 	"github.com/Automaat/finance-buddy/backend-go/internal/debts"
 	equitygrants "github.com/Automaat/finance-buddy/backend-go/internal/equity_grants"
@@ -134,6 +135,9 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	r.Post("/api/simulations/mortgage-vs-invest", simHandler.MortgageVsInvest)
 	r.Post("/api/simulations/retirement", simHandler.Retirement)
 	r.Get("/api/simulations/prefill", simHandler.Prefill)
+
+	dashHandler := dashboard.NewHandler(dashboard.NewStore(pool), logger)
+	r.Get("/api/dashboard", dashHandler.Get)
 }
 
 func registerCoreRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -93,6 +93,7 @@ func registerAPIRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 	registerCPIAndPayrollRoutes(r, pool, logger)
 	registerPortfolioRoutes(r, pool, logger)
 	registerLedgerRoutes(r, pool, logger)
+	registerDashboardRoutes(r, pool, logger)
 }
 
 func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
@@ -135,7 +136,9 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	r.Post("/api/simulations/mortgage-vs-invest", simHandler.MortgageVsInvest)
 	r.Post("/api/simulations/retirement", simHandler.Retirement)
 	r.Get("/api/simulations/prefill", simHandler.Prefill)
+}
 
+func registerDashboardRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 	dashHandler := dashboard.NewHandler(dashboard.NewStore(pool), logger)
 	r.Get("/api/dashboard", dashHandler.Get)
 }

--- a/migration/proxy/routes.yaml
+++ b/migration/proxy/routes.yaml
@@ -190,3 +190,8 @@ rules:
   - method: POST
     path_prefix: /api/simulations
     upstream: http://backend-go:8000
+  # Group 13 — /api/dashboard cut over to Go. Final cutover: aggregate-backed
+  # hot path + raw fallback, MoM/YoY deltas, allocation analysis, time series.
+  - method: GET
+    path_prefix: /api/dashboard
+    upstream: http://backend-go:8000


### PR DESCRIPTION
## Motivation

**Final cutover.** GET /api/dashboard — the highest-risk endpoint and the last of the 13 groups. Closes #448. Depends on every prior group.

~1400 lines of pandas-heavy aggregation ported to Go: aggregate-backed hot path (reads snapshot_aggregates) + raw fallback (full merge), MoM/YoY tile deltas, allocation analysis, 5 time-series.

## Implementation information

### Faithful two-path port

`Compute` dispatches exactly like `get_dashboard_data`: when `snapshot_aggregates` has rows → `computeFromAggregates`; empty → `computeRaw`. Both produce the same `result` struct.

- **Aggregate path:** net-worth history from per-snapshot aggregate sums; latest snapshot = `max(snapshot_id)`; totals + allocation from the latest snapshot's aggregate rows.
- **Raw path:** full `snapshot_values ⨝ assets ⨝ accounts ⨝ snapshots` merge; net-worth grouped by date; latest snapshot = `max(date, id)`.

Both branches match Python's selection logic byte-for-byte.

### Files

- `store.go` — all 8 table reads.
- `compute.go` — `mergedRow` model + the signed-value rule (account asset/liability sign; asset-table positive) + `perSnapshotTotals`.
- `metrics.go` — tile deltas (MoM `[latest-45d, latest-15d]`, YoY `[latest-395d, latest-335d]`, latest excluded from baselines), savings rate (3-delta avg ÷ 3-salary avg).
- `timeseries.go` — investment / wrapper / category builders. Cumulative contributions use the sorted-cumsum + searchsorted algorithm from the Python `_cum_contributions_per_snapshot`.
- `paths.go` — both compute paths + shared `buildMetricCards` / `buildAllocationAnalysis`.
- `handler.go` — chi route + full nested wire types; `pyFloat` money, nullable delta/ratio fields.

### Parity

```
tests/test_dashboard.py::test_get_dashboard_returns_documented_shape  PASSED
tests/test_dashboard.py::test_dashboard_nested_keys_present           PASSED
```

The bb-test suite has shape-only checks for the dashboard (no golden). Byte-level value parity is verified against the **production dataset** post-deploy — every nested field diffed Go-vs-Python on real data (87 snapshots, 1783 snapshot_values).

> Note on float-sum ordering: pandas `groupby().sum()` sums in DataFrame row order; Go sums in query order. For million-PLN net-worth totals any divergence is float-epsilon (~1e-10), far under the 0.01 PLN tolerance the issue documents. The prod diff confirms whether it's within that bound.

## Completes the migration

With this merged, all 13 cutover groups are on Go. Remaining umbrella work: scheduler decision (#449), decommission Python (#450) + proxy (#451).

## Supporting documentation

- Umbrella: #435
- Subissue: #448
- Procedure: `migration/CUTOVER.md`

> Changelog: skip