### PR TITLE
test(go): expand backend unit test coverage

### DIFF
--- a/backend-go/internal/accounts/handler_test.go
+++ b/backend-go/internal/accounts/handler_test.go
@@ -1,0 +1,129 @@
+package accounts
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+)
+
+func TestIsoNaiveMarshalJSON(t *testing.T) {
+	tm := isoNaive(time.Date(2026, 5, 23, 10, 11, 12, 345678000, time.UTC))
+	got, err := tm.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `"2026-05-23T10:11:12.345678"`
+	if string(got) != want {
+		t.Fatalf("got %s want %s", got, want)
+	}
+}
+
+func TestIsoNaiveZeroValueFormatsAsZero(t *testing.T) {
+	tm := isoNaive(time.Time{})
+	got, err := tm.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatalf("zero time should still marshal to a quoted string, got %s", got)
+	}
+}
+
+func TestPyFloatIntegerGetsDotZero(t *testing.T) {
+	got, err := pyFloat(5).MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(got) != "5.0" {
+		t.Fatalf("got %s want 5.0", got)
+	}
+}
+
+func TestPyFloatPreservesDecimal(t *testing.T) {
+	got, err := pyFloat(5.5).MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(got) != "5.5" {
+		t.Fatalf("got %s want 5.5", got)
+	}
+}
+
+func TestPyFloatNegative(t *testing.T) {
+	got, err := pyFloat(-12.34).MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(got) != "-12.34" {
+		t.Fatalf("got %s want -12.34", got)
+	}
+}
+
+func TestToResponseSquareMetersOmitWhenNil(t *testing.T) {
+	a := &Account{
+		ID: 7, Name: "Konto", Type: "asset", Category: "bank",
+		Currency: "PLN", Purpose: "general",
+	}
+	r := toResponse(a, decimal.NewFromInt(100))
+	if r.SquareMeters != nil {
+		t.Fatalf("square meters should be nil, got %+v", r.SquareMeters)
+	}
+	if float64(r.CurrentValue) != 100 {
+		t.Fatalf("current value mismatch: %v", r.CurrentValue)
+	}
+}
+
+func TestToResponseSquareMetersForwarded(t *testing.T) {
+	sq := decimal.NewFromFloat(55.5)
+	a := &Account{
+		ID: 1, Name: "Mieszkanie", Type: "asset", Category: "real_estate",
+		Currency: "PLN", Purpose: "general",
+		SquareMeters: &sq,
+	}
+	r := toResponse(a, decimal.Zero)
+	if r.SquareMeters == nil || float64(*r.SquareMeters) != 55.5 {
+		t.Fatalf("square meters mismatch: %+v", r.SquareMeters)
+	}
+}
+
+func TestParseIDParamValid(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/accounts/42", http.NoBody)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "42")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	id, ok := parseIDParam(rec, req)
+	if !ok || id != 42 {
+		t.Fatalf("expected id=42 ok=true, got %d %v", id, ok)
+	}
+}
+
+func TestParseIDParamInvalidWrites422(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/accounts/abc", http.NoBody)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "abc")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	_, ok := parseIDParam(rec, req)
+	if ok {
+		t.Fatal("expected ok=false on bad id")
+	}
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", rec.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body not json: %v", err)
+	}
+	if _, ok := body["detail"]; !ok {
+		t.Fatalf("expected detail key in error body: %s", rec.Body)
+	}
+}

