### PR TITLE
fix(docker): copy .npmrc before npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM node:24-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+# Copy package files (.npmrc carries legacy-peer-deps for the npm ci below)
+COPY package*.json .npmrc ./
 
 # Install dependencies
 RUN npm ci

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,8 +2,8 @@ FROM node:24-alpine
 
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+# Copy package files (.npmrc carries legacy-peer-deps for the npm ci below)
+COPY package*.json .npmrc ./
 
 # Install dependencies
 RUN npm ci


### PR DESCRIPTION
## Motivation

The v0.28.0 release build failed: the frontend image's `npm ci` hit `ERESOLVE`. `openapi-typescript` (added for the OpenAPI→TS pipeline) peer-requires `typescript@^5.x`, but the project is on `typescript@6`.

`.npmrc` already sets `legacy-peer-deps=true`, which makes npm tolerate this — but the Dockerfiles copied only `package*.json`, so the in-image `npm ci` ran without `.npmrc` and failed. Local builds passed because `.npmrc` is present in the working tree.

## Implementation information

`COPY package*.json .npmrc ./` before `npm ci` in both `Dockerfile` and `Dockerfile.dev`. `.npmrc` is not `.dockerignore`d, so it's already in the build context.

> Changelog: skip