### PR TITLE
chore(deps): clear stale Python alerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,7 +28,11 @@
     {
       "description": "Group black-box test Python dependencies",
       "groupName": "backend-bb-tests python",
-      "matchFileNames": ["backend-bb-tests/**"]
+      "matchManagers": ["pep621", "pip_requirements", "poetry"],
+      "matchFileNames": [
+        "backend-bb-tests/pyproject.toml",
+        "backend-bb-tests/uv.lock"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -26,16 +26,9 @@
       ]
     },
     {
-      "description": "Group the FastAPI / Pydantic / SQLAlchemy backend stack",
-      "groupName": "fastapi stack",
-      "matchPackageNames": [
-        "fastapi",
-        "starlette",
-        "uvicorn",
-        "alembic",
-        "/^pydantic/",
-        "/^sqlalchemy/"
-      ]
+      "description": "Group black-box test Python dependencies",
+      "groupName": "backend-bb-tests python",
+      "matchFileNames": ["backend-bb-tests/**"]
     }
   ]
 }


### PR DESCRIPTION
## Motivation

The Python backend was removed in earlier work but GitHub still flagged 14 open Dependabot alerts against the deleted `uv.lock` and `backend/uv.lock` manifests. The remaining tracked Python lockfile (`backend-bb-tests/uv.lock`) already pins patched versions, so those alerts were noise that hid the only actionable alert (#7, cookie via SvelteKit — tracked by issue #510).

## Implementation information

- Dismissed Dependabot alerts 1-6 and 8-15 as stale removed-manifest alerts via the API.
- Verified `backend-bb-tests/uv.lock` contains: idna 3.15, urllib3 2.7.0, python-dotenv 1.2.2, pytest 9.0.3, pygments 2.20.0, requests 2.34.2.
- Replaced the dead FastAPI/Pydantic/SQLAlchemy package group in `renovate.json` with a `backend-bb-tests/**` file scope so future Python test dep PRs stay grouped.
- Left the npm cookie alert (#7) open — that one is real and is being addressed in #510.

Closes #511

> Changelog: chore(deps): clear stale Python alerts