### PR TITLE
feat(go): register remaining openapi domains

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -208,41 +208,6 @@
             }
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "Currency": {
-                    "type": "string"
-                  },
-                  "DebtType": {
-                    "type": "string"
-                  },
-                  "InitialAmount": {
-                    "type": "string"
-                  },
-                  "InterestRate": {
-                    "type": "string"
-                  },
-                  "Name": {
-                    "type": "string"
-                  },
-                  "Notes": {
-                    "nullable": true,
-                    "type": "string"
-                  },
-                  "StartDate": {
-                    "format": "date-time",
-                    "type": "string"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
           "201": {
             "content": {
@@ -406,28 +371,6 @@
             }
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "Amount": {
-                    "type": "string"
-                  },
-                  "Date": {
-                    "format": "date-time",
-                    "type": "string"
-                  },
-                  "Owner": {
-                    "type": "string"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
           "201": {
             "content": {
@@ -588,32 +531,6 @@
             }
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "Amount": {
-                    "type": "string"
-                  },
-                  "Date": {
-                    "format": "date-time",
-                    "type": "string"
-                  },
-                  "Owner": {
-                    "type": "string"
-                  },
-                  "TransactionType": {
-                    "nullable": true,
-                    "type": "string"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
           "201": {
             "content": {
@@ -1030,44 +947,6 @@
         ]
       },
       "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "Amount": {
-                    "type": "string"
-                  },
-                  "Company": {
-                    "type": "string"
-                  },
-                  "ContractType": {
-                    "type": "string"
-                  },
-                  "Currency": {
-                    "type": "string"
-                  },
-                  "Date": {
-                    "format": "date-time",
-                    "type": "string"
-                  },
-                  "Notes": {
-                    "nullable": true,
-                    "type": "string"
-                  },
-                  "Owner": {
-                    "type": "string"
-                  },
-                  "Type": {
-                    "type": "string"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
           "201": {
             "content": {
@@ -1397,50 +1276,6 @@
         ]
       },
       "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "CommonStockDiscountPct": {
-                    "nullable": true,
-                    "type": "string"
-                  },
-                  "Company": {
-                    "type": "string"
-                  },
-                  "Currency": {
-                    "type": "string"
-                  },
-                  "Date": {
-                    "format": "date-time",
-                    "type": "string"
-                  },
-                  "FMVHigh": {
-                    "nullable": true,
-                    "type": "string"
-                  },
-                  "FMVLow": {
-                    "nullable": true,
-                    "type": "string"
-                  },
-                  "FMVPerShare": {
-                    "type": "string"
-                  },
-                  "Notes": {
-                    "nullable": true,
-                    "type": "string"
-                  },
-                  "Source": {
-                    "type": "string"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
           "201": {
             "content": {
@@ -4253,34 +4088,6 @@
             }
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "AccountWrapper": {
-                    "type": "string"
-                  },
-                  "LimitAmount": {
-                    "type": "string"
-                  },
-                  "Notes": {
-                    "nullable": true,
-                    "type": "string"
-                  },
-                  "Owner": {
-                    "type": "string"
-                  },
-                  "Year": {
-                    "type": "integer"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
           "200": {
             "content": {
@@ -4323,27 +4130,6 @@
     },
     "/api/retirement/ppk-contributions/generate": {
       "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "Month": {
-                    "type": "integer"
-                  },
-                  "Owner": {
-                    "type": "string"
-                  },
-                  "Year": {
-                    "type": "integer"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
           "200": {
             "content": {

--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -196,6 +196,503 @@
         ]
       }
     },
+    "/api/accounts/{account_id}/debts": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "Currency": {
+                    "type": "string"
+                  },
+                  "DebtType": {
+                    "type": "string"
+                  },
+                  "InitialAmount": {
+                    "type": "string"
+                  },
+                  "InterestRate": {
+                    "type": "string"
+                  },
+                  "Name": {
+                    "type": "string"
+                  },
+                  "Notes": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "StartDate": {
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account_id": {
+                      "type": "integer"
+                    },
+                    "account_name": {
+                      "type": "string"
+                    },
+                    "account_owner": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "debt_type": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "initial_amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "interest_paid": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "interest_rate": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "latest_balance": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "latest_balance_date": {
+                      "format": "date",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "notes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "start_date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "total_paid": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create a debt",
+        "tags": [
+          "debts"
+        ]
+      }
+    },
+    "/api/accounts/{account_id}/payments": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "payment_count": {
+                      "type": "integer"
+                    },
+                    "payments": {
+                      "items": {
+                        "properties": {
+                          "account_id": {
+                            "type": "integer"
+                          },
+                          "account_name": {
+                            "type": "string"
+                          },
+                          "amount": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "created_at": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "owner": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total_paid": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List an account's debt payments",
+        "tags": [
+          "debt-payments"
+        ]
+      },
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "Amount": {
+                    "type": "string"
+                  },
+                  "Date": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "Owner": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account_id": {
+                      "type": "integer"
+                    },
+                    "account_name": {
+                      "type": "string"
+                    },
+                    "amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "owner": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create a debt payment",
+        "tags": [
+          "debt-payments"
+        ]
+      }
+    },
+    "/api/accounts/{account_id}/payments/{payment_id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "payment_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete a debt payment",
+        "tags": [
+          "debt-payments"
+        ]
+      }
+    },
+    "/api/accounts/{account_id}/transactions": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "total_invested": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "transaction_count": {
+                      "type": "integer"
+                    },
+                    "transactions": {
+                      "items": {
+                        "properties": {
+                          "account_id": {
+                            "type": "integer"
+                          },
+                          "account_name": {
+                            "type": "string"
+                          },
+                          "amount": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "created_at": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "owner": {
+                            "type": "string"
+                          },
+                          "transaction_type": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List an account's transactions",
+        "tags": [
+          "transactions"
+        ]
+      },
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "Amount": {
+                    "type": "string"
+                  },
+                  "Date": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "Owner": {
+                    "type": "string"
+                  },
+                  "TransactionType": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account_id": {
+                      "type": "integer"
+                    },
+                    "account_name": {
+                      "type": "string"
+                    },
+                    "amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "owner": {
+                      "type": "string"
+                    },
+                    "transaction_type": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create a transaction",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/accounts/{account_id}/transactions/{transaction_id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "transaction_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete a transaction",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
     "/api/accounts/{id}": {
       "delete": {
         "parameters": [
@@ -447,6 +944,744 @@
         ]
       }
     },
+    "/api/bonuses": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "available_companies": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "bonus_events": {
+                      "items": {
+                        "properties": {
+                          "amount": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "amount_pln": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "company": {
+                            "type": "string"
+                          },
+                          "contract_type": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "fx_rate": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "is_active": {
+                            "type": "boolean"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "owner": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total_count": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List bonus events",
+        "tags": [
+          "bonuses"
+        ]
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "Amount": {
+                    "type": "string"
+                  },
+                  "Company": {
+                    "type": "string"
+                  },
+                  "ContractType": {
+                    "type": "string"
+                  },
+                  "Currency": {
+                    "type": "string"
+                  },
+                  "Date": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "Notes": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "Owner": {
+                    "type": "string"
+                  },
+                  "Type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "amount_pln": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "company": {
+                      "type": "string"
+                    },
+                    "contract_type": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "fx_rate": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "notes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "owner": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create a bonus event",
+        "tags": [
+          "bonuses"
+        ]
+      }
+    },
+    "/api/bonuses/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete a bonus event",
+        "tags": [
+          "bonuses"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "amount_pln": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "company": {
+                      "type": "string"
+                    },
+                    "contract_type": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "fx_rate": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "notes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "owner": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get a bonus event",
+        "tags": [
+          "bonuses"
+        ]
+      },
+      "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "amount_pln": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "company": {
+                      "type": "string"
+                    },
+                    "contract_type": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "fx_rate": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "notes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "owner": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Update a bonus event",
+        "tags": [
+          "bonuses"
+        ]
+      }
+    },
+    "/api/company-valuations": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "available_companies": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "company_valuations": {
+                      "items": {
+                        "properties": {
+                          "common_stock_discount_pct": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "company": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "fmv_high": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "fmv_low": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "fmv_per_share": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "is_active": {
+                            "type": "boolean"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total_count": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List company valuations",
+        "tags": [
+          "company-valuations"
+        ]
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "CommonStockDiscountPct": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "Company": {
+                    "type": "string"
+                  },
+                  "Currency": {
+                    "type": "string"
+                  },
+                  "Date": {
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "FMVHigh": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "FMVLow": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "FMVPerShare": {
+                    "type": "string"
+                  },
+                  "Notes": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "Source": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "common_stock_discount_pct": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "company": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "fmv_high": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "fmv_low": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "fmv_per_share": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "notes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create a company valuation",
+        "tags": [
+          "company-valuations"
+        ]
+      }
+    },
+    "/api/company-valuations/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete a company valuation",
+        "tags": [
+          "company-valuations"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "common_stock_discount_pct": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "company": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "fmv_high": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "fmv_low": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "fmv_per_share": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "notes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get a company valuation",
+        "tags": [
+          "company-valuations"
+        ]
+      },
+      "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "common_stock_discount_pct": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "company": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "fmv_high": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "fmv_low": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "fmv_per_share": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "notes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Update a company valuation",
+        "tags": [
+          "company-valuations"
+        ]
+      }
+    },
     "/api/config": {
       "get": {
         "responses": {
@@ -597,6 +1832,132 @@
         "summary": "Update application configuration",
         "tags": [
           "config"
+        ]
+      }
+    },
+    "/api/cpi/adjust": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "adjusted_amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "as_of_year": {
+                      "type": "integer"
+                    },
+                    "factor": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "from_date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "original_amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "to_date": {
+                      "format": "date",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Inflation-adjust an amount between two dates",
+        "tags": [
+          "cpi"
+        ]
+      }
+    },
+    "/api/cpi/refresh": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "latest_year": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "rows_written": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Refresh CPI data from GUS",
+        "tags": [
+          "cpi"
+        ]
+      }
+    },
+    "/api/cpi/series": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "base_year": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "latest_year": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "points": {
+                      "items": {
+                        "properties": {
+                          "cumulative_index": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "year": {
+                            "type": "integer"
+                          },
+                          "yoy_rate": {
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get the CPI year-over-year series",
+        "tags": [
+          "cpi"
         ]
       }
     },
@@ -1074,6 +2435,985 @@
         ]
       }
     },
