### PR TITLE
feat(auth): add name, surname and PPK to users

### DIFF
--- a/backend-bb-tests/tests/test_auth.py
+++ b/backend-bb-tests/tests/test_auth.py
@@ -79,3 +79,59 @@ def test_non_admin_cannot_manage_users(client: httpx.Client, base_url: str) -> N
             ).status_code
             == 403
         )
+        assert http.patch("/api/auth/users/1", json={}).status_code == 403
+
+
+def test_create_user_with_profile_and_default_ppk(client: httpx.Client) -> None:
+    explicit = client.post(
+        "/api/auth/users",
+        json={
+            "username": "bb-profile",
+            "password": "profile-pass-1",
+            "name": "Profile",
+            "surname": "Tester",
+            "ppk_employee_rate": 3,
+            "ppk_employer_rate": 2.5,
+        },
+    )
+    assert explicit.status_code == 201
+    body = explicit.json()
+    assert body["name"] == "Profile"
+    assert body["surname"] == "Tester"
+    assert body["ppk_employee_rate"] == "3.00"
+    assert body["ppk_employer_rate"] == "2.50"
+
+    # Omitted rates fall back to the defaults.
+    defaulted = client.post(
+        "/api/auth/users",
+        json={"username": "bb-defaults", "password": "defaults-pass-1"},
+    )
+    assert defaulted.status_code == 201
+    assert defaulted.json()["ppk_employee_rate"] == "2.00"
+    assert defaulted.json()["ppk_employer_rate"] == "1.50"
+
+
+def test_admin_updates_user_profile(client: httpx.Client) -> None:
+    created = client.post(
+        "/api/auth/users",
+        json={"username": "bb-editable", "password": "editable-pass-1"},
+    )
+    assert created.status_code == 201
+    user_id = created.json()["id"]
+
+    updated = client.patch(
+        f"/api/auth/users/{user_id}",
+        json={
+            "name": "Edited",
+            "surname": "Name",
+            "ppk_employee_rate": 1.5,
+            "ppk_employer_rate": 1,
+        },
+    )
+    assert updated.status_code == 200
+    body = updated.json()
+    assert body["name"] == "Edited"
+    assert body["surname"] == "Name"
+    assert body["ppk_employee_rate"] == "1.50"
+
+    assert client.patch("/api/auth/users/999999", json={}).status_code == 404

--- a/backend-bb-tests/tests/test_auth.py
+++ b/backend-bb-tests/tests/test_auth.py
@@ -79,7 +79,7 @@ def test_non_admin_cannot_manage_users(client: httpx.Client, base_url: str) -> N
             ).status_code
             == 403
         )
-        assert http.patch("/api/auth/users/1", json={}).status_code == 403
+        assert http.put("/api/auth/users/1", json={}).status_code == 403
 
 
 def test_create_user_with_profile_and_default_ppk(client: httpx.Client) -> None:
@@ -119,7 +119,7 @@ def test_admin_updates_user_profile(client: httpx.Client) -> None:
     assert created.status_code == 201
     user_id = created.json()["id"]
 
