### PR TITLE
feat(go): in-process CPI refresh scheduler

### DIFF
--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -17,7 +17,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 	"github.com/Automaat/finance-buddy/backend-go/internal/db"
+	"github.com/Automaat/finance-buddy/backend-go/internal/scheduler"
 	"github.com/Automaat/finance-buddy/backend-go/internal/server"
 )
 
@@ -85,6 +87,10 @@ func run() int {
 		defer pool.Close()
 		deps.Pool = pool
 		logger.Info("db pool ready")
+
+		// CPI monthly-refresh scheduler — replaces the Python APScheduler job.
+		sched := scheduler.NewCPIScheduler(cpi.NewStore(pool), cpi.NewGUSFetcher(), logger)
+		go sched.Run(ctx)
 	} else {
 		logger.Warn("no DB config (DATABASE_URL or PGHOST) — DB-backed endpoints will 404")
 	}

--- a/backend-go/internal/cpi/store.go
+++ b/backend-go/internal/cpi/store.go
@@ -43,6 +43,22 @@ func (s *Store) LoadYoYMap(ctx context.Context) (map[int]decimal.Decimal, error)
 	return out, nil
 }
 
+// NeedsRefresh reports whether the CPI table is empty or its freshest
+// fetched_at is older than staleAfter. Mirrors inflation.needs_refresh.
+func (s *Store) NeedsRefresh(ctx context.Context, staleAfter time.Duration) (bool, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT fetched_at FROM cpi_index ORDER BY fetched_at DESC LIMIT 1`,
+	)
+	var latest time.Time
+	if err := row.Scan(&latest); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return true, nil
+		}
+		return false, fmt.Errorf("cpi staleness check: %w", err)
+	}
+	return time.Since(latest) > staleAfter, nil
+}
+
 // LatestKnownYear returns the highest year present in cpi_index, or (0, false)
 // when the table is empty.
 func (s *Store) LatestKnownYear(ctx context.Context) (int, bool, error) {

--- a/backend-go/internal/scheduler/scheduler.go
+++ b/backend-go/internal/scheduler/scheduler.go
@@ -58,8 +58,9 @@ func NewCPIScheduler(store *cpi.Store, fetcher *cpi.GUSFetcher, logger *slog.Log
 func (s *CPIScheduler) Run(ctx context.Context) {
 	s.startupRefresh(ctx)
 	for {
-		next := nextRefresh(s.now().In(s.loc))
-		wait := time.Until(next)
+		now := s.now().In(s.loc)
+		next := nextRefresh(now)
+		wait := max(next.Sub(now), 0)
 		s.logger.Info("scheduler: next CPI refresh", "at", next.Format(time.RFC3339))
 		timer := time.NewTimer(wait)
 		select {

--- a/backend-go/internal/scheduler/scheduler.go
+++ b/backend-go/internal/scheduler/scheduler.go
@@ -1,0 +1,114 @@
+// Package scheduler runs the in-process CPI refresh — the Go replacement for
+// the Python APScheduler job (migration/scheduler.md).
+//
+// One job: pull annual CPI from GUS BDL on the 16th of each month at 04:00
+// Europe/Warsaw, plus a startup refresh when the cpi_index table is stale
+// (>7 days) or empty. Single-instance only, same as the Python original —
+// no leader election.
+//
+// A hand-rolled timer is used rather than a cron library: the single monthly
+// trigger + timezone handling is ~30 lines and adds no dependency.
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
+)
+
+const (
+	cpiStaleAfter = 7 * 24 * time.Hour
+	refreshDay    = 16
+	refreshHour   = 4
+)
+
+// CPIScheduler owns the monthly CPI refresh loop.
+type CPIScheduler struct {
+	store   *cpi.Store
+	fetcher *cpi.GUSFetcher
+	logger  *slog.Logger
+	now     func() time.Time
+	loc     *time.Location
+}
+
+// NewCPIScheduler wires the scheduler. Falls back to UTC if the
+// Europe/Warsaw zone can't be loaded (missing tzdata).
+func NewCPIScheduler(store *cpi.Store, fetcher *cpi.GUSFetcher, logger *slog.Logger) *CPIScheduler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	loc, err := time.LoadLocation("Europe/Warsaw")
+	if err != nil {
+		logger.Warn("scheduler: Europe/Warsaw tz unavailable, using UTC", "err", err)
+		loc = time.UTC
+	}
+	return &CPIScheduler{
+		store:   store,
+		fetcher: fetcher,
+		logger:  logger,
+		now:     time.Now,
+		loc:     loc,
+	}
+}
+
+// Run does the startup staleness check, then loops firing the monthly
+// refresh until ctx is cancelled. Intended to run in its own goroutine.
+func (s *CPIScheduler) Run(ctx context.Context) {
+	s.startupRefresh(ctx)
+	for {
+		next := nextRefresh(s.now().In(s.loc))
+		wait := time.Until(next)
+		s.logger.Info("scheduler: next CPI refresh", "at", next.Format(time.RFC3339))
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			s.logger.Info("scheduler: stopped")
+			return
+		case <-timer.C:
+			s.refresh(ctx)
+		}
+	}
+}
+
+// startupRefresh refreshes immediately when the CPI table is empty or stale,
+// matching Python's _startup_refresh_if_stale.
+func (s *CPIScheduler) startupRefresh(ctx context.Context) {
+	stale, err := s.store.NeedsRefresh(ctx, cpiStaleAfter)
+	if err != nil {
+		s.logger.Warn("scheduler: staleness check failed", "err", err)
+		return
+	}
+	if stale {
+		s.logger.Info("scheduler: CPI stale at startup, refreshing")
+		s.refresh(ctx)
+	}
+}
+
+// refresh runs one GUS fetch + upsert. Failures are logged and swallowed —
+// a transient GUS outage must not crash the process.
+func (s *CPIScheduler) refresh(ctx context.Context) {
+	rows, err := s.fetcher.Fetch(ctx)
+	if err != nil {
+		s.logger.Warn("scheduler: GUS fetch failed", "err", err)
+		return
+	}
+	written, err := s.store.Upsert(ctx, cpi.GUSSourceTag, rows)
+	if err != nil {
+		s.logger.Warn("scheduler: CPI upsert failed", "err", err)
+		return
+	}
+	s.logger.Info("scheduler: CPI refresh complete", "rows_written", written)
+}
+
+// nextRefresh returns the next 16th-of-month 04:00 strictly after `from`,
+// in from's location.
+func nextRefresh(from time.Time) time.Time {
+	candidate := time.Date(from.Year(), from.Month(), refreshDay, refreshHour, 0, 0, 0, from.Location())
+	if !candidate.After(from) {
+		candidate = time.Date(from.Year(), from.Month()+1, refreshDay, refreshHour, 0, 0, 0, from.Location())
+	}
+	return candidate
+}

--- a/migration/scheduler.md
+++ b/migration/scheduler.md
@@ -48,3 +48,16 @@ Total jobs registered: **1** (plus 1 one-shot startup task that uses the same fu
    Pros: dead-simple, no in-process scheduler, decouples scheduling from app lifecycle; OS cron handles restarts/timezones; easy to run ad-hoc (`finance-buddy cpi refresh`). Cons: requires host-level cron (Docker needs a cron sidecar or supervisor); startup-staleness check must move into app boot anyway; logs scattered between cron and app; harder to ship as a single artifact.
 
 **Recommendation:** Option 1 — port to Go with `go-co-op/gocron` (or `robfig/cron`). Single binary preserves current single-instance model, the job is tiny (one HTTP call + upsert) and a clean Go port is cheaper than maintaining a Python sidecar or external cron plumbing.
+
+## Decision (chosen path)
+
+**Option 1 — ported to Go, in-process.** Implemented in `backend-go/internal/scheduler` and started from `cmd/api/main.go` when a DB pool is configured.
+
+One deviation from the recommendation: **no cron library.** A single monthly trigger plus a startup-staleness check is ~30 lines of hand-rolled `time.Timer` logic — adding `gocron`/`robfig/cron` as a dependency (with the Renovate manager wiring that implies) wasn't worth it for one job. The behaviour is identical to the APScheduler original:
+
+- **Monthly job:** 16th of each month, 04:00 `Europe/Warsaw` (falls back to UTC if tzdata is missing). `nextRefresh` computes the next occurrence; a `time.Timer` waits for it; `ctx` cancellation stops the loop cleanly.
+- **Startup refresh:** `Store.NeedsRefresh` (no rows, or freshest `fetched_at` older than 7 days) triggers an immediate refresh on boot — mirrors `_startup_refresh_if_stale`.
+- **Job body:** `GUSFetcher.Fetch` → `Store.Upsert`, the same code path as `POST /api/cpi/refresh`. Transient GUS failures are logged and swallowed, never crash the process.
+- **Single-instance only**, exactly as before — no leader election.
+
+The Python `scheduler_lifespan()` is removed when the Python backend is decommissioned (see umbrella #435).


### PR DESCRIPTION
## Motivation

Closes #449. The CPI monthly-refresh job is the last thing keeping the Python backend's process lifecycle relevant — `scheduler_lifespan()` runs an APScheduler `AsyncIOScheduler`. To decommission the Python backend (#450) the job needs a Go home.

`migration/scheduler.md` picked **option 1 — port to Go, in-process**. This PR implements it.

## Implementation information

### `internal/scheduler`

- **Monthly trigger:** 16th of each month, 04:00 `Europe/Warsaw` (UTC fallback if tzdata is missing). `nextRefresh` computes the next occurrence; a `time.Timer` waits; `ctx` cancellation ends the loop.
- **Startup refresh:** runs immediately when `cpi_index` is empty or the freshest `fetched_at` is >7 days old — mirrors Python's `_startup_refresh_if_stale`.
- **Job body:** `GUSFetcher.Fetch` → `Store.Upsert` — the exact path `POST /api/cpi/refresh` uses. Transient GUS failures are logged and swallowed, never fatal.

### Deviation from the recommendation — no cron library

`scheduler.md` recommended `gocron`/`robfig/cron`. One monthly trigger + a startup check is ~30 lines of `time.Timer` logic; pulling in a cron library (plus the Renovate manager wiring the repo's pinning policy requires) wasn't worth it. Behaviour is identical to the APScheduler original. Documented in `scheduler.md`.

### `cpi.Store.NeedsRefresh`

New — empty table OR freshest `fetched_at` older than the threshold. Ports `inflation.needs_refresh`.

### `cmd/api/main.go`

Starts `sched.Run(ctx)` in a goroutine when a DB pool is configured. Single-instance only, same as the Python original — no leader election.

## Supporting documentation

- Umbrella: #435
- `migration/scheduler.md` — decision recorded

> Changelog: skip