### PR TITLE
test(e2e): parallelize await-in-loop iterations

### DIFF
--- a/e2e-mobile/verify-mobile.mjs
+++ b/e2e-mobile/verify-mobile.mjs
@@ -89,40 +89,43 @@ async function audit(page, url) {
 	}, MIN_TAP);
 }
 
+async function auditRoute(ctx, vpLabel, route) {
+	const page = await ctx.newPage();
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') {
+			console.error(`[${vpLabel}] console error:`, msg.text().slice(0, 200));
+		}
+	});
+	const url = `${BASE_URL}${route.path}`;
+	try {
+		const audit_result = await audit(page, url);
+		const screenshot = join(OUT_DIR, `${vpLabel}-${route.name}.png`);
+		await page.screenshot({ path: screenshot, fullPage: true });
+		const status =
+			audit_result.overflowX === 0 && audit_result.tooSmall.length === 0 ? 'OK' : 'ISSUE';
+		console.log(
+			`  [${vpLabel}] ${route.path} ... ${status}  overflowX=${audit_result.overflowX}px  tapTooSmall=${audit_result.tooSmall.length}`
+		);
+		await page.close();
+		return { viewport: vpLabel, route: route.path, ...audit_result };
+	} catch (err) {
+		console.log(`  [${vpLabel}] ${route.path} ... ERROR: ${err.message.slice(0, 100)}`);
+		await page.close().catch(() => {});
+		return { viewport: vpLabel, route: route.path, error: err.message };
+	}
+}
+
+async function auditViewport(browser, vp) {
+	const ctx = await browser.newContext({ ...vp.device });
+	const results = await Promise.all(ROUTES.map((route) => auditRoute(ctx, vp.label, route)));
+	await ctx.close();
+	return results;
+}
+
 async function run() {
 	const browser = await chromium.launch();
-	const results = [];
-
-	for (const vp of VIEWPORTS) {
-		const ctx = await browser.newContext({ ...vp.device });
-		const page = await ctx.newPage();
-		page.on('console', (msg) => {
-			if (msg.type() === 'error') {
-				console.error(`[${vp.label}] console error:`, msg.text().slice(0, 200));
-			}
-		});
-
-		for (const route of ROUTES) {
-			const url = `${BASE_URL}${route.path}`;
-			process.stdout.write(`  [${vp.label}] ${route.path} ... `);
-			try {
-				const audit_result = await audit(page, url);
-				const screenshot = join(OUT_DIR, `${vp.label}-${route.name}.png`);
-				await page.screenshot({ path: screenshot, fullPage: true });
-
-				const status =
-					audit_result.overflowX === 0 && audit_result.tooSmall.length === 0 ? 'OK' : 'ISSUE';
-				console.log(
-					`${status}  overflowX=${audit_result.overflowX}px  tapTooSmall=${audit_result.tooSmall.length}`
-				);
-				results.push({ viewport: vp.label, route: route.path, ...audit_result });
-			} catch (err) {
-				console.log(`ERROR: ${err.message.slice(0, 100)}`);
-				results.push({ viewport: vp.label, route: route.path, error: err.message });
-			}
-		}
-		await ctx.close();
-	}
+	const perViewport = await Promise.all(VIEWPORTS.map((vp) => auditViewport(browser, vp)));
+	const results = perViewport.flat();
 
 	await browser.close();
 

--- a/e2e-mobile/verify-mobile.mjs
+++ b/e2e-mobile/verify-mobile.mjs
@@ -117,9 +117,11 @@ async function auditRoute(ctx, vpLabel, route) {
 
 async function auditViewport(browser, vp) {
 	const ctx = await browser.newContext({ ...vp.device });
-	const results = await Promise.all(ROUTES.map((route) => auditRoute(ctx, vp.label, route)));
-	await ctx.close();
-	return results;
+	try {
+		return await Promise.all(ROUTES.map((route) => auditRoute(ctx, vp.label, route)));
+	} finally {
+		await ctx.close();
+	}
 }
 
 async function run() {

--- a/e2e-mobile/verify-zus-interaction.mjs
+++ b/e2e-mobile/verify-zus-interaction.mjs
@@ -9,88 +9,99 @@ const VIEWPORTS = [
 
 async function testViewport(browser, vp) {
 	const ctx = await browser.newContext({ ...vp.device });
-	const page = await ctx.newPage();
-	const consoleErrors = [];
-	page.on('pageerror', (err) => consoleErrors.push(err.message));
-	page.on('console', (msg) => {
-		if (msg.type() === 'error') consoleErrors.push(msg.text().slice(0, 400));
-	});
-	page.on('requestfailed', (r) =>
-		consoleErrors.push(`request failed: ${r.url()} ${r.failure()?.errorText}`)
-	);
-	page.on('response', async (r) => {
-		if (r.url().includes('/api/zus') && r.status() >= 400) {
-			const body = await r.text().catch(() => '');
-			consoleErrors.push(`zus api ${r.status()}: ${body.slice(0, 400)}`);
-		}
-	});
-
-	console.log(`\n[${vp.label}] visiting /simulations/zus`);
-	await page.goto(`${BASE_URL}/simulations/zus`, { waitUntil: 'networkidle' });
-	await page.waitForTimeout(500);
-
-	const formVisible = await page.locator('.form-section').isVisible();
-	const runButton = page.locator('button.primary-button');
-	const runButtonVisible = await runButton.isVisible();
-
-	console.log(`  [${vp.label}] form visible: ${formVisible}`);
-	console.log(`  [${vp.label}] run button visible: ${runButtonVisible}`);
-
-	let result = { viewport: vp.label, success: !runButtonVisible };
-
-	if (runButtonVisible) {
-		console.log(`  [${vp.label}] filling form fields...`);
-		await page.locator('input[type="date"]').first().fill('1990-06-15');
-		const retirementAgeInput = page.locator('input[type="number"]').nth(0);
-		// Set a valid retirement age (first numeric input is retirement age in this form)
-		await retirementAgeInput.fill('65');
-		await page.waitForTimeout(200);
-		console.log(`  [${vp.label}] clicking run button...`);
-		await runButton.click();
-
-		try {
-			await page.waitForSelector('.summary-cards', { timeout: 15000 });
-			console.log(`  [${vp.label}] results rendered: OK`);
-
-			const summaryCards = await page.locator('.summary-card').count();
-			console.log(`  [${vp.label}] summary cards: ${summaryCards}`);
-
-			const chartHeight = await page.locator('.chart-container').evaluate((el) => el.offsetHeight);
-			console.log(`  [${vp.label}] chart height: ${chartHeight}px`);
-
-			// Check if table still scrolls nicely on mobile
-			const tableWrapper = page.locator('.projection-table').first();
-			const hasTable = (await tableWrapper.count()) > 0;
-			if (hasTable) {
-				const tableScroll = await tableWrapper.evaluate((el) => ({
-					scrollWidth: el.scrollWidth,
-					clientWidth: el.clientWidth,
-					overflow: getComputedStyle(el).overflowX
-				}));
-				console.log(
-					`  [${vp.label}] projection table: scrollW=${tableScroll.scrollWidth} clientW=${tableScroll.clientWidth} overflow=${tableScroll.overflow}`
-				);
+	try {
+		const page = await ctx.newPage();
+		const consoleErrors = [];
+		page.on('pageerror', (err) => consoleErrors.push(err.message));
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') consoleErrors.push(msg.text().slice(0, 400));
+		});
+		page.on('requestfailed', (r) =>
+			consoleErrors.push(`request failed: ${r.url()} ${r.failure()?.errorText}`)
+		);
+		page.on('response', async (r) => {
+			if (r.url().includes('/api/zus') && r.status() >= 400) {
+				const body = await r.text().catch(() => '');
+				consoleErrors.push(`zus api ${r.status()}: ${body.slice(0, 400)}`);
 			}
+		});
 
-			const pageOverflow = await page.evaluate(
-				() => document.documentElement.scrollWidth - document.documentElement.clientWidth
-			);
-			console.log(`  [${vp.label}] page overflow x: ${pageOverflow}px`);
+		console.log(`\n[${vp.label}] visiting /simulations/zus`);
+		await page.goto(`${BASE_URL}/simulations/zus`, { waitUntil: 'networkidle' });
+		await page.waitForTimeout(500);
 
-			result = { viewport: vp.label, success: true };
-		} catch (err) {
-			console.log(`  [${vp.label}] ERROR waiting for results: ${err.message}`);
-			result = { viewport: vp.label, success: false, error: err.message };
+		const formVisible = await page.locator('.form-section').isVisible();
+		const runButton = page.locator('button.primary-button');
+		const runButtonVisible = await runButton.isVisible();
+
+		console.log(`  [${vp.label}] form visible: ${formVisible}`);
+		console.log(`  [${vp.label}] run button visible: ${runButtonVisible}`);
+
+		let result;
+
+		if (!runButtonVisible) {
+			result = {
+				viewport: vp.label,
+				success: false,
+				error: 'run button not visible — page did not render correctly'
+			};
+		} else {
+			console.log(`  [${vp.label}] filling form fields...`);
+			await page.locator('input[type="date"]').first().fill('1990-06-15');
+			const retirementAgeInput = page.locator('input[type="number"]').nth(0);
+			// Set a valid retirement age (first numeric input is retirement age in this form)
+			await retirementAgeInput.fill('65');
+			await page.waitForTimeout(200);
+			console.log(`  [${vp.label}] clicking run button...`);
+			await runButton.click();
+
+			try {
+				await page.waitForSelector('.summary-cards', { timeout: 15000 });
+				console.log(`  [${vp.label}] results rendered: OK`);
+
+				const summaryCards = await page.locator('.summary-card').count();
+				console.log(`  [${vp.label}] summary cards: ${summaryCards}`);
+
+				const chartHeight = await page
+					.locator('.chart-container')
+					.evaluate((el) => el.offsetHeight);
+				console.log(`  [${vp.label}] chart height: ${chartHeight}px`);
+
+				// Check if table still scrolls nicely on mobile
+				const tableWrapper = page.locator('.projection-table').first();
+				const hasTable = (await tableWrapper.count()) > 0;
+				if (hasTable) {
+					const tableScroll = await tableWrapper.evaluate((el) => ({
+						scrollWidth: el.scrollWidth,
+						clientWidth: el.clientWidth,
+						overflow: getComputedStyle(el).overflowX
+					}));
+					console.log(
+						`  [${vp.label}] projection table: scrollW=${tableScroll.scrollWidth} clientW=${tableScroll.clientWidth} overflow=${tableScroll.overflow}`
+					);
+				}
+
+				const pageOverflow = await page.evaluate(
+					() => document.documentElement.scrollWidth - document.documentElement.clientWidth
+				);
+				console.log(`  [${vp.label}] page overflow x: ${pageOverflow}px`);
+
+				result = { viewport: vp.label, success: true };
+			} catch (err) {
+				console.log(`  [${vp.label}] ERROR waiting for results: ${err.message}`);
+				result = { viewport: vp.label, success: false, error: err.message };
+			}
 		}
-	}
 
-	if (consoleErrors.length > 0) {
-		console.log(`  [${vp.label}] console/page errors:`);
-		for (const e of consoleErrors.slice(0, 3)) console.log(`    - ${e}`);
-	}
+		if (consoleErrors.length > 0) {
+			console.log(`  [${vp.label}] console/page errors:`);
+			for (const e of consoleErrors.slice(0, 3)) console.log(`    - ${e}`);
+		}
 
-	await ctx.close();
-	return result;
+		return result;
+	} finally {
+		await ctx.close();
+	}
 }
 
 async function run() {

--- a/e2e-mobile/verify-zus-interaction.mjs
+++ b/e2e-mobile/verify-zus-interaction.mjs
@@ -2,100 +2,100 @@ import { chromium, devices } from '@playwright/test';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:5174';
 
-async function run() {
-	const browser = await chromium.launch();
-	const results = [];
+const VIEWPORTS = [
+	{ label: 'iphone', device: devices['iPhone 14 Pro'] },
+	{ label: 'ipad', device: devices['iPad Mini'] }
+];
 
-	for (const vp of [
-		{ label: 'iphone', device: devices['iPhone 14 Pro'] },
-		{ label: 'ipad', device: devices['iPad Mini'] }
-	]) {
-		const ctx = await browser.newContext({ ...vp.device });
-		const page = await ctx.newPage();
-		const consoleErrors = [];
-		page.on('pageerror', (err) => consoleErrors.push(err.message));
-		page.on('console', (msg) => {
-			if (msg.type() === 'error') consoleErrors.push(msg.text().slice(0, 400));
-		});
-		page.on('requestfailed', (r) =>
-			consoleErrors.push(`request failed: ${r.url()} ${r.failure()?.errorText}`)
-		);
-		page.on('response', async (r) => {
-			if (r.url().includes('/api/zus') && r.status() >= 400) {
-				const body = await r.text().catch(() => '');
-				consoleErrors.push(`zus api ${r.status()}: ${body.slice(0, 400)}`);
-			}
-		});
+async function testViewport(browser, vp) {
+	const ctx = await browser.newContext({ ...vp.device });
+	const page = await ctx.newPage();
+	const consoleErrors = [];
+	page.on('pageerror', (err) => consoleErrors.push(err.message));
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') consoleErrors.push(msg.text().slice(0, 400));
+	});
+	page.on('requestfailed', (r) =>
+		consoleErrors.push(`request failed: ${r.url()} ${r.failure()?.errorText}`)
+	);
+	page.on('response', async (r) => {
+		if (r.url().includes('/api/zus') && r.status() >= 400) {
+			const body = await r.text().catch(() => '');
+			consoleErrors.push(`zus api ${r.status()}: ${body.slice(0, 400)}`);
+		}
+	});
 
-		console.log(`\n[${vp.label}] visiting /simulations/zus`);
-		await page.goto(`${BASE_URL}/simulations/zus`, { waitUntil: 'networkidle' });
-		await page.waitForTimeout(500);
+	console.log(`\n[${vp.label}] visiting /simulations/zus`);
+	await page.goto(`${BASE_URL}/simulations/zus`, { waitUntil: 'networkidle' });
+	await page.waitForTimeout(500);
 
-		const formVisible = await page.locator('.form-section').isVisible();
-		const runButton = page.locator('button.primary-button');
-		const runButtonVisible = await runButton.isVisible();
+	const formVisible = await page.locator('.form-section').isVisible();
+	const runButton = page.locator('button.primary-button');
+	const runButtonVisible = await runButton.isVisible();
 
-		console.log(`  form visible: ${formVisible}`);
-		console.log(`  run button visible: ${runButtonVisible}`);
+	console.log(`  [${vp.label}] form visible: ${formVisible}`);
+	console.log(`  [${vp.label}] run button visible: ${runButtonVisible}`);
 
-		if (runButtonVisible) {
-			console.log('  filling form fields...');
-			await page.locator('input[type="date"]').first().fill('1990-06-15');
-			const retirementAgeInput = page.locator('input[type="number"]').nth(0);
-			// Set a valid retirement age (first numeric input is retirement age in this form)
-			await retirementAgeInput.fill('65');
-			await page.waitForTimeout(200);
-			console.log('  clicking run button...');
-			await runButton.click();
+	let result = { viewport: vp.label, success: !runButtonVisible };
 
-			// Wait for results
-			try {
-				await page.waitForSelector('.summary-cards', { timeout: 15000 });
-				console.log('  results rendered: OK');
+	if (runButtonVisible) {
+		console.log(`  [${vp.label}] filling form fields...`);
+		await page.locator('input[type="date"]').first().fill('1990-06-15');
+		const retirementAgeInput = page.locator('input[type="number"]').nth(0);
+		// Set a valid retirement age (first numeric input is retirement age in this form)
+		await retirementAgeInput.fill('65');
+		await page.waitForTimeout(200);
+		console.log(`  [${vp.label}] clicking run button...`);
+		await runButton.click();
 
-				const summaryCards = await page.locator('.summary-card').count();
-				console.log(`  summary cards: ${summaryCards}`);
+		try {
+			await page.waitForSelector('.summary-cards', { timeout: 15000 });
+			console.log(`  [${vp.label}] results rendered: OK`);
 
-				const chartHeight = await page
-					.locator('.chart-container')
-					.evaluate((el) => el.offsetHeight);
-				console.log(`  chart height: ${chartHeight}px`);
+			const summaryCards = await page.locator('.summary-card').count();
+			console.log(`  [${vp.label}] summary cards: ${summaryCards}`);
 
-				// Check if table still scrolls nicely on mobile
-				const tableWrapper = page.locator('.projection-table').first();
-				const hasTable = (await tableWrapper.count()) > 0;
-				if (hasTable) {
-					const tableScroll = await tableWrapper.evaluate((el) => ({
-						scrollWidth: el.scrollWidth,
-						clientWidth: el.clientWidth,
-						overflow: getComputedStyle(el).overflowX
-					}));
-					console.log(
-						`  projection table: scrollW=${tableScroll.scrollWidth} clientW=${tableScroll.clientWidth} overflow=${tableScroll.overflow}`
-					);
-				}
+			const chartHeight = await page.locator('.chart-container').evaluate((el) => el.offsetHeight);
+			console.log(`  [${vp.label}] chart height: ${chartHeight}px`);
 
-				// Verify no page-level horizontal overflow
-				const pageOverflow = await page.evaluate(
-					() => document.documentElement.scrollWidth - document.documentElement.clientWidth
+			// Check if table still scrolls nicely on mobile
+			const tableWrapper = page.locator('.projection-table').first();
+			const hasTable = (await tableWrapper.count()) > 0;
+			if (hasTable) {
+				const tableScroll = await tableWrapper.evaluate((el) => ({
+					scrollWidth: el.scrollWidth,
+					clientWidth: el.clientWidth,
+					overflow: getComputedStyle(el).overflowX
+				}));
+				console.log(
+					`  [${vp.label}] projection table: scrollW=${tableScroll.scrollWidth} clientW=${tableScroll.clientWidth} overflow=${tableScroll.overflow}`
 				);
-				console.log(`  page overflow x: ${pageOverflow}px`);
-
-				results.push({ viewport: vp.label, success: true });
-			} catch (err) {
-				console.log(`  ERROR waiting for results: ${err.message}`);
-				results.push({ viewport: vp.label, success: false, error: err.message });
 			}
-		}
 
-		if (consoleErrors.length > 0) {
-			console.log('  console/page errors:');
-			for (const e of consoleErrors.slice(0, 3)) console.log(`    - ${e}`);
-		}
+			const pageOverflow = await page.evaluate(
+				() => document.documentElement.scrollWidth - document.documentElement.clientWidth
+			);
+			console.log(`  [${vp.label}] page overflow x: ${pageOverflow}px`);
 
-		await ctx.close();
+			result = { viewport: vp.label, success: true };
+		} catch (err) {
+			console.log(`  [${vp.label}] ERROR waiting for results: ${err.message}`);
+			result = { viewport: vp.label, success: false, error: err.message };
+		}
 	}
 
+	if (consoleErrors.length > 0) {
+		console.log(`  [${vp.label}] console/page errors:`);
+		for (const e of consoleErrors.slice(0, 3)) console.log(`    - ${e}`);
+	}
+
+	await ctx.close();
+	return result;
+}
+
+async function run() {
+	const browser = await chromium.launch();
+	const results = await Promise.all(VIEWPORTS.map((vp) => testViewport(browser, vp)));
 	await browser.close();
 
 	const ok = results.every((r) => r.success);

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,31 +1,30 @@
 import { test, expect } from '@playwright/test';
 
+const SIDEBAR_LINKS: { label: string; path: string }[] = [
+	{ label: 'Metryki', path: '/metryki' },
+	{ label: 'Konta', path: '/accounts' },
+	{ label: 'Transakcje', path: '/transactions' },
+	{ label: 'Majątek', path: '/assets' },
+	{ label: 'Zobowiązania', path: '/debts' },
+	{ label: 'Cele', path: '/goals' },
+	{ label: 'Snapshoty', path: '/snapshots' },
+	{ label: 'Wynagrodzenia', path: '/salaries' },
+	{ label: 'Konfiguracja', path: '/config' },
+	{ label: 'Ustawienia', path: '/settings' }
+];
+
 test.describe('navigation', () => {
-	test('desktop sidebar links navigate to each page', async ({ page, isMobile }) => {
-		test.skip(isMobile, 'desktop-only sidebar');
-		await page.goto('/');
-
-		const links: { label: string; path: string }[] = [
-			{ label: 'Metryki', path: '/metryki' },
-			{ label: 'Konta', path: '/accounts' },
-			{ label: 'Transakcje', path: '/transactions' },
-			{ label: 'Majątek', path: '/assets' },
-			{ label: 'Zobowiązania', path: '/debts' },
-			{ label: 'Cele', path: '/goals' },
-			{ label: 'Snapshoty', path: '/snapshots' },
-			{ label: 'Wynagrodzenia', path: '/salaries' },
-			{ label: 'Konfiguracja', path: '/config' },
-			{ label: 'Ustawienia', path: '/settings' }
-		];
-
-		for (const link of links) {
+	for (const link of SIDEBAR_LINKS) {
+		test(`desktop sidebar link navigates to ${link.path}`, async ({ page, isMobile }) => {
+			test.skip(isMobile, 'desktop-only sidebar');
+			await page.goto('/');
 			await page
 				.locator('aside')
 				.getByRole('link', { name: new RegExp(`^${link.label}$`) })
 				.click();
 			await expect(page).toHaveURL(new RegExp(`${link.path}$`));
-		}
-	});
+		});
+	}
 
 	test('mobile bottom nav is visible and scrollable', async ({ page, isMobile }) => {
 		test.skip(!isMobile, 'mobile-only nav');


### PR DESCRIPTION
## Motivation

`oxlint` reported 26 `no-await-in-loop` warnings across the e2e and e2e-mobile suites. Beyond noise, the sequential awaits made the verification scripts slower than needed.

## Implementation information

- `e2e/navigation.spec.ts`: registered one Playwright test per sidebar link via a `for...of` around `test()`. The for-loop body now contains no `await`, and Playwright runs the resulting cases in parallel.
- `e2e-mobile/verify-mobile.mjs`: extracted per-viewport audit into `auditViewport`; the route loop is now `Promise.all(ROUTES.map(...))` with a fresh page per route within the same context.
- `e2e-mobile/verify-zus-interaction.mjs`: extracted per-viewport flow into `testViewport`; the viewport loop is now `Promise.all`. Inner per-page logic stayed sequential since it operates on a single page, and the entire sequence sits inside an async helper (no await in a loop).

`npm run lint` is now clean.

Closes #504

> Changelog: test(e2e): parallelize await-in-loop iterations