-    updated = client.patch(
+    updated = client.put(
         f"/api/auth/users/{user_id}",
         json={
             "name": "Edited",
@@ -134,4 +134,4 @@ def test_admin_updates_user_profile(client: httpx.Client) -> None:
     assert body["surname"] == "Name"
     assert body["ppk_employee_rate"] == "1.50"
 
-    assert client.patch("/api/auth/users/999999", json={}).status_code == 404
+    assert client.put("/api/auth/users/999999", json={}).status_code == 404

--- a/backend-go/internal/auth/handler.go
+++ b/backend-go/internal/auth/handler.go
@@ -230,8 +230,10 @@ func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, toUserResponse(user))
 }
 
-// UpdateUser serves PATCH /api/auth/users/{id} (admin only). It updates the
+// UpdateUser serves PUT /api/auth/users/{id} (admin only). It replaces the
 // display name, surname and PPK rates — not username, password or admin flag.
+// PUT (not PATCH): the request always carries the full editable set, so an
+// omitted field clears the value rather than leaving it unchanged.
 func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil {

--- a/backend-go/internal/auth/handler.go
+++ b/backend-go/internal/auth/handler.go
@@ -6,8 +6,12 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
 )
 
 // Session token lifetimes. "Remember me" extends a login from one day to five.
@@ -39,24 +43,60 @@ type loginRequest struct {
 }
 
 type createUserRequest struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username        string           `json:"username"`
+	Password        string           `json:"password"`
+	Name            *string          `json:"name"`
+	Surname         *string          `json:"surname"`
+	PPKEmployeeRate *decimal.Decimal `json:"ppk_employee_rate"`
+	PPKEmployerRate *decimal.Decimal `json:"ppk_employer_rate"`
+}
+
+type updateUserRequest struct {
+	Name            *string          `json:"name"`
+	Surname         *string          `json:"surname"`
+	PPKEmployeeRate *decimal.Decimal `json:"ppk_employee_rate"`
+	PPKEmployerRate *decimal.Decimal `json:"ppk_employer_rate"`
 }
 
 type userResponse struct {
-	ID        int    `json:"id"`
-	Username  string `json:"username"`
-	IsAdmin   bool   `json:"is_admin"`
-	CreatedAt string `json:"created_at"`
+	ID              int     `json:"id"`
+	Username        string  `json:"username"`
+	IsAdmin         bool    `json:"is_admin"`
+	Name            *string `json:"name"`
+	Surname         *string `json:"surname"`
+	PPKEmployeeRate *string `json:"ppk_employee_rate"`
+	PPKEmployerRate *string `json:"ppk_employer_rate"`
+	CreatedAt       string  `json:"created_at"`
+}
+
+// ppkStr renders an optional rate as a quoted 2-decimal string (matches the
+// Numeric(5,2) serialization the frontend already expects from personas).
+func ppkStr(d *decimal.Decimal) *string {
+	if d == nil {
+		return nil
+	}
+	s := d.StringFixed(2)
+	return &s
 }
 
 func toUserResponse(u *User) userResponse {
 	return userResponse{
-		ID:        u.ID,
-		Username:  u.Username,
-		IsAdmin:   u.IsAdmin,
-		CreatedAt: u.CreatedAt.Format("2006-01-02T15:04:05.999999"),
+		ID:              u.ID,
+		Username:        u.Username,
+		IsAdmin:         u.IsAdmin,
+		Name:            u.Name,
+		Surname:         u.Surname,
+		PPKEmployeeRate: ppkStr(u.PPKEmployeeRate),
+		PPKEmployerRate: ppkStr(u.PPKEmployerRate),
+		CreatedAt:       u.CreatedAt.Format("2006-01-02T15:04:05.999999"),
 	}
+}
+
+func derefName(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // Login serves POST /api/auth/login (public). On success it sets the session
@@ -78,7 +118,7 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 	if req.RememberMe {
 		ttl = rememberTTL
 	}
-	token, err := h.tokens.Sign(user.ID, user.Username, user.IsAdmin, ttl)
+	token, err := h.tokens.Sign(user.ID, user.Username, derefName(user.Name), user.IsAdmin, ttl)
 	if err != nil {
 		h.logger.Error("sign token", "err", err)
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
@@ -139,7 +179,7 @@ func (h *Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
 }
 
 // CreateUser serves POST /api/auth/users (admin only). The admin sets the
-// initial password.
+// initial password, display name and PPK rates.
 func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 	var req createUserRequest
 	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
@@ -155,13 +195,29 @@ func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		writeDetailError(w, http.StatusUnprocessableEntity, vErr)
 		return
 	}
+	name, surname, vErr := validateNames(req.Name, req.Surname)
+	if vErr != "" {
+		writeDetailError(w, http.StatusUnprocessableEntity, vErr)
+		return
+	}
+	if vErr := validatePPKPair(req.PPKEmployeeRate, req.PPKEmployerRate); vErr != "" {
+		writeDetailError(w, http.StatusUnprocessableEntity, vErr)
+		return
+	}
 	hash, err := HashPassword(req.Password)
 	if err != nil {
 		h.logger.Error("hash password", "err", err)
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	user, err := h.store.Create(r.Context(), username, hash)
+	user, err := h.store.Create(r.Context(), CreateParams{
+		Username:        username,
+		PasswordHash:    hash,
+		Name:            name,
+		Surname:         surname,
+		PPKEmployeeRate: ppkOrDefault(req.PPKEmployeeRate, defaultPPKEmployeeRate),
+		PPKEmployerRate: ppkOrDefault(req.PPKEmployerRate, defaultPPKEmployerRate),
+	})
 	if err != nil {
 		if errors.Is(err, ErrNameConflict) {
 			writeDetailError(w, http.StatusConflict, "Username '"+username+"' already exists")
@@ -172,6 +228,67 @@ func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, toUserResponse(user))
+}
+
+// UpdateUser serves PATCH /api/auth/users/{id} (admin only). It updates the
+// display name, surname and PPK rates — not username, password or admin flag.
+func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		writeDetailError(w, http.StatusBadRequest, "Invalid user id")
+		return
+	}
+	var req updateUserRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
+		writeDetailError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+	name, surname, vErr := validateNames(req.Name, req.Surname)
+	if vErr != "" {
+		writeDetailError(w, http.StatusUnprocessableEntity, vErr)
+		return
+	}
+	if vErr := validatePPKPair(req.PPKEmployeeRate, req.PPKEmployerRate); vErr != "" {
+		writeDetailError(w, http.StatusUnprocessableEntity, vErr)
+		return
+	}
+	user, err := h.store.Update(r.Context(), id, UpdateParams{
+		Name:            name,
+		Surname:         surname,
+		PPKEmployeeRate: req.PPKEmployeeRate,
+		PPKEmployerRate: req.PPKEmployerRate,
+	})
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			writeDetailError(w, http.StatusNotFound, "User not found")
+			return
+		}
+		h.logger.Error("update user", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusOK, toUserResponse(user))
+}
+
+// validateNames trims name + surname; returns the first non-empty error.
+func validateNames(rawName, rawSurname *string) (*string, *string, string) {
+	name, vErr := optionalName(rawName, "Name")
+	if vErr != "" {
+		return nil, nil, vErr
+	}
+	surname, vErr := optionalName(rawSurname, "Surname")
+	if vErr != "" {
+		return nil, nil, vErr
+	}
+	return name, surname, ""
+}
+
+// validatePPKPair validates both PPK rates; returns the first error message.
+func validatePPKPair(employee, employer *decimal.Decimal) string {
+	if vErr := validatePPK(employee); vErr != "" {
+		return vErr
+	}
+	return validatePPK(employer)
 }
 
 func (h *Handler) setSessionCookie(w http.ResponseWriter, token string, persistent bool, ttl time.Duration) {

--- a/backend-go/internal/auth/store.go
+++ b/backend-go/internal/auth/store.go
@@ -10,15 +10,40 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
 )
 