+    "/api/debts": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "active_debts_count": {
+                      "type": "integer"
+                    },
+                    "debts": {
+                      "items": {
+                        "properties": {
+                          "account_id": {
+                            "type": "integer"
+                          },
+                          "account_name": {
+                            "type": "string"
+                          },
+                          "account_owner": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "debt_type": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "initial_amount": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "interest_paid": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "interest_rate": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "is_active": {
+                            "type": "boolean"
+                          },
+                          "latest_balance": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "latest_balance_date": {
+                            "format": "date",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "start_date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "total_paid": {
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total_count": {
+                      "type": "integer"
+                    },
+                    "total_initial_amount": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List debts",
+        "tags": [
+          "debts"
+        ]
+      }
+    },
+    "/api/debts/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete a debt",
+        "tags": [
+          "debts"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account_id": {
+                      "type": "integer"
+                    },
+                    "account_name": {
+                      "type": "string"
+                    },
+                    "account_owner": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "debt_type": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "initial_amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "interest_paid": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "interest_rate": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "latest_balance": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "latest_balance_date": {
+                      "format": "date",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "notes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "start_date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "total_paid": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get a debt",
+        "tags": [
+          "debts"
+        ]
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account_id": {
+                      "type": "integer"
+                    },
+                    "account_name": {
+                      "type": "string"
+                    },
+                    "account_owner": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "debt_type": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "initial_amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "interest_paid": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "interest_rate": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "latest_balance": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "latest_balance_date": {
+                      "format": "date",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "notes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "start_date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "total_paid": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Update a debt",
+        "tags": [
+          "debts"
+        ]
+      }
+    },
+    "/api/equity-grants": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "available_companies": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "equity_grants": {
+                      "items": {
+                        "properties": {
+                          "company": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "fx_rate": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "grant_date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "is_active": {
+                            "type": "boolean"
+                          },
+                          "liquidity_event_date": {
+                            "format": "date",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "notes": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "owner": {
+                            "type": "string"
+                          },
+                          "paper_value_base": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "paper_value_base_pln": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "paper_value_currency": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "paper_value_high": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "paper_value_high_pln": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "paper_value_low": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "paper_value_low_pln": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "requires_liquidity_event": {
+                            "type": "boolean"
+                          },
+                          "strike_price": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "tax_treatment": {
+                            "type": "string"
+                          },
+                          "total_shares": {
+                            "type": "integer"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "valuation_date": {
+                            "format": "date",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "valuation_source": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "vest_cliff_months": {
+                            "type": "integer"
+                          },
+                          "vest_custom_schedule": {
+                            "items": {
+                              "properties": {
+                                "month": {
+                                  "type": "integer"
+                                },
+                                "pct": {
+                                  "format": "double",
+                                  "type": "number"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "vest_frequency": {
+                            "type": "string"
+                          },
+                          "vest_start_date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "vest_total_months": {
+                            "type": "integer"
+                          },
+                          "vested_shares_today": {
+                            "type": "integer"
+                          },
+                          "vesting_progress_pct": {
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total_count": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List equity grants",
+        "tags": [
+          "equity-grants"
+        ]
+      },
+      "post": {
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "company": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "fx_rate": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "grant_date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "liquidity_event_date": {
+                      "format": "date",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "notes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "owner": {
+                      "type": "string"
+                    },
+                    "paper_value_base": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_base_pln": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_currency": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "paper_value_high": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_high_pln": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_low": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_low_pln": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "requires_liquidity_event": {
+                      "type": "boolean"
+                    },
+                    "strike_price": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "tax_treatment": {
+                      "type": "string"
+                    },
+                    "total_shares": {
+                      "type": "integer"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "valuation_date": {
+                      "format": "date",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "valuation_source": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "vest_cliff_months": {
+                      "type": "integer"
+                    },
+                    "vest_custom_schedule": {
+                      "items": {
+                        "properties": {
+                          "month": {
+                            "type": "integer"
+                          },
+                          "pct": {
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "vest_frequency": {
+                      "type": "string"
+                    },
+                    "vest_start_date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "vest_total_months": {
+                      "type": "integer"
+                    },
+                    "vested_shares_today": {
+                      "type": "integer"
+                    },
+                    "vesting_progress_pct": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create an equity grant",
+        "tags": [
+          "equity-grants"
+        ]
+      }
+    },
+    "/api/equity-grants/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete an equity grant",
+        "tags": [
+          "equity-grants"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "company": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "fx_rate": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "grant_date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "liquidity_event_date": {
+                      "format": "date",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "notes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "owner": {
+                      "type": "string"
+                    },
+                    "paper_value_base": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_base_pln": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_currency": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "paper_value_high": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_high_pln": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_low": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_low_pln": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "requires_liquidity_event": {
+                      "type": "boolean"
+                    },
+                    "strike_price": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "tax_treatment": {
+                      "type": "string"
+                    },
+                    "total_shares": {
+                      "type": "integer"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "valuation_date": {
+                      "format": "date",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "valuation_source": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "vest_cliff_months": {
+                      "type": "integer"
+                    },
+                    "vest_custom_schedule": {
+                      "items": {
+                        "properties": {
+                          "month": {
+                            "type": "integer"
+                          },
+                          "pct": {
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "vest_frequency": {
+                      "type": "string"
+                    },
+                    "vest_start_date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "vest_total_months": {
+                      "type": "integer"
+                    },
+                    "vested_shares_today": {
+                      "type": "integer"
+                    },
+                    "vesting_progress_pct": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get an equity grant",
+        "tags": [
+          "equity-grants"
+        ]
+      },
+      "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "company": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "fx_rate": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "grant_date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "liquidity_event_date": {
+                      "format": "date",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "notes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "owner": {
+                      "type": "string"
+                    },
+                    "paper_value_base": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_base_pln": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_currency": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "paper_value_high": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_high_pln": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_low": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "paper_value_low_pln": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "requires_liquidity_event": {
+                      "type": "boolean"
+                    },
+                    "strike_price": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "tax_treatment": {
+                      "type": "string"
+                    },
+                    "total_shares": {
+                      "type": "integer"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "valuation_date": {
+                      "format": "date",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "valuation_source": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "vest_cliff_months": {
+                      "type": "integer"
+                    },
+                    "vest_custom_schedule": {
+                      "items": {
+                        "properties": {
+                          "month": {
+                            "type": "integer"
+                          },
+                          "pct": {
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "vest_frequency": {
+                      "type": "string"
+                    },
+                    "vest_start_date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "vest_total_months": {
+                      "type": "integer"
+                    },
+                    "vested_shares_today": {
+                      "type": "integer"
+                    },
+                    "vesting_progress_pct": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Update an equity grant",
+        "tags": [
+          "equity-grants"
+        ]
+      }
+    },
     "/api/goals": {
       "get": {
         "responses": {
@@ -1471,6 +3811,172 @@
         ]
       }
     },
+    "/api/investment/bond-stats": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "category": {
+                      "type": "string"
+                    },
+                    "returns": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "roi_percentage": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "total_contributed": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "total_value": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Bond ROI aggregates",
+        "tags": [
+          "investment"
+        ]
+      }
+    },
+    "/api/investment/stock-stats": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "category": {
+                      "type": "string"
+                    },
+                    "returns": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "roi_percentage": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "total_contributed": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "total_value": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Stock ROI aggregates",
+        "tags": [
+          "investment"
+        ]
+      }
+    },
+    "/api/payments": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "payment_count": {
+                      "type": "integer"
+                    },
+                    "payments": {
+                      "items": {
+                        "properties": {
+                          "account_id": {
+                            "type": "integer"
+                          },
+                          "account_name": {
+                            "type": "string"
+                          },
+                          "amount": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "created_at": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "owner": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total_paid": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List all debt payments",
+        "tags": [
+          "debt-payments"
+        ]
+      }
+    },
+    "/api/payments/counts": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Debt-payment counts per account",
+        "tags": [
+          "debt-payments"
+        ]
+      }
+    },
     "/api/personas": {
       "get": {
         "responses": {
@@ -1661,6 +4167,860 @@
         "summary": "Update a persona",
         "tags": [
           "personas"
+        ]
+      }
+    },
+    "/api/retirement/limits/{year}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "year",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "account_wrapper": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "integer"
+                      },
+                      "limit_amount": {
+                        "format": "double",
+                        "type": "number"
+                      },
+                      "notes": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "owner": {
+                        "type": "string"
+                      },
+                      "year": {
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Contribution limits for a year",
+        "tags": [
+          "retirement"
+        ]
+      }
+    },
+    "/api/retirement/limits/{year}/{wrapper}/{owner}": {
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "year",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "wrapper",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "AccountWrapper": {
+                    "type": "string"
+                  },
+                  "LimitAmount": {
+                    "type": "string"
+                  },
+                  "Notes": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "Owner": {
+                    "type": "string"
+                  },
+                  "Year": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account_wrapper": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "limit_amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "notes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "owner": {
+                      "type": "string"
+                    },
+                    "year": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Upsert a contribution limit",
+        "tags": [
+          "retirement"
+        ]
+      }
+    },
+    "/api/retirement/ppk-contributions/generate": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "Month": {
+                    "type": "integer"
+                  },
+                  "Owner": {
+                    "type": "string"
+                  },
+                  "Year": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "employee_amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "employer_amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "gross_salary": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "month": {
+                      "type": "integer"
+                    },
+                    "owner": {
+                      "type": "string"
+                    },
+                    "total_amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "transactions_created": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "year": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Generate monthly PPK contributions",
+        "tags": [
+          "retirement"
+        ]
+      }
+    },
+    "/api/retirement/ppk-stats": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "employee_contributed": {
+                        "format": "double",
+                        "type": "number"
+                      },
+                      "employer_contributed": {
+                        "format": "double",
+                        "type": "number"
+                      },
+                      "government_contributed": {
+                        "format": "double",
+                        "type": "number"
+                      },
+                      "owner": {
+                        "type": "string"
+                      },
+                      "returns": {
+                        "format": "double",
+                        "type": "number"
+                      },
+                      "roi_percentage": {
+                        "format": "double",
+                        "type": "number"
+                      },
+                      "total_contributed": {
+                        "format": "double",
+                        "type": "number"
+                      },
+                      "total_value": {
+                        "format": "double",
+                        "type": "number"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "PPK stats per owner",
+        "tags": [
+          "retirement"
+        ]
+      }
+    },
+    "/api/retirement/stats": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "account_wrapper": {
+                        "type": "string"
+                      },
+                      "employee_contributed": {
+                        "format": "double",
+                        "type": "number"
+                      },
+                      "employer_contributed": {
+                        "format": "double",
+                        "type": "number"
+                      },
+                      "is_warning": {
+                        "type": "boolean"
+                      },
+                      "limit_amount": {
+                        "format": "double",
+                        "nullable": true,
+                        "type": "number"
+                      },
+                      "owner": {
+                        "type": "string"
+                      },
+                      "percentage_used": {
+                        "format": "double",
+                        "nullable": true,
+                        "type": "number"
+                      },
+                      "remaining": {
+                        "format": "double",
+                        "nullable": true,
+                        "type": "number"
+                      },
+                      "total_contributed": {
+                        "format": "double",
+                        "type": "number"
+                      },
+                      "year": {
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "IKE/IKZE yearly stats",
+        "tags": [
+          "retirement"
+        ]
+      }
+    },
+    "/api/salaries": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "available_companies": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "current_salaries": {
+                      "additionalProperties": {
+                        "format": "double",
+                        "nullable": true,
+                        "type": "number"
+                      },
+                      "type": "object"
+                    },
+                    "inflation_context": {
+                      "additionalProperties": {
+                        "properties": {
+                          "cpi_as_of_year": {
+                            "type": "integer"
+                          },
+                          "current_salary": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "last_change_date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "owner": {
+                            "type": "string"
+                          },
+                          "previous_change_date": {
+                            "format": "date",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "previous_salary": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "previous_salary_in_today_pln": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "real_change_pct": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          },
+                          "real_change_pln": {
+                            "format": "double",
+                            "nullable": true,
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "object"
+                    },
+                    "salary_records": {
+                      "items": {
+                        "properties": {
+                          "company": {
+                            "type": "string"
+                          },
+                          "contract_type": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "gross_amount": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "is_active": {
+                            "type": "boolean"
+                          },
+                          "owner": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "total_count": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List salary records",
+        "tags": [
+          "salaries"
+        ]
+      },
+      "post": {
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "company": {
+                      "type": "string"
+                    },
+                    "contract_type": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "gross_amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "owner": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create a salary record",
+        "tags": [
+          "salaries"
+        ]
+      }
+    },
+    "/api/salaries/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete a salary record",
+        "tags": [
+          "salaries"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "company": {
+                      "type": "string"
+                    },
+                    "contract_type": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "gross_amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "owner": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get a salary record",
+        "tags": [
+          "salaries"
+        ]
+      },
+      "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "company": {
+                      "type": "string"
+                    },
+                    "contract_type": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "date": {
+                      "format": "date",
+                      "type": "string"
+                    },
+                    "gross_amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_active": {
+                      "type": "boolean"
+                    },
+                    "owner": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Update a salary record",
+        "tags": [
+          "salaries"
+        ]
+      }
+    },
+    "/api/simulations/mortgage-vs-invest": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "inputs": {
+                      "properties": {
+                        "annual_interest_rate": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "enable_variable_rate": {
+                          "type": "boolean"
+                        },
+                        "expected_annual_return": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "inflation_rate": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "remaining_months": {
+                          "type": "integer"
+                        },
+                        "remaining_principal": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "total_monthly_budget": {
+                          "format": "double",
+                          "type": "number"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "summary": {
+                      "properties": {
+                        "belka_tax_a": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "belka_tax_b": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "break_even_gross_return": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "final_investment_portfolio": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "final_portfolio_a_real": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "final_portfolio_b_real": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "interest_saved": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "months_saved": {
+                          "type": "integer"
+                        },
+                        "net_advantage": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "regular_monthly_payment": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "total_interest_a": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "total_interest_b": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "winning_strategy": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "yearly_projections": {
+                      "items": {
+                        "properties": {
+                          "annual_rate": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "net_advantage_invest": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "scenario_a_after_tax_portfolio": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "scenario_a_cumulative_interest": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "scenario_a_investment_balance": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "scenario_a_mortgage_balance": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "scenario_a_paid_off": {
+                            "type": "boolean"
+                          },
+                          "scenario_a_real_mortgage_balance": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "scenario_a_real_portfolio": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "scenario_b_after_tax_portfolio": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "scenario_b_cumulative_interest": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "scenario_b_investment_balance": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "scenario_b_mortgage_balance": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "scenario_b_real_mortgage_balance": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "scenario_b_real_portfolio": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "year": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Mortgage overpay vs invest comparison",
+        "tags": [
+          "simulations"
+        ]
+      }
+    },
+    "/api/simulations/prefill": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "summary": "Prefill simulation inputs",
+        "tags": [
+          "simulations"
+        ]
+      }
+    },
+    "/api/simulations/retirement": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "summary": "Retirement account projection",
+        "tags": [
+          "simulations"
         ]
       }
     },
@@ -1909,6 +5269,348 @@
         "summary": "Update a snapshot",
         "tags": [
           "snapshots"
+        ]
+      }
+    },
+    "/api/transactions": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "total_invested": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "transaction_count": {
+                      "type": "integer"
+                    },
+                    "transactions": {
+                      "items": {
+                        "properties": {
+                          "account_id": {
+                            "type": "integer"
+                          },
+                          "account_name": {
+                            "type": "string"
+                          },
+                          "amount": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "created_at": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "owner": {
+                            "type": "string"
+                          },
+                          "transaction_type": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List all transactions",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/transactions/counts": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Transaction counts per account",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/zus/calculate": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "inputs": {
+                      "properties": {
+                        "birth_date": {
+                          "format": "date",
+                          "type": "string"
+                        },
+                        "current_gross_monthly_salary": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "gender": {
+                          "type": "string"
+                        },
+                        "has_ofe": {
+                          "type": "boolean"
+                        },
+                        "inflation_rate": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "kapital_poczatkowy": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "owner": {
+                          "type": "string"
+                        },
+                        "retirement_age": {
+                          "type": "integer"
+                        },
+                        "salary_growth_rate": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "salary_history": {
+                          "items": {
+                            "properties": {
+                              "annual_gross": {
+                                "format": "double",
+                                "type": "number"
+                              },
+                              "year": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "valorization_rate_konto": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "valorization_rate_subkonto": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "work_start_year": {
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "kapital_poczatkowy_valorized": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "konto_at_retirement": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "last_gross_salary": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "life_expectancy_months": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "monthly_pension_gross": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "monthly_pension_net": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "replacement_rate": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "sensitivity": {
+                      "items": {
+                        "properties": {
+                          "label": {
+                            "type": "string"
+                          },
+                          "monthly_pension_gross": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "monthly_pension_net": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "replacement_rate": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "valorization_konto": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "valorization_subkonto": {
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "subkonto_at_retirement": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "total_capital": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "yearly_projections": {
+                      "items": {
+                        "properties": {
+                          "age": {
+                            "type": "integer"
+                          },
+                          "annual_gross_salary": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "contribution_konto": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "contribution_subkonto": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "konto_balance": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "salary_capped": {
+                            "type": "boolean"
+                          },
+                          "subkonto_balance": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "total_balance": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "year": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Project a ZUS pension",
+        "tags": [
+          "zus"
+        ]
+      }
+    },
+    "/api/zus/prefill": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "birth_date": {
+                      "format": "date",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "current_gross_monthly_salary": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "gender": {
+                      "type": "string"
+                    },
+                    "owner": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "retirement_age": {
+                      "type": "integer"
+                    },
+                    "salary_history": {
+                      "items": {
+                        "properties": {
+                          "annual_gross": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "year": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "work_start_year": {
+                      "nullable": true,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Prefill ZUS inputs from salary history",
+        "tags": [
+          "zus"
         ]
       }
     },

--- a/backend-go/cmd/gen-openapi/routes.go
+++ b/backend-go/cmd/gen-openapi/routes.go
@@ -4,11 +4,23 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/accounts"
 	"github.com/Automaat/finance-buddy/backend-go/internal/apispec"
 	"github.com/Automaat/finance-buddy/backend-go/internal/assets"
+	bonusevents "github.com/Automaat/finance-buddy/backend-go/internal/bonus_events"
+	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/config"
+	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 	"github.com/Automaat/finance-buddy/backend-go/internal/dashboard"
+	debtpayments "github.com/Automaat/finance-buddy/backend-go/internal/debt_payments"
+	"github.com/Automaat/finance-buddy/backend-go/internal/debts"
+	equitygrants "github.com/Automaat/finance-buddy/backend-go/internal/equity_grants"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
+	"github.com/Automaat/finance-buddy/backend-go/internal/investment"
 	"github.com/Automaat/finance-buddy/backend-go/internal/personas"
+	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
+	"github.com/Automaat/finance-buddy/backend-go/internal/salaries"
+	"github.com/Automaat/finance-buddy/backend-go/internal/simulations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/snapshots"
+	"github.com/Automaat/finance-buddy/backend-go/internal/transactions"
+	"github.com/Automaat/finance-buddy/backend-go/internal/zus"
 )
 
 // healthResponse mirrors the inline /health payload (it has no endpoint
@@ -27,12 +39,29 @@ func allRoutes() []apispec.Route {
 			Response: healthResponse{},
 		},
 	}
-	routes = append(routes, config.APISpec...)
-	routes = append(routes, personas.APISpec...)
-	routes = append(routes, goals.APISpec...)
-	routes = append(routes, accounts.APISpec...)
-	routes = append(routes, assets.APISpec...)
-	routes = append(routes, snapshots.APISpec...)
-	routes = append(routes, dashboard.APISpec...)
+	specs := [][]apispec.Route{
+		config.APISpec,
+		personas.APISpec,
+		goals.APISpec,
+		accounts.APISpec,
+		assets.APISpec,
+		snapshots.APISpec,
+		dashboard.APISpec,
+		companyvaluations.APISpec,
+		bonusevents.APISpec,
+		equitygrants.APISpec,
+		cpi.APISpec,
+		salaries.APISpec,
+		zus.APISpec,
+		retirement.APISpec,
+		investment.APISpec,
+		simulations.APISpec,
+		transactions.APISpec,
+		debtpayments.APISpec,
+		debts.APISpec,
+	}
+	for _, s := range specs {
+		routes = append(routes, s...)
+	}
 	return sortedRoutes(routes)
 }

--- a/backend-go/internal/bonus_events/openapi.go
+++ b/backend-go/internal/bonus_events/openapi.go
@@ -1,0 +1,12 @@
+package bonusevents
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "GET", Path: "/api/bonuses", Tag: "bonuses", Summary: "List bonus events", Response: listResponse{}},
+	{Method: "GET", Path: "/api/bonuses/{id}", Tag: "bonuses", Summary: "Get a bonus event", Response: response{}},
+	{Method: "POST", Path: "/api/bonuses", Tag: "bonuses", Summary: "Create a bonus event", Request: createRequest{}, Response: response{}, Status: 201},
+	{Method: "PATCH", Path: "/api/bonuses/{id}", Tag: "bonuses", Summary: "Update a bonus event", Response: response{}},
+	{Method: "DELETE", Path: "/api/bonuses/{id}", Tag: "bonuses", Summary: "Delete a bonus event", Status: 204},
+}

--- a/backend-go/internal/bonus_events/openapi.go
+++ b/backend-go/internal/bonus_events/openapi.go
@@ -6,7 +6,7 @@ import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
 var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/bonuses", Tag: "bonuses", Summary: "List bonus events", Response: listResponse{}},
 	{Method: "GET", Path: "/api/bonuses/{id}", Tag: "bonuses", Summary: "Get a bonus event", Response: response{}},
-	{Method: "POST", Path: "/api/bonuses", Tag: "bonuses", Summary: "Create a bonus event", Request: createRequest{}, Response: response{}, Status: 201},
+	{Method: "POST", Path: "/api/bonuses", Tag: "bonuses", Summary: "Create a bonus event", Response: response{}, Status: 201},
 	{Method: "PATCH", Path: "/api/bonuses/{id}", Tag: "bonuses", Summary: "Update a bonus event", Response: response{}},
 	{Method: "DELETE", Path: "/api/bonuses/{id}", Tag: "bonuses", Summary: "Delete a bonus event", Status: 204},
 }

--- a/backend-go/internal/company_valuations/openapi.go
+++ b/backend-go/internal/company_valuations/openapi.go
@@ -6,7 +6,7 @@ import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
 var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/company-valuations", Tag: "company-valuations", Summary: "List company valuations", Response: listResponse{}},
 	{Method: "GET", Path: "/api/company-valuations/{id}", Tag: "company-valuations", Summary: "Get a company valuation", Response: response{}},
-	{Method: "POST", Path: "/api/company-valuations", Tag: "company-valuations", Summary: "Create a company valuation", Request: createRequest{}, Response: response{}, Status: 201},
+	{Method: "POST", Path: "/api/company-valuations", Tag: "company-valuations", Summary: "Create a company valuation", Response: response{}, Status: 201},
 	{Method: "PATCH", Path: "/api/company-valuations/{id}", Tag: "company-valuations", Summary: "Update a company valuation", Response: response{}},
 	{Method: "DELETE", Path: "/api/company-valuations/{id}", Tag: "company-valuations", Summary: "Delete a company valuation", Status: 204},
 }

--- a/backend-go/internal/company_valuations/openapi.go
+++ b/backend-go/internal/company_valuations/openapi.go
@@ -1,0 +1,12 @@
+package companyvaluations
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "GET", Path: "/api/company-valuations", Tag: "company-valuations", Summary: "List company valuations", Response: listResponse{}},
+	{Method: "GET", Path: "/api/company-valuations/{id}", Tag: "company-valuations", Summary: "Get a company valuation", Response: response{}},
+	{Method: "POST", Path: "/api/company-valuations", Tag: "company-valuations", Summary: "Create a company valuation", Request: createRequest{}, Response: response{}, Status: 201},
+	{Method: "PATCH", Path: "/api/company-valuations/{id}", Tag: "company-valuations", Summary: "Update a company valuation", Response: response{}},
+	{Method: "DELETE", Path: "/api/company-valuations/{id}", Tag: "company-valuations", Summary: "Delete a company valuation", Status: 204},
+}

--- a/backend-go/internal/cpi/openapi.go
+++ b/backend-go/internal/cpi/openapi.go
@@ -1,0 +1,10 @@
+package cpi
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "GET", Path: "/api/cpi/series", Tag: "cpi", Summary: "Get the CPI year-over-year series", Response: seriesResponse{}},
+	{Method: "POST", Path: "/api/cpi/adjust", Tag: "cpi", Summary: "Inflation-adjust an amount between two dates", Response: adjustResponse{}},
+	{Method: "POST", Path: "/api/cpi/refresh", Tag: "cpi", Summary: "Refresh CPI data from GUS", Response: refreshResponse{}},
+}

--- a/backend-go/internal/debt_payments/openapi.go
+++ b/backend-go/internal/debt_payments/openapi.go
@@ -5,7 +5,7 @@ import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
 // APISpec registers this package's routes for OpenAPI generation.
 var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/accounts/{account_id}/payments", Tag: "debt-payments", Summary: "List an account's debt payments", Response: listResponse{}},
-	{Method: "POST", Path: "/api/accounts/{account_id}/payments", Tag: "debt-payments", Summary: "Create a debt payment", Request: createRequest{}, Response: response{}, Status: 201},
+	{Method: "POST", Path: "/api/accounts/{account_id}/payments", Tag: "debt-payments", Summary: "Create a debt payment", Response: response{}, Status: 201},
 	{Method: "DELETE", Path: "/api/accounts/{account_id}/payments/{payment_id}", Tag: "debt-payments", Summary: "Delete a debt payment", Status: 204},
 	{Method: "GET", Path: "/api/payments", Tag: "debt-payments", Summary: "List all debt payments", Response: listResponse{}},
 	{Method: "GET", Path: "/api/payments/counts", Tag: "debt-payments", Summary: "Debt-payment counts per account", Response: map[string]int{}},

--- a/backend-go/internal/debt_payments/openapi.go
+++ b/backend-go/internal/debt_payments/openapi.go
@@ -1,0 +1,12 @@
+package debtpayments
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "GET", Path: "/api/accounts/{account_id}/payments", Tag: "debt-payments", Summary: "List an account's debt payments", Response: listResponse{}},
+	{Method: "POST", Path: "/api/accounts/{account_id}/payments", Tag: "debt-payments", Summary: "Create a debt payment", Request: createRequest{}, Response: response{}, Status: 201},
+	{Method: "DELETE", Path: "/api/accounts/{account_id}/payments/{payment_id}", Tag: "debt-payments", Summary: "Delete a debt payment", Status: 204},
+	{Method: "GET", Path: "/api/payments", Tag: "debt-payments", Summary: "List all debt payments", Response: listResponse{}},
+	{Method: "GET", Path: "/api/payments/counts", Tag: "debt-payments", Summary: "Debt-payment counts per account", Response: map[string]int{}},
+}

--- a/backend-go/internal/debts/openapi.go
+++ b/backend-go/internal/debts/openapi.go
@@ -1,0 +1,12 @@
+package debts
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "GET", Path: "/api/debts", Tag: "debts", Summary: "List debts", Response: listResponse{}},
+	{Method: "POST", Path: "/api/accounts/{account_id}/debts", Tag: "debts", Summary: "Create a debt", Request: createRequest{}, Response: response{}, Status: 201},
+	{Method: "GET", Path: "/api/debts/{id}", Tag: "debts", Summary: "Get a debt", Response: response{}},
+	{Method: "PUT", Path: "/api/debts/{id}", Tag: "debts", Summary: "Update a debt", Response: response{}},
+	{Method: "DELETE", Path: "/api/debts/{id}", Tag: "debts", Summary: "Delete a debt", Status: 204},
+}

--- a/backend-go/internal/debts/openapi.go
+++ b/backend-go/internal/debts/openapi.go
@@ -5,7 +5,7 @@ import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
 // APISpec registers this package's routes for OpenAPI generation.
 var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/debts", Tag: "debts", Summary: "List debts", Response: listResponse{}},
-	{Method: "POST", Path: "/api/accounts/{account_id}/debts", Tag: "debts", Summary: "Create a debt", Request: createRequest{}, Response: response{}, Status: 201},
+	{Method: "POST", Path: "/api/accounts/{account_id}/debts", Tag: "debts", Summary: "Create a debt", Response: response{}, Status: 201},
 	{Method: "GET", Path: "/api/debts/{id}", Tag: "debts", Summary: "Get a debt", Response: response{}},
 	{Method: "PUT", Path: "/api/debts/{id}", Tag: "debts", Summary: "Update a debt", Response: response{}},
 	{Method: "DELETE", Path: "/api/debts/{id}", Tag: "debts", Summary: "Delete a debt", Status: 204},

--- a/backend-go/internal/equity_grants/openapi.go
+++ b/backend-go/internal/equity_grants/openapi.go
@@ -1,0 +1,12 @@
+package equitygrants
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "GET", Path: "/api/equity-grants", Tag: "equity-grants", Summary: "List equity grants", Response: listResponse{}},
+	{Method: "GET", Path: "/api/equity-grants/{id}", Tag: "equity-grants", Summary: "Get an equity grant", Response: response{}},
+	{Method: "POST", Path: "/api/equity-grants", Tag: "equity-grants", Summary: "Create an equity grant", Response: response{}, Status: 201},
+	{Method: "PATCH", Path: "/api/equity-grants/{id}", Tag: "equity-grants", Summary: "Update an equity grant", Response: response{}},
+	{Method: "DELETE", Path: "/api/equity-grants/{id}", Tag: "equity-grants", Summary: "Delete an equity grant", Status: 204},
+}

--- a/backend-go/internal/investment/openapi.go
+++ b/backend-go/internal/investment/openapi.go
@@ -1,0 +1,9 @@
+package investment
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "GET", Path: "/api/investment/stock-stats", Tag: "investment", Summary: "Stock ROI aggregates", Response: response{}},
+	{Method: "GET", Path: "/api/investment/bond-stats", Tag: "investment", Summary: "Bond ROI aggregates", Response: response{}},
+}

--- a/backend-go/internal/retirement/openapi.go
+++ b/backend-go/internal/retirement/openapi.go
@@ -6,7 +6,7 @@ import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
 var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/retirement/stats", Tag: "retirement", Summary: "IKE/IKZE yearly stats", Response: []yearlyStat{}},
 	{Method: "GET", Path: "/api/retirement/ppk-stats", Tag: "retirement", Summary: "PPK stats per owner", Response: []ppkStat{}},
-	{Method: "POST", Path: "/api/retirement/ppk-contributions/generate", Tag: "retirement", Summary: "Generate monthly PPK contributions", Request: generateRequest{}, Response: ppkGenerateResponse{}},
+	{Method: "POST", Path: "/api/retirement/ppk-contributions/generate", Tag: "retirement", Summary: "Generate monthly PPK contributions", Response: ppkGenerateResponse{}},
 	{Method: "GET", Path: "/api/retirement/limits/{year}", Tag: "retirement", Summary: "Contribution limits for a year", Response: []limitResponse{}},
-	{Method: "PUT", Path: "/api/retirement/limits/{year}/{wrapper}/{owner}", Tag: "retirement", Summary: "Upsert a contribution limit", Request: limitRequest{}, Response: limitResponse{}},
+	{Method: "PUT", Path: "/api/retirement/limits/{year}/{wrapper}/{owner}", Tag: "retirement", Summary: "Upsert a contribution limit", Response: limitResponse{}},
 }

--- a/backend-go/internal/retirement/openapi.go
+++ b/backend-go/internal/retirement/openapi.go
@@ -1,0 +1,12 @@
+package retirement
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "GET", Path: "/api/retirement/stats", Tag: "retirement", Summary: "IKE/IKZE yearly stats", Response: []yearlyStat{}},
+	{Method: "GET", Path: "/api/retirement/ppk-stats", Tag: "retirement", Summary: "PPK stats per owner", Response: []ppkStat{}},
+	{Method: "POST", Path: "/api/retirement/ppk-contributions/generate", Tag: "retirement", Summary: "Generate monthly PPK contributions", Request: generateRequest{}, Response: ppkGenerateResponse{}},
+	{Method: "GET", Path: "/api/retirement/limits/{year}", Tag: "retirement", Summary: "Contribution limits for a year", Response: []limitResponse{}},
+	{Method: "PUT", Path: "/api/retirement/limits/{year}/{wrapper}/{owner}", Tag: "retirement", Summary: "Upsert a contribution limit", Request: limitRequest{}, Response: limitResponse{}},
+}

