### PR TITLE
ci(codecov): fix frontend flag path

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,7 +17,7 @@ coverage:
 flags:
   frontend:
     paths:
-      - frontend/
+      - src/
 
 comment:
   layout: 'reach,diff,flags,tree,footer'


### PR DESCRIPTION
## Motivation

`codecov.yml` scoped the `frontend` flag to `frontend/`, a directory that does not exist in this repo. Frontend code lives under `src/`. The result: the flag matched zero files, the per-flag coverage was effectively empty, and any frontend coverage regression slipped past the per-flag gates.

## Implementation information

One-line config change: `frontend/` → `src/`. The flag continues to be uploaded from the same `npm run test:coverage` step in `.github/workflows/ci.yml`.

Closes #512

> Changelog: ci(codecov): fix frontend flag path