### PR TITLE
fix(frontend): remove no-shadow in assets page

### DIFF
--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -147,8 +147,8 @@
 			});
 
 			if (!response.ok) {
-				const data = await response.json();
-				throw new Error(data.detail || 'Failed to save account');
+				const errorBody = await response.json();
+				throw new Error(errorBody.detail || 'Failed to save account');
 			}
 
 			await invalidateAll();

--- a/src/routes/assets/+page.svelte
+++ b/src/routes/assets/+page.svelte
@@ -64,8 +64,8 @@
 			});
 
 			if (!response.ok) {
-				const data = await response.json();
-				throw new Error(data.detail || 'Failed to save asset');
+				const errorBody = await response.json();
+				throw new Error(errorBody.detail || 'Failed to save asset');
 			}
 
 			await invalidateAll();


### PR DESCRIPTION
## Motivation

`oxlint` reported `no-shadow` on the `data` declared inside the fetch error branches of `src/routes/assets/+page.svelte:67` and `src/routes/accounts/+page.svelte:150`. The outer `data` is the page-props prop, and shadowing it inside the catch path is a subtle footgun.

## Implementation information

Renamed the inner `data` (parsed error body) to `errorBody` in both files. Behavior is unchanged.

Closes #505

> Changelog: fix(frontend): remove no-shadow variable in assets page