### PR TITLE
feat(api): owner_user_id cutover for C3 endpoints

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -928,8 +928,9 @@
                             "nullable": true,
                             "type": "string"
                           },
-                          "owner": {
-                            "type": "string"
+                          "owner_user_id": {
+                            "nullable": true,
+                            "type": "integer"
                           },
                           "type": {
                             "type": "string"
@@ -1003,8 +1004,9 @@
                       "nullable": true,
                       "type": "string"
                     },
-                    "owner": {
-                      "type": "string"
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
                     },
                     "type": {
                       "type": "string"
@@ -1103,8 +1105,9 @@
                       "nullable": true,
                       "type": "string"
                     },
-                    "owner": {
-                      "type": "string"
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
                     },
                     "type": {
                       "type": "string"
@@ -1180,8 +1183,9 @@
                       "nullable": true,
                       "type": "string"
                     },
-                    "owner": {
-                      "type": "string"
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
                     },
                     "type": {
                       "type": "string"
@@ -2642,8 +2646,9 @@
                             "nullable": true,
                             "type": "string"
                           },
-                          "owner": {
-                            "type": "string"
+                          "owner_user_id": {
+                            "nullable": true,
+                            "type": "integer"
                           },
                           "paper_value_base": {
                             "format": "double",
@@ -2802,8 +2807,9 @@
                       "nullable": true,
                       "type": "string"
                     },
-                    "owner": {
-                      "type": "string"
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
                     },
                     "paper_value_base": {
                       "format": "double",
@@ -2987,8 +2993,9 @@
                       "nullable": true,
                       "type": "string"
                     },
-                    "owner": {
-                      "type": "string"
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
                     },
                     "paper_value_base": {
                       "format": "double",
@@ -3149,8 +3156,9 @@
                       "nullable": true,
                       "type": "string"
                     },
-                    "owner": {
-                      "type": "string"
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
                     },
                     "paper_value_base": {
                       "format": "double",
@@ -4350,8 +4358,8 @@
                             "format": "date",
                             "type": "string"
                           },
-                          "owner": {
-                            "type": "string"
+                          "owner_user_id": {
+                            "type": "integer"
                           },
                           "previous_change_date": {
                             "format": "date",
@@ -4410,8 +4418,9 @@
                           "is_active": {
                             "type": "boolean"
                           },
-                          "owner": {
-                            "type": "string"
+                          "owner_user_id": {
+                            "nullable": true,
+                            "type": "integer"
                           }
                         },
                         "type": "object"
@@ -4465,8 +4474,9 @@
                     "is_active": {
                       "type": "boolean"
                     },
-                    "owner": {
-                      "type": "string"
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
                     }
                   },
                   "type": "object"
@@ -4545,8 +4555,9 @@
                     "is_active": {
                       "type": "boolean"
                     },
-                    "owner": {
-                      "type": "string"
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
                     }
                   },
                   "type": "object"
@@ -4602,8 +4613,9 @@
                     "is_active": {
                       "type": "boolean"
                     },
-                    "owner": {
-                      "type": "string"
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
                     }
                   },
                   "type": "object"

--- a/backend-bb-tests/tests/test_bonus_events.py
+++ b/backend-bb-tests/tests/test_bonus_events.py
@@ -8,13 +8,13 @@ import pytest
 from fixtures.seed import COMPANY_MARCIN_EMPLOYER, PERSONA_MARCIN
 
 
-def test_list_bonuses_includes_seeded(client: httpx.Client) -> None:
+def test_list_bonuses_includes_seeded(client: httpx.Client, owner_ids: dict[str, int]) -> None:
     response = client.get("/api/bonuses")
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["total_count"] >= 2
-    owners = {r["owner"] for r in body["bonus_events"]}
-    assert PERSONA_MARCIN in owners
+    owners = {r["owner_user_id"] for r in body["bonus_events"]}
+    assert owner_ids[PERSONA_MARCIN] in owners
     assert COMPANY_MARCIN_EMPLOYER in body["available_companies"]
 
 
@@ -25,7 +25,7 @@ def test_get_bonus_by_id_returns_seeded_record(client: httpx.Client) -> None:
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["id"] == sample["id"]
-    assert body["owner"] == sample["owner"]
+    assert body["owner_user_id"] == sample["owner_user_id"]
     assert body["amount"] == sample["amount"]
 
 
@@ -35,7 +35,9 @@ def test_get_bonus_not_found(client: httpx.Client) -> None:
     assert "detail" in response.json()
 
 
-def test_create_bonus_happy_path(client: httpx.Client, request: pytest.FixtureRequest) -> None:
+def test_create_bonus_happy_path(
+    client: httpx.Client, request: pytest.FixtureRequest, owner_ids: dict[str, int]
+) -> None:
     created_id: int | None = None
     try:
         payload = {
@@ -44,7 +46,7 @@ def test_create_bonus_happy_path(client: httpx.Client, request: pytest.FixtureRe
             "currency": "PLN",
             "type": "spot",
             "company": f"bb-test-{request.node.name}",
-            "owner": PERSONA_MARCIN,
+            "owner_user_id": owner_ids[PERSONA_MARCIN],
             "contract_type": "UOP",
             "notes": "test spot bonus",
         }
@@ -55,20 +57,21 @@ def test_create_bonus_happy_path(client: httpx.Client, request: pytest.FixtureRe
         assert body["amount"] == 3000.0
         assert body["currency"] == "PLN"
         assert body["type"] == "spot"
+        assert body["owner_user_id"] == owner_ids[PERSONA_MARCIN]
         assert body["is_active"] is True
     finally:
         if created_id is not None:
             client.delete(f"/api/bonuses/{created_id}")
 
 
-def test_create_bonus_validation_error(client: httpx.Client) -> None:
+def test_create_bonus_validation_error(client: httpx.Client, owner_ids: dict[str, int]) -> None:
     payload = {
         "date": "2025-09-15",
         "amount": 1000.0,
         "currency": "ZZZ",
         "type": "spot",
         "company": "bb-test-bad-currency",
-        "owner": PERSONA_MARCIN,
+        "owner_user_id": owner_ids[PERSONA_MARCIN],
         "contract_type": "UOP",
     }
     response = client.post("/api/bonuses", json=payload)
@@ -76,7 +79,9 @@ def test_create_bonus_validation_error(client: httpx.Client) -> None:
     assert "detail" in response.json()
 
 
-def test_update_bonus_happy_path(client: httpx.Client, request: pytest.FixtureRequest) -> None:
+def test_update_bonus_happy_path(
+    client: httpx.Client, request: pytest.FixtureRequest, owner_ids: dict[str, int]
+) -> None:
     created_id: int | None = None
     try:
         create_payload = {
@@ -85,7 +90,7 @@ def test_update_bonus_happy_path(client: httpx.Client, request: pytest.FixtureRe
             "currency": "PLN",
             "type": "spot",
             "company": f"bb-test-{request.node.name}",
-            "owner": PERSONA_MARCIN,
+            "owner_user_id": owner_ids[PERSONA_MARCIN],
             "contract_type": "UOP",
         }
         created = client.post("/api/bonuses", json=create_payload)
@@ -106,7 +111,7 @@ def test_update_bonus_happy_path(client: httpx.Client, request: pytest.FixtureRe
 
 
 def test_update_bonus_validation_error(
-    client: httpx.Client, request: pytest.FixtureRequest
+    client: httpx.Client, request: pytest.FixtureRequest, owner_ids: dict[str, int]
 ) -> None:
     created_id: int | None = None
     try:
@@ -116,7 +121,7 @@ def test_update_bonus_validation_error(
             "currency": "PLN",
             "type": "spot",
             "company": f"bb-test-{request.node.name}",
-            "owner": PERSONA_MARCIN,
+            "owner_user_id": owner_ids[PERSONA_MARCIN],
             "contract_type": "UOP",
         }
         created = client.post("/api/bonuses", json=create_payload)
@@ -134,14 +139,16 @@ def test_update_bonus_validation_error(
             client.delete(f"/api/bonuses/{created_id}")
 
 
-def test_delete_bonus_happy_path(client: httpx.Client, request: pytest.FixtureRequest) -> None:
+def test_delete_bonus_happy_path(
+    client: httpx.Client, request: pytest.FixtureRequest, owner_ids: dict[str, int]
+) -> None:
     create_payload = {
         "date": "2025-10-12",
         "amount": 1500.0,
         "currency": "PLN",
         "type": "spot",
         "company": f"bb-test-{request.node.name}",
-        "owner": PERSONA_MARCIN,
+        "owner_user_id": owner_ids[PERSONA_MARCIN],
         "contract_type": "UOP",
     }
     created = client.post("/api/bonuses", json=create_payload)

--- a/backend-bb-tests/tests/test_equity_grants.py
+++ b/backend-bb-tests/tests/test_equity_grants.py
@@ -8,13 +8,15 @@ import pytest
 from fixtures.seed import COMPANY_MARCIN_EMPLOYER, PERSONA_MARCIN
 
 
-def test_list_equity_grants_includes_seeded(client: httpx.Client) -> None:
+def test_list_equity_grants_includes_seeded(
+    client: httpx.Client, owner_ids: dict[str, int]
+) -> None:
     response = client.get("/api/equity-grants")
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["total_count"] >= 1
-    owners = {r["owner"] for r in body["equity_grants"]}
-    assert PERSONA_MARCIN in owners
+    owners = {r["owner_user_id"] for r in body["equity_grants"]}
+    assert owner_ids[PERSONA_MARCIN] in owners
     assert COMPANY_MARCIN_EMPLOYER in body["available_companies"]
 
 
@@ -25,7 +27,7 @@ def test_get_equity_grant_by_id_returns_seeded_record(client: httpx.Client) -> N
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["id"] == sample["id"]
-    assert body["owner"] == sample["owner"]
+    assert body["owner_user_id"] == sample["owner_user_id"]
     assert body["total_shares"] == sample["total_shares"]
 
 
@@ -36,7 +38,7 @@ def test_get_equity_grant_not_found(client: httpx.Client) -> None:
 
 
 def test_create_equity_grant_happy_path(
-    client: httpx.Client, request: pytest.FixtureRequest
+    client: httpx.Client, request: pytest.FixtureRequest, owner_ids: dict[str, int]
 ) -> None:
     created_id: int | None = None
     try:
@@ -44,7 +46,7 @@ def test_create_equity_grant_happy_path(
             "grant_date": "2024-02-01",
             "type": "rsu",
             "company": f"bb-test-{request.node.name}",
-            "owner": PERSONA_MARCIN,
+            "owner_user_id": owner_ids[PERSONA_MARCIN],
             "total_shares": 1200,
             "currency": "USD",
             "vest_start_date": "2024-02-01",
@@ -60,18 +62,21 @@ def test_create_equity_grant_happy_path(
         created_id = body["id"]
         assert body["total_shares"] == 1200
         assert body["type"] == "rsu"
+        assert body["owner_user_id"] == owner_ids[PERSONA_MARCIN]
         assert body["is_active"] is True
     finally:
         if created_id is not None:
             client.delete(f"/api/equity-grants/{created_id}")
 
 
-def test_create_equity_grant_validation_error(client: httpx.Client) -> None:
+def test_create_equity_grant_validation_error(
+    client: httpx.Client, owner_ids: dict[str, int]
+) -> None:
     payload = {
         "grant_date": "2024-02-01",
         "type": "rsu",
         "company": "bb-test-bad",
-        "owner": PERSONA_MARCIN,
+        "owner_user_id": owner_ids[PERSONA_MARCIN],
         "total_shares": 0,
         "currency": "USD",
         "vest_start_date": "2024-02-01",
@@ -86,7 +91,7 @@ def test_create_equity_grant_validation_error(client: httpx.Client) -> None:
 
 
 def test_update_equity_grant_happy_path(
-    client: httpx.Client, request: pytest.FixtureRequest
+    client: httpx.Client, request: pytest.FixtureRequest, owner_ids: dict[str, int]
 ) -> None:
     created_id: int | None = None
     try:
@@ -94,7 +99,7 @@ def test_update_equity_grant_happy_path(
             "grant_date": "2024-03-01",
             "type": "rsu",
             "company": f"bb-test-{request.node.name}",
-            "owner": PERSONA_MARCIN,
+            "owner_user_id": owner_ids[PERSONA_MARCIN],
             "total_shares": 800,
             "currency": "USD",
             "vest_start_date": "2024-03-01",
@@ -121,7 +126,7 @@ def test_update_equity_grant_happy_path(
 
 
 def test_update_equity_grant_validation_error(
-    client: httpx.Client, request: pytest.FixtureRequest
+    client: httpx.Client, request: pytest.FixtureRequest, owner_ids: dict[str, int]
 ) -> None:
     created_id: int | None = None
     try:
@@ -129,7 +134,7 @@ def test_update_equity_grant_validation_error(
             "grant_date": "2024-04-01",
             "type": "rsu",
             "company": f"bb-test-{request.node.name}",
-            "owner": PERSONA_MARCIN,
+            "owner_user_id": owner_ids[PERSONA_MARCIN],
             "total_shares": 800,
             "currency": "USD",
             "vest_start_date": "2024-04-01",
@@ -154,13 +159,13 @@ def test_update_equity_grant_validation_error(
 
 
 def test_delete_equity_grant_happy_path(
-    client: httpx.Client, request: pytest.FixtureRequest
+    client: httpx.Client, request: pytest.FixtureRequest, owner_ids: dict[str, int]
 ) -> None:
     create_payload = {
         "grant_date": "2024-05-01",
         "type": "rsu",
         "company": f"bb-test-{request.node.name}",
-        "owner": PERSONA_MARCIN,
+        "owner_user_id": owner_ids[PERSONA_MARCIN],
         "total_shares": 500,
         "currency": "USD",
         "vest_start_date": "2024-05-01",

--- a/backend-bb-tests/tests/test_salary_records.py
+++ b/backend-bb-tests/tests/test_salary_records.py
@@ -8,13 +8,13 @@ import pytest
 from fixtures.seed import COMPANY_MARCIN_EMPLOYER, PERSONA_MARCIN
 
 
-def test_list_salaries_includes_seeded(client: httpx.Client) -> None:
+def test_list_salaries_includes_seeded(client: httpx.Client, owner_ids: dict[str, int]) -> None:
     response = client.get("/api/salaries")
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["total_count"] >= 3
-    owners = {r["owner"] for r in body["salary_records"]}
-    assert PERSONA_MARCIN in owners
+    owners = {r["owner_user_id"] for r in body["salary_records"]}
+    assert owner_ids[PERSONA_MARCIN] in owners
     assert COMPANY_MARCIN_EMPLOYER in body["available_companies"]
 
 
@@ -25,7 +25,7 @@ def test_get_salary_by_id_returns_seeded_record(client: httpx.Client) -> None:
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["id"] == sample["id"]
-    assert body["owner"] == sample["owner"]
+    assert body["owner_user_id"] == sample["owner_user_id"]
     assert body["gross_amount"] == sample["gross_amount"]
 
 
@@ -35,7 +35,9 @@ def test_get_salary_not_found(client: httpx.Client) -> None:
     assert "detail" in response.json()
 
 
-def test_create_salary_happy_path(client: httpx.Client, request: pytest.FixtureRequest) -> None:
+def test_create_salary_happy_path(
+    client: httpx.Client, request: pytest.FixtureRequest, owner_ids: dict[str, int]
+) -> None:
     created_id: int | None = None
     try:
         payload = {
@@ -43,7 +45,7 @@ def test_create_salary_happy_path(client: httpx.Client, request: pytest.FixtureR
             "gross_amount": 17500.0,
             "contract_type": "UOP",
             "company": f"bb-test-{request.node.name}",
-            "owner": PERSONA_MARCIN,
+            "owner_user_id": owner_ids[PERSONA_MARCIN],
         }
         response = client.post("/api/salaries", json=payload)
         assert response.status_code == 201, response.text
@@ -51,26 +53,29 @@ def test_create_salary_happy_path(client: httpx.Client, request: pytest.FixtureR
         created_id = body["id"]
         assert body["gross_amount"] == 17500.0
         assert body["company"] == payload["company"]
+        assert body["owner_user_id"] == owner_ids[PERSONA_MARCIN]
         assert body["is_active"] is True
     finally:
         if created_id is not None:
             client.delete(f"/api/salaries/{created_id}")
 
 
-def test_create_salary_validation_error(client: httpx.Client) -> None:
+def test_create_salary_validation_error(client: httpx.Client, owner_ids: dict[str, int]) -> None:
     payload = {
         "date": "2024-03-31",
         "gross_amount": -100.0,
         "contract_type": "UOP",
         "company": "bb-test-invalid",
-        "owner": PERSONA_MARCIN,
+        "owner_user_id": owner_ids[PERSONA_MARCIN],
     }
     response = client.post("/api/salaries", json=payload)
     assert response.status_code >= 400, response.text
     assert "detail" in response.json()
 
 
-def test_update_salary_happy_path(client: httpx.Client, request: pytest.FixtureRequest) -> None:
+def test_update_salary_happy_path(
+    client: httpx.Client, request: pytest.FixtureRequest, owner_ids: dict[str, int]
+) -> None:
     created_id: int | None = None
     try:
         create_payload = {
@@ -78,7 +83,7 @@ def test_update_salary_happy_path(client: httpx.Client, request: pytest.FixtureR
             "gross_amount": 16000.0,
             "contract_type": "UOP",
             "company": f"bb-test-{request.node.name}",
-            "owner": PERSONA_MARCIN,
+            "owner_user_id": owner_ids[PERSONA_MARCIN],
         }
         created = client.post("/api/salaries", json=create_payload)
         assert created.status_code == 201, created.text
@@ -96,7 +101,7 @@ def test_update_salary_happy_path(client: httpx.Client, request: pytest.FixtureR
 
 
 def test_update_salary_validation_error(
-    client: httpx.Client, request: pytest.FixtureRequest
+    client: httpx.Client, request: pytest.FixtureRequest, owner_ids: dict[str, int]
 ) -> None:
     created_id: int | None = None
     try:
@@ -105,7 +110,7 @@ def test_update_salary_validation_error(
             "gross_amount": 16000.0,
             "contract_type": "UOP",
             "company": f"bb-test-{request.node.name}",
-            "owner": PERSONA_MARCIN,
+            "owner_user_id": owner_ids[PERSONA_MARCIN],
         }
         created = client.post("/api/salaries", json=create_payload)
         assert created.status_code == 201, created.text
@@ -122,13 +127,15 @@ def test_update_salary_validation_error(
             client.delete(f"/api/salaries/{created_id}")
 
 
-def test_delete_salary_happy_path(client: httpx.Client, request: pytest.FixtureRequest) -> None:
+def test_delete_salary_happy_path(
+    client: httpx.Client, request: pytest.FixtureRequest, owner_ids: dict[str, int]
+) -> None:
     create_payload = {
         "date": "2024-06-30",
         "gross_amount": 15000.0,
         "contract_type": "UOP",
         "company": f"bb-test-{request.node.name}",
-        "owner": PERSONA_MARCIN,
+        "owner_user_id": owner_ids[PERSONA_MARCIN],
     }
     created = client.post("/api/salaries", json=create_payload)
     assert created.status_code == 201, created.text

--- a/backend-go/internal/bonus_events/handler.go
+++ b/backend-go/internal/bonus_events/handler.go
@@ -43,7 +43,7 @@ type response struct {
 	Currency     string   `json:"currency"`
 	Type         string   `json:"type"`
 	Company      string   `json:"company"`
-	Owner        string   `json:"owner"`
+	OwnerUserID  *int     `json:"owner_user_id"`
 	ContractType string   `json:"contract_type"`
 	Notes        *string  `json:"notes"`
 	IsActive     bool     `json:"is_active"`
@@ -65,7 +65,7 @@ type createRequest struct {
 	Currency     string
 	Type         string
 	Company      string
-	Owner        string
+	OwnerUserID  *int
 	ContractType string
 	Notes        *string
 }
@@ -100,7 +100,7 @@ func (h *Handler) toResponse(ctx context.Context, b *BonusEvent) (response, erro
 		Currency:     b.Currency,
 		Type:         b.Type,
 		Company:      b.Company,
-		Owner:        b.Owner,
+		OwnerUserID:  b.OwnerUserID,
 		ContractType: b.ContractType,
 		Notes:        b.Notes,
 		IsActive:     b.IsActive,
@@ -181,7 +181,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		Currency:     req.Currency,
 		Type:         req.Type,
 		Company:      req.Company,
-		Owner:        req.Owner,
+		OwnerUserID:  req.OwnerUserID,
 		ContractType: req.ContractType,
 		Notes:        req.Notes,
 	}
@@ -255,9 +255,12 @@ func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int) {
 
 func parseListFilter(q map[string][]string) (ListFilter, *validationError) {
 	f := ListFilter{}
-	if v := first(q["owner"]); v != "" {
-		s := v
-		f.Owner = &s
+	if v := first(q["owner_user_id"]); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return f, &validationError{Field: "owner_user_id", Msg: "must be an integer"}
+		}
+		f.OwnerUserID = &n
 	}
 	if v := first(q["company"]); v != "" {
 		s := v

--- a/backend-go/internal/bonus_events/store.go
+++ b/backend-go/internal/bonus_events/store.go
@@ -19,6 +19,7 @@ import (
 )
 
 // BonusEvent mirrors backend/app/models/bonus_event.BonusEvent.
+// OwnerUserID is the owning household member; nil means jointly owned.
 type BonusEvent struct {
 	ID           int
 	Date         time.Time
@@ -26,7 +27,7 @@ type BonusEvent struct {
 	Currency     string
 	Type         string
 	Company      string
-	Owner        string
+	OwnerUserID  *int
 	ContractType string
 	Notes        *string
 	IsActive     bool
@@ -39,10 +40,10 @@ var ErrNotFound = errors.New("bonus event not found")
 
 // ListFilter constrains the active rows returned by List.
 type ListFilter struct {
-	Owner    *string
-	DateFrom *time.Time
-	DateTo   *time.Time
-	Company  *string
+	OwnerUserID *int
+	DateFrom    *time.Time
+	DateTo      *time.Time
+	Company     *string
 }
 
 // Store is the persistence boundary.
@@ -56,7 +57,7 @@ func NewStore(pool *pgxpool.Pool) *Store {
 }
 
 const selectColumns = `
-	id, date, amount, currency, type, company, owner,
+	id, date, amount, currency, type, company, owner_user_id,
 	contract_type, notes, is_active, created_at
 `
 
@@ -65,9 +66,9 @@ const selectColumns = `
 func (s *Store) List(ctx context.Context, f ListFilter) ([]BonusEvent, []string, error) {
 	conds := []string{"is_active = true"}
 	args := []any{}
-	if f.Owner != nil {
-		args = append(args, *f.Owner)
-		conds = append(conds, fmt.Sprintf("owner = $%d", len(args)))
+	if f.OwnerUserID != nil {
+		args = append(args, *f.OwnerUserID)
+		conds = append(conds, fmt.Sprintf("owner_user_id = $%d", len(args)))
 	}
 	if f.DateFrom != nil {
 		args = append(args, *f.DateFrom)
@@ -125,15 +126,20 @@ func (s *Store) Get(ctx context.Context, id int) (*BonusEvent, error) {
 	return b, nil
 }
 
-// Create inserts a row.
+// Create inserts a row. The owner string is dual-written from owner_user_id
+// ($6) until a later phase drops the legacy column.
 func (s *Store) Create(ctx context.Context, b *BonusEvent) (*BonusEvent, error) {
 	row := s.pool.QueryRow(ctx, `
 		INSERT INTO bonus_events (
-			date, amount, currency, type, company, owner,
+			date, amount, currency, type, company, owner, owner_user_id,
 			contract_type, notes, is_active, created_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, true, $9)
+		) VALUES (
+			$1, $2, $3, $4, $5,
+			COALESCE((SELECT name FROM users WHERE id = $6), 'Shared'),
+			$6, $7, $8, true, $9
+		)
 		RETURNING `+selectColumns,
-		b.Date, b.Amount, b.Currency, b.Type, b.Company, b.Owner,
+		b.Date, b.Amount, b.Currency, b.Type, b.Company, b.OwnerUserID,
 		b.ContractType, b.Notes, time.Now().UTC(),
 	)
 	return scanBonus(row)
@@ -141,14 +147,15 @@ func (s *Store) Create(ctx context.Context, b *BonusEvent) (*BonusEvent, error) 
 
 // UpdatePatch is a sparse update.
 type UpdatePatch struct {
-	Date         *time.Time
-	Amount       *decimal.Decimal
-	Currency     *string
-	Type         *string
-	Company      *string
-	Owner        *string
-	ContractType *string
-	Notes        *string
+	Date           *time.Time
+	Amount         *decimal.Decimal
+	Currency       *string
+	Type           *string
+	Company        *string
+	OwnerUserIDSet bool
+	OwnerUserID    *int
+	ContractType   *string
+	Notes          *string
 }
 
 // Update applies the patch and returns the refreshed bonus.
@@ -172,8 +179,8 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*BonusEvent,
 	if p.Company != nil {
 		b.Company = *p.Company
 	}
-	if p.Owner != nil {
-		b.Owner = *p.Owner
+	if p.OwnerUserIDSet {
+		b.OwnerUserID = p.OwnerUserID
 	}
 	if p.ContractType != nil {
 		b.ContractType = *p.ContractType
@@ -181,13 +188,16 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*BonusEvent,
 	if p.Notes != nil {
 		b.Notes = p.Notes
 	}
+	// owner is dual-written from owner_user_id ($6) until the legacy column
+	// is dropped.
 	row := s.pool.QueryRow(ctx, `
 		UPDATE bonus_events SET
-			date = $1, amount = $2, currency = $3, type = $4,
-			company = $5, owner = $6, contract_type = $7, notes = $8
+			date = $1, amount = $2, currency = $3, type = $4, company = $5,
+			owner = COALESCE((SELECT name FROM users WHERE id = $6), 'Shared'),
+			owner_user_id = $6, contract_type = $7, notes = $8
 		WHERE id = $9 AND is_active = true
 		RETURNING `+selectColumns,
-		b.Date, b.Amount, b.Currency, b.Type, b.Company, b.Owner,
+		b.Date, b.Amount, b.Currency, b.Type, b.Company, b.OwnerUserID,
 		b.ContractType, b.Notes, id,
 	)
 	updated, err := scanBonus(row)
@@ -242,7 +252,7 @@ func scanBonus(row pgx.Row) (*BonusEvent, error) {
 	var b BonusEvent
 	if err := row.Scan(
 		&b.ID, &b.Date, &b.Amount, &b.Currency, &b.Type, &b.Company,
-		&b.Owner, &b.ContractType, &b.Notes, &b.IsActive, &b.CreatedAt,
+		&b.OwnerUserID, &b.ContractType, &b.Notes, &b.IsActive, &b.CreatedAt,
 	); err != nil {
 		return nil, err
 	}

--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -52,11 +52,11 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *validat
 	}
 	r.Company = company
 
-	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
+	ownerID, vErr := requireIntOrNull(raw, "owner_user_id")
 	if vErr != nil {
 		return r, vErr
 	}
-	r.Owner = owner
+	r.OwnerUserID = ownerID
 
 	r.ContractType, vErr = requireEnumString(raw, "contract_type", validContractTypes)
 	if vErr != nil {
@@ -133,16 +133,17 @@ func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *validationErr
 		}
 		p.Company = &s
 	}
-	if v, ok := raw["owner"]; ok && !isNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &validationError{Field: "owner", Msg: "must be a string"}
+	if v, ok := raw["owner_user_id"]; ok {
+		p.OwnerUserIDSet = true
+		if isNull(v) {
+			p.OwnerUserID = nil
+		} else {
+			var n int
+			if err := json.Unmarshal(v, &n); err != nil {
+				return &validationError{Field: "owner_user_id", Msg: "must be an integer"}
+			}
+			p.OwnerUserID = &n
 		}
-		s = strings.TrimSpace(s)
-		if s == "" {
-			return &validationError{Field: "owner", Msg: "Owner cannot be empty"}
-		}
-		p.Owner = &s
 	}
 	if v, ok := raw["notes"]; ok && !isNull(v) {
 		var s string
@@ -256,6 +257,23 @@ func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[s
 		return "", &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
 	}
 	return s, nil
+}
+
+// requireIntOrNull reads an integer key that must be present; an explicit
+// null is allowed and yields nil (jointly owned).
+func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *validationError) {
+	v, ok := raw[key]
+	if !ok {
+		return nil, &validationError{Field: key, Msg: "Field required"}
+	}
+	if isNull(v) {
+		return nil, nil
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return nil, &validationError{Field: key, Msg: "must be an integer"}
+	}
+	return &n, nil
 }
 
 func today() time.Time {

--- a/backend-go/internal/equity_grants/handler.go
+++ b/backend-go/internal/equity_grants/handler.go
@@ -41,7 +41,7 @@ type response struct {
 	GrantDate              isoDate               `json:"grant_date"`
 	Type                   string                `json:"type"`
 	Company                string                `json:"company"`
-	Owner                  string                `json:"owner"`
+	OwnerUserID            *int                  `json:"owner_user_id"`
 	TotalShares            int                   `json:"total_shares"`
 	StrikePrice            *pyFloat              `json:"strike_price"`
 	Currency               string                `json:"currency"`
@@ -139,7 +139,7 @@ func (h *Handler) toResponse(ctx context.Context, g *EquityGrant) (response, err
 		GrantDate:              isoDate(g.GrantDate),
 		Type:                   g.Type,
 		Company:                g.Company,
-		Owner:                  g.Owner,
+		OwnerUserID:            g.OwnerUserID,
 		TotalShares:            g.TotalShares,
 		Currency:               g.Currency,
 		VestStartDate:          isoDate(g.VestStartDate),
@@ -228,8 +228,13 @@ func pln(amount *decimal.Decimal, currency string, rate fx.Result) *pyFloat {
 // List serves GET /api/equity-grants.
 func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 	filter := ListFilter{}
-	if v := strings.TrimSpace(r.URL.Query().Get("owner")); v != "" {
-		filter.Owner = &v
+	if v := strings.TrimSpace(r.URL.Query().Get("owner_user_id")); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			writeValidationError(w, "owner_user_id", "must be an integer", v)
+			return
+		}
+		filter.OwnerUserID = &n
 	}
 	if v := strings.TrimSpace(r.URL.Query().Get("company")); v != "" {
 		filter.Company = &v

--- a/backend-go/internal/equity_grants/store.go
+++ b/backend-go/internal/equity_grants/store.go
@@ -14,12 +14,13 @@ import (
 )
 
 // EquityGrant mirrors backend/app/models/equity_grant.EquityGrant.
+// OwnerUserID is the owning household member; nil means jointly owned.
 type EquityGrant struct {
 	ID                     int
 	GrantDate              time.Time
 	Type                   string
 	Company                string
-	Owner                  string
+	OwnerUserID            *int
 	TotalShares            int
 	StrikePrice            *decimal.Decimal
 	Currency               string
@@ -53,8 +54,8 @@ func (e *InvariantError) Error() string {
 
 // ListFilter narrows the active rows.
 type ListFilter struct {
-	Owner   *string
-	Company *string
+	OwnerUserID *int
+	Company     *string
 }
 
 // Store is the persistence boundary.
@@ -68,7 +69,7 @@ func NewStore(pool *pgxpool.Pool) *Store {
 }
 
 const selectColumns = `
-	id, grant_date, type, company, owner, total_shares, strike_price, currency,
+	id, grant_date, type, company, owner_user_id, total_shares, strike_price, currency,
 	vest_start_date, vest_cliff_months, vest_total_months, vest_frequency,
 	vest_custom_schedule, requires_liquidity_event, liquidity_event_date,
 	tax_treatment, notes, is_active, created_at
@@ -78,9 +79,9 @@ const selectColumns = `
 func (s *Store) List(ctx context.Context, f ListFilter) ([]EquityGrant, []string, error) {
 	conds := []string{"is_active = true"}
 	args := []any{}
-	if f.Owner != nil {
-		args = append(args, *f.Owner)
-		conds = append(conds, fmt.Sprintf("owner = $%d", len(args)))
+	if f.OwnerUserID != nil {
+		args = append(args, *f.OwnerUserID)
+		conds = append(conds, fmt.Sprintf("owner_user_id = $%d", len(args)))
 	}
 	if f.Company != nil {
 		args = append(args, *f.Company)
@@ -136,17 +137,21 @@ func (s *Store) Create(ctx context.Context, g *EquityGrant) (*EquityGrant, error
 	if err != nil {
 		return nil, fmt.Errorf("encode schedule: %w", err)
 	}
+	// owner ($4-derived) is dual-written from owner_user_id until a later
+	// phase drops the legacy owner string column.
 	row := s.pool.QueryRow(ctx, `
 		INSERT INTO equity_grants (
-			grant_date, type, company, owner, total_shares, strike_price, currency,
+			grant_date, type, company, owner, owner_user_id, total_shares,
+			strike_price, currency,
 			vest_start_date, vest_cliff_months, vest_total_months, vest_frequency,
 			vest_custom_schedule, requires_liquidity_event, liquidity_event_date,
 			tax_treatment, notes, is_active, created_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
+			$1, $2, $3, COALESCE((SELECT name FROM users WHERE id = $4), 'Shared'),
+			$4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
 			true, $17
 		) RETURNING `+selectColumns,
-		g.GrantDate, g.Type, g.Company, g.Owner, g.TotalShares, g.StrikePrice, g.Currency,
+		g.GrantDate, g.Type, g.Company, g.OwnerUserID, g.TotalShares, g.StrikePrice, g.Currency,
 		g.VestStartDate, g.VestCliffMonths, g.VestTotalMonths, g.VestFrequency,
 		customJSON, g.RequiresLiquidityEvent, g.LiquidityEventDate,
 		g.TaxTreatment, g.Notes, time.Now().UTC(),
@@ -159,7 +164,8 @@ type UpdatePatch struct {
 	GrantDate              *time.Time
 	Type                   *string
 	Company                *string
-	Owner                  *string
+	OwnerUserIDSet         bool
+	OwnerUserID            *int
 	TotalShares            *int
 	StrikePrice            *decimal.Decimal
 	Currency               *string
@@ -204,9 +210,13 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*EquityGrant
 	if err != nil {
 		return nil, fmt.Errorf("encode schedule: %w", err)
 	}
+	// owner is dual-written from owner_user_id ($4) until the legacy column
+	// is dropped.
 	row := s.pool.QueryRow(ctx, `
 		UPDATE equity_grants SET
-			grant_date = $1, type = $2, company = $3, owner = $4,
+			grant_date = $1, type = $2, company = $3,
+			owner = COALESCE((SELECT name FROM users WHERE id = $4), 'Shared'),
+			owner_user_id = $4,
 			total_shares = $5, strike_price = $6, currency = $7,
 			vest_start_date = $8, vest_cliff_months = $9, vest_total_months = $10,
 			vest_frequency = $11, vest_custom_schedule = $12,
@@ -214,7 +224,7 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*EquityGrant
 			tax_treatment = $15, notes = $16
 		WHERE id = $17 AND is_active = true
 		RETURNING `+selectColumns,
-		g.GrantDate, g.Type, g.Company, g.Owner,
+		g.GrantDate, g.Type, g.Company, g.OwnerUserID,
 		g.TotalShares, g.StrikePrice, g.Currency,
 		g.VestStartDate, g.VestCliffMonths, g.VestTotalMonths,
 		g.VestFrequency, customJSON,
@@ -273,7 +283,7 @@ func scanGrant(row pgx.Row) (*EquityGrant, error) {
 	var g EquityGrant
 	var customJSON []byte
 	err := row.Scan(
-		&g.ID, &g.GrantDate, &g.Type, &g.Company, &g.Owner,
+		&g.ID, &g.GrantDate, &g.Type, &g.Company, &g.OwnerUserID,
 		&g.TotalShares, &g.StrikePrice, &g.Currency,
 		&g.VestStartDate, &g.VestCliffMonths, &g.VestTotalMonths,
 		&g.VestFrequency, &customJSON,
@@ -312,8 +322,8 @@ func applyPatch(g *EquityGrant, p UpdatePatch) {
 	if p.Company != nil {
 		g.Company = *p.Company
 	}
-	if p.Owner != nil {
-		g.Owner = *p.Owner
+	if p.OwnerUserIDSet {
+		g.OwnerUserID = p.OwnerUserID
 	}
 	if p.TotalShares != nil {
 		g.TotalShares = *p.TotalShares

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -16,7 +16,7 @@ type createRequest struct {
 	GrantDate              time.Time
 	Type                   string
 	Company                string
-	Owner                  string
+	OwnerUserID            *int
 	TotalShares            int
 	StrikePrice            *decimal.Decimal
 	Currency               string
@@ -36,7 +36,7 @@ func requestToGrant(req createRequest) *EquityGrant {
 		GrantDate:              req.GrantDate,
 		Type:                   req.Type,
 		Company:                req.Company,
-		Owner:                  req.Owner,
+		OwnerUserID:            req.OwnerUserID,
 		TotalShares:            req.TotalShares,
 		StrikePrice:            req.StrikePrice,
 		Currency:               req.Currency,
@@ -101,11 +101,11 @@ func requireGrantBasics(raw map[string]json.RawMessage, r *createRequest) *valid
 	}
 	r.Company = company
 
-	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
+	ownerID, vErr := requireIntOrNull(raw, "owner_user_id")
 	if vErr != nil {
 		return vErr
 	}
-	r.Owner = owner
+	r.OwnerUserID = ownerID
 
 	totalShares, vErr := requirePositiveInt(raw, "total_shares", "Total shares must be greater than 0")
 	if vErr != nil {
@@ -225,7 +225,7 @@ func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *validationErr
 	if vErr := patchNonEmptyString(raw, "company", "Company cannot be empty", &p.Company); vErr != nil {
 		return vErr
 	}
-	if vErr := patchNonEmptyString(raw, "owner", "Owner cannot be empty", &p.Owner); vErr != nil {
+	if vErr := patchOwnerUserID(raw, p); vErr != nil {
 		return vErr
 	}
 	if vErr := patchCurrency(raw, &p.Currency); vErr != nil {
@@ -591,6 +591,43 @@ func patchNonNegativeIntPtr(raw map[string]json.RawMessage, key, msg string, des
 		return &validationError{Field: key, Msg: msg}
 	}
 	*dest = &n
+	return nil
+}
+
+// requireIntOrNull reads an integer key that must be present; an explicit
+// null is allowed and yields nil (jointly owned).
+func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *validationError) {
+	v, ok := raw[key]
+	if !ok {
+		return nil, &validationError{Field: key, Msg: "Field required"}
+	}
+	if isNull(v) {
+		return nil, nil
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return nil, &validationError{Field: key, Msg: "must be an integer"}
+	}
+	return &n, nil
+}
+
+// patchOwnerUserID reads owner_user_id from a PATCH body: present marks the
+// field set; explicit null clears it (jointly owned).
+func patchOwnerUserID(raw map[string]json.RawMessage, p *UpdatePatch) *validationError {
+	v, ok := raw["owner_user_id"]
+	if !ok {
+		return nil
+	}
+	p.OwnerUserIDSet = true
+	if isNull(v) {
+		p.OwnerUserID = nil
+		return nil
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return &validationError{Field: "owner_user_id", Msg: "must be an integer"}
+	}
+	p.OwnerUserID = &n
 	return nil
 }
 

--- a/backend-go/internal/salaries/handler.go
+++ b/backend-go/internal/salaries/handler.go
@@ -25,20 +25,21 @@ var (
 )
 
 // response mirrors backend/app/schemas/salary_records.SalaryRecordResponse.
+// OwnerUserID is the owning household member; nil means jointly owned.
 type response struct {
 	ID           int      `json:"id"`
 	Date         isoDate  `json:"date"`
 	GrossAmount  pyFloat  `json:"gross_amount"`
 	ContractType string   `json:"contract_type"`
 	Company      string   `json:"company"`
-	Owner        string   `json:"owner"`
+	OwnerUserID  *int     `json:"owner_user_id"`
 	IsActive     bool     `json:"is_active"`
 	CreatedAt    isoNaive `json:"created_at"`
 }
 
 // inflationContext mirrors backend/app/schemas/salary_records.InflationContext.
 type inflationContext struct {
-	Owner                    string   `json:"owner"`
+	OwnerUserID              int      `json:"owner_user_id"`
 	LastChangeDate           isoDate  `json:"last_change_date"`
 	PreviousChangeDate       *isoDate `json:"previous_change_date"`
 	PreviousSalary           *pyFloat `json:"previous_salary"`
@@ -49,12 +50,14 @@ type inflationContext struct {
 	CPIAsOfYear              int      `json:"cpi_as_of_year"`
 }
 
+// listResponse keys current_salaries and inflation_context by owner_user_id
+// (JSON serialises the integer keys as strings).
 type listResponse struct {
-	SalaryRecords      []response                  `json:"salary_records"`
-	TotalCount         int                         `json:"total_count"`
-	CurrentSalaries    map[string]*pyFloat         `json:"current_salaries"`
-	InflationContext   map[string]inflationContext `json:"inflation_context"`
-	AvailableCompanies []string                    `json:"available_companies"`
+	SalaryRecords      []response               `json:"salary_records"`
+	TotalCount         int                      `json:"total_count"`
+	CurrentSalaries    map[int]*pyFloat         `json:"current_salaries"`
+	InflationContext   map[int]inflationContext `json:"inflation_context"`
+	AvailableCompanies []string                 `json:"available_companies"`
 }
 
 // Handler is the HTTP boundary for /api/salaries.
@@ -82,7 +85,7 @@ func toResponse(r *SalaryRecord) response {
 		GrossAmount:  pyFloat(gross),
 		ContractType: r.ContractType,
 		Company:      r.Company,
-		Owner:        r.Owner,
+		OwnerUserID:  r.OwnerUserID,
 		IsActive:     r.IsActive,
 		CreatedAt:    isoNaive(r.CreatedAt.UTC()),
 	}
@@ -102,19 +105,19 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	today := truncateDay(h.now().UTC())
-	personas, err := h.store.ActivePersonaNames(r.Context())
+	userIDs, err := h.store.ActiveOwnerUserIDs(r.Context())
 	if err != nil {
-		h.logger.Error("persona names", "err", err)
+		h.logger.Error("owner user ids", "err", err)
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	currentSalaries, err := h.store.CurrentSalaryByPersona(r.Context(), personas, today)
+	currentSalaries, err := h.store.CurrentSalaryByUser(r.Context(), userIDs, today)
 	if err != nil {
 		h.logger.Error("current salaries", "err", err)
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	inflationCtx, err := h.buildInflationContext(r.Context(), personas, today)
+	inflationCtx, err := h.buildInflationContext(r.Context(), userIDs, today)
 	if err != nil {
 		h.logger.Error("inflation context", "err", err)
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
@@ -123,7 +126,7 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 	out := listResponse{
 		SalaryRecords:      make([]response, 0, len(rows)),
 		TotalCount:         len(rows),
-		CurrentSalaries:    salariesToFloatMap(personas, currentSalaries),
+		CurrentSalaries:    salariesToFloatMap(userIDs, currentSalaries),
 		InflationContext:   inflationCtx,
 		AvailableCompanies: companies,
 	}
@@ -164,13 +167,13 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		GrossAmount:  req.GrossAmount,
 		ContractType: req.ContractType,
 		Company:      req.Company,
-		Owner:        req.Owner,
+		OwnerUserID:  req.OwnerUserID,
 	})
 	if err != nil {
 		if errors.Is(err, ErrDuplicate) {
 			writeDetailError(w, http.StatusConflict,
-				fmt.Sprintf("Salary record for %s on %s already exists",
-					req.Owner, req.Date.Format("2006-01-02")))
+				fmt.Sprintf("A salary record on %s already exists for this owner",
+					req.Date.Format("2006-01-02")))
 			return
 		}
 		h.logger.Error("create salary", "err", err)
@@ -199,16 +202,10 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 	updated, err := h.store.Update(r.Context(), id, patch)
 	if err != nil {
 		if errors.Is(err, ErrDuplicate) {
-			// Need the merged record's (owner, date) for the message; refetch.
+			// Need the merged record's date for the message; refetch.
 			current, getErr := h.store.Get(r.Context(), id)
-			owner := ""
 			date := ""
 			if getErr == nil {
-				if patch.Owner != nil {
-					owner = *patch.Owner
-				} else {
-					owner = current.Owner
-				}
 				if patch.Date != nil {
 					date = patch.Date.Format("2006-01-02")
 				} else {
@@ -216,8 +213,8 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			writeDetailError(w, http.StatusConflict,
-				fmt.Sprintf("Salary record for %s on %s conflicts with existing record",
-					owner, date))
+				fmt.Sprintf("A salary record on %s conflicts with an existing record",
+					date))
 			return
 		}
 		h.writeStoreError(w, err, id)
@@ -253,10 +250,10 @@ func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int) {
 // persona with at least two recent records, compute previous_salary_in_today_pln
 // via the CPI index, then derive real_change_pln / pct.
 func (h *Handler) buildInflationContext(
-	ctx context.Context, personaNames []string, today time.Time,
-) (map[string]inflationContext, error) {
-	if len(personaNames) == 0 {
-		return map[string]inflationContext{}, nil
+	ctx context.Context, userIDs []int, today time.Time,
+) (map[int]inflationContext, error) {
+	if len(userIDs) == 0 {
+		return map[int]inflationContext{}, nil
 	}
 	asOfYear, hasYear, err := h.cpiStore.LatestKnownYear(ctx)
 	if err != nil {
@@ -267,15 +264,15 @@ func (h *Handler) buildInflationContext(
 		return nil, err
 	}
 	if !hasYear || len(yoyMap) == 0 {
-		return map[string]inflationContext{}, nil
+		return map[int]inflationContext{}, nil
 	}
 	indexMap := cpi.CumulativeIndex(yoyMap)
-	recent, err := h.store.RecentTwoByPersona(ctx, personaNames, today)
+	recent, err := h.store.RecentTwoByUser(ctx, userIDs, today)
 	if err != nil {
 		return nil, err
 	}
-	out := map[string]inflationContext{}
-	for owner, recs := range recent {
+	out := map[int]inflationContext{}
+	for ownerID, recs := range recent {
 		if len(recs) < 2 {
 			continue
 		}
@@ -297,8 +294,8 @@ func (h *Handler) buildInflationContext(
 		prevSalary := pyFloat(prevAmount)
 		prevTodayPLN := pyFloat(prevInToday)
 		realChange := pyFloat(realChangePLN)
-		out[owner] = inflationContext{
-			Owner:                    owner,
+		out[ownerID] = inflationContext{
+			OwnerUserID:              ownerID,
 			LastChangeDate:           isoDate(current.Date),
 			PreviousChangeDate:       &prevDate,
 			PreviousSalary:           &prevSalary,
@@ -313,27 +310,30 @@ func (h *Handler) buildInflationContext(
 }
 
 func salariesToFloatMap(
-	personaNames []string, values map[string]decimal.Decimal,
-) map[string]*pyFloat {
-	out := map[string]*pyFloat{}
-	for _, name := range personaNames {
-		v, ok := values[name]
+	userIDs []int, values map[int]decimal.Decimal,
+) map[int]*pyFloat {
+	out := map[int]*pyFloat{}
+	for _, id := range userIDs {
+		v, ok := values[id]
 		if !ok {
-			out[name] = nil
+			out[id] = nil
 			continue
 		}
 		f, _ := v.Float64()
 		pf := pyFloat(f)
-		out[name] = &pf
+		out[id] = &pf
 	}
 	return out
 }
 
 func parseListFilter(q map[string][]string) (ListFilter, *validationError) {
 	f := ListFilter{}
-	if v := first(q["owner"]); v != "" {
-		s := v
-		f.Owner = &s
+	if v := first(q["owner_user_id"]); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return f, &validationError{Field: "owner_user_id", Msg: "must be an integer"}
+		}
+		f.OwnerUserID = &n
 	}
 	if v := first(q["company"]); v != "" {
 		s := v

--- a/backend-go/internal/salaries/store.go
+++ b/backend-go/internal/salaries/store.go
@@ -19,13 +19,14 @@ import (
 )
 
 // SalaryRecord mirrors backend/app/models/salary_record.SalaryRecord.
+// OwnerUserID is the owning household member; nil means jointly owned.
 type SalaryRecord struct {
 	ID           int
 	Date         time.Time
 	GrossAmount  decimal.Decimal
 	ContractType string
 	Company      string
-	Owner        string
+	OwnerUserID  *int
 	IsActive     bool
 	CreatedAt    time.Time
 }
@@ -33,15 +34,16 @@ type SalaryRecord struct {
 // ErrNotFound is returned for missing or soft-deleted rows.
 var ErrNotFound = errors.New("salary record not found")
 
-// ErrDuplicate is returned when (owner, date) already has an active record.
+// ErrDuplicate is returned when (owner_user_id, date) already has an
+// active record.
 var ErrDuplicate = errors.New("salary record duplicate")
 
 // ListFilter narrows the active rows.
 type ListFilter struct {
-	Owner    *string
-	DateFrom *time.Time
-	DateTo   *time.Time
-	Company  *string
+	OwnerUserID *int
+	DateFrom    *time.Time
+	DateTo      *time.Time
+	Company     *string
 }
 
 // Store is the persistence boundary.
@@ -55,7 +57,7 @@ func NewStore(pool *pgxpool.Pool) *Store {
 }
 
 const selectColumns = `
-	id, date, gross_amount, contract_type, company, owner, is_active, created_at
+	id, date, gross_amount, contract_type, company, owner_user_id, is_active, created_at
 `
 
 // List returns active rows ordered by date desc + the distinct active-company
@@ -63,9 +65,9 @@ const selectColumns = `
 func (s *Store) List(ctx context.Context, f ListFilter) ([]SalaryRecord, []string, error) {
 	conds := []string{"is_active = true"}
 	args := []any{}
-	if f.Owner != nil {
-		args = append(args, *f.Owner)
-		conds = append(conds, fmt.Sprintf("owner = $%d", len(args)))
+	if f.OwnerUserID != nil {
+		args = append(args, *f.OwnerUserID)
+		conds = append(conds, fmt.Sprintf("owner_user_id = $%d", len(args)))
 	}
 	if f.DateFrom != nil {
 		args = append(args, *f.DateFrom)
@@ -122,15 +124,17 @@ func (s *Store) Get(ctx context.Context, id int) (*SalaryRecord, error) {
 	return r, nil
 }
 
-// Create inserts a row. Returns ErrDuplicate when (owner, date) already
-// has an active record — matches Python's 409 contract.
+// Create inserts a row. Returns ErrDuplicate when (owner_user_id, date)
+// already has an active record — matches Python's 409 contract. The owner
+// string is dual-written from owner_user_id ($5) until a later phase drops
+// the legacy column.
 func (s *Store) Create(ctx context.Context, r *SalaryRecord) (*SalaryRecord, error) {
 	var existing int
 	err := s.pool.QueryRow(ctx, `
 		SELECT id FROM salary_records
-		WHERE owner = $1 AND date = $2 AND is_active = true
+		WHERE owner_user_id IS NOT DISTINCT FROM $1 AND date = $2 AND is_active = true
 		LIMIT 1`,
-		r.Owner, r.Date,
+		r.OwnerUserID, r.Date,
 	).Scan(&existing)
 	if err == nil {
 		return nil, ErrDuplicate
@@ -140,21 +144,26 @@ func (s *Store) Create(ctx context.Context, r *SalaryRecord) (*SalaryRecord, err
 	}
 	row := s.pool.QueryRow(ctx, `
 		INSERT INTO salary_records (
-			date, gross_amount, contract_type, company, owner, is_active, created_at
-		) VALUES ($1, $2, $3, $4, $5, true, $6)
+			date, gross_amount, contract_type, company, owner, owner_user_id,
+			is_active, created_at
+		) VALUES (
+			$1, $2, $3, $4, COALESCE((SELECT name FROM users WHERE id = $5), 'Shared'),
+			$5, true, $6
+		)
 		RETURNING `+selectColumns,
-		r.Date, r.GrossAmount, r.ContractType, r.Company, r.Owner, time.Now().UTC(),
+		r.Date, r.GrossAmount, r.ContractType, r.Company, r.OwnerUserID, time.Now().UTC(),
 	)
 	return scanRecord(row)
 }
 
 // UpdatePatch is the sparse update set; nil = no-op.
 type UpdatePatch struct {
-	Date         *time.Time
-	GrossAmount  *decimal.Decimal
-	ContractType *string
-	Company      *string
-	Owner        *string
+	Date           *time.Time
+	GrossAmount    *decimal.Decimal
+	ContractType   *string
+	Company        *string
+	OwnerUserIDSet bool
+	OwnerUserID    *int
 }
 
 // Update applies the patch and returns the refreshed row.
@@ -177,15 +186,16 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*SalaryRecor
 	if p.Company != nil {
 		r.Company = *p.Company
 	}
-	if p.Owner != nil {
-		r.Owner = *p.Owner
+	if p.OwnerUserIDSet {
+		r.OwnerUserID = p.OwnerUserID
 	}
 	var conflict int
 	err = s.pool.QueryRow(ctx, `
 		SELECT id FROM salary_records
-		WHERE owner = $1 AND date = $2 AND id <> $3 AND is_active = true
+		WHERE owner_user_id IS NOT DISTINCT FROM $1 AND date = $2
+		  AND id <> $3 AND is_active = true
 		LIMIT 1`,
-		r.Owner, r.Date, id,
+		r.OwnerUserID, r.Date, id,
 	).Scan(&conflict)
 	if err == nil {
 		return nil, ErrDuplicate
@@ -193,13 +203,16 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*SalaryRecor
 	if !errors.Is(err, pgx.ErrNoRows) {
 		return nil, fmt.Errorf("check duplicate on update: %w", err)
 	}
+	// owner is dual-written from owner_user_id ($5) until the legacy column
+	// is dropped.
 	row := s.pool.QueryRow(ctx, `
 		UPDATE salary_records SET
-			date = $1, gross_amount = $2, contract_type = $3,
-			company = $4, owner = $5
+			date = $1, gross_amount = $2, contract_type = $3, company = $4,
+			owner = COALESCE((SELECT name FROM users WHERE id = $5), 'Shared'),
+			owner_user_id = $5
 		WHERE id = $6 AND is_active = true
 		RETURNING `+selectColumns,
-		r.Date, r.GrossAmount, r.ContractType, r.Company, r.Owner, id,
+		r.Date, r.GrossAmount, r.ContractType, r.Company, r.OwnerUserID, id,
 	)
 	updated, err := scanRecord(row)
 	if err != nil {
@@ -226,35 +239,35 @@ func (s *Store) Delete(ctx context.Context, id int) error {
 	return nil
 }
 
-// CurrentSalaryByPersona returns the latest active gross_amount on/before
-// asOfDate for each persona name in the input list. Personas without any
+// CurrentSalaryByUser returns the latest active gross_amount on/before
+// asOfDate for each owner_user_id in the input list. Users without any
 // matching record are absent from the map (and rendered as null in the
 // response).
-func (s *Store) CurrentSalaryByPersona(
-	ctx context.Context, personaNames []string, asOfDate time.Time,
-) (map[string]decimal.Decimal, error) {
-	if len(personaNames) == 0 {
-		return map[string]decimal.Decimal{}, nil
+func (s *Store) CurrentSalaryByUser(
+	ctx context.Context, userIDs []int, asOfDate time.Time,
+) (map[int]decimal.Decimal, error) {
+	if len(userIDs) == 0 {
+		return map[int]decimal.Decimal{}, nil
 	}
 	rows, err := s.pool.Query(ctx, `
-		SELECT DISTINCT ON (owner) owner, gross_amount
+		SELECT DISTINCT ON (owner_user_id) owner_user_id, gross_amount
 		FROM salary_records
-		WHERE is_active = true AND owner = ANY($1) AND date <= $2
-		ORDER BY owner, date DESC`,
-		personaNames, asOfDate,
+		WHERE is_active = true AND owner_user_id = ANY($1) AND date <= $2
+		ORDER BY owner_user_id, date DESC`,
+		userIDs, asOfDate,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("select current salaries: %w", err)
 	}
 	defer rows.Close()
-	out := map[string]decimal.Decimal{}
+	out := map[int]decimal.Decimal{}
 	for rows.Next() {
-		var owner string
+		var ownerID int
 		var amount decimal.Decimal
-		if err := rows.Scan(&owner, &amount); err != nil {
+		if err := rows.Scan(&ownerID, &amount); err != nil {
 			return nil, fmt.Errorf("scan current salary: %w", err)
 		}
-		out[owner] = amount
+		out[ownerID] = amount
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate current salaries: %w", err)
@@ -262,38 +275,40 @@ func (s *Store) CurrentSalaryByPersona(
 	return out, nil
 }
 
-// RecentTwoByPersona returns up to two most-recent active records per owner
-// on/before asOfDate, ordered by date desc per owner. Used to compute
-// inflation_context (current vs previous salary).
-func (s *Store) RecentTwoByPersona(
-	ctx context.Context, personaNames []string, asOfDate time.Time,
-) (map[string][]SalaryRecord, error) {
-	if len(personaNames) == 0 {
-		return map[string][]SalaryRecord{}, nil
+// RecentTwoByUser returns up to two most-recent active records per
+// owner_user_id on/before asOfDate, ordered by date desc per owner. Used to
+// compute inflation_context (current vs previous salary).
+func (s *Store) RecentTwoByUser(
+	ctx context.Context, userIDs []int, asOfDate time.Time,
+) (map[int][]SalaryRecord, error) {
+	if len(userIDs) == 0 {
+		return map[int][]SalaryRecord{}, nil
 	}
 	rows, err := s.pool.Query(ctx, `
 		WITH ranked AS (
-			SELECT id, date, gross_amount, contract_type, company, owner, is_active, created_at,
-			       ROW_NUMBER() OVER (PARTITION BY owner ORDER BY date DESC) AS rn
+			SELECT id, date, gross_amount, contract_type, company, owner_user_id, is_active, created_at,
+			       ROW_NUMBER() OVER (PARTITION BY owner_user_id ORDER BY date DESC) AS rn
 			FROM salary_records
-			WHERE is_active = true AND owner = ANY($1) AND date <= $2
+			WHERE is_active = true AND owner_user_id = ANY($1) AND date <= $2
 		)
-		SELECT id, date, gross_amount, contract_type, company, owner, is_active, created_at
+		SELECT id, date, gross_amount, contract_type, company, owner_user_id, is_active, created_at
 		FROM ranked WHERE rn <= 2
-		ORDER BY owner, date DESC`,
-		personaNames, asOfDate,
+		ORDER BY owner_user_id, date DESC`,
+		userIDs, asOfDate,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("select recent salaries: %w", err)
 	}
 	defer rows.Close()
-	out := map[string][]SalaryRecord{}
+	out := map[int][]SalaryRecord{}
 	for rows.Next() {
 		r, err := scanRecord(rows)
 		if err != nil {
 			return nil, fmt.Errorf("scan recent salary: %w", err)
 		}
-		out[r.Owner] = append(out[r.Owner], *r)
+		if r.OwnerUserID != nil {
+			out[*r.OwnerUserID] = append(out[*r.OwnerUserID], *r)
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate recent salaries: %w", err)
@@ -301,23 +316,25 @@ func (s *Store) RecentTwoByPersona(
 	return out, nil
 }
 
-// ActivePersonaNames returns the persona names sorted alphabetically.
-func (s *Store) ActivePersonaNames(ctx context.Context) ([]string, error) {
-	rows, err := s.pool.Query(ctx, `SELECT name FROM personas ORDER BY name`)
+// ActiveOwnerUserIDs returns every household member's user id, ordered by
+// username — the set the current-salary and inflation-context maps are
+// keyed by.
+func (s *Store) ActiveOwnerUserIDs(ctx context.Context) ([]int, error) {
+	rows, err := s.pool.Query(ctx, `SELECT id FROM users ORDER BY username`)
 	if err != nil {
-		return nil, fmt.Errorf("select persona names: %w", err)
+		return nil, fmt.Errorf("select owner user ids: %w", err)
 	}
 	defer rows.Close()
-	out := []string{}
+	out := []int{}
 	for rows.Next() {
-		var n string
-		if err := rows.Scan(&n); err != nil {
-			return nil, fmt.Errorf("scan persona name: %w", err)
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan owner user id: %w", err)
 		}
-		out = append(out, n)
+		out = append(out, id)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate persona names: %w", err)
+		return nil, fmt.Errorf("iterate owner user ids: %w", err)
 	}
 	return out, nil
 }
@@ -349,7 +366,7 @@ func scanRecord(row pgx.Row) (*SalaryRecord, error) {
 	var r SalaryRecord
 	if err := row.Scan(
 		&r.ID, &r.Date, &r.GrossAmount, &r.ContractType,
-		&r.Company, &r.Owner, &r.IsActive, &r.CreatedAt,
+		&r.Company, &r.OwnerUserID, &r.IsActive, &r.CreatedAt,
 	); err != nil {
 		return nil, err
 	}

--- a/backend-go/internal/salaries/validation.go
+++ b/backend-go/internal/salaries/validation.go
@@ -10,13 +10,14 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// createRequest is the validated POST body.
+// createRequest is the validated POST body. OwnerUserID is required as a
+// key; an explicit null yields nil (jointly owned).
 type createRequest struct {
 	Date         time.Time
 	GrossAmount  decimal.Decimal
 	ContractType string
 	Company      string
-	Owner        string
+	OwnerUserID  *int
 }
 
 // buildCreateRequest validates the body. Numbers are parsed via
@@ -51,11 +52,11 @@ func buildCreateRequest(raw map[string]json.RawMessage, now func() time.Time) (c
 	}
 	r.Company = company
 
-	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
+	ownerID, vErr := requireIntOrNull(raw, "owner_user_id")
 	if vErr != nil {
 		return r, vErr
 	}
-	r.Owner = owner
+	r.OwnerUserID = ownerID
 	return r, nil
 }
 
@@ -107,18 +108,36 @@ func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (Upd
 		}
 		p.Company = &s
 	}
-	if v, ok := raw["owner"]; ok && !isNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return p, &validationError{Field: "owner", Msg: "must be a string"}
+	if v, ok := raw["owner_user_id"]; ok {
+		p.OwnerUserIDSet = true
+		if isNull(v) {
+			p.OwnerUserID = nil
+		} else {
+			var n int
+			if err := json.Unmarshal(v, &n); err != nil {
+				return p, &validationError{Field: "owner_user_id", Msg: "must be an integer"}
+			}
+			p.OwnerUserID = &n
 		}
-		s = strings.TrimSpace(s)
-		if s == "" {
-			return p, &validationError{Field: "owner", Msg: "Owner cannot be empty"}
-		}
-		p.Owner = &s
 	}
 	return p, nil
+}
+
+// requireIntOrNull reads an integer key that must be present; an explicit
+// null is allowed and yields nil (jointly owned).
+func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *validationError) {
+	v, ok := raw[key]
+	if !ok {
+		return nil, &validationError{Field: key, Msg: "Field required"}
+	}
+	if isNull(v) {
+		return nil, nil
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return nil, &validationError{Field: key, Msg: "must be an integer"}
+	}
+	return &n, nil
 }
 
 func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *validationError) {

--- a/src/lib/components/SalaryCalculator.svelte
+++ b/src/lib/components/SalaryCalculator.svelte
@@ -4,6 +4,7 @@
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
 	import type { SalaryRecord } from '$lib/types/salaries';
+	import { type OwnerOption, ownerName } from '$lib/types/owners';
 	import {
 		type OfferInput,
 		type OfferBreakdown,
@@ -15,7 +16,7 @@
 	} from '$lib/utils/compensation';
 
 	interface Props {
-		data: { latestSalaries: SalaryRecord[] };
+		data: { latestSalaries: SalaryRecord[]; owners: OwnerOption[] };
 	}
 
 	let { data }: Props = $props();
@@ -351,7 +352,9 @@
 									}}
 								>
 									{#each data.latestSalaries as sal, si}
-										<option value={si}>{sal.owner} — {sal.company}</option>
+										<option value={si}>
+											{ownerName(data.owners, sal.owner_user_id)} — {sal.company}
+										</option>
 									{/each}
 								</select>
 							</label>

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -685,7 +685,7 @@ export interface paths {
                                 id?: number;
                                 is_active?: boolean;
                                 notes?: string | null;
-                                owner?: string;
+                                owner_user_id?: number | null;
                                 type?: string;
                             }[];
                             total_count?: number;
@@ -728,7 +728,7 @@ export interface paths {
                             id?: number;
                             is_active?: boolean;
                             notes?: string | null;
-                            owner?: string;
+                            owner_user_id?: number | null;
                             type?: string;
                         };
                     };
@@ -783,7 +783,7 @@ export interface paths {
                             id?: number;
                             is_active?: boolean;
                             notes?: string | null;
-                            owner?: string;
+                            owner_user_id?: number | null;
                             type?: string;
                         };
                     };
@@ -850,7 +850,7 @@ export interface paths {
                             id?: number;
                             is_active?: boolean;
                             notes?: string | null;
-                            owner?: string;
+                            owner_user_id?: number | null;
                             type?: string;
                         };
                     };
@@ -1768,7 +1768,7 @@ export interface paths {
                                 /** Format: date */
                                 liquidity_event_date?: string | null;
                                 notes?: string | null;
-                                owner?: string;
+                                owner_user_id?: number | null;
                                 /** Format: double */
                                 paper_value_base?: number | null;
                                 /** Format: double */
@@ -1842,7 +1842,7 @@ export interface paths {
                             /** Format: date */
                             liquidity_event_date?: string | null;
                             notes?: string | null;
-                            owner?: string;
+                            owner_user_id?: number | null;
                             /** Format: double */
                             paper_value_base?: number | null;
                             /** Format: double */
@@ -1928,7 +1928,7 @@ export interface paths {
                             /** Format: date */
                             liquidity_event_date?: string | null;
                             notes?: string | null;
-                            owner?: string;
+                            owner_user_id?: number | null;
                             /** Format: double */
                             paper_value_base?: number | null;
                             /** Format: double */
@@ -2026,7 +2026,7 @@ export interface paths {
                             /** Format: date */
                             liquidity_event_date?: string | null;
                             notes?: string | null;
-                            owner?: string;
+                            owner_user_id?: number | null;
                             /** Format: double */
                             paper_value_base?: number | null;
                             /** Format: double */
@@ -2934,7 +2934,7 @@ export interface paths {
                                     current_salary?: number;
                                     /** Format: date */
                                     last_change_date?: string;
-                                    owner?: string;
+                                    owner_user_id?: number;
                                     /** Format: date */
                                     previous_change_date?: string | null;
                                     /** Format: double */
@@ -2958,7 +2958,7 @@ export interface paths {
                                 gross_amount?: number;
                                 id?: number;
                                 is_active?: boolean;
-                                owner?: string;
+                                owner_user_id?: number | null;
                             }[];
                             total_count?: number;
                         };
@@ -2994,7 +2994,7 @@ export interface paths {
                             gross_amount?: number;
                             id?: number;
                             is_active?: boolean;
-                            owner?: string;
+                            owner_user_id?: number | null;
                         };
                     };
                 };
@@ -3042,7 +3042,7 @@ export interface paths {
                             gross_amount?: number;
                             id?: number;
                             is_active?: boolean;
-                            owner?: string;
+                            owner_user_id?: number | null;
                         };
                     };
                 };
@@ -3102,7 +3102,7 @@ export interface paths {
                             gross_amount?: number;
                             id?: number;
                             is_active?: boolean;
-                            owner?: string;
+                            owner_user_id?: number | null;
                         };
                     };
                 };

--- a/src/lib/types/salaries.ts
+++ b/src/lib/types/salaries.ts
@@ -4,13 +4,13 @@ export interface SalaryRecord {
 	gross_amount: number;
 	contract_type: string;
 	company: string;
-	owner: string;
+	owner_user_id: number | null;
 	is_active: boolean;
 	created_at: string;
 }
 
 export interface InflationContext {
-	owner: string;
+	owner_user_id: number;
 	last_change_date: string;
 	previous_change_date: string | null;
 	previous_salary: number | null;
@@ -38,7 +38,7 @@ export interface BonusEvent {
 	currency: string;
 	type: BonusType;
 	company: string;
-	owner: string;
+	owner_user_id: number | null;
 	contract_type: string;
 	notes: string | null;
 	is_active: boolean;
@@ -67,7 +67,7 @@ export interface EquityGrant {
 	grant_date: string;
 	type: EquityGrantType;
 	company: string;
-	owner: string;
+	owner_user_id: number | null;
 	total_shares: number;
 	strike_price: number | null;
 	currency: string;

--- a/src/lib/utils/format.test.ts
+++ b/src/lib/utils/format.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { formatSignedPLN, formatSignedPercent } from './format';
+import {
+	calculateChange,
+	formatDate,
+	formatPLN,
+	formatPercent,
+	formatSignedPLN,
+	formatSignedPercent
+} from './format';
 
 describe('formatSignedPLN', () => {
 	it('prefixes positive value with +', () => {
@@ -59,5 +66,70 @@ describe('formatSignedPercent', () => {
 
 	it('returns — for NaN', () => {
 		expect(formatSignedPercent(NaN)).toBe('—');
+	});
+});
+
+describe('formatPLN', () => {
+	it('formats a number as PLN currency', () => {
+		expect(formatPLN(1234)).toContain('1');
+	});
+
+	it('returns — for null, undefined and NaN', () => {
+		expect(formatPLN(null)).toBe('—');
+		expect(formatPLN(undefined)).toBe('—');
+		expect(formatPLN(NaN)).toBe('—');
+	});
+});
+
+describe('formatPercent', () => {
+	it('formats a number as a percentage', () => {
+		expect(formatPercent(50)).toMatch(/50/);
+	});
+
+	it('returns — for null, undefined and NaN', () => {
+		expect(formatPercent(null)).toBe('—');
+		expect(formatPercent(undefined)).toBe('—');
+		expect(formatPercent(NaN)).toBe('—');
+	});
+});
+
+describe('formatDate', () => {
+	it('formats an ISO date string', () => {
+		expect(formatDate('2024-03-15')).toMatch(/2024/);
+	});
+
+	it('formats a Date instance', () => {
+		expect(formatDate(new Date('2024-03-15'))).toMatch(/2024/);
+	});
+
+	it('returns — for empty and invalid input', () => {
+		expect(formatDate(null)).toBe('—');
+		expect(formatDate(undefined)).toBe('—');
+		expect(formatDate('')).toBe('—');
+		expect(formatDate('not-a-date')).toBe('—');
+	});
+});
+
+describe('calculateChange', () => {
+	it('reports an upward change', () => {
+		expect(calculateChange(150, 100)).toEqual({
+			absolute: 50,
+			percent: 50,
+			direction: 'up'
+		});
+	});
+
+	it('reports a downward change', () => {
+		const change = calculateChange(80, 100);
+		expect(change.absolute).toBe(-20);
+		expect(change.direction).toBe('down');
+	});
+
+	it('reports a flat change and guards against division by zero', () => {
+		expect(calculateChange(0, 0)).toEqual({
+			absolute: 0,
+			percent: 0,
+			direction: 'flat'
+		});
 	});
 });

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -35,8 +35,8 @@
 		ValuationSource,
 		VestingFrequency
 	} from '$lib/types/salaries';
-	import type { Persona } from '$lib/types/personas';
 	import type { CpiSeries } from '$lib/types/cpi';
+	import { type OwnerOption, ownerName } from '$lib/types/owners';
 	import type { PageData } from './$types';
 
 	interface Props {
@@ -46,8 +46,8 @@
 	let { data }: Props = $props();
 
 	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
-	const personas = $derived(data.personas as Persona[]);
-	const defaultOwner = $derived(personas.length > 0 ? personas[0].name : 'Marcin');
+	const owners = $derived(data.owners as OwnerOption[]);
+	const defaultOwnerId = $derived<number | null>(owners.length > 0 ? owners[0].id : null);
 	const cpiSeries = $derived(data.cpiSeries as CpiSeries);
 	const inflationContext = $derived(data.salaries.inflation_context ?? {});
 	const inflationEntries = $derived(Object.values(inflationContext));
@@ -90,7 +90,9 @@
 	let chartContainer: HTMLDivElement;
 	let chart: echarts.ECharts | undefined;
 
-	let filterOwner = $state(untrack(() => data.filters.owner || ''));
+	let filterOwnerUserId = $state<number | null>(
+		untrack(() => (data.filters.owner_user_id ? Number(data.filters.owner_user_id) : null))
+	);
 	let filterDateFrom = $state(untrack(() => data.filters.date_from || ''));
 	let filterDateTo = $state(untrack(() => data.filters.date_to || ''));
 	let filterCompany = $state(untrack(() => data.filters.company || ''));
@@ -102,7 +104,7 @@
 		gross_amount: 0,
 		contract_type: 'UOP',
 		company: '',
-		owner: untrack(() => defaultOwner)
+		owner_user_id: untrack(() => defaultOwnerId)
 	});
 	let salaryError = $state('');
 	let savingSalary = $state(false);
@@ -110,15 +112,15 @@
 	const currentYear = new Date().getFullYear();
 
 	const latestContractByOwner = $derived.by(() => {
-		const map = new Map<string, string>();
+		const map = new Map<number | null, string>();
 		for (const r of data.salaries.salary_records) {
-			if (!map.has(r.owner)) map.set(r.owner, r.contract_type);
+			if (!map.has(r.owner_user_id)) map.set(r.owner_user_id, r.contract_type);
 		}
 		return map;
 	});
 
-	function netMonthlyForOwner(owner: string, grossMonthly: number): number | null {
-		const ct = latestContractByOwner.get(owner);
+	function netMonthlyForOwner(ownerUserId: number | null, grossMonthly: number): number | null {
+		const ct = latestContractByOwner.get(ownerUserId);
 		if (!ct) return null;
 		const allowed: PlContractType[] = ['UOP', 'B2B', 'UZ', 'UoD'];
 		if (!allowed.includes(ct as PlContractType)) return null;
@@ -133,11 +135,14 @@
 	};
 
 	const currentSalaryRows = $derived.by<CurrentSalaryRow[]>(() =>
-		Object.entries(data.salaries.current_salaries).map(([name, salary]) => ({
-			name,
-			salary,
-			net: salary !== null ? netMonthlyForOwner(name, salary) : null
-		}))
+		Object.entries(data.salaries.current_salaries).map(([key, salary]) => {
+			const ownerUserId = Number(key);
+			return {
+				name: ownerName(owners, ownerUserId),
+				salary,
+				net: salary !== null ? netMonthlyForOwner(ownerUserId, salary) : null
+			};
+		})
 	);
 
 	const allYears = $derived.by(() => {
@@ -149,11 +154,11 @@
 	});
 
 	let totalCompYear = $state(new Date().getFullYear());
-	let totalCompOwner = $state(untrack(() => defaultOwner));
+	let totalCompOwner = $state<number | null>(untrack(() => defaultOwnerId));
 	let includeEquityInTotal = $state(false);
 
 	type OwnerCompSummary = {
-		owner: string;
+		ownerUserId: number | null;
 		baseAnnualGross: number;
 		baseAnnualNet: number;
 		bonusesPln: number;
@@ -183,12 +188,12 @@
 	}
 
 	const compSummary = $derived.by<OwnerCompSummary | null>(() => {
-		if (!totalCompOwner) return null;
-		const owner = totalCompOwner;
+		if (totalCompOwner === null) return null;
+		const ownerUserId = totalCompOwner;
 		const yearEndIso = isoDateLocal(new Date(totalCompYear, 11, 31));
 
 		const latestSalary = data.salaries.salary_records.find(
-			(r) => r.owner === owner && r.date <= yearEndIso
+			(r) => r.owner_user_id === ownerUserId && r.date <= yearEndIso
 		);
 		const baseMonthly = latestSalary?.gross_amount ?? 0;
 		const baseAnnualGross = baseMonthly * 12;
@@ -202,7 +207,9 @@
 			: 0;
 
 		const bonusesPln = (data.bonuses?.bonus_events ?? [])
-			.filter((b) => b.owner === owner && new Date(b.date).getFullYear() === totalCompYear)
+			.filter(
+				(b) => b.owner_user_id === ownerUserId && new Date(b.date).getFullYear() === totalCompYear
+			)
 			.reduce((s, b) => s + (b.amount_pln ?? (b.currency === 'PLN' ? b.amount : 0)), 0);
 
 		// Net for bonuses: treat as additional gross in the same year and take the
@@ -218,7 +225,7 @@
 		let equityPaperHighPln = 0;
 		let hasEquityWithoutFx = false;
 		for (const g of data.equity?.equity_grants ?? []) {
-			if (g.owner !== owner) continue;
+			if (g.owner_user_id !== ownerUserId) continue;
 			if (g.paper_value_base_pln === null && g.paper_value_base !== null) {
 				hasEquityWithoutFx = true;
 				continue;
@@ -234,7 +241,7 @@
 		const equityNetPln = equityPaperPln * (1 - EQUITY_CAPITAL_GAINS_RATE);
 
 		return {
-			owner,
+			ownerUserId,
 			baseAnnualGross,
 			baseAnnualNet,
 			bonusesPln,
@@ -285,7 +292,7 @@
 		currency: 'PLN',
 		type: 'annual' as BonusType,
 		company: '',
-		owner: untrack(() => defaultOwner),
+		owner_user_id: untrack(() => defaultOwnerId),
 		contract_type: 'UOP',
 		notes: ''
 	});
@@ -305,7 +312,7 @@
 			currency: 'PLN',
 			type: 'annual',
 			company: '',
-			owner: defaultOwner,
+			owner_user_id: defaultOwnerId,
 			contract_type: 'UOP',
 			notes: ''
 		};
@@ -321,7 +328,7 @@
 			currency: bonus.currency,
 			type: bonus.type,
 			company: bonus.company,
-			owner: bonus.owner,
+			owner_user_id: bonus.owner_user_id,
 			contract_type: bonus.contract_type,
 			notes: bonus.notes ?? ''
 		};
@@ -549,7 +556,7 @@
 		grant_date: new Date().toISOString().split('T')[0],
 		type: 'rsu' as EquityGrantType,
 		company: '',
-		owner: untrack(() => defaultOwner),
+		owner_user_id: untrack(() => defaultOwnerId),
 		total_shares: 0,
 		strike_price: null as number | null,
 		currency: 'USD',
@@ -590,7 +597,7 @@
 			grant_date: new Date().toISOString().split('T')[0],
 			type: 'rsu',
 			company: '',
-			owner: defaultOwner,
+			owner_user_id: defaultOwnerId,
 			total_shares: 0,
 			strike_price: null,
 			currency: 'USD',
@@ -638,7 +645,7 @@
 			grant_date: grant.grant_date,
 			type: grant.type,
 			company: grant.company,
-			owner: grant.owner,
+			owner_user_id: grant.owner_user_id,
 			total_shares: grant.total_shares,
 			strike_price: grant.strike_price,
 			currency: grant.currency,
@@ -694,7 +701,7 @@
 				grant_date: equityFormData.grant_date,
 				type: equityFormData.type,
 				company: equityFormData.company,
-				owner: equityFormData.owner,
+				owner_user_id: equityFormData.owner_user_id,
 				total_shares: equityFormData.total_shares,
 				strike_price: equityFormData.type === 'option' ? equityFormData.strike_price : null,
 				currency: equityFormData.currency,
@@ -926,17 +933,17 @@
 		}
 	}
 
-	function getPreviousCompany(owner: string, date: string | null): string | null {
+	function getPreviousCompany(ownerUserId: number | null, date: string | null): string | null {
 		if (!date) return null;
 		return (
-			data.salaries.salary_records.find((r) => r.owner === owner && r.date === date)?.company ??
-			null
+			data.salaries.salary_records.find((r) => r.owner_user_id === ownerUserId && r.date === date)
+				?.company ?? null
 		);
 	}
 
 	function applyFilters() {
 		const params = new URLSearchParams();
-		if (filterOwner) params.set('owner', filterOwner);
+		if (filterOwnerUserId !== null) params.set('owner_user_id', String(filterOwnerUserId));
 		if (filterDateFrom) params.set('date_from', filterDateFrom);
 		if (filterDateTo) params.set('date_to', filterDateTo);
 		if (filterCompany) params.set('company', filterCompany);
@@ -945,7 +952,7 @@
 	}
 
 	function clearFilters() {
-		filterOwner = '';
+		filterOwnerUserId = null;
 		filterDateFrom = '';
 		filterDateTo = '';
 		filterCompany = '';
@@ -959,7 +966,7 @@
 			gross_amount: 0,
 			contract_type: 'UOP',
 			company: '',
-			owner: defaultOwner
+			owner_user_id: defaultOwnerId
 		};
 		salaryError = '';
 		showNewSalaryModal = true;
@@ -972,7 +979,7 @@
 			gross_amount: record.gross_amount,
 			contract_type: record.contract_type,
 			company: record.company,
-			owner: record.owner
+			owner_user_id: record.owner_user_id
 		};
 		salaryError = '';
 		showNewSalaryModal = true;
@@ -1265,8 +1272,8 @@
 				<label class="label">
 					<span class="text-xs">Właściciel</span>
 					<select class="select" bind:value={totalCompOwner}>
-						{#each personas as persona}
-							<option value={persona.name}>{persona.name}</option>
+						{#each owners as owner (owner.id)}
+							<option value={owner.id}>{owner.name}</option>
 						{/each}
 					</select>
 				</label>
@@ -1371,14 +1378,14 @@
 			</p>
 		{:else}
 			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-				{#each inflationEntries as ctx (ctx.owner)}
+				{#each inflationEntries as ctx (ctx.owner_user_id)}
 					<div class="card preset-tonal-surface p-4 space-y-2">
 						<div class="flex items-baseline justify-between flex-wrap gap-2">
-							<strong class="text-lg">{ctx.owner}</strong>
+							<strong class="text-lg">{ownerName(owners, ctx.owner_user_id)}</strong>
 							<span class="text-xs text-surface-700-300">
 								od {new Date(ctx.last_change_date).toLocaleDateString('pl-PL')}
-								{#if getPreviousCompany(ctx.owner, ctx.previous_change_date)}
-									· {getPreviousCompany(ctx.owner, ctx.previous_change_date)}
+								{#if getPreviousCompany(ctx.owner_user_id, ctx.previous_change_date)}
+									· {getPreviousCompany(ctx.owner_user_id, ctx.previous_change_date)}
 								{/if}
 							</span>
 						</div>
@@ -1455,10 +1462,10 @@
 			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
 				<label class="label">
 					<span class="font-semibold text-sm">Właściciel</span>
-					<select class="select" bind:value={filterOwner}>
-						<option value="">Wszystkie</option>
-						{#each personas as persona}
-							<option value={persona.name}>{persona.name}</option>
+					<select class="select" bind:value={filterOwnerUserId}>
+						<option value={null}>Wszystkie</option>
+						{#each owners as owner (owner.id)}
+							<option value={owner.id}>{owner.name}</option>
 						{/each}
 					</select>
 				</label>
@@ -1518,7 +1525,7 @@
 						{#each data.salaries.salary_records as record}
 							<tr>
 								<td>{new Date(record.date).toLocaleDateString('pl-PL')}</td>
-								<td>{record.owner}</td>
+								<td>{ownerName(owners, record.owner_user_id)}</td>
 								<td>{record.company}</td>
 								<td class="font-semibold text-primary-600-400">{formatPLN(record.gross_amount)}</td>
 								<td>{record.contract_type}</td>
@@ -1594,7 +1601,7 @@
 										<tr>
 											<td>{new Date(bonus.date).toLocaleDateString('pl-PL')}</td>
 											<td>{bonusTypeLabels[bonus.type]}</td>
-											<td>{bonus.owner}</td>
+											<td>{ownerName(owners, bonus.owner_user_id)}</td>
 											<td class="font-semibold text-primary-600-400">
 												{formatBonusAmount(bonus.amount, bonus.currency)}
 												{#if bonus.currency !== 'PLN' && bonus.amount_pln !== null}
@@ -1695,7 +1702,7 @@
 										<tr>
 											<td>{new Date(grant.grant_date).toLocaleDateString('pl-PL')}</td>
 											<td>{equityTypeLabels[grant.type]}</td>
-											<td>{grant.owner}</td>
+											<td>{ownerName(owners, grant.owner_user_id)}</td>
 											<td class="font-semibold">
 												{formatShares(grant.vested_shares_today)} /
 												{formatShares(grant.total_shares)}
@@ -1927,9 +1934,9 @@
 
 		<label class="label">
 			<span class="font-semibold text-sm">Właściciel*</span>
-			<select class="select" bind:value={salaryFormData.owner} required>
-				{#each personas as persona}
-					<option value={persona.name}>{persona.name}</option>
+			<select class="select" bind:value={salaryFormData.owner_user_id} required>
+				{#each owners as owner (owner.id)}
+					<option value={owner.id}>{owner.name}</option>
 				{/each}
 			</select>
 		</label>
@@ -2007,9 +2014,9 @@
 
 		<label class="label">
 			<span class="font-semibold text-sm">Właściciel*</span>
-			<select class="select" bind:value={bonusFormData.owner} required>
-				{#each personas as persona}
-					<option value={persona.name}>{persona.name}</option>
+			<select class="select" bind:value={bonusFormData.owner_user_id} required>
+				{#each owners as owner (owner.id)}
+					<option value={owner.id}>{owner.name}</option>
 				{/each}
 			</select>
 		</label>
@@ -2088,9 +2095,9 @@
 
 		<label class="label">
 			<span class="font-semibold text-sm">Właściciel*</span>
-			<select class="select" bind:value={equityFormData.owner} required>
-				{#each personas as persona}
-					<option value={persona.name}>{persona.name}</option>
+			<select class="select" bind:value={equityFormData.owner_user_id} required>
+				{#each owners as owner (owner.id)}
+					<option value={owner.id}>{owner.name}</option>
 				{/each}
 			</select>
 		</label>

--- a/src/routes/salaries/+page.ts
+++ b/src/routes/salaries/+page.ts
@@ -9,6 +9,7 @@ import type {
 	SalariesData
 } from '$lib/types/salaries';
 import type { CpiSeries } from '$lib/types/cpi';
+import type { OwnerOption } from '$lib/types/owners';
 
 const EMPTY_CPI: CpiSeries = { points: [], base_year: null, latest_year: null, source: '' };
 const EMPTY_BONUSES: BonusEventsData = {
@@ -34,13 +35,13 @@ export const load: PageLoad = async ({ fetch, url }) => {
 			throw error(500, 'API URL is not configured');
 		}
 
-		const owner = url.searchParams.get('owner');
+		const ownerUserId = url.searchParams.get('owner_user_id');
 		const dateFrom = url.searchParams.get('date_from');
 		const dateTo = url.searchParams.get('date_to');
 		const company = url.searchParams.get('company');
 
 		const params = new URLSearchParams();
-		if (owner) params.set('owner', owner);
+		if (ownerUserId) params.set('owner_user_id', ownerUserId);
 		if (dateFrom) params.set('date_from', dateFrom);
 		if (dateTo) params.set('date_to', dateTo);
 		if (company) params.set('company', company);
@@ -50,14 +51,14 @@ export const load: PageLoad = async ({ fetch, url }) => {
 		// so it needs the full dataset to switch personas without re-loading.
 		const [
 			salariesResponse,
-			personasResponse,
+			ownersResponse,
 			cpiResponse,
 			bonusesResponse,
 			equityResponse,
 			valuationsResponse
 		] = await Promise.all([
 			fetch(`${apiUrl}/api/salaries?${params.toString()}`),
-			fetch(`${apiUrl}/api/personas`),
+			fetch(`${apiUrl}/api/users`),
 			fetch(`${apiUrl}/api/cpi/series`),
 			fetch(`${apiUrl}/api/bonuses`),
 			fetch(`${apiUrl}/api/equity-grants`),
@@ -69,7 +70,7 @@ export const load: PageLoad = async ({ fetch, url }) => {
 		}
 
 		const data: SalariesData = await salariesResponse.json();
-		const personas = personasResponse.ok ? await personasResponse.json() : [];
+		const owners: OwnerOption[] = ownersResponse.ok ? await ownersResponse.json() : [];
 		const cpiSeries: CpiSeries = cpiResponse.ok ? await cpiResponse.json() : EMPTY_CPI;
 		const bonuses: BonusEventsData = bonusesResponse.ok
 			? await bonusesResponse.json()
@@ -82,12 +83,12 @@ export const load: PageLoad = async ({ fetch, url }) => {
 		return {
 			salaries: data,
 			filters: {
-				owner,
+				owner_user_id: ownerUserId,
 				date_from: dateFrom,
 				date_to: dateTo,
 				company
 			},
-			personas,
+			owners,
 			cpiSeries,
 			bonuses,
 			equity,

--- a/src/routes/salaries/page.test.ts
+++ b/src/routes/salaries/page.test.ts
@@ -40,12 +40,12 @@ const baseData = {
 	salaries: {
 		salary_records: [],
 		total_count: 0,
-		current_salaries: { Marcin: null },
+		current_salaries: { '1': null },
 		inflation_context: {},
 		available_companies: []
 	},
-	filters: { owner: null, date_from: null, date_to: null, company: null },
-	personas: [{ id: 1, name: 'Marcin', ppk_employee_rate: 2, ppk_employer_rate: 1.5 }],
+	filters: { owner_user_id: null, date_from: null, date_to: null, company: null },
+	owners: [{ id: 1, name: 'Marcin' }],
 	cpiSeries: { points: [], base_year: null, latest_year: null, source: '' },
 	bonuses: { bonus_events: [], total_count: 0, available_companies: [] },
 	equity: { equity_grants: [], total_count: 0, available_companies: [] },
@@ -229,7 +229,7 @@ describe('Salaries page — saveSalary validation & error display', () => {
 			gross_amount: 5000,
 			contract_type: 'UOP',
 			company: 'ACME',
-			owner: 'Marcin'
+			owner_user_id: 1
 		});
 		await waitFor(() => expect(invalidateAll).toHaveBeenCalled());
 	});

--- a/src/routes/simulations/kalkulator/+page.svelte
+++ b/src/routes/simulations/kalkulator/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import SalaryCalculator from '$lib/components/SalaryCalculator.svelte';
 	import type { SalaryRecord } from '$lib/types/salaries';
+	import type { OwnerOption } from '$lib/types/owners';
 
 	interface Props {
-		data: { latestSalaries: SalaryRecord[] };
+		data: { latestSalaries: SalaryRecord[]; owners: OwnerOption[] };
 	}
 
 	let { data }: Props = $props();

--- a/src/routes/simulations/kalkulator/+page.ts
+++ b/src/routes/simulations/kalkulator/+page.ts
@@ -2,38 +2,43 @@ import { browser } from '$app/environment';
 import { env } from '$env/dynamic/public';
 import type { PageLoad } from './$types';
 import type { SalaryRecord } from '$lib/types/salaries';
+import type { OwnerOption } from '$lib/types/owners';
 
 export const load: PageLoad = async ({ fetch }) => {
 	try {
 		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) return { latestSalaries: [] };
+		if (!apiUrl) return { latestSalaries: [], owners: [] };
 
-		const res = await fetch(`${apiUrl}/api/salaries`);
-		if (!res.ok) return { latestSalaries: [] };
+		const [res, ownersRes] = await Promise.all([
+			fetch(`${apiUrl}/api/salaries`),
+			fetch(`${apiUrl}/api/users`)
+		]);
+		if (!res.ok) return { latestSalaries: [], owners: [] };
 
 		const data = await res.json();
 		const records: SalaryRecord[] = data.salary_records ?? [];
+		const owners: OwnerOption[] = ownersRes.ok ? await ownersRes.json() : [];
 
 		// Pick the most recent record per owner
-		const byOwner = new Map<string, SalaryRecord>();
+		const byOwner = new Map<number | null, SalaryRecord>();
 		for (const r of records) {
-			const existing = byOwner.get(r.owner);
+			const existing = byOwner.get(r.owner_user_id);
 			if (!existing || r.date > existing.date) {
-				byOwner.set(r.owner, r);
+				byOwner.set(r.owner_user_id, r);
 			}
 		}
 
 		const latestSalaries = [...byOwner.values()].sort((a, b) => {
 			if (a.date === b.date) {
-				if (a.owner === b.owner) return 0;
-				return a.owner < b.owner ? -1 : 1;
+				if (a.owner_user_id === b.owner_user_id) return 0;
+				return (a.owner_user_id ?? -1) < (b.owner_user_id ?? -1) ? -1 : 1;
 			}
 			// Newest dates first
 			return a.date < b.date ? 1 : -1;
 		});
 
-		return { latestSalaries };
+		return { latestSalaries, owners };
 	} catch {
-		return { latestSalaries: [] };
+		return { latestSalaries: [], owners: [] };
 	}
 };


### PR DESCRIPTION
## Motivation

Part of the personas→users merge (umbrella #495, phase C3 — closes #496).
Switches the **salaries**, **bonus_events** and **equity_grants** APIs from
the legacy `owner` string to `owner_user_id` (an FK-shaped integer to
`users`; `null` = jointly owned / "Wspólne").

> Changelog: feat(api): owner_user_id for salaries, bonuses, equity grants

## Implementation information

- **Backend** — wire types expose `owner_user_id *int`; create/update accept
  `owner_user_id` (key required, explicit `null` allowed). Stores
  SELECT/scan `owner_user_id` and dual-write the legacy `owner` string via
  `COALESCE((SELECT name FROM users WHERE id = $N), 'Shared')` until phase D
  drops the column. List filters keyed by `owner` → `owner_user_id`.
- `salaries` `current_salaries` / `inflation_context` maps are rekeyed by
  `owner_user_id` (JSON serialises the integer keys as strings); the
  persona-name lookup becomes `ActiveOwnerUserIDs` over `users`.
- **Frontend** — the salaries page sources owner options from `/api/users`,
  sends `owner_user_id`, and resolves display names via `ownerName()`. The
  salary calculator + kalkulator loader were updated for the type change.
- `api/openapi-go.json` and `src/lib/types/api.generated.ts` regenerated.
- No schema change (the `owner_user_id` column already exists from phase B).

## Supporting documentation

Umbrella issue #495 · sub-issue #496.