### PR TITLE
refactor(config): centralize palette + tax rate

### DIFF
--- a/backend-go/internal/simulations/accounts.go
+++ b/backend-go/internal/simulations/accounts.go
@@ -115,7 +115,6 @@ type BrokerageParams struct {
 // SimulateBrokerageAccount ports simulate_brokerage_account — taxable account
 // with 19% capital-gains tax on positive annual returns.
 func SimulateBrokerageAccount(p BrokerageParams, currentAge, retirementAge, currentYear int, annualReturnRate float64) AccountSimulation {
-	const capitalGainsTaxRate = 19.0
 	years := retirementAge - currentAge
 	balance := p.StartingBalance
 	projections := make([]YearlyProjection, 0, years)
@@ -127,7 +126,7 @@ func SimulateBrokerageAccount(p BrokerageParams, currentAge, retirementAge, curr
 		grossReturns := balance * (annualReturnRate / 100)
 		netReturns := grossReturns
 		if grossReturns > 0 {
-			netReturns = grossReturns * (1 - capitalGainsTaxRate/100)
+			netReturns = grossReturns * (1 - capitalGainsTaxRate)
 		}
 		balance += netReturns
 		cumulativeReturns += netReturns

--- a/backend-go/internal/simulations/mortgage.go
+++ b/backend-go/internal/simulations/mortgage.go
@@ -9,8 +9,6 @@ import (
 	"math"
 )
 
-const belkaRate = 0.19
-
 // MortgageInputs mirrors MortgageVsInvestInputs after validation.
 type MortgageInputs struct {
 	RemainingPrincipal   float64
@@ -76,7 +74,7 @@ func (e *BudgetTooLowError) Error() string { return "budget below required payme
 // backend/app/services/simulations/mortgage.simulate_mortgage_vs_invest.
 func SimulateMortgageVsInvest(in MortgageInputs) (MortgageResult, error) {
 	monthlyRate := in.AnnualInterestRate / 100 / 12
-	monthlyInvestRate := in.ExpectedAnnualReturn * (1 - belkaRate) / 100 / 12
+	monthlyInvestRate := in.ExpectedAnnualReturn * (1 - capitalGainsTaxRate) / 100 / 12
 	n := in.RemainingMonths
 	p := in.RemainingPrincipal
 
@@ -213,7 +211,7 @@ func mortgageSummary(in MortgageInputs, regularPayment float64, s finalState) Mo
 		MonthsSaved:              monthsSaved,
 		WinningStrategy:          winningStrategy,
 		NetAdvantage:             round(netAdvantage, 2),
-		BreakEvenGrossReturn:     round(in.AnnualInterestRate/(1-belkaRate), 4),
+		BreakEvenGrossReturn:     round(in.AnnualInterestRate/(1-capitalGainsTaxRate), 4),
 	}
 }
 

--- a/backend-go/internal/simulations/taxrates.go
+++ b/backend-go/internal/simulations/taxrates.go
@@ -1,0 +1,7 @@
+package simulations
+
+// capitalGainsTaxRate is the Polish capital-gains tax ("podatek Belki"),
+// a flat 19% on investment gains, unchanged since 2004. Defined once here
+// so the brokerage and mortgage simulations share a single source instead
+// of repeating the literal.
+const capitalGainsTaxRate = 0.19

--- a/src/lib/components/DashboardCharts.svelte
+++ b/src/lib/components/DashboardCharts.svelte
@@ -4,6 +4,7 @@
 	import type { EChartsOption } from 'echarts';
 	import { formatPLN } from '$lib/utils/format';
 	import { isMobile, isTablet } from '$lib/utils/viewport';
+	import { chartPalette, chartAccent, chartAccentGradient } from '$lib/utils/theme';
 
 	interface Props {
 		netWorthHistory: { date: string; value: number }[];
@@ -58,11 +59,11 @@
 					smooth: true,
 					areaStyle: {
 						color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-							{ offset: 0, color: 'rgba(225, 29, 72, 0.5)' },
-							{ offset: 1, color: 'rgba(225, 29, 72, 0.1)' }
+							{ offset: 0, color: chartAccentGradient[0] },
+							{ offset: 1, color: chartAccentGradient[1] }
 						])
 					},
-					lineStyle: { color: '#e11d48', width: 2 }
+					lineStyle: { color: chartAccent, width: 2 }
 				}
 			],
 			grid: gridConfig
@@ -79,16 +80,7 @@
 				textStyle: { fontSize: titleFontSize }
 			},
 			tooltip: { trigger: 'item', formatter: '{b}: {c} PLN ({d}%)' },