--- a/backend-go/internal/salaries/openapi.go
+++ b/backend-go/internal/salaries/openapi.go
@@ -1,0 +1,12 @@
+package salaries
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "GET", Path: "/api/salaries", Tag: "salaries", Summary: "List salary records", Response: listResponse{}},
+	{Method: "GET", Path: "/api/salaries/{id}", Tag: "salaries", Summary: "Get a salary record", Response: response{}},
+	{Method: "POST", Path: "/api/salaries", Tag: "salaries", Summary: "Create a salary record", Response: response{}, Status: 201},
+	{Method: "PATCH", Path: "/api/salaries/{id}", Tag: "salaries", Summary: "Update a salary record", Response: response{}},
+	{Method: "DELETE", Path: "/api/salaries/{id}", Tag: "salaries", Summary: "Delete a salary record", Status: 204},
+}

--- a/backend-go/internal/simulations/openapi.go
+++ b/backend-go/internal/simulations/openapi.go
@@ -1,0 +1,13 @@
+package simulations
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+//
+// The retirement + prefill responses are assembled as dynamic maps in the
+// handler, so only their paths are registered (no response schema).
+var APISpec = []apispec.Route{
+	{Method: "POST", Path: "/api/simulations/mortgage-vs-invest", Tag: "simulations", Summary: "Mortgage overpay vs invest comparison", Response: mortgageResponse{}},
+	{Method: "POST", Path: "/api/simulations/retirement", Tag: "simulations", Summary: "Retirement account projection"},
+	{Method: "GET", Path: "/api/simulations/prefill", Tag: "simulations", Summary: "Prefill simulation inputs"},
+}