--- a/backend-go/internal/accounts/validation_test.go
+++ b/backend-go/internal/accounts/validation_test.go
@@ -1,0 +1,277 @@
+package accounts
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func rawJSON(t *testing.T, m map[string]any) map[string]json.RawMessage {
+	t.Helper()
+	out := make(map[string]json.RawMessage, len(m))
+	for k, v := range m {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", k, err)
+		}
+		out[k] = b
+	}
+	return out
+}
+
+func TestBuildCreateRequestMinimal(t *testing.T) {
+	raw := rawJSON(t, map[string]any{
+		"name":          "Konto główne",
+		"type":          "asset",
+		"category":      "bank",
+		"owner_user_id": 1,
+		"purpose":       "general",
+	})
+	r, vErr := buildCreateRequest(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected validation error: %+v", vErr)
+	}
+	if r.Name != "Konto główne" || r.Type != "asset" || r.Category != "bank" || r.Purpose != "general" {
+		t.Fatalf("unexpected request: %+v", r)
+	}
+	if r.OwnerUserID == nil || *r.OwnerUserID != 1 {
+		t.Fatalf("owner mismatch: %+v", r.OwnerUserID)
+	}
+	if r.Currency != "PLN" {
+		t.Fatalf("currency fallback failed: %q", r.Currency)
+	}
+	if !r.ReceivesContributions {
+		t.Fatalf("receives_contributions default should be true")
+	}
+}
+
+func TestBuildCreateRequestSharedOwner(t *testing.T) {
+	raw := rawJSON(t, map[string]any{
+		"name":          "Wspólne",
+		"type":          "asset",
+		"category":      "bank",
+		"owner_user_id": nil,
+		"purpose":       "general",
+	})
+	r, vErr := buildCreateRequest(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if r.OwnerUserID != nil {
+		t.Fatalf("shared owner should be nil, got %+v", r.OwnerUserID)
+	}
+}
+
+func TestBuildCreateRequestRequiredFields(t *testing.T) {
+	cases := []struct {
+		name       string
+		omit       string
+		wantField  string
+		wantSubstr string
+	}{
+		{"missing name", "name", "name", "Field required"},
+		{"missing type", "type", "type", "Field required"},
+		{"missing category", "category", "category", "Field required"},
+		{"missing owner", "owner_user_id", "owner_user_id", "Field required"},
+		{"missing purpose", "purpose", "purpose", "Field required"},
+	}
+	base := map[string]any{
+		"name":          "X",
+		"type":          "asset",
+		"category":      "bank",
+		"owner_user_id": 1,
+		"purpose":       "general",
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := map[string]any{}
+			for k, v := range base {
+				if k == tc.omit {
+					continue
+				}
+				input[k] = v
+			}
+			_, vErr := buildCreateRequest(rawJSON(t, input))
+			if vErr == nil {
+				t.Fatalf("expected validation error for omit %s", tc.omit)
+			}
+			if vErr.Field != tc.wantField {
+				t.Fatalf("field mismatch: got %q want %q", vErr.Field, tc.wantField)
+			}
+		})
+	}
+}
+
+func TestBuildCreateRequestInvalidEnum(t *testing.T) {
+	raw := rawJSON(t, map[string]any{
+		"name":          "X",
+		"type":          "bogus",
+		"category":      "bank",
+		"owner_user_id": 1,
+		"purpose":       "general",
+	})
+	_, vErr := buildCreateRequest(raw)
+	if vErr == nil || vErr.Field != "type" {
+		t.Fatalf("expected type validation error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestBlankName(t *testing.T) {
+	raw := rawJSON(t, map[string]any{
+		"name":          "   ",
+		"type":          "asset",
+		"category":      "bank",
+		"owner_user_id": 1,
+		"purpose":       "general",
+	})
+	_, vErr := buildCreateRequest(raw)
+	if vErr == nil || vErr.Field != "name" {
+		t.Fatalf("expected name validation error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestSquareMeters(t *testing.T) {
+	raw := rawJSON(t, map[string]any{
+		"name":          "Mieszkanie",
+		"type":          "asset",
+		"category":      "real_estate",
+		"owner_user_id": 1,
+		"purpose":       "general",
+		"square_meters": 55.5,
+	})
+	r, vErr := buildCreateRequest(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if r.SquareMeters == nil || !r.SquareMeters.Equal(decimal.RequireFromString("55.5")) {
+		t.Fatalf("square meters mismatch: %+v", r.SquareMeters)
+	}
+}
+
+func TestBuildCreateRequestReceivesContributionsFalse(t *testing.T) {
+	raw := rawJSON(t, map[string]any{
+		"name":                   "Konto",
+		"type":                   "asset",
+		"category":               "bank",
+		"owner_user_id":          1,
+		"purpose":                "general",
+		"receives_contributions": false,
+	})
+	r, vErr := buildCreateRequest(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if r.ReceivesContributions {
+		t.Fatalf("expected receives_contributions=false")
+	}
+}
+
+func TestBuildUpdatePatchEmpty(t *testing.T) {
+	p, vErr := buildUpdatePatch(map[string]json.RawMessage{})
+	if vErr != nil {
+		t.Fatalf("empty patch should be valid, got %+v", vErr)
+	}
+	if p.Name != nil || p.Category != nil || p.OwnerUserIDSet || p.AccountWrapperSet || p.SquareMetersSet || p.ReceivesContributions != nil {
+		t.Fatalf("empty patch should be zero-valued, got %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchOwnerNullClears(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"owner_user_id": nil})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if !p.OwnerUserIDSet {
+		t.Fatalf("OwnerUserIDSet should be true after explicit null")
+	}
+	if p.OwnerUserID != nil {
+		t.Fatalf("OwnerUserID should be nil after explicit null, got %+v", p.OwnerUserID)
+	}
+}
+
+func TestBuildUpdatePatchSquareMetersNullClears(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"square_meters": nil})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if !p.SquareMetersSet || p.SquareMeters != nil {
+		t.Fatalf("expected SquareMetersSet=true and value=nil, got set=%v value=%+v", p.SquareMetersSet, p.SquareMeters)
+	}
+}
+
+func TestBuildUpdatePatchAccountWrapperNullClears(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"account_wrapper": nil})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if !p.AccountWrapperSet || p.AccountWrapper != nil {
+		t.Fatalf("expected wrapper cleared, got set=%v value=%+v", p.AccountWrapperSet, p.AccountWrapper)
+	}
+}
+
+func TestBuildUpdatePatchAccountWrapperInvalid(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"account_wrapper": "BOGUS"})
+	_, vErr := buildUpdatePatch(raw)
+	if vErr == nil || vErr.Field != "account_wrapper" {
+		t.Fatalf("expected account_wrapper validation error, got %+v", vErr)
+	}
+}
+
+func TestBuildUpdatePatchBlankName(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"name": "  "})
+	_, vErr := buildUpdatePatch(raw)
+	if vErr == nil || vErr.Field != "name" {
+		t.Fatalf("expected name validation error, got %+v", vErr)
+	}
+}
+
+func TestIsNullVariants(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"null", true},
+		{"  null  ", true},
+		{`"null"`, false},
+		{"0", false},
+		{`""`, false},
+	}
+	for _, tc := range cases {
+		if got := isNull(json.RawMessage(tc.in)); got != tc.want {
+			t.Errorf("isNull(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestOptionalDecimalParsesAndFails(t *testing.T) {
+	good := rawJSON(t, map[string]any{"x": 12.345})
+	d, vErr := optionalDecimal(good, "x")
+	if vErr != nil || d == nil || !d.Equal(decimal.RequireFromString("12.345")) {
+		t.Fatalf("good parse failed: %+v err=%+v", d, vErr)
+	}
+	bad := map[string]json.RawMessage{"x": json.RawMessage("not-a-number")}
+	if _, vErr := optionalDecimal(bad, "x"); vErr == nil {
+		t.Fatalf("expected error on bad number")
+	}
+	missing := map[string]json.RawMessage{}
+	if d, vErr := optionalDecimal(missing, "x"); d != nil || vErr != nil {
+		t.Fatalf("missing should be nil/nil, got %+v err=%+v", d, vErr)
+	}
+}
+
+func TestOptionalBoolFallbacks(t *testing.T) {
+	if b, vErr := optionalBool(map[string]json.RawMessage{}, "x", true); !b || vErr != nil {
+		t.Fatalf("missing should fall back to true")
+	}
+	if _, vErr := optionalBool(rawJSON(t, map[string]any{"x": nil}), "x", true); vErr == nil {
+		t.Fatalf("null should be a validation error")
+	}
+	b, vErr := optionalBool(rawJSON(t, map[string]any{"x": false}), "x", true)
+	if vErr != nil || b {
+		t.Fatalf("explicit false should pass through")
+	}
+}

--- a/backend-go/internal/accounts/validation_test.go
+++ b/backend-go/internal/accounts/validation_test.go
@@ -253,7 +253,7 @@ func TestOptionalDecimalParsesAndFails(t *testing.T) {
 	if vErr != nil || d == nil || !d.Equal(decimal.RequireFromString("12.345")) {
 		t.Fatalf("good parse failed: %+v err=%+v", d, vErr)
 	}
-	bad := map[string]json.RawMessage{"x": json.RawMessage("not-a-number")}
+	bad := rawJSON(t, map[string]any{"x": "not-a-number"})
 	if _, vErr := optionalDecimal(bad, "x"); vErr == nil {
 		t.Fatalf("expected error on bad number")
 	}

--- a/backend-go/internal/assets/validation_test.go
+++ b/backend-go/internal/assets/validation_test.go
@@ -1,0 +1,102 @@
+package assets
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func rawJSON(t *testing.T, m map[string]any) map[string]json.RawMessage {
+	t.Helper()
+	out := make(map[string]json.RawMessage, len(m))
+	for k, v := range m {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", k, err)
+		}
+		out[k] = b
+	}
+	return out
+}
+
+func TestRequireNameValid(t *testing.T) {
+	name, vErr := requireName(rawJSON(t, map[string]any{"name": "  Konto główne  "}))
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if name != "Konto główne" {
+		t.Fatalf("expected trimmed name, got %q", name)
+	}
+}
+
+func TestRequireNameMissing(t *testing.T) {
+	_, vErr := requireName(map[string]json.RawMessage{})
+	if vErr == nil || vErr.Field != "name" {
+		t.Fatalf("expected name error, got %+v", vErr)
+	}
+}
+
+func TestRequireNameNull(t *testing.T) {
+	_, vErr := requireName(rawJSON(t, map[string]any{"name": nil}))
+	if vErr == nil || vErr.Field != "name" {
+		t.Fatalf("expected name error, got %+v", vErr)
+	}
+}
+
+func TestRequireNameEmpty(t *testing.T) {
+	_, vErr := requireName(rawJSON(t, map[string]any{"name": "   "}))
+	if vErr == nil || vErr.Field != "name" {
+		t.Fatalf("expected name error, got %+v", vErr)
+	}
+}
+
+func TestRequireNameNonString(t *testing.T) {
+	_, vErr := requireName(rawJSON(t, map[string]any{"name": 42}))
+	if vErr == nil || vErr.Field != "name" {
+		t.Fatalf("expected name error, got %+v", vErr)
+	}
+}
+
+func TestOptionalNameAbsentIsNoop(t *testing.T) {
+	p, vErr := optionalName(map[string]json.RawMessage{})
+	if p != nil || vErr != nil {
+		t.Fatalf("expected nil/nil, got %+v err=%+v", p, vErr)
+	}
+}
+
+func TestOptionalNameNullIsNoop(t *testing.T) {
+	p, vErr := optionalName(rawJSON(t, map[string]any{"name": nil}))
+	if p != nil || vErr != nil {
+		t.Fatalf("expected nil/nil, got %+v err=%+v", p, vErr)
+	}
+}
+
+func TestOptionalNameEmptyFails(t *testing.T) {
+	_, vErr := optionalName(rawJSON(t, map[string]any{"name": " "}))
+	if vErr == nil || vErr.Field != "name" {
+		t.Fatalf("expected error, got %+v", vErr)
+	}
+}
+
+func TestOptionalNameTrims(t *testing.T) {
+	p, vErr := optionalName(rawJSON(t, map[string]any{"name": "  Cele  "}))
+	if vErr != nil || p == nil || *p != "Cele" {
+		t.Fatalf("expected trimmed name, got %+v err=%+v", p, vErr)
+	}
+}
+
+func TestIsNullCases(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"null", true},
+		{"  null  ", true},
+		{`"null"`, false},
+		{"0", false},
+	}
+	for _, tc := range cases {
+		if got := isNull(json.RawMessage(tc.in)); got != tc.want {
+			t.Errorf("isNull(%q) = %v want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/backend-go/internal/auth/validation_test.go
+++ b/backend-go/internal/auth/validation_test.go
@@ -1,0 +1,119 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestValidateUsernameTrims(t *testing.T) {
+	u, msg := validateUsername("  alice  ")
+	if msg != "" {
+		t.Fatalf("unexpected error: %s", msg)
+	}
+	if u != "alice" {
+		t.Fatalf("expected alice, got %q", u)
+	}
+}
+
+func TestValidateUsernameEmpty(t *testing.T) {
+	_, msg := validateUsername("   ")
+	if msg == "" {
+		t.Fatal("expected empty error")
+	}
+}
+
+func TestValidateUsernameTooLong(t *testing.T) {
+	_, msg := validateUsername(strings.Repeat("a", 101))
+	if msg == "" {
+		t.Fatal("expected too-long error")
+	}
+}
+
+func TestValidatePasswordTooShort(t *testing.T) {
+	if msg := validatePassword("short"); msg == "" {
+		t.Fatal("expected error for short password")
+	}
+}
+
+func TestValidatePasswordOK(t *testing.T) {
+	if msg := validatePassword("12345678"); msg != "" {
+		t.Fatalf("unexpected error: %s", msg)
+	}
+}
+
+func TestOptionalNameNil(t *testing.T) {
+	out, msg := optionalName(nil, "first_name")
+	if msg != "" || out != nil {
+		t.Fatalf("expected nil/empty, got %+v %q", out, msg)
+	}
+}
+
+func TestOptionalNameEmptyToNil(t *testing.T) {
+	v := "   "
+	out, msg := optionalName(&v, "first_name")
+	if msg != "" || out != nil {
+		t.Fatalf("expected nil/empty, got %+v %q", out, msg)
+	}
+}
+
+func TestOptionalNameTrims(t *testing.T) {
+	v := "  Marcin  "
+	out, msg := optionalName(&v, "first_name")
+	if msg != "" {
+		t.Fatalf("unexpected error: %s", msg)
+	}
+	if out == nil || *out != "Marcin" {
+		t.Fatalf("expected Marcin, got %+v", out)
+	}
+}
+
+func TestOptionalNameTooLong(t *testing.T) {
+	v := strings.Repeat("a", 101)
+	_, msg := optionalName(&v, "first_name")
+	if msg == "" || !strings.Contains(msg, "first_name") {
+		t.Fatalf("expected too-long error mentioning field, got %q", msg)
+	}
+}
+
+func TestValidatePPKNilOK(t *testing.T) {
+	if msg := validatePPK(nil); msg != "" {
+		t.Fatalf("nil should be ok, got %q", msg)
+	}
+}
+
+func TestValidatePPKOutOfRange(t *testing.T) {
+	low := decimal.NewFromFloat(0.1)
+	if msg := validatePPK(&low); msg == "" {
+		t.Fatal("expected error on low rate")
+	}
+	high := decimal.NewFromFloat(5.0)
+	if msg := validatePPK(&high); msg == "" {
+		t.Fatal("expected error on high rate")
+	}
+}
+
+func TestValidatePPKInRange(t *testing.T) {
+	rate := decimal.NewFromFloat(2.0)
+	if msg := validatePPK(&rate); msg != "" {
+		t.Fatalf("in-range should be ok, got %q", msg)
+	}
+}
+
+func TestPPKOrDefaultReturnsProvided(t *testing.T) {
+	rate := decimal.NewFromFloat(3.0)
+	fallback := decimal.NewFromFloat(1.5)
+	got := ppkOrDefault(&rate, fallback)
+	if got == nil || !got.Equal(rate) {
+		t.Fatalf("expected provided rate, got %+v", got)
+	}
+}
+
+func TestPPKOrDefaultReturnsFallback(t *testing.T) {
+	fallback := decimal.NewFromFloat(1.5)
+	got := ppkOrDefault(nil, fallback)
+	if got == nil || !got.Equal(fallback) {
+		t.Fatalf("expected fallback, got %+v", got)
+	}
+}

--- a/backend-go/internal/bonus_events/validation_test.go
+++ b/backend-go/internal/bonus_events/validation_test.go
@@ -1,0 +1,152 @@
+package bonusevents
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func rawJSON(t *testing.T, m map[string]any) map[string]json.RawMessage {
+	t.Helper()
+	out := make(map[string]json.RawMessage, len(m))
+	for k, v := range m {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", k, err)
+		}
+		out[k] = b
+	}
+	return out
+}
+
+func validCreate() map[string]any {
+	return map[string]any{
+		"date":          "2026-01-15",
+		"amount":        5000,
+		"type":          "annual",
+		"company":       "Acme",
+		"owner_user_id": 1,
+		"contract_type": "UOP",
+	}
+}
+
+func TestBuildCreateRequestOK(t *testing.T) {
+	r, vErr := buildCreateRequest(rawJSON(t, validCreate()))
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if r.Currency != "PLN" {
+		t.Fatalf("currency fallback failed: %q", r.Currency)
+	}
+	if r.Type != "annual" || r.ContractType != "UOP" || r.Company != "Acme" {
+		t.Fatalf("fields mismatch: %+v", r)
+	}
+}
+
+func TestBuildCreateRequestFutureDate(t *testing.T) {
+	m := validCreate()
+	m["date"] = time.Now().UTC().AddDate(1, 0, 0).Format("2006-01-02")
+	_, vErr := buildCreateRequest(rawJSON(t, m))
+	if vErr == nil || vErr.Field != "date" {
+		t.Fatalf("expected date error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestNegativeAmount(t *testing.T) {
+	m := validCreate()
+	m["amount"] = -10
+	_, vErr := buildCreateRequest(rawJSON(t, m))
+	if vErr == nil || vErr.Field != "amount" {
+		t.Fatalf("expected amount error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestInvalidType(t *testing.T) {
+	m := validCreate()
+	m["type"] = "bogus"
+	_, vErr := buildCreateRequest(rawJSON(t, m))
+	if vErr == nil || vErr.Field != "type" {
+		t.Fatalf("expected type error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestInvalidContract(t *testing.T) {
+	m := validCreate()
+	m["contract_type"] = "X"
+	_, vErr := buildCreateRequest(rawJSON(t, m))
+	if vErr == nil || vErr.Field != "contract_type" {
+		t.Fatalf("expected contract_type error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestBlankCompany(t *testing.T) {
+	m := validCreate()
+	m["company"] = "  "
+	_, vErr := buildCreateRequest(rawJSON(t, m))
+	if vErr == nil || vErr.Field != "company" {
+		t.Fatalf("expected company error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestNotes(t *testing.T) {
+	m := validCreate()
+	m["notes"] = "tax refund"
+	r, vErr := buildCreateRequest(rawJSON(t, m))
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if r.Notes == nil || *r.Notes != "tax refund" {
+		t.Fatalf("notes mismatch: %+v", r.Notes)
+	}
+}
+
+func TestBuildUpdatePatchEmpty(t *testing.T) {
+	p, vErr := buildUpdatePatch(map[string]json.RawMessage{})
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if p.Date != nil || p.Amount != nil || p.Notes != nil {
+		t.Fatalf("expected zero patch, got %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchNullNotesIsNoop(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"notes": nil})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if p.Notes != nil {
+		t.Fatalf("null notes should be no-op, got %+v", p.Notes)
+	}
+}
+
+func TestBuildUpdatePatchSetsNotes(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"notes": "bonus"})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if p.Notes == nil || *p.Notes != "bonus" {
+		t.Fatalf("notes mismatch: %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchClearsOwnerExplicitly(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"owner_user_id": nil})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if !p.OwnerUserIDSet || p.OwnerUserID != nil {
+		t.Fatalf("expected owner cleared, got %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchInvalidType(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"type": "bogus"})
+	_, vErr := buildUpdatePatch(raw)
+	if vErr == nil || vErr.Field != "type" {
+		t.Fatalf("expected type error, got %+v", vErr)
+	}
+}

--- a/backend-go/internal/config/validation_test.go
+++ b/backend-go/internal/config/validation_test.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func validRequest() *request {
+	birth := time.Date(1990, 1, 15, 0, 0, 0, 0, time.UTC)
+	return &request{
+		BirthDate:               isoDate(birth),
+		RetirementAge:           65,
+		RetirementMonthlySalary: decimal.NewFromInt(5000),
+		AllocationRealEstate:    20,
+		AllocationStocks:        50,
+		AllocationBonds:         30,
+		AllocationGold:          10,
+		AllocationCommodities:   10,
+		MonthlyExpenses:         decimal.NewFromInt(3000),
+		MonthlyMortgagePayment:  decimal.NewFromInt(1500),
+	}
+}
+
+func TestValidateOK(t *testing.T) {
+	r := validRequest()
+	if err := r.validate(); err != nil {
+		t.Fatalf("expected valid, got %+v", err)
+	}
+}
+
+func TestValidateFutureBirthDate(t *testing.T) {
+	r := validRequest()
+	r.BirthDate = isoDate(time.Now().UTC().AddDate(1, 0, 0))
+	if err := r.validate(); err == nil || err.Field != "birth_date" {
+		t.Fatalf("expected birth_date error, got %+v", err)
+	}
+}
+
+func TestValidateAgeUnder18(t *testing.T) {
+	r := validRequest()
+	r.BirthDate = isoDate(time.Now().UTC().AddDate(-10, 0, 0))
+	if err := r.validate(); err == nil || err.Field != "birth_date" {
+		t.Fatalf("expected birth_date error, got %+v", err)
+	}
+}
+
+func TestValidateAgeOver100(t *testing.T) {
+	r := validRequest()
+	r.BirthDate = isoDate(time.Now().UTC().AddDate(-110, 0, 0))
+	if err := r.validate(); err == nil || err.Field != "birth_date" {
+		t.Fatalf("expected birth_date error, got %+v", err)
+	}
+}
+
+func TestValidateRetirementAgeOutOfRange(t *testing.T) {
+	r := validRequest()
+	r.RetirementAge = 10
+	if err := r.validate(); err == nil || err.Field != "retirement_age" {
+		t.Fatalf("expected retirement_age error, got %+v", err)
+	}
+}
+
+func TestValidateRetirementSalaryNonPositive(t *testing.T) {
+	r := validRequest()
+	r.RetirementMonthlySalary = decimal.Zero
+	if err := r.validate(); err == nil || err.Field != "retirement_monthly_salary" {
+		t.Fatalf("expected retirement_monthly_salary error, got %+v", err)
+	}
+}
+
+func TestValidateNegativeExpenses(t *testing.T) {
+	r := validRequest()
+	r.MonthlyExpenses = decimal.NewFromInt(-1)
+	if err := r.validate(); err == nil || err.Field != "monthly_expenses" {
+		t.Fatalf("expected monthly_expenses error, got %+v", err)
+	}
+}
+
+func TestValidateNegativeMortgage(t *testing.T) {
+	r := validRequest()
+	r.MonthlyMortgagePayment = decimal.NewFromInt(-1)
+	if err := r.validate(); err == nil || err.Field != "monthly_mortgage_payment" {
+		t.Fatalf("expected monthly_mortgage_payment error, got %+v", err)
+	}
+}
+
+func TestValidateAllocationOutOfRange(t *testing.T) {
+	r := validRequest()
+	r.AllocationStocks = 150
+	if err := r.validate(); err == nil || err.Field != "allocation_stocks" {
+		t.Fatalf("expected allocation_stocks error, got %+v", err)
+	}
+}
+
+func TestValidateMarketAllocationDoesNotSumTo100(t *testing.T) {
+	r := validRequest()
+	r.AllocationStocks = 40
+	r.AllocationBonds = 30
+	r.AllocationGold = 10
+	r.AllocationCommodities = 10
+	if err := r.validate(); err == nil || err.Field != "allocation_stocks" {
+		t.Fatalf("expected allocation sum error, got %+v", err)
+	}
+}
+
+func TestValidateRetirementAgeBeforeCurrent(t *testing.T) {
+	r := validRequest()
+	now := time.Now().UTC()
+	r.BirthDate = isoDate(now.AddDate(-50, 0, 0))
+	r.RetirementAge = 30
+	if err := r.validate(); err == nil || err.Field != "retirement_age" {
+		t.Fatalf("expected retirement_age (vs current age) error, got %+v", err)
+	}
+}

--- a/backend-go/internal/cpi/inflation_test.go
+++ b/backend-go/internal/cpi/inflation_test.go
@@ -1,0 +1,138 @@
+package cpi
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func d(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+func TestCumulativeIndexEmpty(t *testing.T) {
+	out := CumulativeIndex(map[int]decimal.Decimal{})
+	if len(out) != 0 {
+		t.Fatalf("expected empty, got %+v", out)
+	}
+}
+
+func TestCumulativeIndexSingleYearIsAnchor(t *testing.T) {
+	out := CumulativeIndex(map[int]decimal.Decimal{2024: d("110")})
+	if got := out[2024]; !got.Equal(d("100")) {
+		t.Fatalf("expected anchor 100, got %s", got)
+	}
+}
+
+func TestCumulativeIndexCompoundsForward(t *testing.T) {
+	in := map[int]decimal.Decimal{
+		2022: d("100"),
+		2023: d("110"),
+		2024: d("105"),
+	}
+	out := CumulativeIndex(in)
+	if !out[2022].Equal(d("100")) {
+		t.Fatalf("2022 should anchor at 100, got %s", out[2022])
+	}
+	if !out[2023].Equal(d("110")) {
+		t.Fatalf("2023 expected 110 (100 * 110 / 100), got %s", out[2023])
+	}
+	if !out[2024].Equal(d("115.5")) {
+		t.Fatalf("2024 expected 115.5 (110 * 105 / 100), got %s", out[2024])
+	}
+}
+
+func TestIndexAtDateEmptyIsError(t *testing.T) {
+	_, err := IndexAtDate(map[int]decimal.Decimal{}, time.Now())
+	if !errors.Is(err, ErrInflationDataMissing) {
+		t.Fatalf("expected ErrInflationDataMissing, got %v", err)
+	}
+}
+
+func TestIndexAtDateBelowRangeClampsToEarliest(t *testing.T) {
+	in := map[int]decimal.Decimal{2024: d("100"), 2025: d("110")}
+	got, err := IndexAtDate(in, time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !got.Equal(d("100")) {
+		t.Fatalf("expected 100, got %s", got)
+	}
+}
+
+func TestIndexAtDateAboveRangeClampsToLatest(t *testing.T) {
+	in := map[int]decimal.Decimal{2024: d("100"), 2025: d("110")}
+	got, err := IndexAtDate(in, time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !got.Equal(d("110")) {
+		t.Fatalf("expected 110, got %s", got)
+	}
+}
+
+func TestIndexAtDateInterpolatesMidYear(t *testing.T) {
+	in := map[int]decimal.Decimal{2024: d("100"), 2025: d("110")}
+	// Mid 2025 — 100 + (110-100)*0.5 ≈ 105 (give or take a fraction)
+	mid := time.Date(2025, 7, 2, 0, 0, 0, 0, time.UTC)
+	got, err := IndexAtDate(in, mid)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	f, _ := got.Float64()
+	if f < 104.5 || f > 105.5 {
+		t.Fatalf("expected ~105, got %s", got)
+	}
+}
+
+func TestIndexAtDateMissingYearIsHardError(t *testing.T) {
+	in := map[int]decimal.Decimal{2024: d("100"), 2026: d("110")}
+	_, err := IndexAtDate(in, time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC))
+	if err == nil || errors.Is(err, ErrInflationDataMissing) == false {
+		t.Fatalf("expected wrapped missing-data error, got %v", err)
+	}
+}
+
+func TestAdjustWithIndexEmpty(t *testing.T) {
+	_, err := AdjustWithIndex(map[int]decimal.Decimal{}, 100, time.Now(), time.Now())
+	if !errors.Is(err, ErrInflationDataMissing) {
+		t.Fatalf("expected ErrInflationDataMissing, got %v", err)
+	}
+}
+
+func TestAdjustWithIndexInflate(t *testing.T) {
+	// Index goes 100 -> 110 -> 120 across three contiguous years. Adjusting
+	// 100 PLN from end-2022 to end-2024 should compound to ~120.
+	in := map[int]decimal.Decimal{2022: d("100"), 2023: d("110"), 2024: d("120")}
+	got, err := AdjustWithIndex(in, 100,
+		time.Date(2022, 12, 31, 0, 0, 0, 0, time.UTC),
+		time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got < 119 || got > 121 {
+		t.Fatalf("expected ~120, got %v", got)
+	}
+}
+
+func TestAdjustWithIndexZeroSourceIsError(t *testing.T) {
+	in := map[int]decimal.Decimal{2020: d("0"), 2025: d("110")}
+	_, err := AdjustWithIndex(in, 100,
+		time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	)
+	if err == nil {
+		t.Fatal("expected error on zero source")
+	}
+}
+
+func TestInflationErrorMessage(t *testing.T) {
+	e := newInflationErr("custom")
+	if e.Error() != "custom" {
+		t.Fatalf("got %q want custom", e.Error())
+	}
+	if !errors.Is(e, ErrInflationDataMissing) {
+		t.Fatal("expected errors.Is to match family")
+	}
+}

--- a/backend-go/internal/fx/fx_test.go
+++ b/backend-go/internal/fx/fx_test.go
@@ -1,0 +1,70 @@
+package fx
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestToPLNNilAmountReturnsFalse(t *testing.T) {
+	_, ok := ToPLN(nil, "USD", Result{Rate: decimal.NewFromInt(4), Found: true})
+	if ok {
+		t.Fatal("nil amount should return ok=false")
+	}
+}
+
+func TestToPLNPLNPassesThrough(t *testing.T) {
+	amt := decimal.NewFromInt(100)
+	got, ok := ToPLN(&amt, "PLN", Result{})
+	if !ok {
+		t.Fatal("PLN should always be ok")
+	}
+	if !got.Equal(amt) {
+		t.Fatalf("PLN should pass through, got %s", got)
+	}
+}
+
+func TestToPLNPlnLowercase(t *testing.T) {
+	amt := decimal.NewFromInt(100)
+	got, ok := ToPLN(&amt, "pln", Result{})
+	if !ok || !got.Equal(amt) {
+		t.Fatalf("lowercase pln should also pass through, got %s ok=%v", got, ok)
+	}
+}
+
+func TestToPLNNoRateReturnsFalse(t *testing.T) {
+	amt := decimal.NewFromInt(100)
+	if _, ok := ToPLN(&amt, "USD", Result{Found: false}); ok {
+		t.Fatal("expected ok=false when rate is not found")
+	}
+}
+
+func TestToPLNMultipliesByRate(t *testing.T) {
+	amt := decimal.NewFromInt(100)
+	got, ok := ToPLN(&amt, "USD", Result{Rate: decimal.RequireFromString("4.05"), Found: true})
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if !got.Equal(decimal.RequireFromString("405")) {
+		t.Fatalf("expected 405, got %s", got)
+	}
+}
+
+func TestTruncateDayStripsTime(t *testing.T) {
+	in := time.Date(2026, 5, 23, 13, 45, 30, 999, time.UTC)
+	got := truncateDay(in)
+	want := time.Date(2026, 5, 23, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("got %s want %s", got, want)
+	}
+}
+
+func TestTruncateDayForcesUTC(t *testing.T) {
+	loc, _ := time.LoadLocation("Europe/Warsaw")
+	in := time.Date(2026, 5, 23, 23, 30, 0, 0, loc)
+	got := truncateDay(in)
+	if got.Location() != time.UTC {
+		t.Fatalf("expected UTC, got %s", got.Location())
+	}
+}

--- a/backend-go/internal/fx/fx_test.go
+++ b/backend-go/internal/fx/fx_test.go
@@ -61,8 +61,10 @@ func TestTruncateDayStripsTime(t *testing.T) {
 }
 
 func TestTruncateDayForcesUTC(t *testing.T) {
-	loc, _ := time.LoadLocation("Europe/Warsaw")
-	in := time.Date(2026, 5, 23, 23, 30, 0, 0, loc)
+	// Use a fixed zone so the test doesn't depend on the tzdata being
+	// installed on the runner.
+	warsaw := time.FixedZone("Europe/Warsaw", 2*60*60)
+	in := time.Date(2026, 5, 23, 23, 30, 0, 0, warsaw)
 	got := truncateDay(in)
 	if got.Location() != time.UTC {
 		t.Fatalf("expected UTC, got %s", got.Location())

--- a/backend-go/internal/goals/projection_test.go
+++ b/backend-go/internal/goals/projection_test.go
@@ -1,0 +1,136 @@
+package goals
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+var fixedNow = time.Date(2026, 1, 31, 12, 0, 0, 0, time.UTC)
+
+func TestProjectHitDateCompleted(t *testing.T) {
+	hit := projectHitDate(
+		decimal.NewFromInt(100),
+		decimal.NewFromInt(0),
+		decimal.NewFromInt(10),
+		true,
+		fixedNow,
+	)
+	if hit == nil || !hit.Equal(fixedNow.UTC().Truncate(24*time.Hour)) {
+		t.Fatalf("completed goal should hit today, got %+v", hit)
+	}
+}
+
+func TestProjectHitDateAlreadyReached(t *testing.T) {
+	hit := projectHitDate(
+		decimal.NewFromInt(100),
+		decimal.NewFromInt(150),
+		decimal.NewFromInt(10),
+		false,
+		fixedNow,
+	)
+	if hit == nil || !hit.Equal(fixedNow.UTC().Truncate(24*time.Hour)) {
+		t.Fatalf("reached goal should hit today, got %+v", hit)
+	}
+}
+
+func TestProjectHitDateNoContribution(t *testing.T) {
+	hit := projectHitDate(
+		decimal.NewFromInt(100),
+		decimal.NewFromInt(0),
+		decimal.Zero,
+		false,
+		fixedNow,
+	)
+	if hit != nil {
+		t.Fatalf("zero contribution should be nil, got %+v", hit)
+	}
+}
+
+func TestProjectHitDateBasic(t *testing.T) {
+	// (100 - 0) / 10 = 10 months -> Nov 30 from Jan 31 (clamped to last day)
+	hit := projectHitDate(
+		decimal.NewFromInt(100),
+		decimal.NewFromInt(0),
+		decimal.NewFromInt(10),
+		false,
+		fixedNow,
+	)
+	if hit == nil {
+		t.Fatal("expected non-nil hit date")
+	}
+	want := time.Date(2026, 11, 30, 0, 0, 0, 0, time.UTC)
+	if !hit.Equal(want) {
+		t.Fatalf("expected %s, got %s", want, hit)
+	}
+}
+
+func TestProjectHitDateCeilingPartialMonth(t *testing.T) {
+	// (100 - 0) / 30 = 3.33 -> ceil 4
+	hit := projectHitDate(
+		decimal.NewFromInt(100),
+		decimal.NewFromInt(0),
+		decimal.NewFromInt(30),
+		false,
+		fixedNow,
+	)
+	if hit == nil {
+		t.Fatal("expected non-nil hit date")
+	}
+	want := time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC)
+	if !hit.Equal(want) {
+		t.Fatalf("expected %s, got %s", want, hit)
+	}
+}
+
+func TestAddMonthsDayClamp(t *testing.T) {
+	jan31 := time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC)
+	feb := addMonths(jan31, 1)
+	want := time.Date(2026, 2, 28, 0, 0, 0, 0, time.UTC)
+	if !feb.Equal(want) {
+		t.Fatalf("Jan31+1 should clamp to Feb 28, got %s", feb)
+	}
+}
+
+func TestAddMonthsLeapYear(t *testing.T) {
+	jan31 := time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC)
+	feb := addMonths(jan31, 1)
+	want := time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC)
+	if !feb.Equal(want) {
+		t.Fatalf("leap Feb should be 29, got %s", feb)
+	}
+}
+
+func TestAddMonthsForwardYearRoll(t *testing.T) {
+	dec := time.Date(2026, 12, 15, 0, 0, 0, 0, time.UTC)
+	if got := addMonths(dec, 1); !got.Equal(time.Date(2027, 1, 15, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("Dec+1 should roll to Jan, got %s", got)
+	}
+}
+
+func TestAddMonthsBackwardYearRoll(t *testing.T) {
+	jan := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	if got := addMonths(jan, -1); !got.Equal(time.Date(2025, 12, 15, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("Jan-1 should roll back, got %s", got)
+	}
+}
+
+func TestDaysInMonths(t *testing.T) {
+	cases := []struct {
+		year  int
+		month time.Month
+		want  int
+	}{
+		{2026, time.January, 31},
+		{2026, time.February, 28},
+		{2024, time.February, 29},
+		{2026, time.April, 30},
+		{2026, time.December, 31},
+	}
+	for _, tc := range cases {
+		if got := daysIn(tc.year, tc.month); got != tc.want {
+			t.Errorf("daysIn(%d, %s) = %d, want %d", tc.year, tc.month, got, tc.want)
+		}
+	}
+}

--- a/backend-go/internal/goals/validation_test.go
+++ b/backend-go/internal/goals/validation_test.go
@@ -206,18 +206,24 @@ func TestBuildUpdatePatchTargetDateValid(t *testing.T) {
 	}
 }
 
-func TestPatchPositiveAmount(t *testing.T) {
-	var dest *decimal.Decimal
-	if err := patchPositiveAmount(rawJSON(t, map[string]any{}), "x", &dest, "msg"); err != nil || dest != nil {
-		t.Fatalf("missing key should be no-op")
+func TestBuildUpdatePatchSetsTargetAmount(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"target_amount": 1234.5})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
 	}
-	if err := patchPositiveAmount(rawJSON(t, map[string]any{"x": nil}), "x", &dest, "msg"); err != nil || dest != nil {
-		t.Fatalf("null should be no-op")
+	if p.TargetAmount == nil || !p.TargetAmount.Equal(decimal.NewFromFloat(1234.5)) {
+		t.Fatalf("expected 1234.5, got %+v", p.TargetAmount)
 	}
-	if err := patchPositiveAmount(rawJSON(t, map[string]any{"x": 10}), "x", &dest, "msg"); err != nil || dest == nil {
-		t.Fatalf("positive should set dest")
+}
+
+func TestBuildUpdatePatchSetsMonthlyContribution(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"monthly_contribution": 500})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
 	}
-	if !dest.Equal(decimal.NewFromInt(10)) {
-		t.Fatalf("dest mismatch: %s", dest)
+	if p.MonthlyContribution == nil || !p.MonthlyContribution.Equal(decimal.NewFromInt(500)) {
+		t.Fatalf("expected 500, got %+v", p.MonthlyContribution)
 	}
 }

--- a/backend-go/internal/goals/validation_test.go
+++ b/backend-go/internal/goals/validation_test.go
@@ -1,0 +1,223 @@
+package goals
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func rawJSON(t *testing.T, m map[string]any) map[string]json.RawMessage {
+	t.Helper()
+	out := make(map[string]json.RawMessage, len(m))
+	for k, v := range m {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", k, err)
+		}
+		out[k] = b
+	}
+	return out
+}
+
+func validReq(t *testing.T) *createRequest {
+	t.Helper()
+	return &createRequest{
+		Name:                "Wakacje",
+		TargetAmount:        10000,
+		TargetDate:          isoDate(time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)),
+		CurrentAmount:       1000,
+		MonthlyContribution: 500,
+	}
+}
+
+func TestValidateCreateOK(t *testing.T) {
+	req := validReq(t)
+	if err := validateCreate(req); err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+	if req.Name != "Wakacje" {
+		t.Fatalf("name not trimmed: %q", req.Name)
+	}
+}
+
+func TestValidateCreateTrimsName(t *testing.T) {
+	req := validReq(t)
+	req.Name = "  Wakacje  "
+	if err := validateCreate(req); err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+	if req.Name != "Wakacje" {
+		t.Fatalf("name should be trimmed, got %q", req.Name)
+	}
+}
+
+func TestValidateCreateBlankName(t *testing.T) {
+	req := validReq(t)
+	req.Name = "  "
+	if err := validateCreate(req); err == nil || err.Field != "name" {
+		t.Fatalf("expected name error, got %+v", err)
+	}
+}
+
+func TestValidateCreateMissingDate(t *testing.T) {
+	req := validReq(t)
+	req.TargetDate = isoDate(time.Time{})
+	if err := validateCreate(req); err == nil || err.Field != "target_date" {
+		t.Fatalf("expected target_date error, got %+v", err)
+	}
+}
+
+func TestValidateCreateNonPositiveTarget(t *testing.T) {
+	req := validReq(t)
+	req.TargetAmount = 0
+	if err := validateCreate(req); err == nil || err.Field != "target_amount" {
+		t.Fatalf("expected target_amount error, got %+v", err)
+	}
+}
+
+func TestValidateCreateNegativeCurrent(t *testing.T) {
+	req := validReq(t)
+	req.CurrentAmount = -1
+	if err := validateCreate(req); err == nil || err.Field != "current_amount" {
+		t.Fatalf("expected current_amount error, got %+v", err)
+	}
+}
+
+func TestValidateCreateNegativeMonthly(t *testing.T) {
+	req := validReq(t)
+	req.MonthlyContribution = -1
+	if err := validateCreate(req); err == nil || err.Field != "monthly_contribution" {
+		t.Fatalf("expected monthly_contribution error, got %+v", err)
+	}
+}
+
+func TestValidateCreateInvalidCategory(t *testing.T) {
+	req := validReq(t)
+	bogus := "bogus"
+	req.Category = &bogus
+	if err := validateCreate(req); err == nil || err.Field != "category" {
+		t.Fatalf("expected category error, got %+v", err)
+	}
+}
+
+func TestValidateCreateValidCategory(t *testing.T) {
+	req := validReq(t)
+	cat := "bank"
+	req.Category = &cat
+	if err := validateCreate(req); err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+}
+
+func TestBuildUpdatePatchEmpty(t *testing.T) {
+	p, vErr := buildUpdatePatch(map[string]json.RawMessage{})
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if p.Name != nil || p.TargetAmount != nil || p.AccountIDSet || p.CategorySet {
+		t.Fatalf("expected zero patch, got %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchBlankName(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"name": "  "})
+	_, vErr := buildUpdatePatch(raw)
+	if vErr == nil || vErr.Field != "name" {
+		t.Fatalf("expected name error, got %+v", vErr)
+	}
+}
+
+func TestBuildUpdatePatchClearsAccountID(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"account_id": nil})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if !p.AccountIDSet || p.AccountID != nil {
+		t.Fatalf("expected AccountIDSet=true, value nil; got %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchSetsAccountID(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"account_id": 42})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if !p.AccountIDSet || p.AccountID == nil || *p.AccountID != 42 {
+		t.Fatalf("expected AccountID=42, got %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchClearsCategory(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"category": nil})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if !p.CategorySet || p.Category != nil {
+		t.Fatalf("expected CategorySet=true, value nil; got %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchInvalidCategory(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"category": "bogus"})
+	_, vErr := buildUpdatePatch(raw)
+	if vErr == nil || vErr.Field != "category" {
+		t.Fatalf("expected category error, got %+v", vErr)
+	}
+}
+
+func TestBuildUpdatePatchNonPositiveTarget(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"target_amount": 0})
+	_, vErr := buildUpdatePatch(raw)
+	if vErr == nil || vErr.Field != "target_amount" {
+		t.Fatalf("expected target_amount error, got %+v", vErr)
+	}
+}
+
+func TestBuildUpdatePatchNegativeCurrent(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"current_amount": -1})
+	_, vErr := buildUpdatePatch(raw)
+	if vErr == nil || vErr.Field != "current_amount" {
+		t.Fatalf("expected current_amount error, got %+v", vErr)
+	}
+}
+
+func TestBuildUpdatePatchTargetDateInvalid(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"target_date": "31-01-2026"})
+	_, vErr := buildUpdatePatch(raw)
+	if vErr == nil || vErr.Field != "target_date" {
+		t.Fatalf("expected target_date error, got %+v", vErr)
+	}
+}
+
+func TestBuildUpdatePatchTargetDateValid(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"target_date": "2027-12-31"})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	want := time.Date(2027, 12, 31, 0, 0, 0, 0, time.UTC)
+	if p.TargetDate == nil || !p.TargetDate.Equal(want) {
+		t.Fatalf("date mismatch: %+v want %s", p.TargetDate, want)
+	}
+}
+
+func TestPatchPositiveAmount(t *testing.T) {
+	var dest *decimal.Decimal
+	if err := patchPositiveAmount(rawJSON(t, map[string]any{}), "x", &dest, "msg"); err != nil || dest != nil {
+		t.Fatalf("missing key should be no-op")
+	}
+	if err := patchPositiveAmount(rawJSON(t, map[string]any{"x": nil}), "x", &dest, "msg"); err != nil || dest != nil {
+		t.Fatalf("null should be no-op")
+	}
+	if err := patchPositiveAmount(rawJSON(t, map[string]any{"x": 10}), "x", &dest, "msg"); err != nil || dest == nil {
+		t.Fatalf("positive should set dest")
+	}
+	if !dest.Equal(decimal.NewFromInt(10)) {
+		t.Fatalf("dest mismatch: %s", dest)
+	}
+}

--- a/backend-go/internal/salaries/validation_test.go
+++ b/backend-go/internal/salaries/validation_test.go
@@ -1,0 +1,175 @@
+package salaries
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+var testNow = func() time.Time { return time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC) }
+
+func rawJSON(t *testing.T, m map[string]any) map[string]json.RawMessage {
+	t.Helper()
+	out := make(map[string]json.RawMessage, len(m))
+	for k, v := range m {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", k, err)
+		}
+		out[k] = b
+	}
+	return out
+}
+
+func validCreate() map[string]any {
+	return map[string]any{
+		"date":          "2026-05-01",
+		"gross_amount":  10000,
+		"contract_type": "UOP",
+		"company":       "Acme",
+		"owner_user_id": 1,
+	}
+}
+
+func TestBuildCreateRequestOK(t *testing.T) {
+	r, vErr := buildCreateRequest(rawJSON(t, validCreate()), testNow)
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if r.ContractType != "UOP" || r.Company != "Acme" || *r.OwnerUserID != 1 {
+		t.Fatalf("unexpected: %+v", r)
+	}
+	if !r.GrossAmount.Equal(decimal.NewFromInt(10000)) {
+		t.Fatalf("gross_amount mismatch: %s", r.GrossAmount)
+	}
+}
+
+func TestBuildCreateRequestFutureDate(t *testing.T) {
+	m := validCreate()
+	m["date"] = "2027-01-01"
+	_, vErr := buildCreateRequest(rawJSON(t, m), testNow)
+	if vErr == nil || vErr.Field != "date" {
+		t.Fatalf("expected date error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestInvalidContract(t *testing.T) {
+	m := validCreate()
+	m["contract_type"] = "BOGUS"
+	_, vErr := buildCreateRequest(rawJSON(t, m), testNow)
+	if vErr == nil || vErr.Field != "contract_type" {
+		t.Fatalf("expected contract_type error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestBlankCompany(t *testing.T) {
+	m := validCreate()
+	m["company"] = "  "
+	_, vErr := buildCreateRequest(rawJSON(t, m), testNow)
+	if vErr == nil || vErr.Field != "company" {
+		t.Fatalf("expected company error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestNonPositiveGross(t *testing.T) {
+	m := validCreate()
+	m["gross_amount"] = 0
+	_, vErr := buildCreateRequest(rawJSON(t, m), testNow)
+	if vErr == nil || vErr.Field != "gross_amount" {
+		t.Fatalf("expected gross_amount error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestMissingOwner(t *testing.T) {
+	m := validCreate()
+	delete(m, "owner_user_id")
+	_, vErr := buildCreateRequest(rawJSON(t, m), testNow)
+	if vErr == nil || vErr.Field != "owner_user_id" {
+		t.Fatalf("expected owner_user_id error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestSharedOwner(t *testing.T) {
+	m := validCreate()
+	m["owner_user_id"] = nil
+	r, vErr := buildCreateRequest(rawJSON(t, m), testNow)
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if r.OwnerUserID != nil {
+		t.Fatalf("expected shared owner, got %+v", r.OwnerUserID)
+	}
+}
+
+func TestBuildUpdatePatchEmpty(t *testing.T) {
+	p, vErr := buildUpdatePatch(map[string]json.RawMessage{}, testNow)
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if p.Date != nil || p.GrossAmount != nil || p.ContractType != nil || p.Company != nil || p.OwnerUserIDSet {
+		t.Fatalf("expected zero patch, got %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchClearsOwner(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"owner_user_id": nil})
+	p, vErr := buildUpdatePatch(raw, testNow)
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if !p.OwnerUserIDSet || p.OwnerUserID != nil {
+		t.Fatalf("expected owner cleared, got %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchSetsOwner(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"owner_user_id": 42})
+	p, vErr := buildUpdatePatch(raw, testNow)
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if !p.OwnerUserIDSet || p.OwnerUserID == nil || *p.OwnerUserID != 42 {
+		t.Fatalf("expected owner=42, got %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchFutureDateFails(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"date": "2027-01-01"})
+	_, vErr := buildUpdatePatch(raw, testNow)
+	if vErr == nil || vErr.Field != "date" {
+		t.Fatalf("expected date error, got %+v", vErr)
+	}
+}
+
+func TestBuildUpdatePatchNonPositiveGross(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"gross_amount": -1})
+	_, vErr := buildUpdatePatch(raw, testNow)
+	if vErr == nil || vErr.Field != "gross_amount" {
+		t.Fatalf("expected gross_amount error, got %+v", vErr)
+	}
+}
+
+func TestBuildUpdatePatchInvalidContract(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"contract_type": "WAT"})
+	_, vErr := buildUpdatePatch(raw, testNow)
+	if vErr == nil || vErr.Field != "contract_type" {
+		t.Fatalf("expected contract_type error, got %+v", vErr)
+	}
+}
+
+func TestBuildUpdatePatchBlankCompany(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"company": "  "})
+	_, vErr := buildUpdatePatch(raw, testNow)
+	if vErr == nil || vErr.Field != "company" {
+		t.Fatalf("expected company error, got %+v", vErr)
+	}
+}
+
+func TestRequireDateInvalid(t *testing.T) {
+	_, vErr := requireDate(rawJSON(t, map[string]any{"d": "31-01-2026"}), "d")
+	if vErr == nil || vErr.Field != "d" {
+		t.Fatalf("expected error, got %+v", vErr)
+	}
+}

--- a/backend-go/internal/snapshots/validation_test.go
+++ b/backend-go/internal/snapshots/validation_test.go
@@ -1,0 +1,194 @@
+package snapshots
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func rawJSON(t *testing.T, m map[string]any) map[string]json.RawMessage {
+	t.Helper()
+	out := make(map[string]json.RawMessage, len(m))
+	for k, v := range m {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", k, err)
+		}
+		out[k] = b
+	}
+	return out
+}
+
+func TestBuildCreateRequestMinimal(t *testing.T) {
+	raw := rawJSON(t, map[string]any{
+		"date": "2026-01-31",
+		"values": []map[string]any{
+			{"account_id": 1, "value": 100.5},
+		},
+	})
+	r, vErr := buildCreateRequest(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if r.Date.Format("2006-01-02") != "2026-01-31" {
+		t.Fatalf("date mismatch: %s", r.Date)
+	}
+	if len(r.Values) != 1 || r.Values[0].AccountID == nil || *r.Values[0].AccountID != 1 {
+		t.Fatalf("values mismatch: %+v", r.Values)
+	}
+	if !r.Values[0].Value.Equal(decimal.RequireFromString("100.5")) {
+		t.Fatalf("value mismatch: %s", r.Values[0].Value)
+	}
+}
+
+func TestBuildCreateRequestMissingDate(t *testing.T) {
+	raw := rawJSON(t, map[string]any{
+		"values": []map[string]any{{"account_id": 1, "value": 1}},
+	})
+	_, vErr := buildCreateRequest(raw)
+	if vErr == nil || vErr.Field != "date" {
+		t.Fatalf("expected date error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestInvalidDate(t *testing.T) {
+	raw := rawJSON(t, map[string]any{
+		"date":   "31-01-2026",
+		"values": []map[string]any{{"account_id": 1, "value": 1}},
+	})
+	_, vErr := buildCreateRequest(raw)
+	if vErr == nil || vErr.Field != "date" {
+		t.Fatalf("expected date error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestEmptyValues(t *testing.T) {
+	raw := rawJSON(t, map[string]any{
+		"date":   "2026-01-31",
+		"values": []map[string]any{},
+	})
+	_, vErr := buildCreateRequest(raw)
+	if vErr == nil || vErr.Field != "values" {
+		t.Fatalf("expected values error, got %+v", vErr)
+	}
+}
+
+func TestBuildCreateRequestMissingValues(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"date": "2026-01-31"})
+	_, vErr := buildCreateRequest(raw)
+	if vErr == nil || vErr.Field != "values" {
+		t.Fatalf("expected values error, got %+v", vErr)
+	}
+}
+
+func TestParseValueEntryRequiresOneRef(t *testing.T) {
+	entry := rawJSON(t, map[string]any{"value": 1})
+	_, vErr := parseValueEntry(entry)
+	if vErr == nil || vErr.Field != "values" {
+		t.Fatalf("expected mutual-ref error, got %+v", vErr)
+	}
+}
+
+func TestParseValueEntryRejectsBothRefs(t *testing.T) {
+	entry := rawJSON(t, map[string]any{"asset_id": 1, "account_id": 2, "value": 5})
+	_, vErr := parseValueEntry(entry)
+	if vErr == nil || vErr.Field != "values" {
+		t.Fatalf("expected mutual-ref error, got %+v", vErr)
+	}
+}
+
+func TestParseValueEntryRequiresValue(t *testing.T) {
+	entry := rawJSON(t, map[string]any{"account_id": 1})
+	_, vErr := parseValueEntry(entry)
+	if vErr == nil || vErr.Field != "value" {
+		t.Fatalf("expected value error, got %+v", vErr)
+	}
+}
+
+func TestParseValueEntryInvalidNumber(t *testing.T) {
+	entry := map[string]json.RawMessage{
+		"account_id": json.RawMessage("1"),
+		"value":      json.RawMessage(`"not-a-number"`),
+	}
+	_, vErr := parseValueEntry(entry)
+	if vErr == nil || vErr.Field != "value" {
+		t.Fatalf("expected value parse error, got %+v", vErr)
+	}
+}
+
+func TestBuildUpdatePatchEmptyIsNoop(t *testing.T) {
+	p, vErr := buildUpdatePatch(map[string]json.RawMessage{})
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if p.Date != nil || p.NotesSet || p.ValuesSet {
+		t.Fatalf("expected zero patch, got %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchClearsNotes(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"notes": nil})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if !p.NotesSet || p.Notes != nil {
+		t.Fatalf("expected NotesSet=true, value nil; got %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchSetsNotes(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"notes": "year end"})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if !p.NotesSet || p.Notes == nil || *p.Notes != "year end" {
+		t.Fatalf("notes mismatch: %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchValuesReplaces(t *testing.T) {
+	raw := rawJSON(t, map[string]any{
+		"values": []map[string]any{{"account_id": 7, "value": 99}},
+	})
+	p, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if !p.ValuesSet || len(p.Values) != 1 {
+		t.Fatalf("expected one replacement value, got %+v", p)
+	}
+}
+
+func TestBuildUpdatePatchEmptyValuesArrayFails(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"values": []map[string]any{}})
+	_, vErr := buildUpdatePatch(raw)
+	if vErr == nil || vErr.Field != "values" {
+		t.Fatalf("expected values error, got %+v", vErr)
+	}
+}
+
+func TestOptionalIntParses(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"x": 42})
+	n, vErr := optionalInt(raw, "x")
+	if vErr != nil || n == nil || *n != 42 {
+		t.Fatalf("expected 42, got %+v err=%+v", n, vErr)
+	}
+}
+
+func TestOptionalIntMissingReturnsNil(t *testing.T) {
+	n, vErr := optionalInt(map[string]json.RawMessage{}, "x")
+	if vErr != nil || n != nil {
+		t.Fatalf("expected nil/nil, got %+v err=%+v", n, vErr)
+	}
+}
+
+func TestOptionalIntInvalidFails(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"x": "abc"})
+	_, vErr := optionalInt(raw, "x")
+	if vErr == nil || vErr.Field != "x" {
+		t.Fatalf("expected x error, got %+v", vErr)
+	}
+}

--- a/backend-go/internal/zus/validation_test.go
+++ b/backend-go/internal/zus/validation_test.go
@@ -1,0 +1,170 @@
+package zus
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+var fixedNow = func() time.Time { return time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC) }
+
+func rawJSON(t *testing.T, m map[string]any) map[string]json.RawMessage {
+	t.Helper()
+	out := make(map[string]json.RawMessage, len(m))
+	for k, v := range m {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", k, err)
+		}
+		out[k] = b
+	}
+	return out
+}
+
+func validInputs() map[string]any {
+	return map[string]any{
+		"owner_user_id":                1,
+		"birth_date":                   "1990-06-15",
+		"gender":                       "M",
+		"retirement_age":               65,
+		"current_gross_monthly_salary": 10000,
+		"work_start_year":              2015,
+	}
+}
+
+func TestBuildInputsOK(t *testing.T) {
+	c, vErr := buildInputs(rawJSON(t, validInputs()), fixedNow)
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if c.Inputs.Gender != "M" || c.Inputs.RetirementAge != 65 {
+		t.Fatalf("inputs mismatch: %+v", c)
+	}
+	if c.BirthDate.Year() != 1990 {
+		t.Fatalf("birth year mismatch: %s", c.BirthDate)
+	}
+	if c.Inputs.BirthYear != 1990 {
+		t.Fatalf("birth year not propagated: %+v", c.Inputs)
+	}
+}
+
+func TestBuildInputsInvalidGender(t *testing.T) {
+	m := validInputs()
+	m["gender"] = "Z"
+	_, vErr := buildInputs(rawJSON(t, m), fixedNow)
+	if vErr == nil || vErr.Field != "gender" {
+		t.Fatalf("expected gender error, got %+v", vErr)
+	}
+}
+
+func TestBuildInputsRetirementAgeOutOfRange(t *testing.T) {
+	m := validInputs()
+	m["retirement_age"] = 40
+	_, vErr := buildInputs(rawJSON(t, m), fixedNow)
+	if vErr == nil || vErr.Field != "retirement_age" {
+		t.Fatalf("expected retirement_age error, got %+v", vErr)
+	}
+}
+
+func TestBuildInputsNegativeSalary(t *testing.T) {
+	m := validInputs()
+	m["current_gross_monthly_salary"] = -1
+	_, vErr := buildInputs(rawJSON(t, m), fixedNow)
+	if vErr == nil || vErr.Field != "current_gross_monthly_salary" {
+		t.Fatalf("expected salary error, got %+v", vErr)
+	}
+}
+
+func TestBuildInputsRateOutOfRange(t *testing.T) {
+	m := validInputs()
+	m["inflation_rate"] = 25.0
+	_, vErr := buildInputs(rawJSON(t, m), fixedNow)
+	if vErr == nil || vErr.Field != "inflation_rate" {
+		t.Fatalf("expected inflation_rate error, got %+v", vErr)
+	}
+}
+
+func TestBuildInputsRetirementBeforeCurrentAge(t *testing.T) {
+	m := validInputs()
+	m["birth_date"] = "1950-06-15"
+	m["retirement_age"] = 55
+	_, vErr := buildInputs(rawJSON(t, m), fixedNow)
+	if vErr == nil || vErr.Field != "retirement_age" {
+		t.Fatalf("expected retirement_age error, got %+v", vErr)
+	}
+}
+
+func TestValidateAgeRelationship(t *testing.T) {
+	birth := time.Date(1990, 6, 15, 0, 0, 0, 0, time.UTC)
+	if vErr := validateAgeRelationship(birth, 65, fixedNow); vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if vErr := validateAgeRelationship(birth, 30, fixedNow); vErr == nil {
+		t.Fatal("expected error when retirement <= current age")
+	}
+}
+
+func TestSalaryHistoryParses(t *testing.T) {
+	m := validInputs()
+	m["salary_history"] = []map[string]any{
+		{"year": 2020, "annual_gross": 60000},
+		{"year": 2021, "annual_gross": 70000},
+	}
+	c, vErr := buildInputs(rawJSON(t, m), fixedNow)
+	if vErr != nil {
+		t.Fatalf("unexpected: %+v", vErr)
+	}
+	if len(c.Inputs.SalaryHistory) != 2 {
+		t.Fatalf("expected 2 entries, got %+v", c.Inputs.SalaryHistory)
+	}
+	if c.Inputs.SalaryHistory[2020] != 60000 {
+		t.Fatalf("entry mismatch: %+v", c.Inputs.SalaryHistory)
+	}
+}
+
+func TestSalaryHistoryMissingField(t *testing.T) {
+	m := validInputs()
+	m["salary_history"] = []map[string]any{{"year": 2020}}
+	_, vErr := buildInputs(rawJSON(t, m), fixedNow)
+	if vErr == nil || vErr.Field != "salary_history" {
+		t.Fatalf("expected salary_history error, got %+v", vErr)
+	}
+}
+
+func TestOptionalIntRangeAccepts(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"x": 5})
+	n, vErr := optionalIntRange(raw, "x", 10, 0, 10, "msg")
+	if vErr != nil || n != 5 {
+		t.Fatalf("expected 5, got %d err=%+v", n, vErr)
+	}
+}
+
+func TestOptionalIntRangeFallback(t *testing.T) {
+	n, vErr := optionalIntRange(map[string]json.RawMessage{}, "x", 7, 0, 10, "msg")
+	if vErr != nil || n != 7 {
+		t.Fatalf("expected fallback 7, got %d err=%+v", n, vErr)
+	}
+}
+
+func TestOptionalIntRangeOutOfRange(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"x": 50})
+	_, vErr := optionalIntRange(raw, "x", 0, 0, 10, "msg")
+	if vErr == nil || vErr.Field != "x" {
+		t.Fatalf("expected range error, got %+v", vErr)
+	}
+}
+
+func TestOptionalIntRangeNullIsError(t *testing.T) {
+	raw := rawJSON(t, map[string]any{"x": nil})
+	_, vErr := optionalIntRange(raw, "x", 0, 0, 10, "msg")
+	if vErr == nil || vErr.Field != "x" {
+		t.Fatalf("expected error on null, got %+v", vErr)
+	}
+}
+
+func TestRequireIntRangeRequired(t *testing.T) {
+	_, vErr := requireIntRange(map[string]json.RawMessage{}, "x", 0, 10, "msg")
+	if vErr == nil || vErr.Field != "x" {
+		t.Fatalf("expected required, got %+v", vErr)
+	}
+}


### PR DESCRIPTION
## Motivation

Pre-this-PR, only 3 of the ~25 backend-go packages had test files (`auth/token`, `auth/password`, `server`). Every domain endpoint group depended entirely on the bb-tests integration suite for regressions, leaving validation/parsing logic — small, fast, deterministic — exercised only end-to-end against a live Postgres.

## Implementation information

Added 13 new `*_test.go` files covering pure logic that doesn't need a database. Each file targets one obvious slice of its package:

- `accounts/validation_test.go` + `handler_test.go` (request/patch parsing, `isoNaive`/`pyFloat`, `parseIDParam`)
- `snapshots/validation_test.go` (request/patch parsing, value entries)
- `goals/validation_test.go` + `projection_test.go` (validate, patch, `projectHitDate`, `addMonths`, `daysIn`)
- `assets/validation_test.go` (name helpers, isNull)
- `config/validation_test.go` (every `validate()` branch incl. allocation sum, age relationship)
- `salaries/validation_test.go` (create/patch, future-date guard)
- `bonus_events/validation_test.go` (create/patch, notes / owner-clearing semantics)
- `auth/validation_test.go` (username, password, optional name, PPK bounds)
- `cpi/inflation_test.go` (`CumulativeIndex`, `IndexAtDate` clamp + interpolate + missing-year, `AdjustWithIndex`)
- `fx/fx_test.go` (`ToPLN` currency/rate handling, `truncateDay`)
- `zus/validation_test.go` (`buildInputs` happy + each guard, salary history, range helpers)

Result: 16 test files. `go test ./...` and `golangci-lint run ./...` both clean.

Closes #507

> Changelog: test(go): expand backend unit test coverage