### PR TITLE
feat(auth): add login and user management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,12 +9,27 @@ NODE_ENV=development
 ORIGIN=http://localhost:3000
 APP_PASSWORD=changeme
 
+# Authentication
+# FB_JWT_SECRET signs session tokens — set a long random string (required).
+FB_JWT_SECRET=replace-with-long-random-secret
+# Admin account, seeded/refreshed on every backend startup.
+FB_ADMIN_USERNAME=admin
+FB_ADMIN_PASSWORD=replace-with-strong-admin-password
+# Set true only when the app is served over HTTPS.
+FB_COOKIE_SECURE=false
+
 # Owner Configuration (Backend)
 OWNER_NAMES=Marcin,Ewa,Shared
 DEFAULT_OWNER=Marcin
 
 # Frontend
+# Backend URL for server-side rendering (SvelteKit server -> backend).
 PUBLIC_API_URL=http://localhost:8000
+# The frontend's own origin — browser API calls route through the SvelteKit
+# /api proxy so the session token never reaches client-side JavaScript.
+PUBLIC_API_URL_BROWSER=http://localhost:5173
+# Backend URL the SvelteKit /api proxy forwards to.
+API_PROXY_TARGET=http://localhost:8000
 PUBLIC_OWNER_NAMES=Marcin,Ewa,Shared
 PUBLIC_DEFAULT_OWNER=Marcin
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,12 @@ jobs:
       APP_PASSWORD: test
       CORS_ORIGINS: http://127.0.0.1:4173,http://localhost:4173
       PUBLIC_API_URL: http://127.0.0.1:8000
-      PUBLIC_API_URL_BROWSER: http://127.0.0.1:8000
+      PUBLIC_API_URL_BROWSER: http://127.0.0.1:4173
+      API_PROXY_TARGET: http://127.0.0.1:8000
+      FB_JWT_SECRET: e2e-test-jwt-secret
+      FB_ADMIN_USERNAME: e2e-admin
+      FB_ADMIN_PASSWORD: e2e-admin-password
+      FB_COOKIE_SECURE: 'false'
       E2E_BASE_URL: http://127.0.0.1:4173
       E2E_API_URL: http://127.0.0.1:8000
       E2E_FRONTEND_PORT: '4173'

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ playwright-report/
 test-results/
 playwright/.cache/
 blob-report/
+e2e/.auth/
 
 # Misc
 .vercel

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,6 +85,7 @@ linters:
       excludes:
         - G204 # subprocess args — validated at construction
         - G304 # file inclusion via variable — intentional in this app
+        - G124 # session cookie Secure flag is runtime-configurable (FB_COOKIE_SECURE) for plain-HTTP LAN deploys
 
     govet:
       enable-all: true

--- a/backend-bb-tests/conftest.py
+++ b/backend-bb-tests/conftest.py
@@ -39,6 +39,13 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 BACKEND_GO_DIR = REPO_ROOT / "backend-go"
 STARTUP_TIMEOUT_S = 30
 
+# backend-go now requires auth config to start and gates every /api route.
+# The suite launches it with these credentials and logs in once per session;
+# overridable when driving an externally-running backend via BB_BASE_URL.
+ADMIN_USERNAME = os.environ.get("BB_ADMIN_USERNAME", "admin")
+ADMIN_PASSWORD = os.environ.get("BB_ADMIN_PASSWORD", "bb-test-admin-pw")
+JWT_SECRET = os.environ.get("BB_JWT_SECRET", "bb-test-jwt-secret")
+
 
 def _truthy(value: str | None) -> bool:
     return value is not None and value.lower() in {"1", "true", "yes", "on"}
@@ -115,6 +122,9 @@ def base_url(database_url: str, _go_binary: Path) -> Iterator[str]:
         "DATABASE_URL": database_url,
         "CORS_ORIGINS": "http://localhost:3000",
         "FB_ADDR": f":{port}",