--- a/backend-go/internal/transactions/openapi.go
+++ b/backend-go/internal/transactions/openapi.go
@@ -5,7 +5,7 @@ import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
 // APISpec registers this package's routes for OpenAPI generation.
 var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/accounts/{account_id}/transactions", Tag: "transactions", Summary: "List an account's transactions", Response: listResponse{}},
-	{Method: "POST", Path: "/api/accounts/{account_id}/transactions", Tag: "transactions", Summary: "Create a transaction", Request: createRequest{}, Response: response{}, Status: 201},
+	{Method: "POST", Path: "/api/accounts/{account_id}/transactions", Tag: "transactions", Summary: "Create a transaction", Response: response{}, Status: 201},
 	{Method: "DELETE", Path: "/api/accounts/{account_id}/transactions/{transaction_id}", Tag: "transactions", Summary: "Delete a transaction", Status: 204},
 	{Method: "GET", Path: "/api/transactions", Tag: "transactions", Summary: "List all transactions", Response: listResponse{}},
 	{Method: "GET", Path: "/api/transactions/counts", Tag: "transactions", Summary: "Transaction counts per account", Response: map[string]int{}},

--- a/backend-go/internal/transactions/openapi.go
+++ b/backend-go/internal/transactions/openapi.go
@@ -1,0 +1,12 @@
+package transactions
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "GET", Path: "/api/accounts/{account_id}/transactions", Tag: "transactions", Summary: "List an account's transactions", Response: listResponse{}},
+	{Method: "POST", Path: "/api/accounts/{account_id}/transactions", Tag: "transactions", Summary: "Create a transaction", Request: createRequest{}, Response: response{}, Status: 201},
+	{Method: "DELETE", Path: "/api/accounts/{account_id}/transactions/{transaction_id}", Tag: "transactions", Summary: "Delete a transaction", Status: 204},
+	{Method: "GET", Path: "/api/transactions", Tag: "transactions", Summary: "List all transactions", Response: listResponse{}},
+	{Method: "GET", Path: "/api/transactions/counts", Tag: "transactions", Summary: "Transaction counts per account", Response: map[string]int{}},
+}

