### PR TITLE
feat(db): add owner_user_id column and backfill

### DIFF
--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -126,6 +126,12 @@ func run() int {
 		}
 		logger.Info("admin user ready", "username", adminUsername)
 
+		// In-progress personas->users migration (idempotent, runs every start).
+		if err := db.Migrate(ctx, pool); err != nil {
+			logger.Error("run migration", "err", err)
+			return 2
+		}
+
 		// CPI monthly-refresh scheduler — replaces the Python APScheduler job.
 		sched := scheduler.NewCPIScheduler(cpi.NewStore(pool), cpi.NewGUSFetcher(), logger)
 		go sched.Run(ctx)

--- a/backend-go/internal/db/migrate.go
+++ b/backend-go/internal/db/migrate.go
@@ -1,0 +1,40 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ownerTables are the tables whose `owner` string is being migrated to an
+// `owner_user_id` foreign key as part of the personas->users merge.
+var ownerTables = []string{
+	"accounts", "transactions", "salary_records", "debt_payments",
+	"bonus_events", "equity_grants", "retirement_limits", "snapshot_aggregates",
+}
+
+// Migrate applies the in-progress personas->users schema migration. It is
+// idempotent and runs on every startup, after the users table exists.
+//
+// Phase B: add a nullable owner_user_id column to every owner-bearing table
+// and backfill it from the owner string (matched against users.name). Rows
+// whose owner has no matching user — notably "Shared" — keep owner_user_id
+// NULL. Re-running the backfill each startup also catches rows written before
+// the cutover. The owner string column stays in place until a later phase.
+func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
+	for _, table := range ownerTables {
+		if _, err := pool.Exec(ctx,
+			`ALTER TABLE `+table+` ADD COLUMN IF NOT EXISTS owner_user_id integer`); err != nil {
+			return fmt.Errorf("add owner_user_id to %s: %w", table, err)
+		}
+		if _, err := pool.Exec(ctx, `
+			UPDATE `+table+` AS t
+			SET owner_user_id = u.id
+			FROM users u
+			WHERE t.owner = u.name AND t.owner_user_id IS NULL`); err != nil {
+			return fmt.Errorf("backfill owner_user_id on %s: %w", table, err)
+		}
+	}
+	return nil
+}

--- a/backend-go/internal/db/migrate.go
+++ b/backend-go/internal/db/migrate.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ownerTables are the tables whose `owner` string is being migrated to an
-// `owner_user_id` foreign key as part of the personas->users merge.
+// `owner_user_id` reference as part of the personas->users merge.
 var ownerTables = []string{
 	"accounts", "transactions", "salary_records", "debt_payments",
 	"bonus_events", "equity_grants", "retirement_limits", "snapshot_aggregates",
@@ -17,24 +17,64 @@ var ownerTables = []string{
 // Migrate applies the in-progress personas->users schema migration. It is
 // idempotent and runs on every startup, after the users table exists.
 //
-// Phase B: add a nullable owner_user_id column to every owner-bearing table
-// and backfill it from the owner string (matched against users.name). Rows
-// whose owner has no matching user — notably "Shared" — keep owner_user_id
-// NULL. Re-running the backfill each startup also catches rows written before
-// the cutover. The owner string column stays in place until a later phase.
+// Phase B: every owner-bearing table gets a nullable owner_user_id column,
+// kept in sync with the owner string (matched against users.name). It is a
+// plain integer for now — the foreign key constraint and index are added in
+// a later phase. Rows whose owner matches no user — notably "Shared" — keep
+// owner_user_id NULL.
 func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
 	for _, table := range ownerTables {
-		if _, err := pool.Exec(ctx,
-			`ALTER TABLE `+table+` ADD COLUMN IF NOT EXISTS owner_user_id integer`); err != nil {
-			return fmt.Errorf("add owner_user_id to %s: %w", table, err)
+		if err := ensureOwnerUserIDColumn(ctx, pool, table); err != nil {
+			return err
 		}
-		if _, err := pool.Exec(ctx, `
-			UPDATE `+table+` AS t
-			SET owner_user_id = u.id
-			FROM users u
-			WHERE t.owner = u.name AND t.owner_user_id IS NULL`); err != nil {
-			return fmt.Errorf("backfill owner_user_id on %s: %w", table, err)
+		if err := syncOwnerUserID(ctx, pool, table); err != nil {
+			return err
 		}
+	}
+	return nil
+}
+
+// ensureOwnerUserIDColumn adds owner_user_id only when it is missing, so a
+// no-op startup does not take the ALTER TABLE access-exclusive lock.
+func ensureOwnerUserIDColumn(ctx context.Context, pool *pgxpool.Pool, table string) error {
+	var exists bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_schema = 'public'
+			  AND table_name = $1
+			  AND column_name = 'owner_user_id')`,
+		table).Scan(&exists); err != nil {
+		return fmt.Errorf("check owner_user_id on %s: %w", table, err)
+	}
+	if exists {
+		return nil
+	}
+	if _, err := pool.Exec(ctx,
+		`ALTER TABLE `+table+` ADD COLUMN owner_user_id integer`); err != nil {
+		return fmt.Errorf("add owner_user_id to %s: %w", table, err)
+	}
+	return nil
+}
+
+// syncOwnerUserID re-points owner_user_id at the user whose name equals the
+// row's current owner, and clears it when the owner matches no user. Running
+// it every startup keeps the two columns consistent — e.g. after an owner
+// rename — until the owner string column is dropped.
+func syncOwnerUserID(ctx context.Context, pool *pgxpool.Pool, table string) error {
+	if _, err := pool.Exec(ctx, `
+		UPDATE `+table+` AS t
+		SET owner_user_id = u.id
+		FROM users u
+		WHERE t.owner = u.name AND t.owner_user_id IS DISTINCT FROM u.id`); err != nil {
+		return fmt.Errorf("sync owner_user_id on %s: %w", table, err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE `+table+` AS t
+		SET owner_user_id = NULL
+		WHERE t.owner_user_id IS NOT NULL
+		  AND NOT EXISTS (SELECT 1 FROM users u WHERE u.name = t.owner)`); err != nil {
+		return fmt.Errorf("clear stale owner_user_id on %s: %w", table, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Motivation

Phase B of merging `personas` into `users`. Before the data tables can
reference users instead of free-text owner strings, every owner-bearing
table needs an `owner_user_id` column, populated from the existing
`owner` values.

## Implementation information

- New `db.Migrate` — an idempotent startup migration (runs after the
  users table exists). It adds a nullable `owner_user_id` to all eight
  owner-bearing tables and backfills it from `owner` matched against
  `users.name`. Rows whose owner has no matching user (notably
  "Shared") keep `owner_user_id` NULL.
- The `owner` string column and the API are untouched — this phase is
  purely additive and changes no responses.
- The backfill re-runs on every startup, so rows written before the
  later read-side cutover are also captured; no dual-write needed.

## Supporting documentation

Phase B of 4 in the personas->users merge.