-			color: [
-				'#e11d48',
-				'#f43f5e',
-				'#fb7185',
-				'#fda4af',
-				'#881337',
-				'#9f1239',
-				'#be123c',
-				'#be185d'
-			],
+			color: [...chartPalette],
 			series: [
 				{
 					type: 'pie',

--- a/src/lib/utils/theme.test.ts
+++ b/src/lib/utils/theme.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { chartPalette, chartAccent, chartAccentGradient } from './theme';
+
+describe('theme', () => {
+	it('exposes 8 distinct palette colors', () => {
+		expect(chartPalette).toHaveLength(8);
+		expect(new Set(chartPalette).size).toBe(8);
+	});
+
+	it('every palette entry is a hex color', () => {
+		for (const color of chartPalette) {
+			expect(color).toMatch(/^#[0-9a-f]{6}$/);
+		}
+	});
+
+	it('accent is the first palette color', () => {
+		expect(chartAccent).toBe(chartPalette[0]);
+	});
+
+	it('gradient has two stops derived from the accent', () => {
+		expect(chartAccentGradient).toHaveLength(2);
+		for (const stop of chartAccentGradient) {
+			expect(stop).toMatch(/^rgba\(225, 29, 72, /);
+		}
+	});
+});

--- a/src/lib/utils/theme.ts
+++ b/src/lib/utils/theme.ts
@@ -1,0 +1,20 @@
+// Shared ECharts color tokens. Centralized so chart components don't carry
+// their own hardcoded palettes. Rose/crimson scale matching the app theme.
+
+/** Categorical palette for multi-series charts (e.g. allocation pie). */
+export const chartPalette = [
+	'#e11d48',
+	'#f43f5e',
+	'#fb7185',
+	'#fda4af',
+	'#881337',
+	'#9f1239',
+	'#be123c',
+	'#be185d'
+] as const;
+
+/** Accent color for single-series charts (e.g. net worth line). */
+export const chartAccent = '#e11d48';
+
+/** Area-fill gradient stops for the accent color, top (opaque) to bottom (faint). */
+export const chartAccentGradient = ['rgba(225, 29, 72, 0.5)', 'rgba(225, 29, 72, 0.1)'] as const;

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -113,6 +113,11 @@
 	}
 
 	async function generatePPKContributions() {
+		if (!ppkGenerateData.owner) {
+			ppkGenerateError = 'Wybierz właściciela';
+			return;
+		}
+
 		ppkGenerateError = '';
 		ppkGenerating = true;
 
@@ -142,6 +147,11 @@
 	async function createTransaction() {
 		if (!newTransactionData.account_id) {
 			transactionError = 'Wybierz konto';
+			return;
+		}
+
+		if (!newTransactionData.owner) {
+			transactionError = 'Wybierz właściciela';
 			return;
 		}
 

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -17,7 +17,7 @@
 
 	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
 	const personas = $derived(data.personas as Persona[]);
-	const defaultOwner = $derived(personas.length > 0 ? personas[0].name : 'Marcin');
+	const defaultOwner = $derived(personas.length > 0 ? personas[0].name : '');
 
 	let filterAccountId = $state(untrack(() => data.filters.account_id || ''));
 	let filterOwner = $state(untrack(() => data.filters.owner || ''));


### PR DESCRIPTION
## Motivation

Issue #360 — hardcoded values bleed into components and prevent
personalization: the dashboard ECharts palette, a literal default owner
in transactions, and a 19% capital-gains tax rate duplicated across two
simulation files.

> Changelog: refactor(config): centralize chart palette + tax rate

## Implementation information

- **Chart palette** → new `src/lib/utils/theme.ts` exporting `chartPalette`,
  `chartAccent`, `chartAccentGradient`. `DashboardCharts.svelte` imports them
  instead of carrying its own hex literals. Chose `theme.ts` over CSS vars
  since ECharts options are plain JS and consume the tokens directly.
- **Default owner** → dropped the `'Marcin'` literal in
  `transactions/+page.svelte`. The owner `<select>` is populated from the
  personas list, so the default is now the first persona (empty when none
  exist); the literal was an unreachable fallback. `AppConfig` has no owner
  field, so personas remain the source of truth.
- **Tax rate** → unified the duplicated 19% Belka capital-gains tax (a
  percent literal in `accounts.go`, a fraction in `mortgage.go`) into one
  `capitalGainsTaxRate` constant in `simulations/taxrates.go`. No DB
  `tax_rates` table: the rate has been flat 19% since 2004, no simulation
  applies tax per-year, and a year-keyed table would be unused complexity
  against the project's frozen-baseline `schema.sql` and simplicity rules.
  Numerically identical (`19.0/100 == 0.19`), so black-box golden snapshots
  are unaffected.

Quality gates: oxlint + prettier, svelte-check (0 errors), full vitest
suite (207 passing, incl. new `theme.test.ts`), `go build`, `golangci-lint`.

Closes #360