--- a/backend-go/internal/zus/openapi.go
+++ b/backend-go/internal/zus/openapi.go
@@ -1,0 +1,9 @@
+package zus
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "POST", Path: "/api/zus/calculate", Tag: "zus", Summary: "Project a ZUS pension", Response: calculateResponse{}},
+	{Method: "GET", Path: "/api/zus/prefill", Tag: "zus", Summary: "Prefill ZUS inputs from salary history", Response: prefillResponse{}},
+}


### PR DESCRIPTION
## Motivation

Second of 3 PRs for #457. PR 1 built the generator + registered 7 core domains. This PR registers the **remaining 11 endpoint groups** so the spec covers everything backend-go serves.

## Implementation information

Adds `openapi.go` (an exported `APISpec []apispec.Route`) to: company-valuations, bonuses, equity-grants, cpi, salaries, zus, retirement, investment, simulations, transactions, debt-payments, debts. Each is wired into `allRoutes()` in `cmd/gen-openapi/routes.go`.

`api/openapi-go.json` now covers **all 75 operations across 47 paths**. The CI drift gate (added in PR 1) keeps it honest.

### Known gap

`simulations`' `POST /api/simulations/retirement` and `GET /api/simulations/prefill` assemble their responses as dynamic `map[string]any` in the handler — only their paths are registered, no response schema. Documented in `simulations/openapi.go`.

## Out of scope (PR 3)

Frontend `openapi-typescript` codegen + `api.generated.ts` + a consumer + the TS drift gate.

> Changelog: skip