-// User is an application login account.
+// User is an application login account and household member. Name/Surname and
+// the PPK rates are nullable — older accounts and the seeded admin may not
+// have them set yet.
 type User struct {
-	ID           int
-	Username     string
-	PasswordHash string
-	IsAdmin      bool
-	CreatedAt    time.Time
+	ID              int
+	Username        string
+	PasswordHash    string
+	IsAdmin         bool
+	Name            *string
+	Surname         *string
+	PPKEmployeeRate *decimal.Decimal
+	PPKEmployerRate *decimal.Decimal
+	CreatedAt       time.Time
+}
+
+// CreateParams is the input for creating a user.
+type CreateParams struct {
+	Username        string
+	PasswordHash    string
+	Name            *string
+	Surname         *string
+	PPKEmployeeRate *decimal.Decimal
+	PPKEmployerRate *decimal.Decimal
+}
+
+// UpdateParams is the editable subset of a user (not username/password/admin).
+type UpdateParams struct {
+	Name            *string
+	Surname         *string
+	PPKEmployeeRate *decimal.Decimal
+	PPKEmployerRate *decimal.Decimal
 }
 
 // Sentinel errors so handlers map to HTTP status without sniffing pg text.
@@ -37,13 +62,15 @@ func NewStore(pool *pgxpool.Pool) *Store {
 	return &Store{pool: pool}
 }
 
-const userColumns = `id, username, password_hash, is_admin, created_at`
+const userColumns = `id, username, password_hash, is_admin, name, surname,
+	ppk_employee_rate, ppk_employer_rate, created_at`
 
-// EnsureSchema creates the users table if it does not exist.
+// EnsureSchema creates the users table if absent and adds any columns missing
+// on databases created before the persona-merge migration.
 //
 // The baseline schema.sql is applied only to empty databases (see
-// db.ApplySchema), so this additive table needs its own idempotent DDL that
-// also runs against existing production databases.
+// db.ApplySchema), so this additive DDL also runs against existing
+// production databases and must be idempotent.
 func (s *Store) EnsureSchema(ctx context.Context) error {
 	if _, err := s.pool.Exec(ctx, `
 		CREATE TABLE IF NOT EXISTS users (
@@ -51,9 +78,23 @@ func (s *Store) EnsureSchema(ctx context.Context) error {
 			username varchar(100) NOT NULL UNIQUE,
 			password_hash text NOT NULL,
 			is_admin boolean NOT NULL DEFAULT false,
+			name varchar(100),
+			surname varchar(100),
+			ppk_employee_rate numeric(5,2),
+			ppk_employer_rate numeric(5,2),
 			created_at timestamp without time zone NOT NULL DEFAULT (now() AT TIME ZONE 'utc')
 		)`); err != nil {
 		return fmt.Errorf("ensure users table: %w", err)
+	}
+	for _, col := range []string{
+		"name varchar(100)",
+		"surname varchar(100)",
+		"ppk_employee_rate numeric(5,2)",
+		"ppk_employer_rate numeric(5,2)",
+	} {
+		if _, err := s.pool.Exec(ctx, `ALTER TABLE users ADD COLUMN IF NOT EXISTS `+col); err != nil {
+			return fmt.Errorf("add users column %q: %w", col, err)
+		}
 	}
 	return nil
 }
