### PR TITLE
feat(auth): add /api/users owner-picker endpoint

### DIFF
--- a/backend-bb-tests/tests/test_auth.py
+++ b/backend-bb-tests/tests/test_auth.py
@@ -111,6 +111,31 @@ def test_create_user_with_profile_and_default_ppk(client: httpx.Client) -> None:
     assert defaulted.json()["ppk_employer_rate"] == "1.50"
 
 
+def test_owner_picker_list(client: httpx.Client, base_url: str) -> None:
+    created = client.post(
+        "/api/auth/users",
+        json={"username": "bb-owner", "password": "owner-pass-1", "name": "Owner One"},
+    )
+    assert created.status_code == 201
+
+    response = client.get("/api/users")
+    assert response.status_code == 200
+    options = response.json()
+    assert isinstance(options, list)
+    entry = next(o for o in options if o["id"] == created.json()["id"])
+    assert entry == {"id": created.json()["id"], "name": "Owner One"}
+    # Every option exposes only id + display name.
+    assert all(set(o.keys()) == {"id", "name"} for o in options)
+
+    # Reachable by a non-admin user too.
+    with httpx.Client(base_url=base_url, timeout=10.0) as http:
+        http.post(
+            "/api/auth/login",
+            json={"username": "bb-owner", "password": "owner-pass-1"},
+        )
+        assert http.get("/api/users").status_code == 200
+
+
 def test_admin_updates_user_profile(client: httpx.Client) -> None:
     created = client.post(
         "/api/auth/users",

--- a/backend-go/internal/auth/handler.go
+++ b/backend-go/internal/auth/handler.go
@@ -163,6 +163,34 @@ func (h *Handler) Me(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, toUserResponse(user))
 }
 
+// ownerOption is a household member offered as an owner-picker choice.
+type ownerOption struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// ListOwners serves GET /api/users — every household member as an
+// owner-picker option (id + display name). Authenticated, not admin-only;
+// it carries no sensitive fields. The display name falls back to the
+// username when no name is set.
+func (h *Handler) ListOwners(w http.ResponseWriter, r *http.Request) {
+	users, err := h.store.List(r.Context())
+	if err != nil {
+		h.logger.Error("list owners", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := make([]ownerOption, 0, len(users))
+	for i := range users {
+		name := users[i].Username
+		if users[i].Name != nil && *users[i].Name != "" {
+			name = *users[i].Name
+		}
+		out = append(out, ownerOption{ID: users[i].ID, Name: name})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
 // ListUsers serves GET /api/auth/users (admin only).
 func (h *Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	users, err := h.store.List(r.Context())

--- a/backend-go/internal/auth/handler.go
+++ b/backend-go/internal/auth/handler.go
@@ -174,19 +174,19 @@ type ownerOption struct {
 // it carries no sensitive fields. The display name falls back to the
 // username when no name is set.
 func (h *Handler) ListOwners(w http.ResponseWriter, r *http.Request) {
-	users, err := h.store.List(r.Context())
+	owners, err := h.store.ListOwners(r.Context())
 	if err != nil {
 		h.logger.Error("list owners", "err", err)
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	out := make([]ownerOption, 0, len(users))
-	for i := range users {
-		name := users[i].Username
-		if users[i].Name != nil && *users[i].Name != "" {
-			name = *users[i].Name
+	out := make([]ownerOption, 0, len(owners))
+	for i := range owners {
+		name := owners[i].Username
+		if owners[i].Name != nil && *owners[i].Name != "" {
+			name = *owners[i].Name
 		}
-		out = append(out, ownerOption{ID: users[i].ID, Name: name})
+		out = append(out, ownerOption{ID: owners[i].ID, Name: name})
 	}
 	writeJSON(w, http.StatusOK, out)
 }

--- a/backend-go/internal/auth/store.go
+++ b/backend-go/internal/auth/store.go
@@ -126,6 +126,36 @@ func (s *Store) List(ctx context.Context) ([]User, error) {
 	return out, nil
 }
 
+// OwnerRef is the minimal user identity behind the owner-picker endpoint.
+type OwnerRef struct {
+	ID       int
+	Username string
+	Name     *string
+}
+
+// ListOwners returns every user's id + names, ordered by username. It is a
+// lean query — no password hash loaded — for the frequently-hit, non-admin
+// owner-picker endpoint.
+func (s *Store) ListOwners(ctx context.Context) ([]OwnerRef, error) {
+	rows, err := s.pool.Query(ctx, `SELECT id, username, name FROM users ORDER BY username`)
+	if err != nil {
+		return nil, fmt.Errorf("select owners: %w", err)
+	}
+	defer rows.Close()
+	out := []OwnerRef{}
+	for rows.Next() {
+		var o OwnerRef
+		if err := rows.Scan(&o.ID, &o.Username, &o.Name); err != nil {
+			return nil, fmt.Errorf("scan owner: %w", err)
+		}
+		out = append(out, o)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate owners: %w", err)
+	}
+	return out, nil
+}
+
 // Create inserts a non-admin user; ErrNameConflict on duplicate username.
 func (s *Store) Create(ctx context.Context, p CreateParams) (*User, error) {
 	row := s.pool.QueryRow(ctx, `

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -107,6 +107,7 @@ func registerRoutes(r chi.Router, cfg Config, pool *pgxpool.Pool, logger *slog.L
 	r.Group(func(r chi.Router) {
 		r.Use(auth.Authenticate(tokens))
 		r.Get("/api/auth/me", authHandler.Me)
+		r.Get("/api/users", authHandler.ListOwners)
 		r.With(auth.RequireAdmin).Get("/api/auth/users", authHandler.ListUsers)
 		r.With(auth.RequireAdmin).Post("/api/auth/users", authHandler.CreateUser)
 		r.With(auth.RequireAdmin).Put("/api/auth/users/{id}", authHandler.UpdateUser)


### PR DESCRIPTION
## Motivation

Phase C1 of the personas->users merge. Before the data tables can
expose `owner_user_id` instead of an owner string, the frontend owner
dropdowns need a source of household members keyed by user id.

## Implementation information

Adds an authenticated (non-admin) `GET /api/users` returning every
user as an owner-picker option — `{id, name}`, where `name` is the
display name (falling back to username). It carries no sensitive
fields, unlike the admin-only `/api/auth/users`.

Purely additive: no existing endpoint or response changes. The later
C2-C4 sub-phases consume this when switching each domain's API to
`owner_user_id`.

## Supporting documentation

Phase C1 of 4 — owner_user_id API cutover.