### PR TITLE
feat(api): owner_user_id cutover for C4 endpoints

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -1823,9 +1823,9 @@
                           "category": {
                             "type": "string"
                           },
-                          "owner": {
+                          "owner_user_id": {
                             "nullable": true,
-                            "type": "string"
+                            "type": "integer"
                           },
                           "value": {
                             "format": "double",
@@ -4059,8 +4059,9 @@
                         "nullable": true,
                         "type": "string"
                       },
-                      "owner": {
-                        "type": "string"
+                      "owner_user_id": {
+                        "nullable": true,
+                        "type": "integer"
                       },
                       "year": {
                         "type": "integer"
@@ -4081,7 +4082,7 @@
         ]
       }
     },
-    "/api/retirement/limits/{year}/{wrapper}/{owner}": {
+    "/api/retirement/limits/{year}/{wrapper}/{owner_user_id}": {
       "put": {
         "parameters": [
           {
@@ -4102,7 +4103,7 @@
           },
           {
             "in": "path",
-            "name": "owner",
+            "name": "owner_user_id",
             "required": true,
             "schema": {
               "type": "string"
@@ -4129,8 +4130,9 @@
                       "nullable": true,
                       "type": "string"
                     },
-                    "owner": {
-                      "type": "string"
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
                     },
                     "year": {
                       "type": "integer"
@@ -4172,8 +4174,9 @@
                     "month": {
                       "type": "integer"
                     },
-                    "owner": {
-                      "type": "string"
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
                     },
                     "total_amount": {
                       "format": "double",
@@ -4223,8 +4226,9 @@
                         "format": "double",
                         "type": "number"
                       },
-                      "owner": {
-                        "type": "string"
+                      "owner_user_id": {
+                        "nullable": true,
+                        "type": "integer"
                       },
                       "returns": {
                         "format": "double",
@@ -4286,8 +4290,9 @@
                         "nullable": true,
                         "type": "number"
                       },
-                      "owner": {
-                        "type": "string"
+                      "owner_user_id": {
+                        "nullable": true,
+                        "type": "integer"
                       },
                       "percentage_used": {
                         "format": "double",
@@ -5204,8 +5209,9 @@
                           "format": "double",
                           "type": "number"
                         },
-                        "owner": {
-                          "type": "string"
+                        "owner_user_id": {
+                          "nullable": true,
+                          "type": "integer"
                         },
                         "retirement_age": {
                           "type": "integer"
@@ -5386,9 +5392,9 @@
                     "gender": {
                       "type": "string"
                     },
-                    "owner": {
+                    "owner_user_id": {
                       "nullable": true,
-                      "type": "string"
+                      "type": "integer"
                     },
                     "retirement_age": {
                       "type": "integer"

--- a/backend-bb-tests/fixtures/seed.py
+++ b/backend-bb-tests/fixtures/seed.py
@@ -151,18 +151,41 @@ _OWNER_TABLES = (
 def _seed_users(cur: psycopg2.extensions.cursor) -> None:
     """Insert Marcin/Ewa as users so owner_user_id can reference them.
 
+    PPK rates live on the users table now that owner-aware code resolves
+    them via owner_user_id instead of the personas table.
+
     The users table is not truncated (it holds the backend-seeded admin),
     so the insert is idempotent on username.
     """
     cur.executemany(
         """
-        INSERT INTO users (username, password_hash, name, is_admin, created_at)
-        VALUES (%s, %s, %s, FALSE, %s)
-        ON CONFLICT (username) DO UPDATE SET name = EXCLUDED.name
+        INSERT INTO users (
+            username, password_hash, name, is_admin,
+            ppk_employee_rate, ppk_employer_rate, created_at
+        )
+        VALUES (%s, %s, %s, FALSE, %s, %s, %s)
+        ON CONFLICT (username) DO UPDATE SET
+            name = EXCLUDED.name,
+            ppk_employee_rate = EXCLUDED.ppk_employee_rate,
+            ppk_employer_rate = EXCLUDED.ppk_employer_rate
         """,
         [
-            ("marcin", "!seed-no-login", PERSONA_MARCIN, SEED_CREATED_AT),
-            ("ewa", "!seed-no-login", PERSONA_EWA, SEED_CREATED_AT),
+            (
+                "marcin",
+                "!seed-no-login",
+                PERSONA_MARCIN,
+                Decimal("2.0"),
+                Decimal("1.5"),
+                SEED_CREATED_AT,
+            ),
+            (
+                "ewa",
+                "!seed-no-login",
+                PERSONA_EWA,
+                Decimal("2.0"),
+                Decimal("1.5"),
+                SEED_CREATED_AT,
+            ),
         ],
     )
 

--- a/backend-bb-tests/golden/retirement_limits_2025.json
+++ b/backend-bb-tests/golden/retirement_limits_2025.json
@@ -4,7 +4,7 @@
     "id": 1,
     "limit_amount": 23472.0,
     "notes": "2025 IKE limit",
-    "owner": "Marcin",
+    "owner_user_id": 2,
     "year": 2025
   },
   {
@@ -12,7 +12,7 @@
     "id": 2,
     "limit_amount": 9388.8,
     "notes": "2025 IKZE limit",
-    "owner": "Marcin",
+    "owner_user_id": 2,
     "year": 2025
   }
 ]

--- a/backend-bb-tests/golden/retirement_ppk_stats.json
+++ b/backend-bb-tests/golden/retirement_ppk_stats.json
@@ -3,7 +3,7 @@
     "employee_contributed": 0.0,
     "employer_contributed": 400.0,
     "government_contributed": 250.0,
-    "owner": "Marcin",
+    "owner_user_id": 2,
     "returns": 12950.0,
     "roi_percentage": 1992.31,
     "total_contributed": 650.0,

--- a/backend-bb-tests/golden/retirement_stats_2025.json
+++ b/backend-bb-tests/golden/retirement_stats_2025.json
@@ -5,7 +5,7 @@
     "employer_contributed": 0.0,
     "is_warning": false,
     "limit_amount": 23472.0,
-    "owner": "Marcin",
+    "owner_user_id": 2,
     "percentage_used": 6.4,
     "remaining": 21972.0,
     "total_contributed": 1500.0,

--- a/backend-bb-tests/golden/simulations_prefill.json
+++ b/backend-bb-tests/golden/simulations_prefill.json
@@ -1,25 +1,17 @@
 {
   "balances": {
-    "ike_ewa": 0.0,
-    "ike_marcin": 46100.0,
-    "ikze_ewa": 0.0,
-    "ikze_marcin": 0.0
+    "ike_2": 46100.0,
+    "ikze_2": 0.0
   },
   "current_age": 35,
   "monthly_salaries": {
-    "ewa": null,
-    "marcin": 21000.0
+    "2": 21000.0
   },
   "ppk_balances": {
-    "ewa": 0.0,
-    "marcin": 13600.0
+    "2": 13600.0
   },
   "ppk_rates": {
-    "ewa": {
-      "employee": 2.0,
-      "employer": 1.5
-    },
-    "marcin": {
+    "2": {
       "employee": 2.0,
       "employer": 1.5
     }

--- a/backend-bb-tests/golden/simulations_retirement.json
+++ b/backend-bb-tests/golden/simulations_retirement.json
@@ -10,7 +10,7 @@
         "balance": 46100.0,
         "enabled": true,
         "monthly_contribution": 1500.0,
-        "owner": "Marcin",
+        "owner_user_id": 2,
         "tax_rate": 0.0,
         "wrapper": "IKE"
       }

--- a/backend-bb-tests/golden/zus_calculate_marcin.json
+++ b/backend-bb-tests/golden/zus_calculate_marcin.json
@@ -6,7 +6,7 @@
     "has_ofe": false,
     "inflation_rate": 3.0,
     "kapital_poczatkowy": 0.0,
-    "owner": "Marcin",
+    "owner_user_id": 2,
     "retirement_age": 65,
     "salary_growth_rate": 3.0,
     "salary_history": [],

--- a/backend-bb-tests/golden/zus_prefill_marcin.json
+++ b/backend-bb-tests/golden/zus_prefill_marcin.json
@@ -2,7 +2,7 @@
   "birth_date": "1990-06-15",
   "current_gross_monthly_salary": 21000.0,
   "gender": "M",
-  "owner": "Marcin",
+  "owner_user_id": 2,
   "retirement_age": 65,
   "salary_history": [
     {

--- a/backend-bb-tests/tests/test_retirement.py
+++ b/backend-bb-tests/tests/test_retirement.py
@@ -26,7 +26,7 @@ def test_get_retirement_stats_shape(client: httpx.Client) -> None:
         required = {
             "year",
             "account_wrapper",
-            "owner",
+            "owner_user_id",
             "total_contributed",
             "employee_contributed",
             "employer_contributed",
@@ -65,51 +65,57 @@ def test_get_limits_for_year_shape(client: httpx.Client) -> None:
     body = response.json()
     assert isinstance(body, list)
     assert body, "Seeded retirement_limits is empty"
-    required = {"id", "year", "account_wrapper", "owner", "limit_amount"}
+    required = {"id", "year", "account_wrapper", "owner_user_id", "limit_amount"}
     assert required.issubset(body[0].keys())
 
 
-def test_put_retirement_limit_upsert(client: httpx.Client) -> None:
+def test_put_retirement_limit_upsert(client: httpx.Client, owner_ids: dict[str, int]) -> None:
     # Idempotent upsert — picking a year we own the row for so this is safe
     # to re-run. Use 2025/IKE/Marcin which is seeded.
+    marcin = owner_ids[PERSONA_MARCIN]
     payload = {
         "year": 2025,
         "account_wrapper": "IKE",
-        "owner": PERSONA_MARCIN,
+        "owner_user_id": marcin,
         "limit_amount": 23472.0,
         "notes": "Black-box upsert test",
     }
     response = client.put(
-        f"/api/retirement/limits/2025/IKE/{PERSONA_MARCIN}",
+        f"/api/retirement/limits/2025/IKE/{marcin}",
         json=payload,
     )
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["year"] == 2025
     assert body["account_wrapper"] == "IKE"
-    assert body["owner"] == PERSONA_MARCIN
+    assert body["owner_user_id"] == marcin
     assert body["limit_amount"] == 23472.0
 
 
-def test_put_retirement_limit_validation_error(client: httpx.Client) -> None:
+def test_put_retirement_limit_validation_error(
+    client: httpx.Client, owner_ids: dict[str, int]
+) -> None:
     # year out of allowed range triggers validator
+    marcin = owner_ids[PERSONA_MARCIN]
     payload = {
         "year": 1999,
         "account_wrapper": "IKE",
-        "owner": PERSONA_MARCIN,
+        "owner_user_id": marcin,
         "limit_amount": 1000.0,
     }
     response = client.put(
-        f"/api/retirement/limits/1999/IKE/{PERSONA_MARCIN}",
+        f"/api/retirement/limits/1999/IKE/{marcin}",
         json=payload,
     )
     assert response.status_code >= 400, response.text
     assert "detail" in response.json()
 
 
-def test_post_ppk_contributions_validation_error(client: httpx.Client) -> None:
+def test_post_ppk_contributions_validation_error(
+    client: httpx.Client, owner_ids: dict[str, int]
+) -> None:
     # Invalid month → 422
-    payload = {"owner": PERSONA_MARCIN, "month": 13, "year": 2025}
+    payload = {"owner_user_id": owner_ids[PERSONA_MARCIN], "month": 13, "year": 2025}
     response = client.post("/api/retirement/ppk-contributions/generate", json=payload)
     assert response.status_code >= 400, response.text
     assert "detail" in response.json()

--- a/backend-bb-tests/tests/test_simulations.py
+++ b/backend-bb-tests/tests/test_simulations.py
@@ -83,7 +83,9 @@ def test_post_mortgage_vs_invest_validation_error(client: httpx.Client) -> None:
 
 
 @pytest.mark.golden
-def test_post_simulate_retirement_matches_golden(client: httpx.Client, update_golden: bool) -> None:
+def test_post_simulate_retirement_matches_golden(
+    client: httpx.Client, update_golden: bool, owner_ids: dict[str, int]
+) -> None:
     from _golden import assert_matches_golden
 
     payload = {
@@ -93,7 +95,7 @@ def test_post_simulate_retirement_matches_golden(client: httpx.Client, update_go
             {
                 "enabled": True,
                 "wrapper": "IKE",
-                "owner": PERSONA_MARCIN,
+                "owner_user_id": owner_ids[PERSONA_MARCIN],
                 "balance": 46100.0,
                 "auto_fill_limit": False,
                 "monthly_contribution": 1500.0,
@@ -136,7 +138,9 @@ def _round_floats(value: object) -> object:
     return value
 
 
-def test_post_simulate_retirement_happy_path(client: httpx.Client) -> None:
+def test_post_simulate_retirement_happy_path(
+    client: httpx.Client, owner_ids: dict[str, int]
+) -> None:
     payload = {
         "current_age": 35,
         "retirement_age": 65,
@@ -144,7 +148,7 @@ def test_post_simulate_retirement_happy_path(client: httpx.Client) -> None:
             {
                 "enabled": True,
                 "wrapper": "IKE",
-                "owner": PERSONA_MARCIN,
+                "owner_user_id": owner_ids[PERSONA_MARCIN],
                 "balance": 46100.0,
                 "monthly_contribution": 1500.0,
             }

--- a/backend-bb-tests/tests/test_zus.py
+++ b/backend-bb-tests/tests/test_zus.py
@@ -9,16 +9,18 @@ from fixtures.seed import PERSONA_MARCIN
 
 
 @pytest.mark.golden
-def test_get_zus_prefill_matches_golden(client: httpx.Client, update_golden: bool) -> None:
+def test_get_zus_prefill_matches_golden(
+    client: httpx.Client, update_golden: bool, owner_ids: dict[str, int]
+) -> None:
     from _golden import assert_matches_golden
 
-    response = client.get("/api/zus/prefill", params={"owner": PERSONA_MARCIN})
+    response = client.get("/api/zus/prefill", params={"owner_user_id": owner_ids[PERSONA_MARCIN]})
     assert response.status_code == 200, response.text
     assert_matches_golden("zus_prefill_marcin", response.json(), update=update_golden)
 
 
-def test_get_zus_prefill_shape(client: httpx.Client) -> None:
-    response = client.get("/api/zus/prefill", params={"owner": PERSONA_MARCIN})
+def test_get_zus_prefill_shape(client: httpx.Client, owner_ids: dict[str, int]) -> None:
+    response = client.get("/api/zus/prefill", params={"owner_user_id": owner_ids[PERSONA_MARCIN]})
     assert response.status_code == 200, response.text
     body = response.json()
     required = {
@@ -26,18 +28,21 @@ def test_get_zus_prefill_shape(client: httpx.Client) -> None:
         "retirement_age",
         "gender",
         "current_gross_monthly_salary",
+        "owner_user_id",
         "salary_history",
     }
     assert required.issubset(body.keys())
 
 
 @pytest.mark.golden
-def test_post_zus_calculate_matches_golden(client: httpx.Client, update_golden: bool) -> None:
+def test_post_zus_calculate_matches_golden(
+    client: httpx.Client, update_golden: bool, owner_ids: dict[str, int]
+) -> None:
     from _golden import assert_matches_golden
 
     # Deterministic input — no DB reads in calculate, pure computation.
     payload = {
-        "owner": PERSONA_MARCIN,
+        "owner_user_id": owner_ids[PERSONA_MARCIN],
         "birth_date": "1990-06-15",
         "gender": "M",
         "retirement_age": 65,
@@ -56,9 +61,9 @@ def test_post_zus_calculate_matches_golden(client: httpx.Client, update_golden: 
     assert_matches_golden("zus_calculate_marcin", response.json(), update=update_golden)
 
 
-def test_post_zus_calculate_happy_path(client: httpx.Client) -> None:
+def test_post_zus_calculate_happy_path(client: httpx.Client, owner_ids: dict[str, int]) -> None:
     payload = {
-        "owner": PERSONA_MARCIN,
+        "owner_user_id": owner_ids[PERSONA_MARCIN],
         "birth_date": "1990-06-15",
         "gender": "M",
         "retirement_age": 65,
@@ -82,10 +87,12 @@ def test_post_zus_calculate_happy_path(client: httpx.Client) -> None:
     assert required.issubset(body.keys())
 
 
-def test_post_zus_calculate_validation_error(client: httpx.Client) -> None:
+def test_post_zus_calculate_validation_error(
+    client: httpx.Client, owner_ids: dict[str, int]
+) -> None:
     # Invalid gender → validator raises
     payload = {
-        "owner": PERSONA_MARCIN,
+        "owner_user_id": owner_ids[PERSONA_MARCIN],
         "birth_date": "1990-06-15",
         "gender": "X",
         "retirement_age": 65,

--- a/backend-go/internal/aggregates/spec.go
+++ b/backend-go/internal/aggregates/spec.go
@@ -11,11 +11,12 @@ import (
 )
 
 // AccountInput is the subset of Account columns the spec consumes.
+// OwnerUserID is the owning household member; nil means jointly owned.
 type AccountInput struct {
-	ID       int
-	Owner    string
-	Type     string
-	Category string
+	ID          int
+	OwnerUserID *int
+	Type        string
+	Category    string
 }
 
 // SnapshotValueInput is one row from snapshot_values.
@@ -37,15 +38,38 @@ type AllocationEntry struct {
 	Value    decimal.Decimal
 }
 
-// AggregateRow is one precomputed row per (snapshot_id, owner).
+// AggregateRow is one precomputed row per (snapshot_id, owner_user_id).
+// OwnerUserID is nil for the jointly-owned ("Shared") bucket.
 type AggregateRow struct {
 	SnapshotID       int
 	Month            time.Time
-	Owner            string
+	OwnerUserID      *int
 	TotalAssets      decimal.Decimal
 	TotalLiabilities decimal.Decimal
 	NetWorth         decimal.Decimal
 	Allocation       []AllocationEntry
+}
+
+// ownerKey is a comparable map key for owner buckets. A nil owner_user_id
+// (jointly owned / asset-table rows) maps to {shared: true}.
+type ownerKey struct {
+	id     int
+	shared bool
+}
+
+func keyFor(ownerUserID *int) ownerKey {
+	if ownerUserID == nil {
+		return ownerKey{shared: true}
+	}
+	return ownerKey{id: *ownerUserID}
+}
+
+func (k ownerKey) ownerUserID() *int {
+	if k.shared {
+		return nil
+	}
+	id := k.id
+	return &id
 }
 
 // ComputeAggregates is the pure-math port of aggregate_spec.compute_aggregates.
@@ -66,13 +90,13 @@ func ComputeAggregates(
 		liabilities decimal.Decimal
 		alloc       map[string]decimal.Decimal
 	}
-	totals := map[string]*bucket{}
-	getBucket := func(owner string) *bucket {
-		if b, ok := totals[owner]; ok {
+	totals := map[ownerKey]*bucket{}
+	getBucket := func(k ownerKey) *bucket {
+		if b, ok := totals[k]; ok {
 			return b
 		}
 		b := &bucket{alloc: map[string]decimal.Decimal{}}
-		totals[owner] = b
+		totals[k] = b
 		return b
 	}
 
@@ -81,7 +105,7 @@ func ComputeAggregates(
 		switch {
 		case sv.AssetID != nil:
 			if _, active := activeAssetIDs[*sv.AssetID]; active {
-				b := getBucket("Shared")
+				b := getBucket(ownerKey{shared: true})
 				b.assets = b.assets.Add(v)
 			}
 		case sv.AccountID != nil:
@@ -89,7 +113,7 @@ func ComputeAggregates(
 			if !ok {
 				continue
 			}
-			b := getBucket(acc.Owner)
+			b := getBucket(keyFor(acc.OwnerUserID))
 			if acc.Type == "asset" {
 				b.assets = b.assets.Add(v)
 				b.alloc[acc.Category] = b.alloc[acc.Category].Add(v)
@@ -102,21 +126,27 @@ func ComputeAggregates(
 	month := firstOfMonth(snap.Date)
 	if len(totals) == 0 {
 		return []AggregateRow{{
-			SnapshotID: snap.ID,
-			Month:      month,
-			Owner:      "Shared",
-			Allocation: []AllocationEntry{},
+			SnapshotID:  snap.ID,
+			Month:       month,
+			OwnerUserID: nil,
+			Allocation:  []AllocationEntry{},
 		}}
 	}
 
-	owners := make([]string, 0, len(totals))
-	for o := range totals {
-		owners = append(owners, o)
+	keys := make([]ownerKey, 0, len(totals))
+	for k := range totals {
+		keys = append(keys, k)
 	}
-	sort.Strings(owners)
-	out := make([]AggregateRow, 0, len(owners))
-	for _, owner := range owners {
-		b, ok := totals[owner]
+	// Deterministic order: the jointly-owned (Shared) bucket first, then by id.
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].shared != keys[j].shared {
+			return keys[i].shared
+		}
+		return keys[i].id < keys[j].id
+	})
+	out := make([]AggregateRow, 0, len(keys))
+	for _, k := range keys {
+		b, ok := totals[k]
 		if !ok || b == nil {
 			continue
 		}
@@ -132,7 +162,7 @@ func ComputeAggregates(
 		out = append(out, AggregateRow{
 			SnapshotID:       snap.ID,
 			Month:            month,
-			Owner:            owner,
+			OwnerUserID:      k.ownerUserID(),
 			TotalAssets:      b.assets,
 			TotalLiabilities: b.liabilities,
 			NetWorth:         b.assets.Sub(b.liabilities),

--- a/backend-go/internal/aggregates/store.go
+++ b/backend-go/internal/aggregates/store.go
@@ -80,12 +80,17 @@ func (s *Store) RecomputeForSnapshot(ctx context.Context, tx pgx.Tx, snapshotID 
 		if err != nil {
 			return fmt.Errorf("encode allocation_json: %w", err)
 		}
+		// owner is dual-written from owner_user_id ($3) until the legacy
+		// column is dropped in a later phase.
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO snapshot_aggregates (
-				snapshot_id, month, owner, total_assets, total_liabilities,
-				net_worth, allocation_json, computed_at
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-			r.SnapshotID, r.Month, r.Owner,
+				snapshot_id, month, owner, owner_user_id, total_assets,
+				total_liabilities, net_worth, allocation_json, computed_at
+			) VALUES (
+				$1, $2, COALESCE((SELECT name FROM users WHERE id = $3), 'Shared'),
+				$3, $4, $5, $6, $7, $8
+			)`,
+			r.SnapshotID, r.Month, r.OwnerUserID,
 			r.TotalAssets, r.TotalLiabilities, r.NetWorth, allocJSON, now,
 		); err != nil {
 			return fmt.Errorf("insert snapshot_aggregates: %w", err)
@@ -200,7 +205,7 @@ func loadActiveAccounts(ctx context.Context, tx pgx.Tx, ids []int) ([]AccountInp
 		return []AccountInput{}, nil
 	}
 	rows, err := tx.Query(ctx, `
-		SELECT id, owner, type, category
+		SELECT id, owner_user_id, type, category
 		FROM accounts WHERE id = ANY($1) AND is_active = true`,
 		ids,
 	)
@@ -211,7 +216,7 @@ func loadActiveAccounts(ctx context.Context, tx pgx.Tx, ids []int) ([]AccountInp
 	out := []AccountInput{}
 	for rows.Next() {
 		var a AccountInput
-		if err := rows.Scan(&a.ID, &a.Owner, &a.Type, &a.Category); err != nil {
+		if err := rows.Scan(&a.ID, &a.OwnerUserID, &a.Type, &a.Category); err != nil {
 			return nil, fmt.Errorf("scan account: %w", err)
 		}
 		out = append(out, a)

--- a/backend-go/internal/dashboard/compute.go
+++ b/backend-go/internal/dashboard/compute.go
@@ -22,11 +22,11 @@ type mergedRow struct {
 	Value      float64
 
 	// account columns (nil when account_id is nil or account inactive)
-	AccType  *string
-	Category *string
-	Owner    *string
-	Wrapper  *string
-	Purpose  *string
+	AccType     *string
+	Category    *string
+	OwnerUserID *int
+	Wrapper     *string
+	Purpose     *string
 }
 
 // signedValue mirrors the pandas vectorized sign rule:
@@ -80,11 +80,10 @@ func buildMergedRows(
 			if acc, ok := accounts[*v.AccountID]; ok {
 				t := acc.Type
 				c := acc.Category
-				o := acc.Owner
 				p := acc.Purpose
 				row.AccType = &t
 				row.Category = &c
-				row.Owner = &o
+				row.OwnerUserID = acc.OwnerUserID
 				row.Purpose = &p
 				row.Wrapper = acc.AccountWrapper
 			}

--- a/backend-go/internal/dashboard/dashboard.go
+++ b/backend-go/internal/dashboard/dashboard.go
@@ -14,9 +14,9 @@ type netWorthPoint struct {
 
 // allocationItem mirrors AllocationItem.
 type allocationItem struct {
-	Category string
-	Owner    *string
-	Value    float64
+	Category    string
+	OwnerUserID *int
+	Value       float64
 }
 
 // metricCards mirrors MetricCards. The four ratio fields are nil-able.
@@ -189,19 +189,20 @@ func latestSnapshotByDate(rows []mergedRow) (int, time.Time, bool) {
 	return bestID, bestDate, found
 }
 
-// sortAllocation orders allocation items by (category, owner).
+// sortAllocation orders allocation items by (category, owner_user_id).
+// A nil owner_user_id (jointly owned) sorts before any concrete id.
 func sortAllocation(items []allocationItem) {
 	sort.Slice(items, func(i, j int) bool {
 		if items[i].Category != items[j].Category {
 			return items[i].Category < items[j].Category
 		}
-		oi, oj := "", ""
-		if items[i].Owner != nil {
-			oi = *items[i].Owner
+		oi, oj := items[i].OwnerUserID, items[j].OwnerUserID
+		if (oi == nil) != (oj == nil) {
+			return oi == nil
 		}
-		if items[j].Owner != nil {
-			oj = *items[j].Owner
+		if oi == nil {
+			return false
 		}
-		return oi < oj
+		return *oi < *oj
 	})
 }

--- a/backend-go/internal/dashboard/handler.go
+++ b/backend-go/internal/dashboard/handler.go
@@ -64,9 +64,9 @@ type netWorthPointWire struct {
 }
 
 type allocationItemWire struct {
-	Category string  `json:"category"`
-	Owner    *string `json:"owner"`
-	Value    pyFloat `json:"value"`
+	Category    string  `json:"category"`
+	OwnerUserID *int    `json:"owner_user_id"`
+	Value       pyFloat `json:"value"`
 }
 
 type deltaValueWire struct {
@@ -182,7 +182,7 @@ func toWire(res result) dashboardWire {
 	w.Allocation = make([]allocationItemWire, 0, len(res.Allocation))
 	for _, a := range res.Allocation {
 		w.Allocation = append(w.Allocation, allocationItemWire{
-			Category: a.Category, Owner: a.Owner, Value: pyFloat(a.Value),
+			Category: a.Category, OwnerUserID: a.OwnerUserID, Value: pyFloat(a.Value),
 		})
 	}
 	w.InvestmentTimeSeries = seriesToWire(res.InvestmentTimeSeries)

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -73,11 +73,9 @@ func computeFromAggregates(ctx context.Context, s *Store, aggRows []AggregateRow
 		tl, _ := r.TotalLiabilities.Float64()
 		res.TotalAssets += ta
 		res.TotalLiabilities += tl
-		owner := r.Owner
 		for _, item := range r.Allocation {
-			o := owner
 			res.Allocation = append(res.Allocation, allocationItem{
-				Category: item.Category, Owner: &o, Value: item.Value,
+				Category: item.Category, OwnerUserID: r.OwnerUserID, Value: item.Value,
 			})
 		}
 	}
@@ -210,21 +208,37 @@ func rawTotals(latestRows []mergedRow) (float64, float64) {
 }
 
 func rawAllocation(latestRows []mergedRow) []allocationItem {
-	type key struct{ cat, owner string }
+	// owner is *int — pack it into a comparable key. shared==true marks a
+	// nil owner_user_id (jointly owned).
+	type key struct {
+		cat    string
+		owner  int
+		shared bool
+	}
 	sums := map[key]float64{}
 	for _, r := range latestRows {
 		if r.AccountID == nil || r.AccType == nil || *r.AccType != "asset" {
 			continue
 		}
-		if r.Category == nil || r.Owner == nil {
+		if r.Category == nil {
 			continue
 		}
-		sums[key{*r.Category, *r.Owner}] += r.Value
+		k := key{cat: *r.Category}
+		if r.OwnerUserID == nil {
+			k.shared = true
+		} else {
+			k.owner = *r.OwnerUserID
+		}
+		sums[k] += r.Value
 	}
 	out := make([]allocationItem, 0, len(sums))
 	for k, v := range sums {
-		o := k.owner
-		out = append(out, allocationItem{Category: k.cat, Owner: &o, Value: v})
+		item := allocationItem{Category: k.cat, Value: v}
+		if !k.shared {
+			id := k.owner
+			item.OwnerUserID = &id
+		}
+		out = append(out, item)
 	}
 	sortAllocation(out)
 	return out
@@ -320,7 +334,7 @@ func buildMetricCards(
 	realEstateIDs := map[int]struct{}{}
 	totalPropertySQM := 0.0
 	for _, a := range shared.accountList {
-		if a.Category == "real_estate" && (a.Owner == "Marcin" || a.Owner == "Shared") {
+		if a.Category == "real_estate" {
 			realEstateIDs[a.ID] = struct{}{}
 			if a.SquareMeters != nil {
 				sqm, _ := a.SquareMeters.Float64()

--- a/backend-go/internal/dashboard/store.go
+++ b/backend-go/internal/dashboard/store.go
@@ -20,11 +20,12 @@ type Store struct{ pool *pgxpool.Pool }
 // NewStore wraps a pool.
 func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
 
-// AggregateRow mirrors a snapshot_aggregates row.
+// AggregateRow mirrors a snapshot_aggregates row. OwnerUserID is nil for
+// the jointly-owned ("Shared") bucket.
 type AggregateRow struct {
 	SnapshotID       int
 	Month            time.Time
-	Owner            string
+	OwnerUserID      *int
 	TotalAssets      decimal.Decimal
 	TotalLiabilities decimal.Decimal
 	NetWorth         decimal.Decimal
@@ -38,12 +39,13 @@ type AllocationJSONItem struct {
 }
 
 // Account mirrors the columns the dashboard reads from accounts.
+// OwnerUserID is nil for jointly-owned accounts.
 type Account struct {
 	ID             int
 	Name           string
 	Type           string
 	Category       string
-	Owner          string
+	OwnerUserID    *int
 	AccountWrapper *string
 	Purpose        string
 	SquareMeters   *decimal.Decimal
@@ -83,7 +85,7 @@ type SnapshotMeta struct {
 // LoadAggregateRows returns every snapshot_aggregates row.
 func (s *Store) LoadAggregateRows(ctx context.Context) ([]AggregateRow, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT snapshot_id, month, owner, total_assets, total_liabilities,
+		SELECT snapshot_id, month, owner_user_id, total_assets, total_liabilities,
 		       net_worth, allocation_json
 		FROM snapshot_aggregates`,
 	)
@@ -96,7 +98,7 @@ func (s *Store) LoadAggregateRows(ctx context.Context) ([]AggregateRow, error) {
 		var r AggregateRow
 		var allocJSON []byte
 		if err := rows.Scan(
-			&r.SnapshotID, &r.Month, &r.Owner,
+			&r.SnapshotID, &r.Month, &r.OwnerUserID,
 			&r.TotalAssets, &r.TotalLiabilities, &r.NetWorth, &allocJSON,
 		); err != nil {
 			return nil, fmt.Errorf("scan aggregate: %w", err)
@@ -163,7 +165,7 @@ func (s *Store) AllSnapshots(ctx context.Context) ([]SnapshotMeta, error) {
 // ActiveAccounts returns every active account.
 func (s *Store) ActiveAccounts(ctx context.Context) ([]Account, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, name, type, category, owner, account_wrapper, purpose, square_meters
+		SELECT id, name, type, category, owner_user_id, account_wrapper, purpose, square_meters
 		FROM accounts WHERE is_active = true`,
 	)
 	if err != nil {
@@ -174,7 +176,7 @@ func (s *Store) ActiveAccounts(ctx context.Context) ([]Account, error) {
 	for rows.Next() {
 		var a Account
 		if err := rows.Scan(
-			&a.ID, &a.Name, &a.Type, &a.Category, &a.Owner,
+			&a.ID, &a.Name, &a.Type, &a.Category, &a.OwnerUserID,
 			&a.AccountWrapper, &a.Purpose, &a.SquareMeters,
 		); err != nil {
 			return nil, fmt.Errorf("scan account: %w", err)

--- a/backend-go/internal/retirement/handler.go
+++ b/backend-go/internal/retirement/handler.go
@@ -21,7 +21,7 @@ import (
 type yearlyStat struct {
 	Year                int      `json:"year"`
 	AccountWrapper      string   `json:"account_wrapper"`
-	Owner               string   `json:"owner"`
+	OwnerUserID         *int     `json:"owner_user_id"`
 	LimitAmount         *pyFloat `json:"limit_amount"`
 	TotalContributed    pyFloat  `json:"total_contributed"`
 	EmployeeContributed pyFloat  `json:"employee_contributed"`
@@ -32,7 +32,7 @@ type yearlyStat struct {
 }
 
 type ppkStat struct {
-	Owner                 string  `json:"owner"`
+	OwnerUserID           *int    `json:"owner_user_id"`
 	TotalValue            pyFloat `json:"total_value"`
 	EmployeeContributed   pyFloat `json:"employee_contributed"`
 	EmployerContributed   pyFloat `json:"employer_contributed"`
@@ -46,13 +46,13 @@ type limitResponse struct {
 	ID             int     `json:"id"`
 	Year           int     `json:"year"`
 	AccountWrapper string  `json:"account_wrapper"`
-	Owner          string  `json:"owner"`
+	OwnerUserID    *int    `json:"owner_user_id"`
 	LimitAmount    pyFloat `json:"limit_amount"`
 	Notes          *string `json:"notes"`
 }
 
 type ppkGenerateResponse struct {
-	Owner               string  `json:"owner"`
+	OwnerUserID         *int    `json:"owner_user_id"`
 	Month               int     `json:"month"`
 	Year                int     `json:"year"`
 	GrossSalary         pyFloat `json:"gross_salary"`
@@ -88,8 +88,13 @@ func (h *Handler) Stats(w http.ResponseWriter, r *http.Request) {
 		}
 		year = n
 	}
-	owners, err := h.resolveOwners(r.Context(), r.URL.Query().Get("owner"))
+	owners, err := h.resolveOwners(r.Context(), r.URL.Query().Get("owner_user_id"))
 	if err != nil {
+		if errors.Is(err, errBadOwnerParam) {
+			writeValidationError(w, "owner_user_id", "must be an integer",
+				r.URL.Query().Get("owner_user_id"))
+			return
+		}
 		h.logger.Error("resolve owners", "err", err)
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
@@ -111,8 +116,8 @@ func (h *Handler) Stats(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
-func (h *Handler) buildYearlyStat(ctx context.Context, year int, wrapper, owner string) (yearlyStat, bool, error) {
-	accountIDs, err := h.store.AccountIDsForWrapper(ctx, wrapper, owner)
+func (h *Handler) buildYearlyStat(ctx context.Context, year int, wrapper string, ownerUserID *int) (yearlyStat, bool, error) {
+	accountIDs, err := h.store.AccountIDsForWrapper(ctx, wrapper, ownerUserID)
 	if err != nil {
 		return yearlyStat{}, false, err
 	}
@@ -123,7 +128,7 @@ func (h *Handler) buildYearlyStat(ctx context.Context, year int, wrapper, owner 
 	if err != nil {
 		return yearlyStat{}, false, err
 	}
-	limit, configured, err := h.store.LimitConfigured(ctx, year, wrapper, owner)
+	limit, configured, err := h.store.LimitConfigured(ctx, year, wrapper, ownerUserID)
 	if err != nil {
 		return yearlyStat{}, false, err
 	}
@@ -149,7 +154,7 @@ func (h *Handler) buildYearlyStat(ctx context.Context, year int, wrapper, owner 
 	rem := pyFloat(remaining)
 	pct := pyFloat(math.Round(percentage*10) / 10)
 	return yearlyStat{
-		Year: year, AccountWrapper: wrapper, Owner: owner,
+		Year: year, AccountWrapper: wrapper, OwnerUserID: ownerUserID,
 		LimitAmount:         &lAmt,
 		TotalContributed:    pyFloat(totalF),
 		EmployeeContributed: pyFloat(employeeF),
@@ -165,8 +170,13 @@ func (h *Handler) buildYearlyStat(ctx context.Context, year int, wrapper, owner 
 
 // PPKStats serves GET /api/retirement/ppk-stats.
 func (h *Handler) PPKStats(w http.ResponseWriter, r *http.Request) {
-	owners, err := h.resolveOwners(r.Context(), r.URL.Query().Get("owner"))
+	owners, err := h.resolveOwners(r.Context(), r.URL.Query().Get("owner_user_id"))
 	if err != nil {
+		if errors.Is(err, errBadOwnerParam) {
+			writeValidationError(w, "owner_user_id", "must be an integer",
+				r.URL.Query().Get("owner_user_id"))
+			return
+		}
 		h.logger.Error("resolve owners", "err", err)
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
@@ -186,8 +196,8 @@ func (h *Handler) PPKStats(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
-func (h *Handler) buildPPKStat(ctx context.Context, owner string) (ppkStat, bool, error) {
-	accountIDs, err := h.store.AccountIDsForWrapper(ctx, "PPK", owner)
+func (h *Handler) buildPPKStat(ctx context.Context, ownerUserID *int) (ppkStat, bool, error) {
+	accountIDs, err := h.store.AccountIDsForWrapper(ctx, "PPK", ownerUserID)
 	if err != nil {
 		return ppkStat{}, false, err
 	}
@@ -217,7 +227,7 @@ func (h *Handler) buildPPKStat(ctx context.Context, owner string) (ppkStat, bool
 	}
 	roiRounded := math.Round(roi*100) / 100
 	return ppkStat{
-		Owner:                 owner,
+		OwnerUserID:           ownerUserID,
 		TotalValue:            pyFloat(totalValue),
 		EmployeeContributed:   pyFloat(employeeF),
 		EmployerContributed:   pyFloat(employerF),
@@ -246,13 +256,13 @@ func (h *Handler) LimitsForYear(w http.ResponseWriter, r *http.Request) {
 		amt, _ := l.LimitAmount.Float64()
 		out = append(out, limitResponse{
 			ID: l.ID, Year: l.Year, AccountWrapper: l.AccountWrapper,
-			Owner: l.Owner, LimitAmount: pyFloat(amt), Notes: l.Notes,
+			OwnerUserID: l.OwnerUserID, LimitAmount: pyFloat(amt), Notes: l.Notes,
 		})
 	}
 	writeJSON(w, http.StatusOK, out)
 }
 
-// UpsertLimit serves PUT /api/retirement/limits/{year}/{wrapper}/{owner}.
+// UpsertLimit serves PUT /api/retirement/limits/{year}/{wrapper}/{owner_user_id}.
 func (h *Handler) UpsertLimit(w http.ResponseWriter, r *http.Request) {
 	year, err := strconv.Atoi(chi.URLParam(r, "year"))
 	if err != nil {
@@ -260,7 +270,17 @@ func (h *Handler) UpsertLimit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	wrapper := chi.URLParam(r, "wrapper")
-	owner := chi.URLParam(r, "owner")
+	ownerParam := chi.URLParam(r, "owner_user_id")
+	// The literal "null" addresses the jointly-owned (Shared) limit row.
+	var ownerUserID *int
+	if ownerParam != "null" {
+		n, err := strconv.Atoi(ownerParam)
+		if err != nil {
+			writeValidationError(w, "owner_user_id", "must be an integer", ownerParam)
+			return
+		}
+		ownerUserID = &n
+	}
 	raw := map[string]json.RawMessage{}
 	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
 		writeValidationError(w, "body", "Invalid JSON body", err.Error())
@@ -271,7 +291,7 @@ func (h *Handler) UpsertLimit(w http.ResponseWriter, r *http.Request) {
 		writePydanticError(w, vErr)
 		return
 	}
-	l, err := h.store.UpsertLimit(r.Context(), year, wrapper, owner, req.LimitAmount, req.Notes)
+	l, err := h.store.UpsertLimit(r.Context(), year, wrapper, ownerUserID, req.LimitAmount, req.Notes)
 	if err != nil {
 		h.logger.Error("upsert limit", "err", err)
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
@@ -280,7 +300,7 @@ func (h *Handler) UpsertLimit(w http.ResponseWriter, r *http.Request) {
 	amt, _ := l.LimitAmount.Float64()
 	writeJSON(w, http.StatusOK, limitResponse{
 		ID: l.ID, Year: l.Year, AccountWrapper: l.AccountWrapper,
-		Owner: l.Owner, LimitAmount: pyFloat(amt), Notes: l.Notes,
+		OwnerUserID: l.OwnerUserID, LimitAmount: pyFloat(amt), Notes: l.Notes,
 	})
 }
 
@@ -297,22 +317,23 @@ func (h *Handler) GeneratePPKContributions(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	firstDay := time.Date(req.Year, time.Month(req.Month), 1, 0, 0, 0, 0, time.UTC)
-	gross, err := h.store.CurrentSalaryFor(r.Context(), req.Owner, firstDay)
+	gross, err := h.store.CurrentSalaryFor(r.Context(), req.OwnerUserID, firstDay)
 	if err != nil {
 		if errors.Is(err, ErrNoSalary) {
 			writeDetailError(w, http.StatusBadRequest,
-				fmt.Sprintf("No salary record found for %s in %d/%d", req.Owner, req.Month, req.Year))
+				fmt.Sprintf("No salary record found for user %s in %d/%d",
+					ownerLabel(req.OwnerUserID), req.Month, req.Year))
 			return
 		}
 		h.logger.Error("ppk salary", "err", err)
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	employeeRate, employerRate, err := h.store.PersonaPPKRates(r.Context(), req.Owner)
+	employeeRate, employerRate, err := h.store.UserPPKRates(r.Context(), req.OwnerUserID)
 	if err != nil {
-		if errors.Is(err, ErrPersonaNotFound) {
+		if errors.Is(err, ErrUserNotFound) {
 			writeDetailError(w, http.StatusNotFound,
-				fmt.Sprintf("Persona '%s' not found", req.Owner))
+				fmt.Sprintf("User %s not found", ownerLabel(req.OwnerUserID)))
 			return
 		}
 		h.logger.Error("ppk rates", "err", err)
@@ -322,12 +343,13 @@ func (h *Handler) GeneratePPKContributions(w http.ResponseWriter, r *http.Reques
 	hundred := decimal.NewFromInt(100)
 	employeeAmt := gross.Mul(employeeRate).Div(hundred)
 	employerAmt := gross.Mul(employerRate).Div(hundred)
-	accountID, err := h.store.ActivePPKAccountForOwner(r.Context(), req.Owner)
+	accountID, err := h.store.ActivePPKAccountForOwner(r.Context(), req.OwnerUserID)
 	if err != nil {
 		if errors.Is(err, ErrNoPPKAccount) {
 			writeDetailError(w, http.StatusNotFound,
-				fmt.Sprintf("No active PPK account found for %s. "+
-					"Mark one PPK account as receiving contributions.", req.Owner))
+				fmt.Sprintf("No active PPK account found for user %s. "+
+					"Mark one PPK account as receiving contributions.",
+					ownerLabel(req.OwnerUserID)))
 			return
 		}
 		h.logger.Error("ppk account", "err", err)
@@ -337,7 +359,7 @@ func (h *Handler) GeneratePPKContributions(w http.ResponseWriter, r *http.Reques
 	lastDay := time.Date(req.Year, time.Month(req.Month)+1, 0, 0, 0, 0, 0, time.UTC)
 	ids, err := h.store.InsertPPKContributions(r.Context(), PPKContribution{
 		AccountID: accountID, EmployeeAmt: employeeAmt, EmployerAmt: employerAmt,
-		Date: lastDay, Owner: req.Owner,
+		Date: lastDay, OwnerUserID: req.OwnerUserID,
 	})
 	if err != nil {
 		if errors.Is(err, ErrContributionsExist) {
@@ -353,7 +375,7 @@ func (h *Handler) GeneratePPKContributions(w http.ResponseWriter, r *http.Reques
 	empF, _ := employeeAmt.Float64()
 	emprF, _ := employerAmt.Float64()
 	writeJSON(w, http.StatusOK, ppkGenerateResponse{
-		Owner: req.Owner, Month: req.Month, Year: req.Year,
+		OwnerUserID: req.OwnerUserID, Month: req.Month, Year: req.Year,
 		GrossSalary:         pyFloat(grossF),
 		EmployeeAmount:      pyFloat(empF),
 		EmployerAmount:      pyFloat(emprF),
@@ -362,11 +384,35 @@ func (h *Handler) GeneratePPKContributions(w http.ResponseWriter, r *http.Reques
 	})
 }
 
-func (h *Handler) resolveOwners(ctx context.Context, queryOwner string) ([]string, error) {
+// errBadOwnerParam marks a non-integer owner_user_id query value.
+var errBadOwnerParam = errors.New("owner_user_id must be an integer")
+
+func (h *Handler) resolveOwners(ctx context.Context, queryOwner string) ([]*int, error) {
 	if queryOwner != "" {
-		return []string{queryOwner}, nil
+		n, err := strconv.Atoi(queryOwner)
+		if err != nil {
+			return nil, errBadOwnerParam
+		}
+		return []*int{&n}, nil
 	}
-	return h.store.PersonaNames(ctx)
+	ids, err := h.store.UserIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*int, 0, len(ids))
+	for i := range ids {
+		id := ids[i]
+		out = append(out, &id)
+	}
+	return out, nil
+}
+
+// ownerLabel renders an owner_user_id for error messages.
+func ownerLabel(id *int) string {
+	if id == nil {
+		return "Shared"
+	}
+	return strconv.Itoa(*id)
 }
 
 // --- request parsing ---
@@ -374,7 +420,7 @@ func (h *Handler) resolveOwners(ctx context.Context, queryOwner string) ([]strin
 type limitRequest struct {
 	Year           int
 	AccountWrapper string
-	Owner          string
+	OwnerUserID    *int
 	LimitAmount    decimal.Decimal
 	Notes          *string
 }
@@ -399,11 +445,11 @@ func buildLimitRequest(raw map[string]json.RawMessage, now func() time.Time) (li
 	}
 	r.AccountWrapper = wrap
 
-	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
+	owner, vErr := requireIntOrNull(raw, "owner_user_id")
 	if vErr != nil {
 		return r, vErr
 	}
-	r.Owner = owner
+	r.OwnerUserID = owner
 
 	amt, vErr := requirePositiveDecimal(raw, "limit_amount", "Limit amount must be greater than 0")
 	if vErr != nil {
@@ -422,18 +468,18 @@ func buildLimitRequest(raw map[string]json.RawMessage, now func() time.Time) (li
 }
 
 type generateRequest struct {
-	Owner string
-	Month int
-	Year  int
+	OwnerUserID *int
+	Month       int
+	Year        int
 }
 
 func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) (generateRequest, *validationError) {
 	var r generateRequest
-	owner, vErr := requireString(raw, "owner", "Owner cannot be empty")
+	owner, vErr := requireIntOrNull(raw, "owner_user_id")
 	if vErr != nil {
 		return r, vErr
 	}
-	r.Owner = owner
+	r.OwnerUserID = owner
 
 	month, vErr := requireIntRange(raw, "month", 1, 12, "Month must be between 1 and 12")
 	if vErr != nil {
@@ -453,20 +499,21 @@ func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) 
 
 // --- helpers ---
 
-func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *validationError) {
+// requireIntOrNull reads an integer key that must be present; an explicit
+// null is allowed and yields nil (jointly owned).
+func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *validationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
-		return "", &validationError{Field: key, Msg: "Field required"}
+	if !ok {
+		return nil, &validationError{Field: key, Msg: "Field required"}
 	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &validationError{Field: key, Msg: "must be a string"}
+	if isNull(v) {
+		return nil, nil
 	}
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return "", &validationError{Field: key, Msg: emptyMsg}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return nil, &validationError{Field: key, Msg: "must be an integer"}
 	}
-	return s, nil
+	return &n, nil
 }
 
 func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *validationError) {

--- a/backend-go/internal/retirement/handler.go
+++ b/backend-go/internal/retirement/handler.go
@@ -475,11 +475,14 @@ type generateRequest struct {
 
 func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) (generateRequest, *validationError) {
 	var r generateRequest
-	owner, vErr := requireIntOrNull(raw, "owner_user_id")
+	// PPK contributions are always generated for a specific person — a null
+	// (jointly owned) owner is rejected up front rather than failing later
+	// with a confusing 404.
+	owner, vErr := requireInt(raw, "owner_user_id")
 	if vErr != nil {
 		return r, vErr
 	}
-	r.OwnerUserID = owner
+	r.OwnerUserID = &owner
 
 	month, vErr := requireIntRange(raw, "month", 1, 12, "Month must be between 1 and 12")
 	if vErr != nil {
@@ -498,6 +501,19 @@ func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) 
 }
 
 // --- helpers ---
+
+// requireInt reads an integer key that must be present and non-null.
+func requireInt(raw map[string]json.RawMessage, key string) (int, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return 0, &validationError{Field: key, Msg: "Field required"}
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return 0, &validationError{Field: key, Msg: "must be an integer"}
+	}
+	return n, nil
+}
 
 // requireIntOrNull reads an integer key that must be present; an explicit
 // null is allowed and yields nil (jointly owned).

--- a/backend-go/internal/retirement/openapi.go
+++ b/backend-go/internal/retirement/openapi.go
@@ -8,5 +8,5 @@ var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/retirement/ppk-stats", Tag: "retirement", Summary: "PPK stats per owner", Response: []ppkStat{}},
 	{Method: "POST", Path: "/api/retirement/ppk-contributions/generate", Tag: "retirement", Summary: "Generate monthly PPK contributions", Response: ppkGenerateResponse{}},
 	{Method: "GET", Path: "/api/retirement/limits/{year}", Tag: "retirement", Summary: "Contribution limits for a year", Response: []limitResponse{}},
-	{Method: "PUT", Path: "/api/retirement/limits/{year}/{wrapper}/{owner}", Tag: "retirement", Summary: "Upsert a contribution limit", Response: limitResponse{}},
+	{Method: "PUT", Path: "/api/retirement/limits/{year}/{wrapper}/{owner_user_id}", Tag: "retirement", Summary: "Upsert a contribution limit", Response: limitResponse{}},
 }

--- a/backend-go/internal/retirement/store.go
+++ b/backend-go/internal/retirement/store.go
@@ -19,22 +19,23 @@ import (
 // Sentinel errors.
 var (
 	ErrNoSalary           = errors.New("no salary record for owner")
-	ErrPersonaNotFound    = errors.New("persona not found")
+	ErrUserNotFound       = errors.New("user not found")
 	ErrNoPPKAccount       = errors.New("no active PPK account for owner")
 	ErrContributionsExist = errors.New("contributions already exist for month")
 )
 
 // errNoLimit is the internal sentinel for "no retirement_limit row matches
-// (year, wrapper, owner)" — unexported because callers use the (nil, err)
-// branch directly.
+// (year, wrapper, owner_user_id)" — unexported because callers use the
+// (nil, err) branch directly.
 var errNoLimit = errors.New("no limit configured for wrapper")
 
 // Limit mirrors backend/app/models/retirement_limit.RetirementLimit.
+// OwnerUserID is the owning household member; nil means jointly owned.
 type Limit struct {
 	ID             int
 	Year           int
 	AccountWrapper string
-	Owner          string
+	OwnerUserID    *int
 	LimitAmount    decimal.Decimal
 	Notes          *string
 }
@@ -45,33 +46,38 @@ type Store struct{ pool *pgxpool.Pool }
 // NewStore wraps a pool.
 func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
 
-// PersonaNames returns persona names alphabetically.
-func (s *Store) PersonaNames(ctx context.Context) ([]string, error) {
-	rows, err := s.pool.Query(ctx, `SELECT name FROM personas ORDER BY name`)
+// UserIDs returns every named user id ordered by name — the owner set used
+// when the request omits an owner filter. Unnamed accounts (e.g. admin) are
+// skipped: they hold no IKE/IKZE/PPK accounts.
+func (s *Store) UserIDs(ctx context.Context) ([]int, error) {
+	rows, err := s.pool.Query(ctx, `SELECT id FROM users WHERE name IS NOT NULL ORDER BY name`)
 	if err != nil {
-		return nil, fmt.Errorf("personas: %w", err)
+		return nil, fmt.Errorf("users: %w", err)
 	}
 	defer rows.Close()
-	out := []string{}
+	out := []int{}
 	for rows.Next() {
-		var n string
-		if err := rows.Scan(&n); err != nil {
-			return nil, fmt.Errorf("scan persona: %w", err)
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan user id: %w", err)
 		}
-		out = append(out, n)
+		out = append(out, id)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate personas: %w", err)
+		return nil, fmt.Errorf("iterate users: %w", err)
 	}
 	return out, nil
 }
 
-// AccountIDsForWrapper returns the active account IDs for one wrapper+owner.
-func (s *Store) AccountIDsForWrapper(ctx context.Context, wrapper, owner string) ([]int, error) {
+// AccountIDsForWrapper returns the active account IDs for one
+// wrapper + owner_user_id.
+func (s *Store) AccountIDsForWrapper(ctx context.Context, wrapper string, ownerUserID *int) ([]int, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT id FROM accounts
-		WHERE account_wrapper = $1 AND owner = $2 AND is_active = true`,
-		wrapper, owner,
+		WHERE account_wrapper = $1
+		  AND owner_user_id IS NOT DISTINCT FROM $2
+		  AND is_active = true`,
+		wrapper, ownerUserID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("account ids: %w", err)
@@ -183,7 +189,7 @@ func (s *Store) LatestSnapshotValueSum(ctx context.Context, accountIDs []int) (d
 // LimitsForYear returns all RetirementLimit rows for a year, ordered by id.
 func (s *Store) LimitsForYear(ctx context.Context, year int) ([]Limit, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, year, account_wrapper, owner, limit_amount, notes
+		SELECT id, year, account_wrapper, owner_user_id, limit_amount, notes
 		FROM retirement_limits WHERE year = $1
 		ORDER BY id`,
 		year,
@@ -195,7 +201,7 @@ func (s *Store) LimitsForYear(ctx context.Context, year int) ([]Limit, error) {
 	out := []Limit{}
 	for rows.Next() {
 		var l Limit
-		if err := rows.Scan(&l.ID, &l.Year, &l.AccountWrapper, &l.Owner, &l.LimitAmount, &l.Notes); err != nil {
+		if err := rows.Scan(&l.ID, &l.Year, &l.AccountWrapper, &l.OwnerUserID, &l.LimitAmount, &l.Notes); err != nil {
 			return nil, fmt.Errorf("scan limit: %w", err)
 		}
 		out = append(out, l)
@@ -206,17 +212,19 @@ func (s *Store) LimitsForYear(ctx context.Context, year int) ([]Limit, error) {
 	return out, nil
 }
 
-// LimitFor returns the Limit row for (year, wrapper, owner). errNoLimit
-// when the row is absent — callers handle that as "no limit configured".
-func (s *Store) LimitFor(ctx context.Context, year int, wrapper, owner string) (*Limit, error) {
+// LimitFor returns the Limit row for (year, wrapper, owner_user_id).
+// errNoLimit when the row is absent — callers handle that as "no limit
+// configured".
+func (s *Store) LimitFor(ctx context.Context, year int, wrapper string, ownerUserID *int) (*Limit, error) {
 	row := s.pool.QueryRow(ctx, `
-		SELECT id, year, account_wrapper, owner, limit_amount, notes
+		SELECT id, year, account_wrapper, owner_user_id, limit_amount, notes
 		FROM retirement_limits
-		WHERE year = $1 AND account_wrapper = $2 AND owner = $3`,
-		year, wrapper, owner,
+		WHERE year = $1 AND account_wrapper = $2
+		  AND owner_user_id IS NOT DISTINCT FROM $3`,
+		year, wrapper, ownerUserID,
 	)
 	var l Limit
-	if err := row.Scan(&l.ID, &l.Year, &l.AccountWrapper, &l.Owner, &l.LimitAmount, &l.Notes); err != nil {
+	if err := row.Scan(&l.ID, &l.Year, &l.AccountWrapper, &l.OwnerUserID, &l.LimitAmount, &l.Notes); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, errNoLimit
 		}
@@ -227,8 +235,8 @@ func (s *Store) LimitFor(ctx context.Context, year int, wrapper, owner string) (
 
 // LimitConfigured wraps LimitFor with the "no row" branch surfaced via the
 // bool — callers can ignore the sentinel and not worry about a nil deref.
-func (s *Store) LimitConfigured(ctx context.Context, year int, wrapper, owner string) (Limit, bool, error) {
-	l, err := s.LimitFor(ctx, year, wrapper, owner)
+func (s *Store) LimitConfigured(ctx context.Context, year int, wrapper string, ownerUserID *int) (Limit, bool, error) {
+	l, err := s.LimitFor(ctx, year, wrapper, ownerUserID)
 	if err != nil {
 		if errors.Is(err, errNoLimit) {
 			return Limit{}, false, nil
@@ -238,33 +246,39 @@ func (s *Store) LimitConfigured(ctx context.Context, year int, wrapper, owner st
 	return *l, true, nil
 }
 
-// UpsertLimit creates the (year, wrapper, owner) row or updates limit_amount
-// + notes when it exists. Mirrors Python's update_limit fall-through.
-func (s *Store) UpsertLimit(ctx context.Context, year int, wrapper, owner string, amount decimal.Decimal, notes *string) (*Limit, error) {
+// UpsertLimit creates the (year, wrapper, owner_user_id) row or updates
+// limit_amount + notes when it exists. The legacy owner string is
+// dual-written from owner_user_id ($3) until the column is dropped; the
+// uq_year_wrapper_owner constraint still keys on it.
+func (s *Store) UpsertLimit(ctx context.Context, year int, wrapper string, ownerUserID *int, amount decimal.Decimal, notes *string) (*Limit, error) {
 	row := s.pool.QueryRow(ctx, `
-		INSERT INTO retirement_limits (year, account_wrapper, owner, limit_amount, notes)
-		VALUES ($1, $2, $3, $4, $5)
+		INSERT INTO retirement_limits (year, account_wrapper, owner, owner_user_id, limit_amount, notes)
+		VALUES (
+			$1, $2, COALESCE((SELECT name FROM users WHERE id = $3), 'Shared'),
+			$3, $4, $5
+		)
 		ON CONFLICT (year, account_wrapper, owner) DO UPDATE
 		SET limit_amount = EXCLUDED.limit_amount,
+		    owner_user_id = EXCLUDED.owner_user_id,
 		    notes = COALESCE(EXCLUDED.notes, retirement_limits.notes)
-		RETURNING id, year, account_wrapper, owner, limit_amount, notes`,
-		year, wrapper, owner, amount, notes,
+		RETURNING id, year, account_wrapper, owner_user_id, limit_amount, notes`,
+		year, wrapper, ownerUserID, amount, notes,
 	)
 	var l Limit
-	if err := row.Scan(&l.ID, &l.Year, &l.AccountWrapper, &l.Owner, &l.LimitAmount, &l.Notes); err != nil {
+	if err := row.Scan(&l.ID, &l.Year, &l.AccountWrapper, &l.OwnerUserID, &l.LimitAmount, &l.Notes); err != nil {
 		return nil, fmt.Errorf("upsert limit: %w", err)
 	}
 	return &l, nil
 }
 
 // CurrentSalaryFor returns the latest active gross_amount on/before asOfDate
-// for one owner.
-func (s *Store) CurrentSalaryFor(ctx context.Context, owner string, asOfDate time.Time) (decimal.Decimal, error) {
+// for one owner_user_id.
+func (s *Store) CurrentSalaryFor(ctx context.Context, ownerUserID *int, asOfDate time.Time) (decimal.Decimal, error) {
 	row := s.pool.QueryRow(ctx, `
 		SELECT gross_amount FROM salary_records
-		WHERE owner = $1 AND is_active = true AND date <= $2
+		WHERE owner_user_id IS NOT DISTINCT FROM $1 AND is_active = true AND date <= $2
 		ORDER BY date DESC LIMIT 1`,
-		owner, asOfDate,
+		ownerUserID, asOfDate,
 	)
 	var v decimal.Decimal
 	if err := row.Scan(&v); err != nil {
@@ -276,18 +290,22 @@ func (s *Store) CurrentSalaryFor(ctx context.Context, owner string, asOfDate tim
 	return v, nil
 }
 
-// PersonaPPKRates returns (employee_rate, employer_rate) percentages from
-// the personas table or ErrPersonaNotFound.
-func (s *Store) PersonaPPKRates(ctx context.Context, owner string) (decimal.Decimal, decimal.Decimal, error) {
+// UserPPKRates returns (employee_rate, employer_rate) percentages from the
+// users table or ErrUserNotFound. A user with NULL PPK rates yields zero
+// rates (treated as "configured but not contributing").
+func (s *Store) UserPPKRates(ctx context.Context, ownerUserID *int) (decimal.Decimal, decimal.Decimal, error) {
+	if ownerUserID == nil {
+		return decimal.Zero, decimal.Zero, ErrUserNotFound
+	}
 	row := s.pool.QueryRow(ctx, `
-		SELECT ppk_employee_rate, ppk_employer_rate
-		FROM personas WHERE name = $1`,
-		owner,
+		SELECT COALESCE(ppk_employee_rate, 0), COALESCE(ppk_employer_rate, 0)
+		FROM users WHERE id = $1`,
+		*ownerUserID,
 	)
 	var employee, employer decimal.Decimal
 	if err := row.Scan(&employee, &employer); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return decimal.Zero, decimal.Zero, ErrPersonaNotFound
+			return decimal.Zero, decimal.Zero, ErrUserNotFound
 		}
 		return decimal.Zero, decimal.Zero, fmt.Errorf("ppk rates: %w", err)
 	}
@@ -295,13 +313,13 @@ func (s *Store) PersonaPPKRates(ctx context.Context, owner string) (decimal.Deci
 }
 
 // ActivePPKAccountForOwner returns the receiving PPK account or ErrNoPPKAccount.
-func (s *Store) ActivePPKAccountForOwner(ctx context.Context, owner string) (int, error) {
+func (s *Store) ActivePPKAccountForOwner(ctx context.Context, ownerUserID *int) (int, error) {
 	row := s.pool.QueryRow(ctx, `
 		SELECT id FROM accounts
-		WHERE account_wrapper = 'PPK' AND owner = $1
+		WHERE account_wrapper = 'PPK' AND owner_user_id IS NOT DISTINCT FROM $1
 		  AND is_active = true AND receives_contributions = true
 		LIMIT 1`,
-		owner,
+		ownerUserID,
 	)
 	var id int
 	if err := row.Scan(&id); err != nil {
@@ -319,7 +337,7 @@ type PPKContribution struct {
 	EmployeeAmt decimal.Decimal
 	EmployerAmt decimal.Decimal
 	Date        time.Time
-	Owner       string
+	OwnerUserID *int
 }
 
 // InsertPPKContributions writes the employee + employer transactions
@@ -365,11 +383,16 @@ func (s *Store) InsertPPKContributions(ctx context.Context, c PPKContribution) (
 	}
 	now := time.Now().UTC()
 	var empID, emprID int
+	// owner is dual-written from owner_user_id ($4) until the legacy column
+	// is dropped in a later phase.
 	if err := tx.QueryRow(ctx, `
-		INSERT INTO transactions (account_id, amount, date, owner, transaction_type, is_active, created_at)
-		VALUES ($1, $2, $3, $4, 'employee', true, $5)
+		INSERT INTO transactions (account_id, amount, date, owner, owner_user_id, transaction_type, is_active, created_at)
+		VALUES (
+			$1, $2, $3, COALESCE((SELECT name FROM users WHERE id = $4), 'Shared'),
+			$4, 'employee', true, $5
+		)
 		RETURNING id`,
-		c.AccountID, c.EmployeeAmt, c.Date, c.Owner, now,
+		c.AccountID, c.EmployeeAmt, c.Date, c.OwnerUserID, now,
 	).Scan(&empID); err != nil {
 		if isUniqueViolation(err) {
 			return nil, ErrContributionsExist
@@ -377,10 +400,13 @@ func (s *Store) InsertPPKContributions(ctx context.Context, c PPKContribution) (
 		return nil, fmt.Errorf("insert employee txn: %w", err)
 	}
 	if err := tx.QueryRow(ctx, `
-		INSERT INTO transactions (account_id, amount, date, owner, transaction_type, is_active, created_at)
-		VALUES ($1, $2, $3, $4, 'employer', true, $5)
+		INSERT INTO transactions (account_id, amount, date, owner, owner_user_id, transaction_type, is_active, created_at)
+		VALUES (
+			$1, $2, $3, COALESCE((SELECT name FROM users WHERE id = $4), 'Shared'),
+			$4, 'employer', true, $5
+		)
 		RETURNING id`,
-		c.AccountID, c.EmployerAmt, c.Date, c.Owner, now,
+		c.AccountID, c.EmployerAmt, c.Date, c.OwnerUserID, now,
 	).Scan(&emprID); err != nil {
 		if isUniqueViolation(err) {
 			return nil, ErrContributionsExist

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -153,7 +153,7 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	r.Get("/api/retirement/ppk-stats", retHandler.PPKStats)
 	r.Post("/api/retirement/ppk-contributions/generate", retHandler.GeneratePPKContributions)
 	r.Get("/api/retirement/limits/{year}", retHandler.LimitsForYear)
-	r.Put("/api/retirement/limits/{year}/{wrapper}/{owner}", retHandler.UpsertLimit)
+	r.Put("/api/retirement/limits/{year}/{wrapper}/{owner_user_id}", retHandler.UpsertLimit)
 
 	invHandler := investment.NewHandler(investment.NewStore(pool), logger)
 	r.Get("/api/investment/stock-stats", invHandler.StockStats)

--- a/backend-go/internal/simulations/accounts.go
+++ b/backend-go/internal/simulations/accounts.go
@@ -36,10 +36,11 @@ type AccountSimulation struct {
 
 // IkeIkzeParams is the per-account input for simulateAccount. BaseLimit is
 // resolved by the caller via the retirement_limits table (DB read kept out
-// of the pure math).
+// of the pure math). OwnerName is the resolved display label for AccountName.
 type IkeIkzeParams struct {
 	Wrapper             string
-	Owner               string
+	OwnerUserID         *int
+	OwnerName           string
 	StartingBalance     float64
 	AutoFillLimit       bool
 	MonthlyContribution float64
@@ -95,7 +96,7 @@ func SimulateAccount(p IkeIkzeParams, yearsToRetirement, currentAge, currentYear
 	}
 
 	return AccountSimulation{
-		AccountName:        p.Wrapper + " (" + p.Owner + ")",
+		AccountName:        p.Wrapper + " (" + p.OwnerName + ")",
 		StartingBalance:    p.StartingBalance,
 		TotalContributions: cumulativeContributions,
 		TotalReturns:       cumulativeReturns,
@@ -107,7 +108,8 @@ func SimulateAccount(p IkeIkzeParams, yearsToRetirement, currentAge, currentYear
 
 // BrokerageParams is the per-account input for simulateBrokerageAccount.
 type BrokerageParams struct {
-	Owner               string
+	OwnerUserID         *int
+	OwnerName           string
 	StartingBalance     float64
 	MonthlyContribution float64
 }
@@ -144,7 +146,7 @@ func SimulateBrokerageAccount(p BrokerageParams, currentAge, retirementAge, curr
 	}
 
 	return AccountSimulation{
-		AccountName:        "Rachunek maklerski (" + p.Owner + ")",
+		AccountName:        "Rachunek maklerski (" + p.OwnerName + ")",
 		StartingBalance:    p.StartingBalance,
 		TotalContributions: cumulativeContributions,
 		TotalReturns:       cumulativeReturns,
@@ -155,7 +157,8 @@ func SimulateBrokerageAccount(p BrokerageParams, currentAge, retirementAge, curr
 
 // PPKParams is the per-account input for simulatePPKAccount.
 type PPKParams struct {
-	Owner                string
+	OwnerUserID          *int
+	OwnerName            string
 	StartingBalance      float64
 	MonthlyGrossSalary   float64
 	EmployeeRate         float64
@@ -236,7 +239,7 @@ func SimulatePPKAccount(p PPKParams, currentAge, retirementAge int, salaryGrowth
 	}
 
 	return AccountSimulation{
-		AccountName:        "PPK (" + p.Owner + ")",
+		AccountName:        "PPK (" + p.OwnerName + ")",
 		StartingBalance:    p.StartingBalance,
 		TotalContributions: totalContributions,
 		TotalReturns:       balance - totalContributions - totalSubsidies,

--- a/backend-go/internal/simulations/handler.go
+++ b/backend-go/internal/simulations/handler.go
@@ -224,18 +224,24 @@ func (h *Handler) Retirement(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) runSimulation(ctx context.Context, in simulationInputs) ([]AccountSimulation, error) {
 	yearsToRetirement := in.RetirementAge - in.CurrentAge
 	currentYear := h.now().UTC().Year()
+	userNames, err := h.store.UserNames(ctx)
+	if err != nil {
+		return nil, err
+	}
 	sims := []AccountSimulation{}
 
 	for _, acc := range in.IkeIkzeAccounts {
 		if !acc.Enabled {
 			continue
 		}
-		baseLimit, err := h.store.LimitForYear(ctx, currentYear, acc.Wrapper, acc.Owner)
+		baseLimit, err := h.store.LimitForYear(ctx, currentYear, acc.Wrapper, acc.OwnerUserID)
 		if err != nil {
 			return nil, err
 		}
 		sims = append(sims, SimulateAccount(IkeIkzeParams{
-			Wrapper: acc.Wrapper, Owner: acc.Owner,
+			Wrapper:         acc.Wrapper,
+			OwnerUserID:     acc.OwnerUserID,
+			OwnerName:       ownerLabel(userNames, acc.OwnerUserID),
 			StartingBalance: acc.Balance, AutoFillLimit: acc.AutoFillLimit,
 			MonthlyContribution: acc.MonthlyContribution, TaxRate: acc.TaxRate,
 			BaseLimit: baseLimit,
@@ -246,7 +252,9 @@ func (h *Handler) runSimulation(ctx context.Context, in simulationInputs) ([]Acc
 			continue
 		}
 		sims = append(sims, SimulatePPKAccount(PPKParams{
-			Owner: ppk.Owner, StartingBalance: ppk.StartingBalance,
+			OwnerUserID:        ppk.OwnerUserID,
+			OwnerName:          ownerLabel(userNames, ppk.OwnerUserID),
+			StartingBalance:    ppk.StartingBalance,
 			MonthlyGrossSalary: ppk.MonthlyGrossSalary,
 			EmployeeRate:       ppk.EmployeeRate, EmployerRate: ppk.EmployerRate,
 			SalaryBelowThreshold: ppk.SalaryBelowThreshold,
@@ -259,11 +267,25 @@ func (h *Handler) runSimulation(ctx context.Context, in simulationInputs) ([]Acc
 			continue
 		}
 		sims = append(sims, SimulateBrokerageAccount(BrokerageParams{
-			Owner: brk.Owner, StartingBalance: brk.Balance,
+			OwnerUserID:         brk.OwnerUserID,
+			OwnerName:           ownerLabel(userNames, brk.OwnerUserID),
+			StartingBalance:     brk.Balance,
 			MonthlyContribution: brk.MonthlyContribution,
 		}, in.CurrentAge, in.RetirementAge, currentYear, in.AnnualReturnRate))
 	}
 	return sims, nil
+}
+
+// ownerLabel resolves an owner_user_id to a display name for AccountName.
+// A nil id (jointly owned) renders as "Wspólne".
+func ownerLabel(names map[int]string, id *int) string {
+	if id == nil {
+		return "Wspólne"
+	}
+	if n, ok := names[*id]; ok {
+		return n
+	}
+	return "—"
 }
 
 func (h *Handler) buildSimulationResponse(in simulationInputs, sims []AccountSimulation) map[string]any {

--- a/backend-go/internal/simulations/store.go
+++ b/backend-go/internal/simulations/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
+	"strconv"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -25,11 +25,12 @@ func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
 
 // LimitForYear ports get_limit_for_year — retirement_limits row or the
 // wrapper default.
-func (s *Store) LimitForYear(ctx context.Context, year int, wrapper, owner string) (float64, error) {
+func (s *Store) LimitForYear(ctx context.Context, year int, wrapper string, ownerUserID *int) (float64, error) {
 	row := s.pool.QueryRow(ctx, `
 		SELECT limit_amount FROM retirement_limits
-		WHERE year = $1 AND account_wrapper = $2 AND owner = $3`,
-		year, wrapper, owner,
+		WHERE year = $1 AND account_wrapper = $2
+		  AND owner_user_id IS NOT DISTINCT FROM $3`,
+		year, wrapper, ownerUserID,
 	)
 	var amount float64
 	if err := row.Scan(&amount); err != nil {
@@ -48,10 +49,14 @@ func (s *Store) LimitForYear(ctx context.Context, year int, wrapper, owner strin
 	return amount, nil
 }
 
-// PrefillData is everything GET /api/simulations/prefill needs.
+// PrefillData is everything GET /api/simulations/prefill needs. The
+// owner-keyed maps are keyed by the owner_user_id rendered as a string
+// (JSON object keys must be strings); Balances composite keys are
+// "ike_<id>" / "ikze_<id>".
 type PrefillData struct {
 	CurrentAge      int
 	RetirementAge   int
+	Owners          []userRow
 	Balances        map[string]float64
 	PPKRates        map[string]map[string]float64
 	MonthlySalaries map[string]*float64
@@ -76,22 +81,23 @@ func (s *Store) LoadPrefill(ctx context.Context) (PrefillData, error) {
 	}
 	data.CurrentAge = ageFromBirth(birth)
 
-	personas, err := s.loadPersonas(ctx)
+	users, err := s.loadUsers(ctx)
 	if err != nil {
 		return data, err
 	}
-	for _, p := range personas {
-		lower := strings.ToLower(p.name)
-		data.Balances["ike_"+lower] = 0
-		data.Balances["ikze_"+lower] = 0
-		data.PPKBalances[lower] = 0
-		data.PPKRates[lower] = map[string]float64{
-			"employee": p.employeeRate,
-			"employer": p.employerRate,
+	data.Owners = users
+	for _, u := range users {
+		key := strconv.Itoa(u.id)
+		data.Balances["ike_"+key] = 0
+		data.Balances["ikze_"+key] = 0
+		data.PPKBalances[key] = 0
+		data.PPKRates[key] = map[string]float64{
+			"employee": u.employeeRate,
+			"employer": u.employerRate,
 		}
-		data.MonthlySalaries[lower] = nil
+		data.MonthlySalaries[key] = nil
 	}
-	if err := s.fillLatestSalaries(ctx, personas, data.MonthlySalaries); err != nil {
+	if err := s.fillLatestSalaries(ctx, users, data.MonthlySalaries); err != nil {
 		return data, err
 	}
 	if err := s.fillWrapperBalances(ctx, data); err != nil {
@@ -100,7 +106,10 @@ func (s *Store) LoadPrefill(ctx context.Context) (PrefillData, error) {
 	return data, nil
 }
 
-type personaRow struct {
+// userRow is one household member with PPK rate defaults. NULL PPK rates on
+// the users table fall back to zero.
+type userRow struct {
+	id           int
 	name         string
 	employeeRate float64
 	employerRate float64
@@ -121,35 +130,52 @@ func (s *Store) loadConfig(ctx context.Context) (*time.Time, int, error) {
 	return birth, ra, nil
 }
 
-func (s *Store) loadPersonas(ctx context.Context) ([]personaRow, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT name, ppk_employee_rate, ppk_employer_rate FROM personas ORDER BY name`,
+func (s *Store) loadUsers(ctx context.Context) ([]userRow, error) {
+	// The prefill owner picker covers named users who own retirement data:
+	// an IKE/IKZE/PPK account or a salary record. This excludes the admin
+	// account (NULL name) and any login-only user with no financial rows.
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, name,
+		       COALESCE(ppk_employee_rate, 0), COALESCE(ppk_employer_rate, 0)
+		FROM users u
+		WHERE name IS NOT NULL
+		  AND (
+		    EXISTS (
+		      SELECT 1 FROM accounts a
+		      WHERE a.owner_user_id = u.id
+		        AND a.account_wrapper IN ('IKE', 'IKZE', 'PPK')
+		    )
+		    OR EXISTS (
+		      SELECT 1 FROM salary_records sr WHERE sr.owner_user_id = u.id
+		    )
+		  )
+		ORDER BY name`,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("load personas: %w", err)
+		return nil, fmt.Errorf("load users: %w", err)
 	}
 	defer rows.Close()
-	out := []personaRow{}
+	out := []userRow{}
 	for rows.Next() {
-		var p personaRow
-		if err := rows.Scan(&p.name, &p.employeeRate, &p.employerRate); err != nil {
-			return nil, fmt.Errorf("scan persona: %w", err)
+		var u userRow
+		if err := rows.Scan(&u.id, &u.name, &u.employeeRate, &u.employerRate); err != nil {
+			return nil, fmt.Errorf("scan user: %w", err)
 		}
-		out = append(out, p)
+		out = append(out, u)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate personas: %w", err)
+		return nil, fmt.Errorf("iterate users: %w", err)
 	}
 	return out, nil
 }
 
-func (s *Store) fillLatestSalaries(ctx context.Context, personas []personaRow, dest map[string]*float64) error {
-	for _, p := range personas {
+func (s *Store) fillLatestSalaries(ctx context.Context, users []userRow, dest map[string]*float64) error {
+	for _, u := range users {
 		row := s.pool.QueryRow(ctx, `
 			SELECT gross_amount FROM salary_records
-			WHERE owner = $1 AND is_active = true
+			WHERE owner_user_id = $1 AND is_active = true
 			ORDER BY date DESC LIMIT 1`,
-			p.name,
+			u.id,
 		)
 		var v float64
 		if err := row.Scan(&v); err != nil {
@@ -159,7 +185,7 @@ func (s *Store) fillLatestSalaries(ctx context.Context, personas []personaRow, d
 			return fmt.Errorf("latest salary: %w", err)
 		}
 		val := v
-		dest[strings.ToLower(p.name)] = &val
+		dest[strconv.Itoa(u.id)] = &val
 	}
 	return nil
 }
@@ -179,11 +205,12 @@ func (s *Store) fillWrapperBalances(ctx context.Context, data PrefillData) error
 		return fmt.Errorf("latest snapshot: %w", err)
 	}
 	rows, err := s.pool.Query(ctx, `
-		SELECT a.account_wrapper, a.owner, sv.value
+		SELECT a.account_wrapper, a.owner_user_id, sv.value
 		FROM accounts a
 		JOIN snapshot_values sv ON sv.account_id = a.id
 		WHERE a.is_active = true
 		  AND a.account_wrapper IN ('IKE', 'IKZE', 'PPK')
+		  AND a.owner_user_id IS NOT NULL
 		  AND sv.snapshot_id = $1`,
 		snapshotID,
 	)
@@ -192,22 +219,51 @@ func (s *Store) fillWrapperBalances(ctx context.Context, data PrefillData) error
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var wrapper, owner string
+		var wrapper string
+		var ownerUserID int
 		var value float64
-		if err := rows.Scan(&wrapper, &owner, &value); err != nil {
+		if err := rows.Scan(&wrapper, &ownerUserID, &value); err != nil {
 			return fmt.Errorf("scan wrapper balance: %w", err)
 		}
-		ownerLower := strings.ToLower(owner)
+		key := strconv.Itoa(ownerUserID)
 		if wrapper == "PPK" {
-			data.PPKBalances[ownerLower] = value
+			data.PPKBalances[key] = value
 			continue
 		}
-		data.Balances[strings.ToLower(wrapper)+"_"+ownerLower] = value
+		switch wrapper {
+		case "IKE":
+			data.Balances["ike_"+key] = value
+		case "IKZE":
+			data.Balances["ikze_"+key] = value
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("iterate wrapper balances: %w", err)
 	}
 	return nil
+}
+
+// UserNames returns an owner_user_id -> name map for every named user — the
+// retirement handler uses it to render AccountName labels.
+func (s *Store) UserNames(ctx context.Context) (map[int]string, error) {
+	rows, err := s.pool.Query(ctx, `SELECT id, name FROM users WHERE name IS NOT NULL`)
+	if err != nil {
+		return nil, fmt.Errorf("user names: %w", err)
+	}
+	defer rows.Close()
+	out := map[int]string{}
+	for rows.Next() {
+		var id int
+		var name string
+		if err := rows.Scan(&id, &name); err != nil {
+			return nil, fmt.Errorf("scan user name: %w", err)
+		}
+		out[id] = name
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate user names: %w", err)
+	}
+	return out, nil
 }
 
 func ageFromBirth(birth *time.Time) int {

--- a/backend-go/internal/simulations/validation.go
+++ b/backend-go/internal/simulations/validation.go
@@ -74,7 +74,7 @@ func buildMortgageInputs(raw map[string]json.RawMessage) (MortgageInputs, *valid
 type ikeIkzeInput struct {
 	Enabled             bool
 	Wrapper             string
-	Owner               string
+	OwnerUserID         *int
 	Balance             float64
 	AutoFillLimit       bool
 	MonthlyContribution float64
@@ -82,7 +82,7 @@ type ikeIkzeInput struct {
 }
 
 type ppkInput struct {
-	Owner                string
+	OwnerUserID          *int
 	Enabled              bool
 	StartingBalance      float64
 	MonthlyGrossSalary   float64
@@ -95,7 +95,7 @@ type ppkInput struct {
 
 type brokerageInput struct {
 	Enabled             bool
-	Owner               string
+	OwnerUserID         *int
 	Balance             float64
 	MonthlyContribution float64
 }
@@ -121,7 +121,7 @@ func (s simulationInputs) echo() map[string]any {
 		ike = append(ike, map[string]any{
 			"enabled":              a.Enabled,
 			"wrapper":              a.Wrapper,
-			"owner":                a.Owner,
+			"owner_user_id":        a.OwnerUserID,
 			"balance":              pyFloat(a.Balance),
 			"auto_fill_limit":      a.AutoFillLimit,
 			"monthly_contribution": pyFloat(a.MonthlyContribution),
@@ -131,7 +131,7 @@ func (s simulationInputs) echo() map[string]any {
 	ppk := make([]map[string]any, 0, len(s.PPKAccounts))
 	for _, a := range s.PPKAccounts {
 		ppk = append(ppk, map[string]any{
-			"owner":                  a.Owner,
+			"owner_user_id":          a.OwnerUserID,
 			"enabled":                a.Enabled,
 			"starting_balance":       pyFloat(a.StartingBalance),
 			"monthly_gross_salary":   pyFloat(a.MonthlyGrossSalary),
@@ -146,7 +146,7 @@ func (s simulationInputs) echo() map[string]any {
 	for _, a := range s.BrokerageAccounts {
 		brk = append(brk, map[string]any{
 			"enabled":              a.Enabled,
-			"owner":                a.Owner,
+			"owner_user_id":        a.OwnerUserID,
 			"balance":              pyFloat(a.Balance),
 			"monthly_contribution": pyFloat(a.MonthlyContribution),
 		})
@@ -273,11 +273,11 @@ func parseIkeIkze(raw json.RawMessage) ([]ikeIkzeInput, *validationError) {
 			return nil, vErr
 		}
 		a.Wrapper = wrapper
-		owner, vErr := requiredStringField(e, "owner")
+		owner, vErr := requiredIntOrNullField(e, "owner_user_id")
 		if vErr != nil {
 			return nil, vErr
 		}
-		a.Owner = owner
+		a.OwnerUserID = owner
 		a.Balance = floatField(e, "balance")
 		a.AutoFillLimit = boolField(e, "auto_fill_limit")
 		a.MonthlyContribution = floatField(e, "monthly_contribution")
@@ -304,11 +304,11 @@ func parsePPK(raw json.RawMessage) ([]ppkInput, *validationError) {
 	out := make([]ppkInput, 0, len(entries))
 	for _, e := range entries {
 		var a ppkInput
-		owner, vErr := requiredStringField(e, "owner")
+		owner, vErr := requiredIntOrNullField(e, "owner_user_id")
 		if vErr != nil {
 			return nil, vErr
 		}
-		a.Owner = owner
+		a.OwnerUserID = owner
 		a.Enabled = boolField(e, "enabled")
 		a.StartingBalance = floatField(e, "starting_balance")
 		a.MonthlyGrossSalary = floatField(e, "monthly_gross_salary")
@@ -349,11 +349,11 @@ func parseBrokerage(raw json.RawMessage) ([]brokerageInput, *validationError) {
 	for _, e := range entries {
 		var a brokerageInput
 		a.Enabled = boolField(e, "enabled")
-		owner, vErr := requiredStringField(e, "owner")
+		owner, vErr := requiredIntOrNullField(e, "owner_user_id")
 		if vErr != nil {
 			return nil, vErr
 		}
-		a.Owner = owner
+		a.OwnerUserID = owner
 		a.Balance = floatField(e, "balance")
 		a.MonthlyContribution = floatField(e, "monthly_contribution")
 		if a.Balance < 0 || a.MonthlyContribution < 0 {
@@ -414,7 +414,7 @@ func isNullRaw(v json.RawMessage) bool {
 }
 
 // requiredStringField enforces a non-empty string for fields the Pydantic
-// schema marks required (wrapper, owner) — missing/wrong-type/empty -> 422.
+// schema marks required (wrapper) — missing/wrong-type/empty -> 422.
 func requiredStringField(m map[string]any, key string) (string, *validationError) {
 	v, ok := m[key]
 	if !ok || v == nil {
@@ -428,6 +428,25 @@ func requiredStringField(m map[string]any, key string) (string, *validationError
 		return "", &validationError{Field: key, Msg: key + " cannot be empty"}
 	}
 	return s, nil
+}
+
+// requiredIntOrNullField reads an integer key that must be present; an
+// explicit null is allowed and yields nil (jointly owned). JSON numbers
+// decode into map[string]any as float64.
+func requiredIntOrNullField(m map[string]any, key string) (*int, *validationError) {
+	v, ok := m[key]
+	if !ok {
+		return nil, &validationError{Field: key, Msg: "Field required"}
+	}
+	if v == nil {
+		return nil, nil
+	}
+	f, ok := v.(float64)
+	if !ok || f != float64(int(f)) {
+		return nil, &validationError{Field: key, Msg: "must be an integer"}
+	}
+	n := int(f)
+	return &n, nil
 }
 
 func floatField(m map[string]any, key string) float64 {

--- a/backend-go/internal/zus/calculator.go
+++ b/backend-go/internal/zus/calculator.go
@@ -38,8 +38,9 @@ var lifeExpectancyMonths = map[int]float64{
 }
 
 // Inputs mirrors the Pydantic ZusCalculatorInputs after validation.
+// OwnerUserID is the owning household member; nil means jointly owned.
 type Inputs struct {
-	Owner                     string
+	OwnerUserID               *int
 	BirthYear                 int
 	Gender                    string
 	RetirementAge             int

--- a/backend-go/internal/zus/handler.go
+++ b/backend-go/internal/zus/handler.go
@@ -34,7 +34,7 @@ type salaryHistoryEntry struct {
 }
 
 type inputsResponse struct {
-	Owner                     string               `json:"owner"`
+	OwnerUserID               *int                 `json:"owner_user_id"`
 	BirthDate                 isoDate              `json:"birth_date"`
 	Gender                    string               `json:"gender"`
 	RetirementAge             int                  `json:"retirement_age"`
@@ -90,7 +90,7 @@ type prefillResponse struct {
 	RetirementAge             int                  `json:"retirement_age"`
 	Gender                    string               `json:"gender"`
 	CurrentGrossMonthlySalary *pyFloat             `json:"current_gross_monthly_salary"`
-	Owner                     *string              `json:"owner"`
+	OwnerUserID               *int                 `json:"owner_user_id"`
 	SalaryHistory             []salaryHistoryEntry `json:"salary_history"`
 	WorkStartYear             *int                 `json:"work_start_year"`
 }
@@ -113,7 +113,7 @@ func (h *Handler) Calculate(w http.ResponseWriter, r *http.Request) {
 	hist := historyAsList(req.Inputs.SalaryHistory)
 	resp := calculateResponse{
 		Inputs: inputsResponse{
-			Owner:                     req.Inputs.Owner,
+			OwnerUserID:               req.Inputs.OwnerUserID,
 			BirthDate:                 isoDate(req.BirthDate),
 			Gender:                    req.Inputs.Gender,
 			RetirementAge:             req.Inputs.RetirementAge,
@@ -166,15 +166,16 @@ func (h *Handler) Calculate(w http.ResponseWriter, r *http.Request) {
 
 // Prefill serves GET /api/zus/prefill.
 func (h *Handler) Prefill(w http.ResponseWriter, r *http.Request) {
-	// Mirror Python's `if not owner` semantics: empty string from the query
-	// param falls through to the first-persona fallback exactly like Python's
-	// `Query(None)` default. Don't TrimSpace — Python doesn't.
-	var ownerHint *string
-	if r.URL.Query().Has("owner") {
-		v := r.URL.Query().Get("owner")
-		if v != "" {
-			ownerHint = &v
+	// An empty owner_user_id query value falls through to the first-user
+	// fallback, mirroring Python's `Query(None)` default.
+	var ownerHint *int
+	if v := r.URL.Query().Get("owner_user_id"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			writeValidationError(w, "owner_user_id", "must be an integer", v)
+			return
 		}
+		ownerHint = &n
 	}
 	data, err := h.store.LoadPrefill(r.Context(), ownerHint)
 	if err != nil {
@@ -190,10 +191,7 @@ func (h *Handler) Prefill(w http.ResponseWriter, r *http.Request) {
 		d := isoDate(*data.BirthDate)
 		resp.BirthDate = &d
 	}
-	if data.Owner != nil {
-		o := *data.Owner
-		resp.Owner = &o
-	}
+	resp.OwnerUserID = data.OwnerUserID
 	if data.CurrentGrossMonthlySalary != nil {
 		v := pyFloat(*data.CurrentGrossMonthlySalary)
 		resp.CurrentGrossMonthlySalary = &v

--- a/backend-go/internal/zus/store.go
+++ b/backend-go/internal/zus/store.go
@@ -16,7 +16,7 @@ import (
 // not part of the package API.
 var errNoSalary = errors.New("no salary record for owner")
 
-// Store reads salary records + persona + app_config for prefill.
+// Store reads salary records + users + app_config for prefill.
 type Store struct {
 	pool *pgxpool.Pool
 }
@@ -28,8 +28,9 @@ func NewStore(pool *pgxpool.Pool) *Store {
 
 // PrefillData bundles everything prefill needs in a single struct so the
 // handler can compose the response without per-field branching.
+// OwnerUserID is the resolved household member; nil means jointly owned.
 type PrefillData struct {
-	Owner                     *string
+	OwnerUserID               *int
 	BirthDate                 *time.Time
 	RetirementAge             int
 	CurrentGrossMonthlySalary *float64
@@ -39,10 +40,10 @@ type PrefillData struct {
 
 // LoadPrefill fetches the data Python's get_zus_prefill assembles:
 // - config (birth_date + retirement_age)
-// - resolved owner (passed-in or first persona alphabetically)
+// - resolved owner (passed-in owner_user_id or first user alphabetically)
 // - latest active salary for owner -> current_gross_monthly_salary
 // - all active salaries for owner -> yearly history (latest record per year)
-func (s *Store) LoadPrefill(ctx context.Context, ownerHint *string) (PrefillData, error) {
+func (s *Store) LoadPrefill(ctx context.Context, ownerHint *int) (PrefillData, error) {
 	data := PrefillData{RetirementAge: 65, YearlySalaryHistory: map[int]float64{}}
 
 	birth, ra, err := s.loadConfig(ctx)
@@ -56,20 +57,20 @@ func (s *Store) LoadPrefill(ctx context.Context, ownerHint *string) (PrefillData
 		data.RetirementAge = ra
 	}
 
-	owner := ""
-	if ownerHint != nil && *ownerHint != "" {
-		owner = *ownerHint
+	var owner *int
+	if ownerHint != nil {
+		owner = ownerHint
 	} else {
-		first, err := s.firstPersona(ctx)
+		first, found, err := s.firstUser(ctx)
 		if err != nil {
 			return data, err
 		}
-		owner = first
+		if !found {
+			return data, nil
+		}
+		owner = &first
 	}
-	if owner == "" {
-		return data, nil
-	}
-	data.Owner = &owner
+	data.OwnerUserID = owner
 
 	current, err := s.latestSalary(ctx, owner)
 	if err != nil && !errors.Is(err, errNoSalary) {
@@ -105,26 +106,29 @@ func (s *Store) loadConfig(ctx context.Context) (*time.Time, int, error) {
 	return birth, ra, nil
 }
 
-func (s *Store) firstPersona(ctx context.Context) (string, error) {
+// firstUser returns the id of the first named user ordered by name. The
+// bool is false when no named users exist. Unnamed accounts (e.g. admin)
+// are skipped — the ZUS prefill owner picker only covers household members.
+func (s *Store) firstUser(ctx context.Context) (int, bool, error) {
 	row := s.pool.QueryRow(ctx,
-		`SELECT name FROM personas ORDER BY name LIMIT 1`,
+		`SELECT id FROM users WHERE name IS NOT NULL ORDER BY name LIMIT 1`,
 	)
-	var n string
-	if err := row.Scan(&n); err != nil {
+	var id int
+	if err := row.Scan(&id); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return "", nil
+			return 0, false, nil
 		}
-		return "", fmt.Errorf("select first persona: %w", err)
+		return 0, false, fmt.Errorf("select first user: %w", err)
 	}
-	return n, nil
+	return id, true, nil
 }
 
-func (s *Store) latestSalary(ctx context.Context, owner string) (*float64, error) {
+func (s *Store) latestSalary(ctx context.Context, ownerUserID *int) (*float64, error) {
 	row := s.pool.QueryRow(ctx, `
 		SELECT gross_amount FROM salary_records
-		WHERE owner = $1 AND is_active = true
+		WHERE owner_user_id IS NOT DISTINCT FROM $1 AND is_active = true
 		ORDER BY date DESC LIMIT 1`,
-		owner,
+		ownerUserID,
 	)
 	var v float64
 	if err := row.Scan(&v); err != nil {
@@ -136,12 +140,12 @@ func (s *Store) latestSalary(ctx context.Context, owner string) (*float64, error
 	return &v, nil
 }
 
-func (s *Store) yearlyHistory(ctx context.Context, owner string) (map[int]float64, *int, error) {
+func (s *Store) yearlyHistory(ctx context.Context, ownerUserID *int) (map[int]float64, *int, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT date, gross_amount FROM salary_records
-		WHERE owner = $1 AND is_active = true
+		WHERE owner_user_id IS NOT DISTINCT FROM $1 AND is_active = true
 		ORDER BY date`,
-		owner,
+		ownerUserID,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("select salary history: %w", err)

--- a/backend-go/internal/zus/validation.go
+++ b/backend-go/internal/zus/validation.go
@@ -19,7 +19,7 @@ type calculateInputs struct {
 func buildInputs(raw map[string]json.RawMessage, now func() time.Time) (calculateInputs, *validationError) {
 	var c calculateInputs
 	var err *validationError
-	c.Inputs.Owner, err = requireString(raw, "owner", "Owner cannot be empty")
+	c.Inputs.OwnerUserID, err = requireIntOrNull(raw, "owner_user_id")
 	if err != nil {
 		return c, err
 	}
@@ -147,19 +147,21 @@ func validateAgeRelationship(birth time.Time, retirementAge int, now func() time
 
 // --- helpers ---
 
-func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *validationError) {
+// requireIntOrNull reads an integer key that must be present; an explicit
+// null is allowed and yields nil (jointly owned).
+func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *validationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
-		return "", &validationError{Field: key, Msg: "Field required"}
+	if !ok {
+		return nil, &validationError{Field: key, Msg: "Field required"}
 	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &validationError{Field: key, Msg: "must be a string"}
+	if isNull(v) {
+		return nil, nil
 	}
-	if s == "" {
-		return "", &validationError{Field: key, Msg: emptyMsg}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return nil, &validationError{Field: key, Msg: "must be an integer"}
 	}
-	return s, nil
+	return &n, nil
 }
 
 func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *validationError) {

--- a/src/lib/components/DashboardCharts.svelte
+++ b/src/lib/components/DashboardCharts.svelte
@@ -5,13 +5,15 @@
 	import { formatPLN } from '$lib/utils/format';
 	import { isMobile, isTablet } from '$lib/utils/viewport';
 	import { chartPalette, chartAccent, chartAccentGradient } from '$lib/utils/theme';
+	import { ownerName, type OwnerOption } from '$lib/types/owners';
 
 	interface Props {
 		netWorthHistory: { date: string; value: number }[];
-		allocation: { category: string; owner: string | null; value: number }[];
+		allocation: { category: string; owner_user_id: number | null; value: number }[];
+		owners: OwnerOption[];
 	}
 
-	let { netWorthHistory, allocation }: Props = $props();
+	let { netWorthHistory, allocation, owners }: Props = $props();
 
 	let chartContainer: HTMLDivElement | undefined;
 	let pieChartContainer: HTMLDivElement | undefined;
@@ -86,7 +88,7 @@
 					type: 'pie',
 					radius: ['40%', '70%'],
 					data: allocation.map((a) => ({
-						name: `${a.category}${a.owner ? ` (${a.owner})` : ''}`,
+						name: `${a.category} (${ownerName(owners, a.owner_user_id)})`,
 						value: a.value
 					})),
 					emphasis: {

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -1333,7 +1333,7 @@ export interface paths {
                         "application/json": {
                             allocation?: {
                                 category?: string;
-                                owner?: string | null;
+                                owner_user_id?: number | null;
                                 /** Format: double */
                                 value?: number;
                             }[];
@@ -2682,7 +2682,7 @@ export interface paths {
                             /** Format: double */
                             limit_amount?: number;
                             notes?: string | null;
-                            owner?: string;
+                            owner_user_id?: number | null;
                             year?: number;
                         }[];
                     };
@@ -2697,7 +2697,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/retirement/limits/{year}/{wrapper}/{owner}": {
+    "/api/retirement/limits/{year}/{wrapper}/{owner_user_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -2713,7 +2713,7 @@ export interface paths {
                 path: {
                     year: number;
                     wrapper: string;
-                    owner: string;
+                    owner_user_id: string;
                 };
                 cookie?: never;
             };
@@ -2731,7 +2731,7 @@ export interface paths {
                             /** Format: double */
                             limit_amount?: number;
                             notes?: string | null;
-                            owner?: string;
+                            owner_user_id?: number | null;
                             year?: number;
                         };
                     };
@@ -2778,7 +2778,7 @@ export interface paths {
                             /** Format: double */
                             gross_salary?: number;
                             month?: number;
-                            owner?: string;
+                            owner_user_id?: number | null;
                             /** Format: double */
                             total_amount?: number;
                             transactions_created?: number[];
@@ -2824,7 +2824,7 @@ export interface paths {
                             employer_contributed?: number;
                             /** Format: double */
                             government_contributed?: number;
-                            owner?: string;
+                            owner_user_id?: number | null;
                             /** Format: double */
                             returns?: number;
                             /** Format: double */
@@ -2878,7 +2878,7 @@ export interface paths {
                             is_warning?: boolean;
                             /** Format: double */
                             limit_amount?: number | null;
-                            owner?: string;
+                            owner_user_id?: number | null;
                             /** Format: double */
                             percentage_used?: number | null;
                             /** Format: double */
@@ -3580,7 +3580,7 @@ export interface paths {
                                 inflation_rate?: number;
                                 /** Format: double */
                                 kapital_poczatkowy?: number;
-                                owner?: string;
+                                owner_user_id?: number | null;
                                 retirement_age?: number;
                                 /** Format: double */
                                 salary_growth_rate?: number;
@@ -3683,7 +3683,7 @@ export interface paths {
                             /** Format: double */
                             current_gross_monthly_salary?: number | null;
                             gender?: string;
-                            owner?: string | null;
+                            owner_user_id?: number | null;
                             retirement_age?: number;
                             salary_history?: {
                                 /** Format: double */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,7 +17,7 @@
 	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
-	import type { Persona } from '$lib/types/personas';
+	import { ownerName, type OwnerOption } from '$lib/types/owners';
 	import type { PageData } from './$types';
 
 	interface Props {
@@ -26,12 +26,12 @@
 
 	let { data }: Props = $props();
 
-	let personas: Persona[] = $state([]);
+	let owners: OwnerOption[] = $state([]);
 
 	$effect(() => {
 		let cancelled = false;
-		Promise.resolve(data.personas).then((p) => {
-			if (!cancelled) personas = (p ?? []) as Persona[];
+		Promise.resolve(data.owners).then((o) => {
+			if (!cancelled) owners = (o ?? []) as OwnerOption[];
 		});
 		return () => {
 			cancelled = true;
@@ -44,7 +44,7 @@
 
 	type RetirementStat = {
 		account_wrapper: string;
-		owner: string;
+		owner_user_id: number | null;
 		total_contributed: number;
 		limit_amount: number;
 		remaining: number;
@@ -53,13 +53,13 @@
 
 	function openLimitsModal(retirementStats: RetirementStat[]) {
 		limits = {};
-		for (const persona of personas) {
+		for (const owner of owners) {
 			for (const wrapper of ['IKE', 'IKZE']) {
-				limits[`${wrapper}_${persona.name}`] = 0;
+				limits[`${wrapper}_${owner.id}`] = 0;
 			}
 		}
 		for (const stat of retirementStats) {
-			const key = `${stat.account_wrapper}_${stat.owner}`;
+			const key = `${stat.account_wrapper}_${stat.owner_user_id}`;
 			if (key in limits) {
 				limits[key] = stat.limit_amount || 0;
 			}
@@ -73,21 +73,18 @@
 			const requests = Object.entries(limits).map(([key, amount]) => {
 				const sep = key.indexOf('_');
 				const wrapper = key.slice(0, sep);
-				const owner = key.slice(sep + 1);
-				return fetch(
-					`${apiUrl}/api/retirement/limits/${limitsYear}/${wrapper}/${encodeURIComponent(owner)}`,
-					{
-						method: 'PUT',
-						headers: { 'Content-Type': 'application/json' },
-						body: JSON.stringify({
-							year: limitsYear,
-							account_wrapper: wrapper,
-							owner: owner,
-							limit_amount: amount,
-							notes: ''
-						})
-					}
-				);
+				const ownerUserId = Number(key.slice(sep + 1));
+				return fetch(`${apiUrl}/api/retirement/limits/${limitsYear}/${wrapper}/${ownerUserId}`, {
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						year: limitsYear,
+						account_wrapper: wrapper,
+						owner_user_id: ownerUserId,
+						limit_amount: amount,
+						notes: ''
+					})
+				});
 			});
 
 			const responses = await Promise.all(requests);
@@ -227,7 +224,9 @@
 					{#each dashboard.retirementStats as stat}
 						<div class="card preset-tonal-surface p-4 space-y-2">
 							<div class="flex items-start justify-between gap-2">
-								<h4 class="font-bold">{stat.account_wrapper} ({stat.owner})</h4>
+								<h4 class="font-bold">
+									{stat.account_wrapper} ({ownerName(owners, stat.owner_user_id)})
+								</h4>
 								<span class="text-sm font-semibold whitespace-nowrap">
 									{formatPLN(stat.total_contributed)} / {formatPLN(stat.limit_amount)}
 								</span>
@@ -279,6 +278,7 @@
 		<DashboardCharts
 			netWorthHistory={dashboard.net_worth_history}
 			allocation={dashboard.allocation}
+			{owners}
 		/>
 	{:catch err}
 		<div class="card preset-filled-error-500 p-4">
@@ -313,13 +313,13 @@
 
 		<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 			{#each ['IKE', 'IKZE'] as wrapper}
-				{#each personas as persona}
+				{#each owners as owner}
 					<label class="label">
-						<span class="font-semibold text-sm">{wrapper} {persona.name} (PLN)</span>
+						<span class="font-semibold text-sm">{wrapper} {owner.name} (PLN)</span>
 						<input
 							type="number"
 							class="input"
-							bind:value={limits[`${wrapper}_${persona.name}`]}
+							bind:value={limits[`${wrapper}_${owner.id}`]}
 							step="0.01"
 							required
 						/>

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -10,8 +10,8 @@ export async function load({ fetch }) {
 
 	const currentYear = new Date().getFullYear();
 
-	const personas = (async () => {
-		const res = await fetch(`${apiUrl}/api/personas`);
+	const owners = (async () => {
+		const res = await fetch(`${apiUrl}/api/users`);
 		return res.ok ? await res.json() : [];
 	})();
 
@@ -43,7 +43,7 @@ export async function load({ fetch }) {
 
 	return {
 		dashboardData,
-		personas,
+		owners,
 		currentYear
 	};
 }

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -10,6 +10,7 @@
 		buildWrapperTrendChartOption,
 		buildYearlyRoiChartOption
 	} from '$lib/utils/charts/metryki';
+	import { ownerName, type OwnerOption } from '$lib/types/owners';
 
 	import type { PageData } from './$types';
 
@@ -268,7 +269,9 @@
 	{#if data.ppkStats && data.ppkStats.length > 0}
 		<h2 class="h2">Podsumowanie PPK</h2>
 		{#each data.ppkStats as ppkStat}
-			<h3 class="h4 font-semibold mt-4 mb-3">{ppkStat.owner}</h3>
+			<h3 class="h4 font-semibold mt-4 mb-3">
+				{ownerName((data.owners ?? []) as OwnerOption[], ppkStat.owner_user_id)}
+			</h3>
 			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 				<MetricCard
 					label="PPK - Wartość całkowita"

--- a/src/routes/metryki/+page.ts
+++ b/src/routes/metryki/+page.ts
@@ -38,6 +38,10 @@ export async function load({ fetch }) {
 			bondStats = await bondStatsRes.json();
 		}
 
+		// Fetch owners for owner_user_id resolution
+		const ownersRes = await fetch(`${apiUrl}/api/users`);
+		const owners = ownersRes.ok ? await ownersRes.json() : [];
+
 		return {
 			metricCards: dashboard.metric_cards,
 			allocationAnalysis: dashboard.allocation_analysis,
@@ -46,7 +50,8 @@ export async function load({ fetch }) {
 			categoryTimeSeries: dashboard.category_time_series,
 			ppkStats,
 			stockStats,
-			bondStats
+			bondStats,
+			owners
 		};
 	} catch (err) {
 		if (err instanceof Error && 'status' in err) {

--- a/src/routes/metryki/page.test.ts
+++ b/src/routes/metryki/page.test.ts
@@ -61,7 +61,8 @@ const mockData = {
 	categoryTimeSeries: { stock: [], bond: [] },
 	ppkStats: [],
 	stockStats: null,
-	bondStats: null
+	bondStats: null,
+	owners: []
 };
 
 describe('Metryki Page', () => {
@@ -143,7 +144,7 @@ describe('Metryki Page with populated data', () => {
 		},
 		ppkStats: [
 			{
-				owner: 'Marcin',
+				owner_user_id: 1,
 				total_value: 20000,
 				employee_contributed: 8000,
 				employer_contributed: 6000,
@@ -164,7 +165,8 @@ describe('Metryki Page with populated data', () => {
 			total_contributed: 9500,
 			returns: 500,
 			roi_percentage: 5.26
-		}
+		},
+		owners: [{ id: 1, name: 'Marcin' }]
 	};
 
 	it('renders the rebalancing suggestions when present', () => {

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -75,7 +75,7 @@ const baseTileDeltas = {
 function buildData(
 	overrides: {
 		dashboardData?: Promise<Record<string, unknown>> | Record<string, unknown>;
-		personas?: { name: string }[];
+		owners?: { id: number; name: string }[];
 		currentYear?: number;
 	} = {}
 ) {
@@ -89,8 +89,8 @@ function buildData(
 		total_assets: 10000,
 		total_liabilities: 4000,
 		allocation: [
-			{ category: 'banking', owner: 'John', value: 5000 },
-			{ category: 'investments', owner: 'John', value: 5000 }
+			{ category: 'banking', owner_user_id: 1, value: 5000 },
+			{ category: 'investments', owner_user_id: 1, value: 5000 }
 		],
 		retirementStats: [] as unknown[],
 		tile_deltas: baseTileDeltas
@@ -107,7 +107,7 @@ function buildData(
 	return {
 		user: null,
 		dashboardData,
-		personas: Promise.resolve(overrides.personas ?? []),
+		owners: Promise.resolve(overrides.owners ?? []),
 		currentYear: overrides.currentYear ?? 2024
 	};
 }
@@ -176,7 +176,7 @@ describe('Dashboard Page', () => {
 describe('Dashboard retirement limits save flow', () => {
 	const retirementStat = {
 		account_wrapper: 'IKE',
-		owner: 'Marcin',
+		owner_user_id: 1,
 		total_contributed: 5000,
 		limit_amount: 23000,
 		remaining: 18000,
@@ -191,10 +191,10 @@ describe('Dashboard retirement limits save flow', () => {
 				change_vs_last_month: 1000,
 				total_assets: 10000,
 				total_liabilities: 4000,
-				allocation: [{ category: 'banking', owner: 'Marcin', value: 5000 }],
+				allocation: [{ category: 'banking', owner_user_id: 1, value: 5000 }],
 				retirementStats: [retirementStat]
 			},
-			personas: [{ name: 'Marcin' }]
+			owners: [{ id: 1, name: 'Marcin' }]
 		});
 	}
 
@@ -213,7 +213,7 @@ describe('Dashboard retirement limits save flow', () => {
 		);
 	});
 
-	it('opens the limits modal and PUTs each persona/wrapper limit on save', async () => {
+	it('opens the limits modal and PUTs each owner/wrapper limit on save', async () => {
 		const fetchMock = vi.fn().mockResolvedValue({ ok: true });
 		vi.stubGlobal('fetch', fetchMock);
 
@@ -229,8 +229,8 @@ describe('Dashboard retirement limits save flow', () => {
 		const urls = fetchMock.mock.calls.map((c) => c[0] as string);
 		expect(urls).toEqual(
 			expect.arrayContaining([
-				'http://localhost:8000/api/retirement/limits/2024/IKE/Marcin',
-				'http://localhost:8000/api/retirement/limits/2024/IKZE/Marcin'
+				'http://localhost:8000/api/retirement/limits/2024/IKE/1',
+				'http://localhost:8000/api/retirement/limits/2024/IKZE/1'
 			])
 		);
 		for (const call of fetchMock.mock.calls) {

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -8,6 +8,7 @@
 		buildRetirementProjectionOption,
 		type AccountSimulation
 	} from '$lib/utils/charts/simulations';
+	import { ownerName, type OwnerOption } from '$lib/types/owners';
 
 	interface SimulationSummary {
 		total_final_balance: number;
@@ -28,7 +29,7 @@
 	interface IkeIkzeConfig {
 		enabled: boolean;
 		wrapper: string;
-		owner: string;
+		ownerUserId: number;
 		balance: number;
 		autoFill: boolean;
 		monthly: number;
@@ -37,7 +38,7 @@
 
 	interface PpkConfig {
 		enabled: boolean;
-		owner: string;
+		ownerUserId: number;
 		balance: number;
 		salary: number;
 		employeeRate: number;
@@ -48,7 +49,7 @@
 
 	interface BrokerageConfig {
 		enabled: boolean;
-		owner: string;
+		ownerUserId: number;
 		balance: number;
 		monthly: number;
 	}
@@ -61,12 +62,12 @@
 
 	let { data }: Props = $props();
 
-	const personas = $derived((data.personas || []) as Array<{ name: string }>);
+	const owners = $derived((data.owners || []) as OwnerOption[]);
 
 	let currentAge = $state(untrack(() => data.current_age));
 	let retirementAge = $state(untrack(() => data.retirement_age));
 
-	// Dynamic IKE/IKZE accounts - one per persona per wrapper
+	// Dynamic IKE/IKZE accounts - one per owner per wrapper
 	let ikeIkzeAccounts: IkeIkzeConfig[] = $state([]);
 	let ppkAccounts: PpkConfig[] = $state([]);
 	let brokerageAccounts: BrokerageConfig[] = $state([]);
@@ -76,15 +77,15 @@
 		ppkAccounts = [];
 		brokerageAccounts = [];
 
-		for (const persona of personas) {
-			const ownerLower = persona.name.toLowerCase();
+		for (const owner of owners) {
+			const key = String(owner.id);
 
 			for (const wrapper of ['IKE', 'IKZE']) {
-				const balanceKey = `${wrapper.toLowerCase()}_${ownerLower}`;
+				const balanceKey = `${wrapper.toLowerCase()}_${key}`;
 				ikeIkzeAccounts.push({
 					enabled: true,
 					wrapper,
-					owner: persona.name,
+					ownerUserId: owner.id,
 					balance: data.balances?.[balanceKey] ?? 0,
 					autoFill: false,
 					monthly: 0,
@@ -94,18 +95,18 @@
 
 			ppkAccounts.push({
 				enabled: false,
-				owner: persona.name,
-				balance: data.ppk_balances?.[ownerLower] ?? 0,
-				salary: data.monthly_salaries?.[ownerLower] ?? 10000,
-				employeeRate: data.ppk_rates?.[ownerLower]?.employee ?? 2.0,
-				employerRate: data.ppk_rates?.[ownerLower]?.employer ?? 1.5,
+				ownerUserId: owner.id,
+				balance: data.ppk_balances?.[key] ?? 0,
+				salary: data.monthly_salaries?.[key] ?? 10000,
+				employeeRate: data.ppk_rates?.[key]?.employee ?? 2.0,
+				employerRate: data.ppk_rates?.[key]?.employer ?? 1.5,
 				belowThreshold: false,
 				includeSubsidies: true
 			});
 
 			brokerageAccounts.push({
 				enabled: false,
-				owner: persona.name,
+				ownerUserId: owner.id,
 				balance: 0,
 				monthly: 0
 			});
@@ -113,7 +114,7 @@
 	}
 
 	$effect(() => {
-		if (personas.length > 0 && ikeIkzeAccounts.length === 0) {
+		if (owners.length > 0 && ikeIkzeAccounts.length === 0) {
 			initAccounts();
 		}
 	});
@@ -142,18 +143,19 @@
 			// Validate PPK inputs
 			for (const ppk of ppkAccounts) {
 				if (!ppk.enabled) continue;
+				const label = ownerName(owners, ppk.ownerUserId);
 				if (ppk.salary > SALARY_THRESHOLD_2026 && ppk.belowThreshold) {
-					error = `PPK ${ppk.owner}: Wynagrodzenie przekracza próg (${SALARY_THRESHOLD_2026} PLN)`;
+					error = `PPK ${label}: Wynagrodzenie przekracza próg (${SALARY_THRESHOLD_2026} PLN)`;
 					loading = false;
 					return;
 				}
 				if (ppk.employeeRate < 0.5 || ppk.employeeRate > 4.0) {
-					error = `PPK ${ppk.owner}: Składka pracownika musi być w zakresie 0.5-4%`;
+					error = `PPK ${label}: Składka pracownika musi być w zakresie 0.5-4%`;
 					loading = false;
 					return;
 				}
 				if (ppk.employerRate < 1.5 || ppk.employerRate > 4.0) {
-					error = `PPK ${ppk.owner}: Składka pracodawcy musi być w zakresie 1.5-4%`;
+					error = `PPK ${label}: Składka pracodawcy musi być w zakresie 1.5-4%`;
 					loading = false;
 					return;
 				}
@@ -168,7 +170,7 @@
 				ike_ikze_accounts: ikeIkzeAccounts.map((a) => ({
 					enabled: a.enabled,
 					wrapper: a.wrapper,
-					owner: a.owner,
+					owner_user_id: a.ownerUserId,
 					balance: a.balance,
 					auto_fill_limit: a.autoFill,
 					monthly_contribution: a.monthly,
@@ -177,7 +179,7 @@
 				ppk_accounts: ppkAccounts
 					.filter((p) => p.enabled)
 					.map((p) => ({
-						owner: p.owner,
+						owner_user_id: p.ownerUserId,
 						enabled: true,
 						starting_balance: p.balance,
 						monthly_gross_salary: p.salary,
@@ -189,7 +191,7 @@
 					})),
 				brokerage_accounts: brokerageAccounts.map((b) => ({
 					enabled: b.enabled,
-					owner: b.owner,
+					owner_user_id: b.ownerUserId,
 					balance: b.balance,
 					monthly_contribution: b.monthly
 				})),
@@ -281,7 +283,9 @@
 					<div class="card preset-tonal-surface p-4 flex flex-col gap-2">
 						<label class="flex items-center gap-2 cursor-pointer">
 							<input type="checkbox" bind:checked={ikeIkzeAccounts[i].enabled} class="checkbox" />
-							<span class="text-sm font-semibold">{account.wrapper} ({account.owner})</span>
+							<span class="text-sm font-semibold"
+								>{account.wrapper} ({ownerName(owners, account.ownerUserId)})</span
+							>
 						</label>
 						{#if account.enabled}
 							<label class="label">
@@ -335,7 +339,7 @@
 					<div class="card preset-tonal-surface p-4 flex flex-col gap-2">
 						<label class="flex items-center gap-2 cursor-pointer">
 							<input type="checkbox" bind:checked={ppkAccounts[i].enabled} class="checkbox" />
-							<span class="text-sm font-semibold">PPK ({ppk.owner})</span>
+							<span class="text-sm font-semibold">PPK ({ownerName(owners, ppk.ownerUserId)})</span>
 						</label>
 						{#if ppk.enabled}
 							<label class="label">
@@ -419,7 +423,9 @@
 					<div class="card preset-tonal-surface p-4 flex flex-col gap-2">
 						<label class="flex items-center gap-2 cursor-pointer">
 							<input type="checkbox" bind:checked={brokerageAccounts[i].enabled} class="checkbox" />
-							<span class="text-sm font-semibold">Rachunek maklerski ({brokerage.owner})</span>
+							<span class="text-sm font-semibold"
+								>Rachunek maklerski ({ownerName(owners, brokerage.ownerUserId)})</span
+							>
 						</label>
 						{#if brokerage.enabled}
 							<label class="label">

--- a/src/routes/simulations/+page.ts
+++ b/src/routes/simulations/+page.ts
@@ -2,21 +2,22 @@ import { error } from '@sveltejs/kit';
 import { browser } from '$app/environment';
 import { env } from '$env/dynamic/public';
 import type { PageLoad } from './$types';
+import type { OwnerOption } from '$lib/types/owners';
 
 export const load: PageLoad = async ({ fetch }) => {
 	try {
 		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
 		if (!apiUrl) throw error(500, 'API URL not configured');
 
-		const [prefillRes, personasRes] = await Promise.all([
+		const [prefillRes, ownersRes] = await Promise.all([
 			fetch(`${apiUrl}/api/simulations/prefill`),
-			fetch(`${apiUrl}/api/personas`)
+			fetch(`${apiUrl}/api/users`)
 		]);
 		if (!prefillRes.ok) throw error(prefillRes.status, 'Failed to load prefill data');
 
 		const prefill = await prefillRes.json();
-		const personas = personasRes.ok ? await personasRes.json() : [];
-		return { ...prefill, personas };
+		const owners: OwnerOption[] = ownersRes.ok ? await ownersRes.json() : [];
+		return { ...prefill, owners };
 	} catch (err) {
 		if (err instanceof Error && 'status' in err) throw err;
 		throw error(500, 'Failed to load simulation data');

--- a/src/routes/simulations/page.test.ts
+++ b/src/routes/simulations/page.test.ts
@@ -34,7 +34,10 @@ vi.mock('echarts', () => ({
 const mockData = {
 	current_age: 35,
 	retirement_age: 65,
-	personas: [{ name: 'Marcin' }, { name: 'Ewa' }],
+	owners: [
+		{ id: 1, name: 'Marcin' },
+		{ id: 2, name: 'Ewa' }
+	],
 	balances: {},
 	ppk_balances: {},
 	monthly_salaries: {},

--- a/src/routes/simulations/zus/+page.svelte
+++ b/src/routes/simulations/zus/+page.svelte
@@ -4,6 +4,7 @@
 	import { env } from '$env/dynamic/public';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
+	import type { OwnerOption } from '$lib/types/owners';
 
 	interface Props {
 		data: {
@@ -12,11 +13,11 @@
 				retirement_age: number;
 				gender: string;
 				current_gross_monthly_salary: number | null;
-				owner: string | null;
+				owner_user_id: number | null;
 				salary_history: { year: number; annual_gross: number }[];
 				work_start_year: number | null;
 			};
-			personas: { name: string }[];
+			owners: OwnerOption[];
 		};
 	}
 
@@ -58,7 +59,7 @@
 	}
 
 	// Form state
-	let owner = $state(untrack(() => data.prefill.owner ?? data.personas[0]?.name ?? ''));
+	let ownerUserId = $state(untrack(() => data.prefill.owner_user_id ?? data.owners[0]?.id ?? null));
 	let birthDate = $state(untrack(() => data.prefill.birth_date ?? ''));
 	let gender = $state(untrack(() => data.prefill.gender ?? 'M'));
 	let retirementAge = $state(untrack(() => data.prefill.retirement_age ?? 65));
@@ -100,7 +101,7 @@
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
-					owner,
+					owner_user_id: ownerUserId,
 					birth_date: birthDate,
 					gender,
 					retirement_age: retirementAge,
@@ -216,9 +217,9 @@
 			<div class="flex flex-col gap-3">
 				<label class="label">
 					<span class="text-sm font-semibold">Osoba</span>
-					<select bind:value={owner} class="select">
-						{#each data.personas as persona}
-							<option value={persona.name}>{persona.name}</option>
+					<select bind:value={ownerUserId} class="select">
+						{#each data.owners as owner}
+							<option value={owner.id}>{owner.name}</option>
 						{/each}
 					</select>
 				</label>

--- a/src/routes/simulations/zus/+page.ts
+++ b/src/routes/simulations/zus/+page.ts
@@ -2,21 +2,22 @@ import { error } from '@sveltejs/kit';
 import { browser } from '$app/environment';
 import { env } from '$env/dynamic/public';
 import type { PageLoad } from './$types';
+import type { OwnerOption } from '$lib/types/owners';
 
 export const load: PageLoad = async ({ fetch }) => {
 	try {
 		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
 		if (!apiUrl) throw error(500, 'API URL not configured');
 
-		const [prefillRes, personasRes] = await Promise.all([
+		const [prefillRes, ownersRes] = await Promise.all([
 			fetch(`${apiUrl}/api/zus/prefill`),
-			fetch(`${apiUrl}/api/personas`)
+			fetch(`${apiUrl}/api/users`)
 		]);
 		if (!prefillRes.ok) throw error(prefillRes.status, 'Failed to load ZUS prefill data');
 
 		const prefill = await prefillRes.json();
-		const personas = personasRes.ok ? await personasRes.json() : [];
-		return { prefill, personas };
+		const owners: OwnerOption[] = ownersRes.ok ? await ownersRes.json() : [];
+		return { prefill, owners };
 	} catch (err) {
 		if (err instanceof Error && 'status' in err) throw err;
 		throw error(500, 'Failed to load ZUS calculator data');


### PR DESCRIPTION
## Motivation

Part of the personas→users merge (umbrella #495, phase C4 — closes #497).
Switches the remaining owner-aware packages — **retirement**, **dashboard**,
**aggregates**, **simulations**, **zus** — from the legacy `owner` string to
`owner_user_id` (FK-shaped integer to `users`; `null` = jointly owned).

> Changelog: feat(api): owner_user_id for retirement, dashboard, sims, zus

## Implementation information

- **retirement** — `retirement_limits.owner` → `owner_user_id`; the route
  `/api/retirement/limits/{year}/{wrapper}/{owner}` path param is renamed to
  `{owner_user_id}` (literal `null` addresses the Shared row). PPK rates +
  names resolve via `users` (phase A moved PPK off `personas`). `owner` is
  dual-written; the `uq_year_wrapper_owner` constraint is untouched (phase D
  rebuilds it).
- **aggregates** — `ComputeAggregates` keys buckets by `owner_user_id`
  (comparable struct key; `nil` = the Shared bucket); `snapshot_aggregates`
  INSERT dual-writes `owner`.
- **dashboard** — allocation grouped by `owner_user_id`; the hardcoded
  `owner == "Marcin" || "Shared"` real-estate filter in `paths.go` is removed.
- **simulations / zus** — owner-keyed prefill maps keyed by `owner_user_id`;
  request/response `owner` fields → `owner_user_id`.
- **Frontend** — dashboard, metryki and simulations pages source owner
  options from `/api/users` and resolve names via `ownerName()`.
- `api/openapi-go.json` + `src/lib/types/api.generated.ts` regenerated;
  affected golden snapshots regenerated (owner-string → integer-id shape only).
- No schema change (the `owner_user_id` columns already exist from phase B).

## Supporting documentation

Umbrella issue #495 · sub-issue #497.