@@ -73,11 +114,11 @@ func (s *Store) List(ctx context.Context) ([]User, error) {
 	defer rows.Close()
 	out := []User{}
 	for rows.Next() {
-		var u User
-		if err := rows.Scan(&u.ID, &u.Username, &u.PasswordHash, &u.IsAdmin, &u.CreatedAt); err != nil {
-			return nil, fmt.Errorf("scan user: %w", err)
+		u, err := scanUser(rows)
+		if err != nil {
+			return nil, err
 		}
-		out = append(out, u)
+		out = append(out, *u)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate users: %w", err)
@@ -86,12 +127,13 @@ func (s *Store) List(ctx context.Context) ([]User, error) {
 }
 
 // Create inserts a non-admin user; ErrNameConflict on duplicate username.
-func (s *Store) Create(ctx context.Context, username, passwordHash string) (*User, error) {
+func (s *Store) Create(ctx context.Context, p CreateParams) (*User, error) {
 	row := s.pool.QueryRow(ctx, `
-		INSERT INTO users (username, password_hash, is_admin)
-		VALUES ($1, $2, false)
+		INSERT INTO users (username, password_hash, is_admin, name, surname,
+			ppk_employee_rate, ppk_employer_rate)
+		VALUES ($1, $2, false, $3, $4, $5, $6)
 		RETURNING `+userColumns,
-		username, passwordHash)
+		p.Username, p.PasswordHash, p.Name, p.Surname, p.PPKEmployeeRate, p.PPKEmployerRate)
 	u, err := scanUser(row)
 	if err != nil {
 		if isUniqueViolation(err) {
@@ -102,8 +144,25 @@ func (s *Store) Create(ctx context.Context, username, passwordHash string) (*Use
 	return u, nil
 }
 
+// Update replaces a user's editable fields (name, surname, PPK rates);
+// ErrNotFound if no user has that id.
+func (s *Store) Update(ctx context.Context, id int, p UpdateParams) (*User, error) {
+	row := s.pool.QueryRow(ctx, `
+		UPDATE users
+		SET name = $1, surname = $2, ppk_employee_rate = $3, ppk_employer_rate = $4
+		WHERE id = $5
+		RETURNING `+userColumns,
+		p.Name, p.Surname, p.PPKEmployeeRate, p.PPKEmployerRate, id)
+	u, err := scanUser(row)
+	if err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
 // UpsertAdmin creates or refreshes the admin account from configuration.
-// Runs on every startup so a changed FB_ADMIN_PASSWORD takes effect.
+// Runs on every startup so a changed FB_ADMIN_PASSWORD takes effect. It does
+// not touch name/surname/PPK — those are managed through the users UI.
 func (s *Store) UpsertAdmin(ctx context.Context, username, passwordHash string) error {
 	if _, err := s.pool.Exec(ctx, `
 		INSERT INTO users (username, password_hash, is_admin)
@@ -118,7 +177,8 @@ func (s *Store) UpsertAdmin(ctx context.Context, username, passwordHash string) 
 
 func scanUser(row pgx.Row) (*User, error) {
 	var u User
-	if err := row.Scan(&u.ID, &u.Username, &u.PasswordHash, &u.IsAdmin, &u.CreatedAt); err != nil {
+	if err := row.Scan(&u.ID, &u.Username, &u.PasswordHash, &u.IsAdmin,
+		&u.Name, &u.Surname, &u.PPKEmployeeRate, &u.PPKEmployerRate, &u.CreatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
 		}

--- a/backend-go/internal/auth/token.go
+++ b/backend-go/internal/auth/token.go
@@ -16,6 +16,7 @@ import (
 type Claims struct {
 	UserID   int    `json:"uid"`
 	Username string `json:"username"`
+	Name     string `json:"name"`
 	IsAdmin  bool   `json:"is_admin"`
 	jwt.RegisteredClaims
 }
@@ -30,12 +31,14 @@ func NewTokenService(secret string) *TokenService {
 	return &TokenService{secret: []byte(secret)}
 }
 
-// Sign issues a token for the user that expires after ttl.
-func (t *TokenService) Sign(userID int, username string, isAdmin bool, ttl time.Duration) (string, error) {
+// Sign issues a token for the user that expires after ttl. name is the
+// display name carried for the UI; it may be empty.
+func (t *TokenService) Sign(userID int, username, name string, isAdmin bool, ttl time.Duration) (string, error) {
 	now := time.Now().UTC()
 	claims := Claims{
 		UserID:   userID,
 		Username: username,
+		Name:     name,
 		IsAdmin:  isAdmin,
 		RegisteredClaims: jwt.RegisteredClaims{
 			IssuedAt:  jwt.NewNumericDate(now),

--- a/backend-go/internal/auth/token_test.go
+++ b/backend-go/internal/auth/token_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestTokenSignVerifyRoundtrip(t *testing.T) {
 	ts := NewTokenService("test-secret")
-	token, err := ts.Sign(42, "marcin", true, time.Hour)
+	token, err := ts.Sign(42, "marcin", "Marcin", true, time.Hour)
 	if err != nil {
 		t.Fatalf("Sign: %v", err)
 	}
@@ -15,14 +15,14 @@ func TestTokenSignVerifyRoundtrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
-	if claims.UserID != 42 || claims.Username != "marcin" || !claims.IsAdmin {
+	if claims.UserID != 42 || claims.Username != "marcin" || claims.Name != "Marcin" || !claims.IsAdmin {
 		t.Fatalf("claims mismatch: %+v", claims)
 	}
 }
 
 func TestTokenVerifyRejectsExpired(t *testing.T) {
 	ts := NewTokenService("test-secret")
-	token, err := ts.Sign(1, "ewa", false, -time.Minute)
+	token, err := ts.Sign(1, "ewa", "Ewa", false, -time.Minute)
 	if err != nil {
 		t.Fatalf("Sign: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestTokenVerifyRejectsExpired(t *testing.T) {
 }
 
 func TestTokenVerifyRejectsWrongSecret(t *testing.T) {
-	token, err := NewTokenService("secret-a").Sign(1, "ewa", false, time.Hour)
+	token, err := NewTokenService("secret-a").Sign(1, "ewa", "Ewa", false, time.Hour)
 	if err != nil {
 		t.Fatalf("Sign: %v", err)
 	}

--- a/backend-go/internal/auth/validation.go
+++ b/backend-go/internal/auth/validation.go
@@ -1,8 +1,20 @@
 package auth
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/shopspring/decimal"
+)
 
 const minPasswordLen = 8
+
+// PPK rate defaults + bounds, mirroring the persona schema.
+var (
+	defaultPPKEmployeeRate = decimal.NewFromFloat(2.0)
+	defaultPPKEmployerRate = decimal.NewFromFloat(1.5)
+	ppkMin                 = decimal.NewFromFloat(0.5)
+	ppkMax                 = decimal.NewFromFloat(4.0)
+)
 
 // validateUsername trims and bounds the username. The second return value is
 // a non-empty message when validation fails.
@@ -23,4 +35,39 @@ func validatePassword(raw string) string {
 		return "Password must be at least 8 characters"
 	}
 	return ""
+}
+
+// optionalName trims an optional name/surname; an empty string becomes nil.
+// field names the value for the error message.
+func optionalName(raw *string, field string) (*string, string) {
+	if raw == nil {
+		return nil, ""
+	}
+	trimmed := strings.TrimSpace(*raw)
+	if trimmed == "" {
+		return nil, ""
+	}
+	if len(trimmed) > 100 {
+		return nil, field + " too long (max 100 characters)"
+	}
+	return &trimmed, ""
+}
+
+// validatePPK enforces 0.5 <= rate <= 4.0 when a rate is supplied.
+func validatePPK(d *decimal.Decimal) string {
+	if d == nil {
+		return ""
+	}
+	if d.LessThan(ppkMin) || d.GreaterThan(ppkMax) {
+		return "PPK rate must be between 0.5 and 4.0"
+	}
+	return ""
+}
+
+// ppkOrDefault returns the supplied rate, or fallback when none was given.
+func ppkOrDefault(d *decimal.Decimal, fallback decimal.Decimal) *decimal.Decimal {
+	if d != nil {
+		return d
+	}
+	return &fallback
 }

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -109,6 +109,7 @@ func registerRoutes(r chi.Router, cfg Config, pool *pgxpool.Pool, logger *slog.L
 		r.Get("/api/auth/me", authHandler.Me)
 		r.With(auth.RequireAdmin).Get("/api/auth/users", authHandler.ListUsers)
 		r.With(auth.RequireAdmin).Post("/api/auth/users", authHandler.CreateUser)
+		r.With(auth.RequireAdmin).Patch("/api/auth/users/{id}", authHandler.UpdateUser)
 		registerAPIRoutes(r, pool, logger)
 	})
 }

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -109,7 +109,7 @@ func registerRoutes(r chi.Router, cfg Config, pool *pgxpool.Pool, logger *slog.L
 		r.Get("/api/auth/me", authHandler.Me)
 		r.With(auth.RequireAdmin).Get("/api/auth/users", authHandler.ListUsers)
 		r.With(auth.RequireAdmin).Post("/api/auth/users", authHandler.CreateUser)
-		r.With(auth.RequireAdmin).Patch("/api/auth/users/{id}", authHandler.UpdateUser)
+		r.With(auth.RequireAdmin).Put("/api/auth/users/{id}", authHandler.UpdateUser)
 		registerAPIRoutes(r, pool, logger)
 	})
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -4,7 +4,7 @@ declare global {
 	namespace App {
 		// interface Error {}
 		interface Locals {
-			user: { username: string; isAdmin: boolean } | null;
+			user: { username: string; name: string; isAdmin: boolean } | null;
 		}
 		// interface PageData {}
 		// interface PageState {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -3,6 +3,7 @@ import { env } from '$env/dynamic/public';
 
 interface SessionUser {
 	username: string;
+	name: string;
 	isAdmin: boolean;
 }
 
@@ -17,7 +18,12 @@ function decodeUser(token: string): SessionUser | null {
 		}
 		const pad = payload.length % 4 === 0 ? '' : '='.repeat(4 - (payload.length % 4));
 		const json = atob(payload.replace(/-/g, '+').replace(/_/g, '/') + pad);
-		const claims = JSON.parse(json) as { username?: unknown; is_admin?: unknown; exp?: unknown };
+		const claims = JSON.parse(json) as {
+			username?: unknown;
+			name?: unknown;
+			is_admin?: unknown;
+			exp?: unknown;
+		};
 		// Reject malformed claims. The backend still verifies the signature on
 		// every API call — this only stops a bogus token from looking
 		// logged-in to the page-level gating.
@@ -30,7 +36,12 @@ function decodeUser(token: string): SessionUser | null {
 		if (typeof claims.is_admin !== 'boolean') {
 			return null;
 		}
-		return { username: claims.username, isAdmin: claims.is_admin };
+		// name is optional — tokens issued before the persona merge lack it.
+		return {
+			username: claims.username,
+			name: typeof claims.name === 'string' ? claims.name : '',
+			isAdmin: claims.is_admin
+		};
 	} catch {
 		return null;
 	}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -85,7 +85,7 @@
 				<div class="p-3 border-t border-surface-200-800 space-y-2">
 					<div class="flex items-center gap-2 px-1 text-sm text-surface-700-300">
 						<User size={16} />
-						<span class="truncate">{data.user.username}</span>
+						<span class="truncate">{data.user.name || data.user.username}</span>
 					</div>
 					<form method="POST" action="/logout">
 						<button

--- a/src/routes/users/+page.svelte
+++ b/src/routes/users/+page.svelte
@@ -2,49 +2,114 @@
 	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
+	import Modal from '$lib/components/Modal.svelte';
 	import type { PageData } from './$types';
 
 	interface AppUser {
 		id: number;
 		username: string;
 		is_admin: boolean;
+		name: string | null;
+		surname: string | null;
+		ppk_employee_rate: string | null;
+		ppk_employer_rate: string | null;
 		created_at: string;
 	}
 
 	let { data }: { data: PageData } = $props();
 	const users = $derived(data.users as AppUser[]);
+	const apiUrl = env.PUBLIC_API_URL_BROWSER ?? '';
 
 	let username = $state('');
 	let password = $state('');
-	let saving = $state(false);
+	let name = $state('');
+	let surname = $state('');
+	let ppkEmployee = $state(2);
+	let ppkEmployer = $state(1.5);
+	let creating = $state(false);
+
+	let editUser = $state<AppUser | null>(null);
+	let editName = $state('');
+	let editSurname = $state('');
+	let editPpkEmployee = $state(2);
+	let editPpkEmployer = $state(1.5);
+	let editSaving = $state(false);
+
+	async function request(method: string, path: string, body: unknown): Promise<void> {
+		const response = await fetch(`${apiUrl}${path}`, {
+			method,
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify(body)
+		});
+		if (!response.ok) {
+			const err = await response.json().catch(() => null);
+			const detail =
+				err && typeof err === 'object' && 'detail' in err && err.detail
+					? String(err.detail)
+					: 'Operacja nie powiodła się';
+			throw new Error(detail);
+		}
+	}
 
 	async function createUser(event: Event): Promise<void> {
 		event.preventDefault();
-		saving = true;
+		creating = true;
 		try {
-			const apiUrl = env.PUBLIC_API_URL_BROWSER ?? '';
-			const response = await fetch(`${apiUrl}/api/auth/users`, {
-				method: 'POST',
-				headers: { 'content-type': 'application/json' },
-				body: JSON.stringify({ username, password })
+			await request('POST', '/api/auth/users', {
+				username,
+				password,
+				name: name.trim() || null,
+				surname: surname.trim() || null,
+				ppk_employee_rate: ppkEmployee,
+				ppk_employer_rate: ppkEmployer
 			});
-			if (!response.ok) {
-				const body = await response.json().catch(() => null);
-				const detail =
-					body && typeof body === 'object' && 'detail' in body && body.detail
-						? String(body.detail)
-						: 'Nie udało się utworzyć użytkownika';
-				throw new Error(detail);
-			}
 			toast.success(`Użytkownik „${username}” został utworzony`);
 			username = '';
 			password = '';
+			name = '';
+			surname = '';
+			ppkEmployee = 2;
+			ppkEmployer = 1.5;
 			await invalidateAll();
 		} catch (err) {
 			toast.error(err instanceof Error ? err.message : 'Wystąpił błąd');
 		} finally {
-			saving = false;
+			creating = false;
 		}
+	}
+
+	function openEdit(appUser: AppUser): void {
+		editUser = appUser;
+		editName = appUser.name ?? '';
+		editSurname = appUser.surname ?? '';
+		editPpkEmployee = appUser.ppk_employee_rate ? Number(appUser.ppk_employee_rate) : 2;
+		editPpkEmployer = appUser.ppk_employer_rate ? Number(appUser.ppk_employer_rate) : 1.5;
+	}
+
+	async function saveEdit(): Promise<void> {
+		if (!editUser) {
+			return;
+		}
+		editSaving = true;
+		try {
+			await request('PATCH', `/api/auth/users/${editUser.id}`, {
+				name: editName.trim() || null,
+				surname: editSurname.trim() || null,
+				ppk_employee_rate: editPpkEmployee,
+				ppk_employer_rate: editPpkEmployer
+			});
+			toast.success('Zapisano zmiany');
+			editUser = null;
+			await invalidateAll();
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Wystąpił błąd');
+		} finally {
+			editSaving = false;
+		}
+	}
+
+	function fullName(appUser: AppUser): string {
+		return [appUser.name, appUser.surname].filter(Boolean).join(' ') || '—';
 	}
 </script>
 
@@ -53,18 +118,36 @@
 
 	<div class="card preset-filled-surface-50-950 p-5 space-y-4">
 		<h2 class="h4 font-semibold">Dodaj użytkownika</h2>
-		<form class="flex flex-col sm:flex-row sm:items-end gap-3" onsubmit={createUser}>
-			<label class="label flex-1">
+		<form class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3" onsubmit={createUser}>
+			<label class="label">
 				<span class="font-semibold text-sm">Nazwa użytkownika</span>
 				<input bind:value={username} type="text" class="input" required />
 			</label>
-			<label class="label flex-1">
+			<label class="label">
 				<span class="font-semibold text-sm">Hasło (min. 8 znaków)</span>
 				<input bind:value={password} type="password" class="input" minlength="8" required />
 			</label>
-			<button type="submit" class="btn preset-filled-primary-500" disabled={saving}>
-				{saving ? 'Dodawanie...' : 'Dodaj'}
-			</button>
+			<label class="label">
+				<span class="font-semibold text-sm">Imię</span>
+				<input bind:value={name} type="text" class="input" />
+			</label>
+			<label class="label">
+				<span class="font-semibold text-sm">Nazwisko</span>
+				<input bind:value={surname} type="text" class="input" />
+			</label>
+			<label class="label">
+				<span class="font-semibold text-sm">PPK pracownik (%)</span>
+				<input bind:value={ppkEmployee} type="number" step="0.01" min="0.5" max="4" class="input" />
+			</label>
+			<label class="label">
+				<span class="font-semibold text-sm">PPK pracodawca (%)</span>
+				<input bind:value={ppkEmployer} type="number" step="0.01" min="0.5" max="4" class="input" />
+			</label>
+			<div class="sm:col-span-2 lg:col-span-3">
+				<button type="submit" class="btn preset-filled-primary-500" disabled={creating}>
+					{creating ? 'Dodawanie...' : 'Dodaj'}
+				</button>
+			</div>
 		</form>
 	</div>
 
@@ -73,14 +156,19 @@
 			<thead>
 				<tr>
 					<th>Nazwa użytkownika</th>
+					<th>Imię i nazwisko</th>
+					<th>PPK (prac. / prac.)</th>
 					<th>Rola</th>
 					<th>Utworzono</th>
+					<th></th>
 				</tr>
 			</thead>
 			<tbody>
 				{#each users as appUser (appUser.id)}
 					<tr>
 						<td>{appUser.username}</td>
+						<td>{fullName(appUser)}</td>
+						<td>{appUser.ppk_employee_rate ?? '—'} / {appUser.ppk_employer_rate ?? '—'}</td>
 						<td>
 							{#if appUser.is_admin}
 								<span class="badge preset-filled-primary-500">Administrator</span>
@@ -89,9 +177,59 @@
 							{/if}
 						</td>
 						<td>{appUser.created_at.slice(0, 10)}</td>
+						<td>
+							<button
+								type="button"
+								class="btn btn-sm preset-tonal-surface"
+								onclick={() => openEdit(appUser)}
+							>
+								Edytuj
+							</button>
+						</td>
 					</tr>
 				{/each}
 			</tbody>
 		</table>
 	</div>
 </div>
+
+<Modal
+	open={editUser !== null}
+	title="Edytuj użytkownika"
+	confirmDisabled={editSaving}
+	onConfirm={saveEdit}
+	onCancel={() => (editUser = null)}
+>
+	<div class="space-y-3">
+		<label class="label">
+			<span class="font-semibold text-sm">Imię</span>
+			<input bind:value={editName} type="text" class="input" />
+		</label>
+		<label class="label">
+			<span class="font-semibold text-sm">Nazwisko</span>
+			<input bind:value={editSurname} type="text" class="input" />
+		</label>
+		<label class="label">
+			<span class="font-semibold text-sm">PPK pracownik (%)</span>
+			<input
+				bind:value={editPpkEmployee}
+				type="number"
+				step="0.01"
+				min="0.5"
+				max="4"
+				class="input"
+			/>
+		</label>
+		<label class="label">
+			<span class="font-semibold text-sm">PPK pracodawca (%)</span>
+			<input
+				bind:value={editPpkEmployer}
+				type="number"
+				step="0.01"
+				min="0.5"
+				max="4"
+				class="input"
+			/>
+		</label>
+	</div>
+</Modal>

--- a/src/routes/users/+page.svelte
+++ b/src/routes/users/+page.svelte
@@ -24,16 +24,22 @@
 	let password = $state('');
 	let name = $state('');
 	let surname = $state('');
-	let ppkEmployee = $state(2);
-	let ppkEmployer = $state(1.5);
+	let ppkEmployee = $state<number | null>(2);
+	let ppkEmployer = $state<number | null>(1.5);
 	let creating = $state(false);
 
 	let editUser = $state<AppUser | null>(null);
 	let editName = $state('');
 	let editSurname = $state('');
-	let editPpkEmployee = $state(2);
-	let editPpkEmployer = $state(1.5);
+	let editPpkEmployee = $state<number | null>(2);
+	let editPpkEmployer = $state<number | null>(1.5);
 	let editSaving = $state(false);
+
+	// A number input bound to a cleared field yields null/NaN — normalize so
+	// the backend either applies its default (create) or stores NULL (update).
+	function ppkValue(raw: number | null): number | null {
+		return typeof raw === 'number' && Number.isFinite(raw) ? raw : null;
+	}
 
 	async function request(method: string, path: string, body: unknown): Promise<void> {
 		const response = await fetch(`${apiUrl}${path}`, {
@@ -60,8 +66,8 @@
 				password,
 				name: name.trim() || null,
 				surname: surname.trim() || null,
-				ppk_employee_rate: ppkEmployee,
-				ppk_employer_rate: ppkEmployer
+				ppk_employee_rate: ppkValue(ppkEmployee),
+				ppk_employer_rate: ppkValue(ppkEmployer)
 			});
 			toast.success(`Użytkownik „${username}” został utworzony`);
 			username = '';
@@ -92,11 +98,11 @@
 		}
 		editSaving = true;
 		try {
-			await request('PATCH', `/api/auth/users/${editUser.id}`, {
+			await request('PUT', `/api/auth/users/${editUser.id}`, {
 				name: editName.trim() || null,
 				surname: editSurname.trim() || null,
-				ppk_employee_rate: editPpkEmployee,
-				ppk_employer_rate: editPpkEmployer
+				ppk_employee_rate: ppkValue(editPpkEmployee),
+				ppk_employer_rate: ppkValue(editPpkEmployer)
 			});
 			toast.success('Zapisano zmiany');
 			editUser = null;
@@ -157,7 +163,7 @@
 				<tr>
 					<th>Nazwa użytkownika</th>
 					<th>Imię i nazwisko</th>
-					<th>PPK (prac. / prac.)</th>
+					<th>PPK (prac. / pracod.)</th>
 					<th>Rola</th>
 					<th>Utworzono</th>
 					<th></th>


### PR DESCRIPTION
## Motivation

Phase A of merging the `personas` concept into `users`. Each household
member should be a single entity — a login account that also carries a
display name and PPK retirement rates. This phase makes `users` hold
those attributes; `personas` and the `owner` columns are untouched and
the app behaves identically.

## Implementation information

- `users` gains nullable `name`, `surname`, `ppk_employee_rate`,
  `ppk_employer_rate`. Added via idempotent `ALTER … ADD COLUMN IF NOT
  EXISTS` in `EnsureSchema`, so existing databases pick them up.
- `POST /api/auth/users` accepts the new fields; PPK rates default to
  2.00 / 1.50 when omitted.
- New `PATCH /api/auth/users/{id}` (admin) edits name/surname/PPK.
- The session JWT carries the display `name`; the layout shows it,
  falling back to `username` for tokens issued before this change.
- `/users` page: create form gains the fields; an edit modal is added;
  the table shows name/surname/PPK.

Backfill of the two existing users (name + PPK) is a one-time step done
during deploy, not in code.

## Supporting documentation

Part of the personas→users merge plan (Phase A of 4).