+        "FB_JWT_SECRET": JWT_SECRET,
+        "FB_ADMIN_USERNAME": ADMIN_USERNAME,
+        "FB_ADMIN_PASSWORD": ADMIN_PASSWORD,
     }
     proc = subprocess.Popen(
         [str(_go_binary)],
@@ -138,8 +148,14 @@ def base_url(database_url: str, _go_binary: Path) -> Iterator[str]:
 
 @pytest.fixture(scope="session")
 def client(base_url: str) -> Iterator[httpx.Client]:
-    """Session-scoped httpx client pointed at the live backend."""
+    """Session-scoped httpx client, logged in as admin so the session cookie
+    rides every request to the now-gated /api routes."""
     with httpx.Client(base_url=base_url, timeout=10.0) as http:
+        response = http.post(
+            "/api/auth/login",
+            json={"username": ADMIN_USERNAME, "password": ADMIN_PASSWORD},
+        )
+        response.raise_for_status()
         yield http
 
 

--- a/backend-bb-tests/tests/test_auth.py
+++ b/backend-bb-tests/tests/test_auth.py
@@ -1,0 +1,81 @@
+"""Auth endpoints: login, session gating, admin-only user management.
+
+The shared `client` fixture is logged in as admin and session-scoped, so its
+cookie jar must not be mutated here — login flows use fresh clients.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from conftest import ADMIN_PASSWORD, ADMIN_USERNAME
+
+
+def test_login_success(base_url: str) -> None:
+    with httpx.Client(base_url=base_url, timeout=10.0) as http:
+        response = http.post(
+            "/api/auth/login",
+            json={"username": ADMIN_USERNAME, "password": ADMIN_PASSWORD},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["token"]
+        assert body["user"]["username"] == ADMIN_USERNAME
+        assert body["user"]["is_admin"] is True
+        assert "fb_token" in response.cookies
+
+
+def test_login_wrong_password(base_url: str) -> None:
+    with httpx.Client(base_url=base_url, timeout=10.0) as http:
+        response = http.post(
+            "/api/auth/login",
+            json={"username": ADMIN_USERNAME, "password": "wrong"},
+        )
+        assert response.status_code == 401
+
+
+def test_gated_route_rejects_unauthenticated(base_url: str) -> None:
+    with httpx.Client(base_url=base_url, timeout=10.0) as http:
+        assert http.get("/api/accounts").status_code == 401
+
+
+def test_me_returns_current_user(client: httpx.Client) -> None:
+    response = client.get("/api/auth/me")
+    assert response.status_code == 200
+    assert response.json()["username"] == ADMIN_USERNAME
+
+
+def test_admin_creates_user_who_can_log_in(client: httpx.Client, base_url: str) -> None:
+    created = client.post(
+        "/api/auth/users",
+        json={"username": "bb-member", "password": "member-pass-1"},
+    )
+    assert created.status_code == 201
+    assert created.json()["is_admin"] is False
+
+    with httpx.Client(base_url=base_url, timeout=10.0) as http:
+        login = http.post(
+            "/api/auth/login",
+            json={"username": "bb-member", "password": "member-pass-1"},
+        )
+        assert login.status_code == 200
+
+
+def test_non_admin_cannot_manage_users(client: httpx.Client, base_url: str) -> None:
+    client.post(
+        "/api/auth/users",
+        json={"username": "bb-plain", "password": "plain-pass-1"},
+    )
+    with httpx.Client(base_url=base_url, timeout=10.0) as http:
+        http.post(
+            "/api/auth/login",
+            json={"username": "bb-plain", "password": "plain-pass-1"},
+        )
+        assert http.get("/api/auth/users").status_code == 403
+        assert (
+            http.post(
+                "/api/auth/users",
+                json={"username": "nope", "password": "nope-pass-1"},
+            ).status_code
+            == 403
+        )

--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Automaat/finance-buddy/backend-go/internal/auth"
 	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 	"github.com/Automaat/finance-buddy/backend-go/internal/db"
 	"github.com/Automaat/finance-buddy/backend-go/internal/scheduler"
@@ -63,9 +64,23 @@ func run() int {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
 
+	jwtSecret := os.Getenv("FB_JWT_SECRET")
+	if jwtSecret == "" {
+		logger.Error("FB_JWT_SECRET is required")
+		return 2
+	}
+	adminUsername := envOr("FB_ADMIN_USERNAME", "admin")
+	adminPassword := os.Getenv("FB_ADMIN_PASSWORD")
+	if adminPassword == "" {
+		logger.Error("FB_ADMIN_PASSWORD is required")
+		return 2
+	}
+
 	cfg := server.Config{
-		Addr:        envOr("FB_ADDR", ":8000"),
-		CORSOrigins: envOrPresent("CORS_ORIGINS", "http://localhost:3000"),
+		Addr:         envOr("FB_ADDR", ":8000"),
+		CORSOrigins:  envOrPresent("CORS_ORIGINS", "http://localhost:3000"),
+		JWTSecret:    jwtSecret,
+		CookieSecure: envOr("FB_COOKIE_SECURE", "false") == "true",
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -92,6 +107,24 @@ func run() int {
 			logger.Error("apply schema", "err", err)
 			return 2
 		}
+
+		// The users table is additive — schema.sql is only applied to empty
+		// databases, so it needs its own idempotent DDL plus admin seeding.
+		authStore := auth.NewStore(pool)
+		if err := authStore.EnsureSchema(ctx); err != nil {
+			logger.Error("ensure users schema", "err", err)
+			return 2
+		}
+		adminHash, err := auth.HashPassword(adminPassword)
+		if err != nil {
+			logger.Error("hash admin password", "err", err)
+			return 2
+		}
+		if err := authStore.UpsertAdmin(ctx, adminUsername, adminHash); err != nil {
+			logger.Error("seed admin user", "err", err)
+			return 2
+		}
+		logger.Info("admin user ready", "username", adminUsername)
 
 		// CPI monthly-refresh scheduler — replaces the Python APScheduler job.
 		sched := scheduler.NewCPIScheduler(cpi.NewStore(pool), cpi.NewGUSFetcher(), logger)

--- a/backend-go/go.mod
+++ b/backend-go/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/getkin/kin-openapi v0.138.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/shopspring/decimal v1.4.0
+	golang.org/x/crypto v0.52.0
 )
 
 require (
@@ -25,7 +27,7 @@ require (
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect
-	golang.org/x/sync v0.17.0 // indirect
-	golang.org/x/text v0.29.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/backend-go/go.sum
+++ b/backend-go/go.sum
@@ -15,6 +15,8 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6 h1:D/V0gu4zQ3cL2WKeVNVM4r2gLxGGf6McLwgXzRTo2RQ=
 github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
@@ -58,10 +60,12 @@ github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
 github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
-golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
-golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
-golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
-golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/backend-go/internal/auth/errors.go
+++ b/backend-go/internal/auth/errors.go
@@ -1,0 +1,19 @@
+package auth
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}

--- a/backend-go/internal/auth/handler.go
+++ b/backend-go/internal/auth/handler.go
@@ -68,8 +68,9 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	user, err := h.store.GetByUsername(r.Context(), strings.TrimSpace(req.Username))
-	if err != nil || !checkPassword(user.PasswordHash, req.Password) {
-		// Uniform message — don't reveal whether the username exists.
+	// The user == nil guard short-circuits before checkPassword on the error
+	// path; the uniform message avoids revealing whether the username exists.
+	if err != nil || user == nil || !checkPassword(user.PasswordHash, req.Password) {
 		writeDetailError(w, http.StatusUnauthorized, "Invalid username or password")
 		return
 	}

--- a/backend-go/internal/auth/handler.go
+++ b/backend-go/internal/auth/handler.go
@@ -1,0 +1,191 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Session token lifetimes. "Remember me" extends a login from one day to five.
+const (
+	sessionTTL  = 24 * time.Hour
+	rememberTTL = 5 * 24 * time.Hour
+)
+
+// Handler is the HTTP boundary for /api/auth.
+type Handler struct {
+	store        *Store
+	tokens       *TokenService
+	logger       *slog.Logger
+	cookieSecure bool
+}
+
+// NewHandler wires the store, token service, cookie policy and logger.
+func NewHandler(store *Store, tokens *TokenService, cookieSecure bool, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, tokens: tokens, cookieSecure: cookieSecure, logger: logger}
+}
+
+type loginRequest struct {
+	Username   string `json:"username"`
+	Password   string `json:"password"`
+	RememberMe bool   `json:"remember_me"`
+}
+
+type createUserRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type userResponse struct {
+	ID        int    `json:"id"`
+	Username  string `json:"username"`
+	IsAdmin   bool   `json:"is_admin"`
+	CreatedAt string `json:"created_at"`
+}
+
+func toUserResponse(u *User) userResponse {
+	return userResponse{
+		ID:        u.ID,
+		Username:  u.Username,
+		IsAdmin:   u.IsAdmin,
+		CreatedAt: u.CreatedAt.Format("2006-01-02T15:04:05.999999"),
+	}
+}
+
+// Login serves POST /api/auth/login (public). On success it sets the session
+// cookie and returns the token plus the user.
+func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
+	var req loginRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
+		writeDetailError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+	user, err := h.store.GetByUsername(r.Context(), strings.TrimSpace(req.Username))
+	if err != nil || !checkPassword(user.PasswordHash, req.Password) {
+		// Uniform message — don't reveal whether the username exists.
+		writeDetailError(w, http.StatusUnauthorized, "Invalid username or password")
+		return
+	}
+	ttl := sessionTTL
+	if req.RememberMe {
+		ttl = rememberTTL
+	}
+	token, err := h.tokens.Sign(user.ID, user.Username, user.IsAdmin, ttl)
+	if err != nil {
+		h.logger.Error("sign token", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	h.setSessionCookie(w, token, req.RememberMe, ttl)
+	writeJSON(w, http.StatusOK, map[string]any{"token": token, "user": toUserResponse(user)})
+}
+
+// Logout serves POST /api/auth/logout (public). It clears the session cookie;
+// the stateless token itself simply expires.
+func (h *Handler) Logout(w http.ResponseWriter, _ *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     CookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   h.cookieSecure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Me serves GET /api/auth/me — the currently authenticated user.
+func (h *Handler) Me(w http.ResponseWriter, r *http.Request) {
+	claims, ok := claimsFrom(r.Context())
+	if !ok {
+		writeDetailError(w, http.StatusUnauthorized, "Not authenticated")
+		return
+	}
+	user, err := h.store.GetByUsername(r.Context(), claims.Username)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			writeDetailError(w, http.StatusUnauthorized, "Not authenticated")
+			return
+		}
+		h.logger.Error("get user", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusOK, toUserResponse(user))
+}
+
+// ListUsers serves GET /api/auth/users (admin only).
+func (h *Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
+	users, err := h.store.List(r.Context())
+	if err != nil {
+		h.logger.Error("list users", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := make([]userResponse, 0, len(users))
+	for i := range users {
+		out = append(out, toUserResponse(&users[i]))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// CreateUser serves POST /api/auth/users (admin only). The admin sets the
+// initial password.
+func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
+	var req createUserRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
+		writeDetailError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+	username, vErr := validateUsername(req.Username)
+	if vErr != "" {
+		writeDetailError(w, http.StatusUnprocessableEntity, vErr)
+		return
+	}
+	if vErr := validatePassword(req.Password); vErr != "" {
+		writeDetailError(w, http.StatusUnprocessableEntity, vErr)
+		return
+	}
+	hash, err := HashPassword(req.Password)
+	if err != nil {
+		h.logger.Error("hash password", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	user, err := h.store.Create(r.Context(), username, hash)
+	if err != nil {
+		if errors.Is(err, ErrNameConflict) {
+			writeDetailError(w, http.StatusConflict, "Username '"+username+"' already exists")
+			return
+		}
+		h.logger.Error("create user", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toUserResponse(user))
+}
+
+func (h *Handler) setSessionCookie(w http.ResponseWriter, token string, persistent bool, ttl time.Duration) {
+	c := &http.Cookie{
+		Name:     CookieName,
+		Value:    token,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   h.cookieSecure,
+		SameSite: http.SameSiteLaxMode,
+	}
+	// Persistent cookie for "remember me"; otherwise a session cookie that
+	// the browser drops on close.
+	if persistent {
+		c.MaxAge = int(ttl.Seconds())
+	}
+	http.SetCookie(w, c)
+}

--- a/backend-go/internal/auth/middleware.go
+++ b/backend-go/internal/auth/middleware.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+// CookieName is the session cookie carrying the JWT.
+const CookieName = "fb_token"
+
+type ctxKey int
+
+const claimsKey ctxKey = 0
+
+// Authenticate verifies the session JWT — taken from the fb_token cookie or a
+// Bearer Authorization header — and stores the claims in the request context.
+// Requests without a valid token get 401.
+func Authenticate(tokens *TokenService) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			raw := tokenFromRequest(r)
+			if raw == "" {
+				writeDetailError(w, http.StatusUnauthorized, "Not authenticated")
+				return
+			}
+			claims, err := tokens.Verify(raw)
+			if err != nil {
+				writeDetailError(w, http.StatusUnauthorized, "Invalid or expired token")
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), claimsKey, claims)))
+		})
+	}
+}
+
+// RequireAdmin rejects authenticated non-admin users with 403. It must run
+// after Authenticate.
+func RequireAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims, ok := claimsFrom(r.Context())
+		if !ok || !claims.IsAdmin {
+			writeDetailError(w, http.StatusForbidden, "Admin privileges required")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func tokenFromRequest(r *http.Request) string {
+	if c, err := r.Cookie(CookieName); err == nil && c.Value != "" {
+		return c.Value
+	}
+	const prefix = "Bearer "
+	if h := r.Header.Get("Authorization"); strings.HasPrefix(h, prefix) {
+		return strings.TrimPrefix(h, prefix)
+	}
+	return ""
+}
+
+func claimsFrom(ctx context.Context) (*Claims, bool) {
+	c, ok := ctx.Value(claimsKey).(*Claims)
+	return c, ok
+}

--- a/backend-go/internal/auth/password.go
+++ b/backend-go/internal/auth/password.go
@@ -1,0 +1,21 @@
+package auth
+
+import (
+	"fmt"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// HashPassword returns a bcrypt hash of the plaintext password.
+func HashPassword(plain string) (string, error) {
+	h, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.DefaultCost)
+	if err != nil {
+		return "", fmt.Errorf("hash password: %w", err)
+	}
+	return string(h), nil
+}
+
+// checkPassword reports whether plain matches the stored bcrypt hash.
+func checkPassword(hash, plain string) bool {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(plain)) == nil
+}

--- a/backend-go/internal/auth/password_test.go
+++ b/backend-go/internal/auth/password_test.go
@@ -1,0 +1,30 @@
+package auth
+
+import "testing"
+
+func TestPasswordHashVerifyRoundtrip(t *testing.T) {
+	hash, err := HashPassword("correct horse")
+	if err != nil {
+		t.Fatalf("HashPassword: %v", err)
+	}
+	if !checkPassword(hash, "correct horse") {
+		t.Fatal("expected matching password to verify")
+	}
+	if checkPassword(hash, "wrong password") {
+		t.Fatal("expected wrong password to fail")
+	}
+}
+
+func TestPasswordHashIsSalted(t *testing.T) {
+	a, err := HashPassword("same-password")
+	if err != nil {
+		t.Fatalf("HashPassword: %v", err)
+	}
+	b, err := HashPassword("same-password")
+	if err != nil {
+		t.Fatalf("HashPassword: %v", err)
+	}
+	if a == b {
+		t.Fatal("expected distinct salted hashes for the same password")
+	}
+}

--- a/backend-go/internal/auth/store.go
+++ b/backend-go/internal/auth/store.go
@@ -1,0 +1,136 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// User is an application login account.
+type User struct {
+	ID           int
+	Username     string
+	PasswordHash string
+	IsAdmin      bool
+	CreatedAt    time.Time
+}
+
+// Sentinel errors so handlers map to HTTP status without sniffing pg text.
+var (
+	ErrNotFound     = errors.New("user not found")
+	ErrNameConflict = errors.New("username already exists")
+)
+
+// Store is the persistence boundary for users.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const userColumns = `id, username, password_hash, is_admin, created_at`
+
+// EnsureSchema creates the users table if it does not exist.
+//
+// The baseline schema.sql is applied only to empty databases (see
+// db.ApplySchema), so this additive table needs its own idempotent DDL that
+// also runs against existing production databases.
+func (s *Store) EnsureSchema(ctx context.Context) error {
+	if _, err := s.pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS users (
+			id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+			username varchar(100) NOT NULL UNIQUE,
+			password_hash text NOT NULL,
+			is_admin boolean NOT NULL DEFAULT false,
+			created_at timestamp without time zone NOT NULL DEFAULT (now() AT TIME ZONE 'utc')
+		)`); err != nil {
+		return fmt.Errorf("ensure users table: %w", err)
+	}
+	return nil
+}
+
+// GetByUsername looks up a user by exact username; ErrNotFound when absent.
+func (s *Store) GetByUsername(ctx context.Context, username string) (*User, error) {
+	row := s.pool.QueryRow(ctx, `SELECT `+userColumns+` FROM users WHERE username = $1`, username)
+	return scanUser(row)
+}
+
+// List returns all users ordered by username.
+func (s *Store) List(ctx context.Context) ([]User, error) {
+	rows, err := s.pool.Query(ctx, `SELECT `+userColumns+` FROM users ORDER BY username`)
+	if err != nil {
+		return nil, fmt.Errorf("select users: %w", err)
+	}
+	defer rows.Close()
+	out := []User{}
+	for rows.Next() {
+		var u User
+		if err := rows.Scan(&u.ID, &u.Username, &u.PasswordHash, &u.IsAdmin, &u.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan user: %w", err)
+		}
+		out = append(out, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate users: %w", err)
+	}
+	return out, nil
+}
+
+// Create inserts a non-admin user; ErrNameConflict on duplicate username.
+func (s *Store) Create(ctx context.Context, username, passwordHash string) (*User, error) {
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO users (username, password_hash, is_admin)
+		VALUES ($1, $2, false)
+		RETURNING `+userColumns,
+		username, passwordHash)
+	u, err := scanUser(row)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return nil, ErrNameConflict
+		}
+		return nil, fmt.Errorf("insert user: %w", err)
+	}
+	return u, nil
+}
+
+// UpsertAdmin creates or refreshes the admin account from configuration.
+// Runs on every startup so a changed FB_ADMIN_PASSWORD takes effect.
+func (s *Store) UpsertAdmin(ctx context.Context, username, passwordHash string) error {
+	if _, err := s.pool.Exec(ctx, `
+		INSERT INTO users (username, password_hash, is_admin)
+		VALUES ($1, $2, true)
+		ON CONFLICT (username) DO UPDATE
+		SET password_hash = EXCLUDED.password_hash, is_admin = true`,
+		username, passwordHash); err != nil {
+		return fmt.Errorf("upsert admin: %w", err)
+	}
+	return nil
+}
+
+func scanUser(row pgx.Row) (*User, error) {
+	var u User
+	if err := row.Scan(&u.ID, &u.Username, &u.PasswordHash, &u.IsAdmin, &u.CreatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("scan user: %w", err)
+	}
+	return &u, nil
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr == nil {
+		return false
+	}
+	return pgErr.Code == pgerrcode.UniqueViolation
+}

--- a/backend-go/internal/auth/token.go
+++ b/backend-go/internal/auth/token.go
@@ -1,0 +1,66 @@
+// Package auth implements application login: a users table, password
+// hashing, JWT session tokens, and the chi middleware that gates /api.
+//
+// Users authenticate; they are intentionally separate from `personas`,
+// which own financial data. Linking the two is deliberately out of scope.
+package auth
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// Claims is the JWT payload: who the user is and whether they are admin.
+type Claims struct {
+	UserID   int    `json:"uid"`
+	Username string `json:"username"`
+	IsAdmin  bool   `json:"is_admin"`
+	jwt.RegisteredClaims
+}
+
+// TokenService signs and verifies session JWTs with a single HMAC secret.
+type TokenService struct {
+	secret []byte
+}
+
+// NewTokenService wraps the configured signing secret.
+func NewTokenService(secret string) *TokenService {
+	return &TokenService{secret: []byte(secret)}
+}
+
+// Sign issues a token for the user that expires after ttl.
+func (t *TokenService) Sign(userID int, username string, isAdmin bool, ttl time.Duration) (string, error) {
+	now := time.Now().UTC()
+	claims := Claims{
+		UserID:   userID,
+		Username: username,
+		IsAdmin:  isAdmin,
+		RegisteredClaims: jwt.RegisteredClaims{
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
+		},
+	}
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(t.secret)
+	if err != nil {
+		return "", fmt.Errorf("sign token: %w", err)
+	}
+	return signed, nil
+}
+
+// Verify parses and validates a token, returning its claims. Expired or
+// tampered tokens yield an error.
+func (t *TokenService) Verify(raw string) (*Claims, error) {
+	var claims Claims
+	_, err := jwt.ParseWithClaims(raw, &claims, func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return t.secret, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("verify token: %w", err)
+	}
+	return &claims, nil
+}

--- a/backend-go/internal/auth/token_test.go
+++ b/backend-go/internal/auth/token_test.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTokenSignVerifyRoundtrip(t *testing.T) {
+	ts := NewTokenService("test-secret")
+	token, err := ts.Sign(42, "marcin", true, time.Hour)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	claims, err := ts.Verify(token)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if claims.UserID != 42 || claims.Username != "marcin" || !claims.IsAdmin {
+		t.Fatalf("claims mismatch: %+v", claims)
+	}
+}
+
+func TestTokenVerifyRejectsExpired(t *testing.T) {
+	ts := NewTokenService("test-secret")
+	token, err := ts.Sign(1, "ewa", false, -time.Minute)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if _, err := ts.Verify(token); err == nil {
+		t.Fatal("expected expired token to be rejected")
+	}
+}
+
+func TestTokenVerifyRejectsWrongSecret(t *testing.T) {
+	token, err := NewTokenService("secret-a").Sign(1, "ewa", false, time.Hour)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if _, err := NewTokenService("secret-b").Verify(token); err == nil {
+		t.Fatal("expected token signed with another secret to be rejected")
+	}
+}
+
+func TestTokenVerifyRejectsGarbage(t *testing.T) {
+	if _, err := NewTokenService("test-secret").Verify("not-a-jwt"); err == nil {
+		t.Fatal("expected garbage token to be rejected")
+	}
+}

--- a/backend-go/internal/auth/validation.go
+++ b/backend-go/internal/auth/validation.go
@@ -1,0 +1,26 @@
+package auth
+
+import "strings"
+
+const minPasswordLen = 8
+
+// validateUsername trims and bounds the username. The second return value is
+// a non-empty message when validation fails.
+func validateUsername(raw string) (string, string) {
+	u := strings.TrimSpace(raw)
+	if u == "" {
+		return "", "Username cannot be empty"
+	}
+	if len(u) > 100 {
+		return "", "Username too long (max 100 characters)"
+	}
+	return u, ""
+}
+
+// validatePassword returns a non-empty message when the password is too short.
+func validatePassword(raw string) string {
+	if len(raw) < minPasswordLen {
+		return "Password must be at least 8 characters"
+	}
+	return ""
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/accounts"
 	"github.com/Automaat/finance-buddy/backend-go/internal/aggregates"
 	"github.com/Automaat/finance-buddy/backend-go/internal/assets"
+	"github.com/Automaat/finance-buddy/backend-go/internal/auth"
 	bonusevents "github.com/Automaat/finance-buddy/backend-go/internal/bonus_events"
 	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/config"
@@ -52,6 +53,11 @@ type Config struct {
 	// split on "," verbatim (no trimming, no wildcard fallback) to match
 	// the Python backend's `settings.cors_origins.split(",")`.
 	CORSOrigins string
+	// JWTSecret signs and verifies session tokens (FB_JWT_SECRET).
+	JWTSecret string
+	// CookieSecure marks the session cookie Secure (FB_COOKIE_SECURE).
+	// Off by default so plain-HTTP local/LAN deploys work.
+	CookieSecure bool
 }
 
 // Deps bundles the runtime dependencies the router needs to construct
@@ -81,10 +87,30 @@ func New(cfg Config, logger *slog.Logger, deps Deps) http.Handler {
 	r.Get("/health", healthHandler(logger))
 
 	if deps.Pool != nil {
-		registerAPIRoutes(r, deps.Pool, logger)
+		registerRoutes(r, cfg, deps.Pool, logger)
 	}
 
 	return r
+}
+
+// registerRoutes wires the public auth endpoints, then gates every other
+// /api route behind a valid session.
+func registerRoutes(r chi.Router, cfg Config, pool *pgxpool.Pool, logger *slog.Logger) {
+	tokens := auth.NewTokenService(cfg.JWTSecret)
+	authHandler := auth.NewHandler(auth.NewStore(pool), tokens, cfg.CookieSecure, logger)
+
+	// Public — reachable without a session.
+	r.Post("/api/auth/login", authHandler.Login)
+	r.Post("/api/auth/logout", authHandler.Logout)
+
+	// Everything else requires authentication.
+	r.Group(func(r chi.Router) {
+		r.Use(auth.Authenticate(tokens))
+		r.Get("/api/auth/me", authHandler.Me)
+		r.With(auth.RequireAdmin).Get("/api/auth/users", authHandler.ListUsers)
+		r.With(auth.RequireAdmin).Post("/api/auth/users", authHandler.CreateUser)
+		registerAPIRoutes(r, pool, logger)
+	})
 }
 
 func registerAPIRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,6 +26,10 @@ services:
       - DATABASE_URL=postgresql://finance:${POSTGRES_PASSWORD:-password}@postgres:5432/finance
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:5174,http://localhost:3000}
       - FB_ADDR=:8000
+      - FB_JWT_SECRET=${FB_JWT_SECRET:-dev-jwt-secret-change-me}
+      - FB_ADMIN_USERNAME=${FB_ADMIN_USERNAME:-admin}
+      - FB_ADMIN_PASSWORD=${FB_ADMIN_PASSWORD:-admin}
+      - FB_COOKIE_SECURE=false
     depends_on:
       postgres:
         condition: service_healthy
@@ -48,7 +52,9 @@ services:
       - '5174:5173'
     environment:
       - PUBLIC_API_URL=http://backend-go:8000
-      - PUBLIC_API_URL_BROWSER=http://localhost:8000
+      - PUBLIC_API_URL_BROWSER=http://localhost:5174
+      - API_PROXY_TARGET=http://backend-go:8000
+      - FB_COOKIE_SECURE=false
     depends_on:
       backend-go:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,10 @@ services:
       - DATABASE_URL=${DATABASE_URL:-postgresql://finance:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/finance}
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:3000}
       - FB_ADDR=:8000
+      - FB_JWT_SECRET=${FB_JWT_SECRET:?FB_JWT_SECRET must be set}
+      - FB_ADMIN_USERNAME=${FB_ADMIN_USERNAME:-admin}
+      - FB_ADMIN_PASSWORD=${FB_ADMIN_PASSWORD:?FB_ADMIN_PASSWORD must be set}
+      - FB_COOKIE_SECURE=${FB_COOKIE_SECURE:-false}
     ports:
       - '8000:8000'
     restart: unless-stopped
@@ -19,9 +23,11 @@ services:
       - '3000:3000'
     environment:
       - PUBLIC_API_URL=http://backend-go:8000
-      - PUBLIC_API_URL_BROWSER=${PUBLIC_API_URL_BROWSER:-http://localhost:8000}
+      - PUBLIC_API_URL_BROWSER=${ORIGIN:-http://localhost:3000}
+      - API_PROXY_TARGET=http://backend-go:8000
       - ORIGIN=${ORIGIN:-http://localhost:3000}
       - APP_PASSWORD=${APP_PASSWORD:?APP_PASSWORD must be set}
+      - FB_COOKIE_SECURE=${FB_COOKIE_SECURE:-false}
     restart: unless-stopped
     depends_on:
       - backend-go

--- a/e2e/accounts.spec.ts
+++ b/e2e/accounts.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { uniqueName } from './utils';
+import { openDialog, uniqueName } from './utils';
 
 test.describe('accounts CRUD', () => {
 	test('create asset account then soft-delete it', async ({ page }) => {
@@ -8,10 +8,8 @@ test.describe('accounts CRUD', () => {
 
 		const name = uniqueName('e2e-bank');
 
-		await page.getByRole('button', { name: /Nowe Konto/ }).click();
-
+		await openDialog(page, /Nowe Konto/);
 		const dialog = page.getByRole('dialog');
-		await expect(dialog).toBeVisible();
 
 		await dialog.locator('label:has-text("Nazwa") input').fill(name);
 		await dialog.locator('label:has-text("Typ") select').selectOption('asset');

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,40 @@
+import { test as setup } from '@playwright/test';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { ADMIN_USERNAME, ADMIN_PASSWORD, STORAGE_STATE } from './credentials';
+
+const API_URL = process.env.E2E_API_URL ?? 'http://127.0.0.1:8000';
+
+// Logs in once as admin and writes a storageState the test projects reuse.
+setup('authenticate', async ({ request }) => {
+	const response = await request.post(`${API_URL}/api/auth/login`, {
+		data: { username: ADMIN_USERNAME, password: ADMIN_PASSWORD }
+	});
+	if (!response.ok()) {
+		throw new Error(`E2E login failed: ${response.status()} ${await response.text()}`);
+	}
+	const { token } = (await response.json()) as { token: string };
+
+	// A single JWT cookie scoped to the bare host — cookies are not
+	// port-specific, so it rides both the frontend (page navigations) and the
+	// backend (direct API requests in *.spec.ts).
+	mkdirSync(dirname(STORAGE_STATE), { recursive: true });
+	writeFileSync(
+		STORAGE_STATE,
+		JSON.stringify({
+			cookies: [
+				{
+					name: 'fb_token',
+					value: token,
+					domain: '127.0.0.1',
+					path: '/',
+					expires: -1,
+					httpOnly: true,
+					secure: false,
+					sameSite: 'Lax'
+				}
+			],
+			origins: []
+		})
+	);
+});

--- a/e2e/credentials.ts
+++ b/e2e/credentials.ts
@@ -1,0 +1,8 @@
+// Shared E2E auth config — consumed by playwright.config.ts (to launch the
+// backend + frontend with matching settings) and by auth.setup.ts (to log in).
+export const ADMIN_USERNAME = process.env.FB_ADMIN_USERNAME ?? 'e2e-admin';
+export const ADMIN_PASSWORD = process.env.FB_ADMIN_PASSWORD ?? 'e2e-admin-password';
+export const JWT_SECRET = process.env.FB_JWT_SECRET ?? 'e2e-test-jwt-secret';
+
+// Where auth.setup.ts writes the logged-in session for the test projects.
+export const STORAGE_STATE = 'e2e/.auth/state.json';

--- a/e2e/goals.spec.ts
+++ b/e2e/goals.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { uniqueName } from './utils';
+import { openDialog, uniqueName } from './utils';
 
 test.describe('goals CRUD', () => {
 	test('create, verify, then delete a goal', async ({ page }) => {
@@ -8,10 +8,8 @@ test.describe('goals CRUD', () => {
 
 		const name = uniqueName('e2e-goal');
 
-		await page.getByRole('button', { name: /Nowy cel/ }).click();
-
+		await openDialog(page, /Nowy cel/);
 		const dialog = page.getByRole('dialog');
-		await expect(dialog).toBeVisible();
 
 		await dialog.locator('label:has-text("Nazwa") input').fill(name);
 		await dialog.locator('label:has-text("Cel (PLN)") input').fill('25000');

--- a/e2e/transactions.spec.ts
+++ b/e2e/transactions.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { INVESTMENT_CATEGORIES } from '../src/lib/constants';
+import { openDialog } from './utils';
 
 const apiUrl = process.env.E2E_API_URL ?? 'http://127.0.0.1:8000';
 
@@ -35,7 +36,7 @@ test.describe('transactions', () => {
 		const account = await pickInvestmentAccount(request);
 
 		await page.goto('/transactions');
-		await page.getByRole('button', { name: /Nowa Transakcja/ }).click();
+		await openDialog(page, /Nowa Transakcja/);
 
 		const dialog = page.getByRole('dialog').filter({ hasText: 'Nowa Transakcja' });
 		await expect(dialog).toBeVisible();

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,4 +1,19 @@
+import { expect, type Page } from '@playwright/test';
+
 export function uniqueName(prefix: string): string {
 	const stamp = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
 	return `${prefix}-${stamp}`;
+}
+
+// openDialog clicks a trigger button and waits for its modal, retrying the
+// click to absorb the brief window after SSR before SvelteKit finishes
+// hydrating — where the button exists but its handler isn't attached yet.
+export async function openDialog(page: Page, triggerName: RegExp | string): Promise<void> {
+	const dialog = page.getByRole('dialog');
+	await expect(async () => {
+		if (!(await dialog.isVisible())) {
+			await page.getByRole('button', { name: triggerName }).click();
+		}
+		await expect(dialog).toBeVisible({ timeout: 1000 });
+	}).toPass({ timeout: 15_000 });
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { ADMIN_USERNAME, ADMIN_PASSWORD, JWT_SECRET, STORAGE_STATE } from './e2e/credentials';
 
 const PORT = Number(process.env.E2E_FRONTEND_PORT ?? 4173);
 const BASE_URL = process.env.E2E_BASE_URL ?? `http://127.0.0.1:${PORT}`;
@@ -30,11 +31,19 @@ export default defineConfig({
 		navigationTimeout: 30_000
 	},
 	projects: [
-		{ name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+		// Logs in once; the test projects reuse its storageState.
+		{ name: 'setup', testMatch: /auth\.setup\.ts/ },
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
+			testIgnore: /auth\.setup\.ts/,
+			dependencies: ['setup']
+		},
 		{
 			name: 'mobile-chrome',
-			use: { ...devices['Pixel 7'] },
-			testMatch: /navigation\.spec\.ts$/
+			use: { ...devices['Pixel 7'], storageState: STORAGE_STATE },
+			testMatch: /navigation\.spec\.ts$/,
+			dependencies: ['setup']
 		}
 	],
 	webServer: skipWebServer
@@ -53,7 +62,10 @@ export default defineConfig({
 					env: {
 						DATABASE_URL,
 						FB_ADDR: '127.0.0.1:8000',
-						CORS_ORIGINS: `${BASE_URL},http://localhost:${PORT},http://127.0.0.1:${PORT}`
+						CORS_ORIGINS: `${BASE_URL},http://localhost:${PORT},http://127.0.0.1:${PORT}`,
+						FB_JWT_SECRET: JWT_SECRET,
+						FB_ADMIN_USERNAME: ADMIN_USERNAME,
+						FB_ADMIN_PASSWORD: ADMIN_PASSWORD
 					}
 				},
 				{
@@ -68,8 +80,12 @@ export default defineConfig({
 						PORT: String(PORT),
 						HOST: '127.0.0.1',
 						ORIGIN: BASE_URL,
+						// SSR talks straight to the backend; the browser routes
+						// through the SvelteKit /api proxy at its own origin.
 						PUBLIC_API_URL: API_URL,
-						PUBLIC_API_URL_BROWSER: API_URL
+						PUBLIC_API_URL_BROWSER: BASE_URL,
+						API_PROXY_TARGET: API_URL,
+						FB_COOKIE_SECURE: 'false'
 					}
 				}
 			]

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -3,7 +3,9 @@
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
+		interface Locals {
+			user: { username: string; isAdmin: boolean } | null;
+		}
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -12,13 +12,25 @@ interface SessionUser {
 function decodeUser(token: string): SessionUser | null {
 	try {
 		const payload = token.split('.')[1];
-		const pad = payload.length % 4 === 0 ? '' : '='.repeat(4 - (payload.length % 4));
-		const json = atob(payload.replace(/-/g, '+').replace(/_/g, '/') + pad);
-		const claims = JSON.parse(json) as { username?: string; is_admin?: boolean; exp?: number };
-		if (typeof claims.exp === 'number' && claims.exp * 1000 < Date.now()) {
+		if (!payload) {
 			return null;
 		}
-		return { username: claims.username ?? '', isAdmin: claims.is_admin ?? false };
+		const pad = payload.length % 4 === 0 ? '' : '='.repeat(4 - (payload.length % 4));
+		const json = atob(payload.replace(/-/g, '+').replace(/_/g, '/') + pad);
+		const claims = JSON.parse(json) as { username?: unknown; is_admin?: unknown; exp?: unknown };
+		// Reject malformed claims. The backend still verifies the signature on
+		// every API call — this only stops a bogus token from looking
+		// logged-in to the page-level gating.
+		if (typeof claims.exp !== 'number' || claims.exp * 1000 < Date.now()) {
+			return null;
+		}
+		if (typeof claims.username !== 'string' || claims.username === '') {
+			return null;
+		}
+		if (typeof claims.is_admin !== 'boolean') {
+			return null;
+		}
+		return { username: claims.username, isAdmin: claims.is_admin };
 	} catch {
 		return null;
 	}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,71 @@
+import { redirect, type Handle, type HandleFetch } from '@sveltejs/kit';
+import { env } from '$env/dynamic/public';
+
+interface SessionUser {
+	username: string;
+	isAdmin: boolean;
+}
+
+// decodeUser reads the JWT payload without verifying the signature (the
+// backend does that on every API call) — enough to know who is logged in and
+// to drop a token whose `exp` has already passed.
+function decodeUser(token: string): SessionUser | null {
+	try {
+		const payload = token.split('.')[1];
+		const pad = payload.length % 4 === 0 ? '' : '='.repeat(4 - (payload.length % 4));
+		const json = atob(payload.replace(/-/g, '+').replace(/_/g, '/') + pad);
+		const claims = JSON.parse(json) as { username?: string; is_admin?: boolean; exp?: number };
+		if (typeof claims.exp === 'number' && claims.exp * 1000 < Date.now()) {
+			return null;
+		}
+		return { username: claims.username ?? '', isAdmin: claims.is_admin ?? false };
+	} catch {
+		return null;
+	}
+}
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const { pathname } = event.url;
+	const token = event.cookies.get('fb_token');
+	const user = token ? decodeUser(token) : null;
+	event.locals.user = user;
+
+	if (user) {
+		return resolve(event);
+	}
+
+	// A lingering expired/invalid token — clear it so the browser stops sending it.
+	if (token) {
+		event.cookies.delete('fb_token', { path: '/' });
+	}
+
+	const isAsset = pathname.startsWith('/_app/') || /\.\w+$/.test(pathname);
+	const isLogin = pathname === '/login';
+	const isPublicApi = pathname === '/api/auth/login' || pathname === '/api/auth/logout';
+	if (isAsset || isLogin || isPublicApi) {
+		return resolve(event);
+	}
+
+	// API calls get a JSON 401; page navigations get sent to the login screen.
+	if (pathname.startsWith('/api/')) {
+		return new Response(JSON.stringify({ detail: 'Not authenticated' }), {
+			status: 401,
+			headers: { 'content-type': 'application/json' }
+		});
+	}
+	redirect(303, '/login');
+};
+
+// handleFetch attaches the session token to server-side load() calls that go
+// straight to the backend (PUBLIC_API_URL). Browser-side calls instead route
+// through the /api proxy, which adds the token itself.
+export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
+	const backend = env.PUBLIC_API_URL;
+	if (backend && request.url.startsWith(backend)) {
+		const token = event.cookies.get('fb_token');
+		if (token) {
+			request.headers.set('authorization', `Bearer ${token}`);
+		}
+	}
+	return fetch(request);
+};

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,6 @@
+import type { LayoutServerLoad } from './$types';
+
+// Expose the authenticated user to the layout (and, via parent(), to pages).
+export const load: LayoutServerLoad = ({ locals }) => {
+	return { user: locals.user };
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,10 +15,15 @@
 		Settings,
 		Target,
 		User,
-		ShieldCheck
+		Users,
+		ShieldCheck,
+		LogOut
 	} from 'lucide-svelte';
+	import type { LayoutData } from './$types';
 
-	const navItems = [
+	let { children, data }: { children: import('svelte').Snippet; data: LayoutData } = $props();
+
+	const baseNav = [
 		{ href: '/', label: 'Dashboard', icon: LayoutDashboard },
 		{ href: '/metryki', label: 'Metryki', icon: TrendingUp },
 		{ href: '/simulations', label: 'Symulacje', icon: Sparkles },
@@ -33,7 +38,14 @@
 		{ href: '/settings', label: 'Ustawienia', icon: User }
 	];
 
-	let { children } = $props();
+	// The user-management screen is admin-only.
+	const navItems = $derived(
+		data.user?.isAdmin
+			? [...baseNav, { href: '/users', label: 'Użytkownicy', icon: Users }]
+			: baseNav
+	);
+
+	const isLoginPage = $derived($page.url.pathname === '/login');
 
 	function isActive(href: string): boolean {
 		return href === '/simulations'
@@ -44,58 +56,86 @@
 
 <Toast />
 
-<div class="flex min-h-screen bg-surface-50-950 text-surface-950-50">
-	<aside
-		class="hidden md:flex md:flex-col md:w-60 md:shrink-0 md:border-r md:border-surface-200-800 md:bg-surface-100-900"
-	>
-		<div class="p-4 flex items-center gap-2 text-lg font-bold">
-			<ShieldCheck class="text-primary-500" size={24} />
-			<span>Finansowa Forteca</span>
-		</div>
-		<nav class="flex-1 overflow-y-auto p-2 space-y-1">
-			{#each navItems as item}
-				<a
-					href={item.href}
-					class="flex items-center gap-3 px-3 py-2 rounded-container text-sm transition-colors
-						{isActive(item.href)
-						? 'preset-filled-primary-500 font-semibold'
-						: 'hover:preset-tonal-primary text-surface-800-200'}"
-				>
-					<item.icon size={18} />
-					<span>{item.label}</span>
-				</a>
-			{/each}
-		</nav>
-	</aside>
-
-	<div class="flex flex-1 flex-col min-w-0">
-		<header
-			class="md:hidden sticky top-0 z-20 flex items-center justify-between px-4 py-3 bg-surface-100-900 border-b border-surface-200-800"
+{#if isLoginPage}
+	{@render children?.()}
+{:else}
+	<div class="flex min-h-screen bg-surface-50-950 text-surface-950-50">
+		<aside
+			class="hidden md:flex md:flex-col md:w-60 md:shrink-0 md:border-r md:border-surface-200-800 md:bg-surface-100-900"
 		>
-			<span class="flex items-center gap-2 text-base font-bold">
-				<ShieldCheck class="text-primary-500" size={20} />
+			<div class="p-4 flex items-center gap-2 text-lg font-bold">
+				<ShieldCheck class="text-primary-500" size={24} />
 				<span>Finansowa Forteca</span>
-			</span>
-		</header>
+			</div>
+			<nav class="flex-1 overflow-y-auto p-2 space-y-1">
+				{#each navItems as item}
+					<a
+						href={item.href}
+						class="flex items-center gap-3 px-3 py-2 rounded-container text-sm transition-colors
+							{isActive(item.href)
+							? 'preset-filled-primary-500 font-semibold'
+							: 'hover:preset-tonal-primary text-surface-800-200'}"
+					>
+						<item.icon size={18} />
+						<span>{item.label}</span>
+					</a>
+				{/each}
+			</nav>
+			{#if data.user}
+				<div class="p-3 border-t border-surface-200-800 space-y-2">
+					<div class="flex items-center gap-2 px-1 text-sm text-surface-700-300">
+						<User size={16} />
+						<span class="truncate">{data.user.username}</span>
+					</div>
+					<form method="POST" action="/logout">
+						<button
+							type="submit"
+							class="flex w-full items-center gap-3 px-3 py-2 rounded-container text-sm hover:preset-tonal-primary text-surface-800-200"
+						>
+							<LogOut size={18} />
+							<span>Wyloguj</span>
+						</button>
+					</form>
+				</div>
+			{/if}
+		</aside>
 
-		<main class="flex-1 w-full max-w-[1200px] mx-auto p-4 md:p-6 lg:p-8 pb-24 md:pb-8">
-			{@render children?.()}
-		</main>
+		<div class="flex flex-1 flex-col min-w-0">
+			<header
+				class="md:hidden sticky top-0 z-20 flex items-center justify-between px-4 py-3 bg-surface-100-900 border-b border-surface-200-800"
+			>
+				<span class="flex items-center gap-2 text-base font-bold">
+					<ShieldCheck class="text-primary-500" size={20} />
+					<span>Finansowa Forteca</span>
+				</span>
+				{#if data.user}
+					<form method="POST" action="/logout">
+						<button type="submit" class="btn-icon btn-icon-sm" aria-label="Wyloguj">
+							<LogOut size={20} />
+						</button>
+					</form>
+				{/if}
+			</header>
 
-		<nav
-			class="md:hidden fixed bottom-0 left-0 right-0 z-30 flex overflow-x-auto bg-surface-100-900 border-t border-surface-200-800"
-			aria-label="Mobile navigation"
-		>
-			{#each navItems as item}
-				<a
-					href={item.href}
-					class="flex flex-col items-center justify-center gap-1 min-w-16 shrink-0 px-3 py-2 text-[10px]
-						{isActive(item.href) ? 'text-primary-500 font-semibold' : 'text-surface-700-300'}"
-				>
-					<item.icon size={20} />
-					<span class="whitespace-nowrap">{item.label}</span>
-				</a>
-			{/each}
-		</nav>
+			<main class="flex-1 w-full max-w-[1200px] mx-auto p-4 md:p-6 lg:p-8 pb-24 md:pb-8">
+				{@render children?.()}
+			</main>
+
+			<nav
+				class="md:hidden fixed bottom-0 left-0 right-0 z-30 flex overflow-x-auto bg-surface-100-900 border-t border-surface-200-800"
+				aria-label="Mobile navigation"
+			>
+				{#each navItems as item}
+					<a
+						href={item.href}
+						class="flex flex-col items-center justify-center gap-1 min-w-16 shrink-0 px-3 py-2 text-[10px]
+							{isActive(item.href) ? 'text-primary-500 font-semibold' : 'text-surface-700-300'}"
+					>
+						<item.icon size={20} />
+						<span class="whitespace-nowrap">{item.label}</span>
+					</a>
+				{/each}
+			</nav>
+		</div>
 	</div>
-</div>
+{/if}

--- a/src/routes/api/[...path]/+server.ts
+++ b/src/routes/api/[...path]/+server.ts
@@ -1,0 +1,47 @@
+// Server-side proxy for the Go backend.
+//
+// The browser only ever talks to this SvelteKit origin; this route forwards
+// /api/* to the backend and attaches the session token from the fb_token
+// cookie as a Bearer header. Keeps the JWT out of client-side JavaScript.
+import { env } from '$env/dynamic/private';
+import type { RequestHandler } from './$types';
+
+function backendURL(path: string, search: string): string {
+	const base = env.API_PROXY_TARGET ?? 'http://localhost:8000';
+	return `${base}/api/${path}${search}`;
+}
+
+const proxy: RequestHandler = async ({ request, params, cookies, url, fetch }) => {
+	const headers = new Headers();
+	const contentType = request.headers.get('content-type');
+	if (contentType) {
+		headers.set('content-type', contentType);
+	}
+	const token = cookies.get('fb_token');
+	if (token) {
+		headers.set('authorization', `Bearer ${token}`);
+	}
+
+	const init: RequestInit = { method: request.method, headers };
+	if (request.method !== 'GET' && request.method !== 'HEAD') {
+		init.body = await request.text();
+	}
+
+	const upstream = await fetch(backendURL(params.path, url.search), init);
+	const body = await upstream.arrayBuffer();
+	const responseHeaders = new Headers();
+	const responseType = upstream.headers.get('content-type');
+	if (responseType) {
+		responseHeaders.set('content-type', responseType);
+	}
+	// 204/304 are null-body statuses — Response throws if handed a body, even
+	// an empty one (e.g. the backend's 204 on DELETE).
+	const responseBody = body.byteLength > 0 ? body : null;
+	return new Response(responseBody, { status: upstream.status, headers: responseHeaders });
+};
+
+export const GET = proxy;
+export const POST = proxy;
+export const PUT = proxy;
+export const PATCH = proxy;
+export const DELETE = proxy;

--- a/src/routes/api/[...path]/+server.ts
+++ b/src/routes/api/[...path]/+server.ts
@@ -29,6 +29,9 @@ const proxy: RequestHandler = async ({ request, params, cookies, url, fetch }) =
 
 	const upstream = await fetch(backendURL(params.path, url.search), init);
 	const body = await upstream.arrayBuffer();
+	// Only content-type is forwarded. Set-Cookie in particular is dropped on
+	// purpose — the backend's own session cookie must never reach the browser;
+	// frontend sessions are managed by the /login and /logout routes.
 	const responseHeaders = new Headers();
 	const responseType = upstream.headers.get('content-type');
 	if (responseType) {

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -20,8 +20,15 @@ export const actions: Actions = {
 			headers: { 'content-type': 'application/json' },
 			body: JSON.stringify({ username, password, remember_me: rememberMe })
 		});
-		if (!response.ok) {
+		if (response.status === 401) {
 			return fail(401, { error: 'Nieprawidłowa nazwa użytkownika lub hasło', username });
+		}
+		if (!response.ok) {
+			// A non-401 failure is a backend/network problem, not bad credentials.
+			return fail(response.status, {
+				error: 'Logowanie chwilowo niedostępne — spróbuj ponownie później',
+				username
+			});
 		}
 
 		const { token } = (await response.json()) as { token: string };

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,0 +1,38 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import type { Actions } from './$types';
+
+const cookieSecure = env.FB_COOKIE_SECURE === 'true';
+
+export const actions: Actions = {
+	default: async ({ request, cookies, fetch }) => {
+		const form = await request.formData();
+		const username = String(form.get('username') ?? '').trim();
+		const password = String(form.get('password') ?? '');
+		const rememberMe = form.get('remember_me') === 'on';
+
+		if (!username || !password) {
+			return fail(400, { error: 'Podaj nazwę użytkownika i hasło', username });
+		}
+
+		const response = await fetch('/api/auth/login', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ username, password, remember_me: rememberMe })
+		});
+		if (!response.ok) {
+			return fail(401, { error: 'Nieprawidłowa nazwa użytkownika lub hasło', username });
+		}
+
+		const { token } = (await response.json()) as { token: string };
+		cookies.set('fb_token', token, {
+			path: '/',
+			httpOnly: true,
+			sameSite: 'lax',
+			secure: cookieSecure,
+			// "Remember me" persists for 5 days; otherwise a session cookie.
+			maxAge: rememberMe ? 5 * 24 * 60 * 60 : undefined
+		});
+		redirect(303, '/');
+	}
+};

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { ShieldCheck } from 'lucide-svelte';
+	import type { ActionData } from './$types';
+
+	let { form }: { form: ActionData } = $props();
+	let submitting = $state(false);
+</script>
+
+<div
+	class="flex min-h-screen items-center justify-center bg-surface-50-950 text-surface-950-50 p-4"
+>
+	<div class="card preset-filled-surface-50-950 w-full max-w-sm shadow-xl p-6 space-y-5">
+		<div class="flex items-center gap-2 text-lg font-bold">
+			<ShieldCheck class="text-primary-500" size={24} />
+			<span>Finansowa Forteca</span>
+		</div>
+
+		<form
+			method="POST"
+			class="space-y-4"
+			use:enhance={() => {
+				submitting = true;
+				return async ({ update }) => {
+					await update();
+					submitting = false;
+				};
+			}}
+		>
+			<label class="label">
+				<span class="font-semibold text-sm">Nazwa użytkownika</span>
+				<input
+					name="username"
+					type="text"
+					class="input"
+					autocomplete="username"
+					value={form?.username ?? ''}
+					required
+				/>
+			</label>
+
+			<label class="label">
+				<span class="font-semibold text-sm">Hasło</span>
+				<input
+					name="password"
+					type="password"
+					class="input"
+					autocomplete="current-password"
+					required
+				/>
+			</label>
+
+			<label class="flex items-center gap-2 text-sm">
+				<input name="remember_me" type="checkbox" class="checkbox" />
+				<span>Zapamiętaj mnie</span>
+			</label>
+
+			{#if form?.error}
+				<div class="card preset-filled-error-500 p-3 text-sm">{form.error}</div>
+			{/if}
+
+			<button type="submit" class="btn preset-filled-primary-500 w-full" disabled={submitting}>
+				{submitting ? 'Logowanie...' : 'Zaloguj'}
+			</button>
+		</form>
+	</div>
+</div>

--- a/src/routes/logout/+server.ts
+++ b/src/routes/logout/+server.ts
@@ -1,0 +1,7 @@
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = ({ cookies }) => {
+	cookies.delete('fb_token', { path: '/' });
+	redirect(303, '/login');
+};

--- a/src/routes/metryki/page.test.ts
+++ b/src/routes/metryki/page.test.ts
@@ -48,6 +48,7 @@ const metricCards = {
 };
 
 const mockData = {
+	user: null,
 	metricCards,
 	allocationAnalysis: {
 		by_category: [],
@@ -108,6 +109,7 @@ describe('Metryki Page', () => {
 
 describe('Metryki Page with populated data', () => {
 	const populatedData = {
+		user: null,
 		metricCards: {
 			property_sqm: 42,
 			emergency_fund_months: 8,

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -105,6 +105,7 @@ function buildData(
 				});
 
 	return {
+		user: null,
 		dashboardData,
 		personas: Promise.resolve(overrides.personas ?? []),
 		currentYear: overrides.currentYear ?? 2024

--- a/src/routes/salaries/page.test.ts
+++ b/src/routes/salaries/page.test.ts
@@ -36,6 +36,7 @@ vi.mock('echarts', () => ({
 }));
 
 const baseData = {
+	user: null,
 	salaries: {
 		salary_records: [],
 		total_count: 0,

--- a/src/routes/users/+page.svelte
+++ b/src/routes/users/+page.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import { env } from '$env/dynamic/public';
+	import { invalidateAll } from '$app/navigation';
+	import { toast } from '$lib/stores/toast.svelte';
+	import type { PageData } from './$types';
+
+	interface AppUser {
+		id: number;
+		username: string;
+		is_admin: boolean;
+		created_at: string;
+	}
+
+	let { data }: { data: PageData } = $props();
+	const users = $derived(data.users as AppUser[]);
+
+	let username = $state('');
+	let password = $state('');
+	let saving = $state(false);
+
+	async function createUser(event: Event): Promise<void> {
+		event.preventDefault();
+		saving = true;
+		try {
+			const apiUrl = env.PUBLIC_API_URL_BROWSER ?? '';
+			const response = await fetch(`${apiUrl}/api/auth/users`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ username, password })
+			});
+			if (!response.ok) {
+				const body = await response.json().catch(() => null);
+				const detail =
+					body && typeof body === 'object' && 'detail' in body && body.detail
+						? String(body.detail)
+						: 'Nie udało się utworzyć użytkownika';
+				throw new Error(detail);
+			}
+			toast.success(`Użytkownik „${username}" został utworzony`);
+			username = '';
+			password = '';
+			await invalidateAll();
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Wystąpił błąd');
+		} finally {
+			saving = false;
+		}
+	}
+</script>
+
+<div class="space-y-6">
+	<h1 class="h2 font-bold">Użytkownicy</h1>
+
+	<div class="card preset-filled-surface-50-950 p-5 space-y-4">
+		<h2 class="h4 font-semibold">Dodaj użytkownika</h2>
+		<form class="flex flex-col sm:flex-row sm:items-end gap-3" onsubmit={createUser}>
+			<label class="label flex-1">
+				<span class="font-semibold text-sm">Nazwa użytkownika</span>
+				<input bind:value={username} type="text" class="input" required />
+			</label>
+			<label class="label flex-1">
+				<span class="font-semibold text-sm">Hasło (min. 8 znaków)</span>
+				<input bind:value={password} type="password" class="input" minlength="8" required />
+			</label>
+			<button type="submit" class="btn preset-filled-primary-500" disabled={saving}>
+				{saving ? 'Dodawanie...' : 'Dodaj'}
+			</button>
+		</form>
+	</div>
+
+	<div class="card preset-filled-surface-50-950 p-5">
+		<table class="table">
+			<thead>
+				<tr>
+					<th>Nazwa użytkownika</th>
+					<th>Rola</th>
+					<th>Utworzono</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each users as appUser (appUser.id)}
+					<tr>
+						<td>{appUser.username}</td>
+						<td>
+							{#if appUser.is_admin}
+								<span class="badge preset-filled-primary-500">Administrator</span>
+							{:else}
+								<span class="badge preset-tonal-surface">Użytkownik</span>
+							{/if}
+						</td>
+						<td>{appUser.created_at.slice(0, 10)}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/src/routes/users/+page.svelte
+++ b/src/routes/users/+page.svelte
@@ -36,7 +36,7 @@
 						: 'Nie udało się utworzyć użytkownika';
 				throw new Error(detail);
 			}
-			toast.success(`Użytkownik „${username}" został utworzony`);
+			toast.success(`Użytkownik „${username}” został utworzony`);
 			username = '';
 			password = '';
 			await invalidateAll();

--- a/src/routes/users/+page.ts
+++ b/src/routes/users/+page.ts
@@ -1,0 +1,22 @@
+import { error, redirect } from '@sveltejs/kit';
+import { env } from '$env/dynamic/public';
+import { browser } from '$app/environment';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ fetch, parent }) => {
+	const { user } = await parent();
+	if (!user?.isAdmin) {
+		redirect(303, '/');
+	}
+
+	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+	if (!apiUrl) {
+		throw error(500, 'API URL is not configured');
+	}
+
+	const response = await fetch(`${apiUrl}/api/auth/users`);
+	if (!response.ok) {
+		throw error(response.status, 'Nie udało się pobrać użytkowników');
+	}
+	return { users: await response.json() };
+};


### PR DESCRIPTION
## Motivation

The app had no authentication — anyone who could reach it had full
access to the household's financial data. We want a private,
self-hosted dashboard: a login screen, an admin account, and a way
for the admin to add the household members as users.

## Implementation information

Backend (`backend-go/internal/auth`):
- Stateless JWT (HS256), bcrypt password hashing, a `users` table.
- Endpoints: login, logout, me, list/create users.
- Middleware gates every `/api` route except login/logout; user
  management is admin-only.
- The admin account is seeded from `FB_ADMIN_*` config on each
  startup. The `users` table is created idempotently so it also
  reaches existing databases (the baseline schema bootstrap only
  runs on empty ones).
- "Remember me" issues a 5-day token; otherwise a 1-day session
  cookie.

Frontend:
- `/login` screen and an admin-only `/users` page.
- `hooks.server.ts` redirects unauthenticated page loads to
  `/login` and returns 401 for API calls.
- A SvelteKit `/api` proxy attaches the token server-side, so the
  JWT stays in an HttpOnly cookie and never reaches client-side
  JavaScript.

The `users` table is kept separate from `personas` — financial data
stays shared across the household. Linking users to personas is
deliberately out of scope for this change.

Tests: black-box auth tests, Go unit tests for tokens and passwords,
and a Playwright auth-setup project. The CRUD e2e specs were also
hardened against a hydration race surfaced once the suite ran under
enforced login, and the `/api` proxy was fixed to pass through 204
responses without a body.

## Supporting documentation

None.