### PR TITLE
fix(frontend): rename _exhaustive in pl_tax

### DIFF
--- a/src/lib/utils/pl_tax.ts
+++ b/src/lib/utils/pl_tax.ts
@@ -186,8 +186,8 @@ export function grossToNet(
 		case 'UoD':
 			return netUod(grossMonthly, year);
 		default: {
-			const _exhaustive: never = contractType;
-			throw new Error(`Unknown contract type: ${String(_exhaustive)}`);
+			const exhaustiveCheck: never = contractType;
+			throw new Error(`Unknown contract type: ${String(exhaustiveCheck)}`);
 		}
 	}
 }


### PR DESCRIPTION
## Motivation

`oxlint` flagged `_exhaustive` in `src/lib/utils/pl_tax.ts:189` as `no-underscore-dangle`. It is a standard exhaustiveness check in the contract-type switch.

## Implementation information

Renamed `_exhaustive` to `exhaustiveCheck`. No behavior change.

Closes #506

> Changelog: fix(frontend): remove dangling underscore in pl_tax