### PR TITLE
test(frontend): raise coverage and ratchet floor

### DIFF
--- a/src/lib/utils/charts/simulations.test.ts
+++ b/src/lib/utils/charts/simulations.test.ts
@@ -68,4 +68,49 @@ describe('buildRetirementProjectionOption', () => {
 		expect(series).toEqual([]);
 		expect(xAxis.data).toEqual([]);
 	});
+
+	it('formats y-axis labels as thousands', () => {
+		const option = buildRetirementProjectionOption([makeSimulation('X', [1000])]);
+		const yAxis = option.yAxis as { axisLabel: { formatter: (n: number) => string } };
+		expect(yAxis.axisLabel.formatter(15000)).toBe('15k');
+		expect(yAxis.axisLabel.formatter(1000)).toBe('1k');
+		expect(yAxis.axisLabel.formatter(0)).toBe('0k');
+	});
+
+	it('tooltip formatter renders rows per series', () => {
+		const option = buildRetirementProjectionOption([makeSimulation('IKE', [1000])]);
+		const tooltip = option.tooltip as unknown as {
+			formatter: (params: Array<{ name: number; seriesName: string; value: number }>) => string;
+		};
+		const html = tooltip.formatter([
+			{ name: 2025, seriesName: 'IKE', value: 12000 },
+			{ name: 2025, seriesName: 'IKZE', value: 7500 }
+		]);
+		expect(html).toContain('Rok 2025');
+		expect(html).toContain('IKE');
+		expect(html).toContain('IKZE');
+		// Polish locale's thousand separator is environment-dependent; assert
+		// the rendered numbers via toLocaleString to stay portable.
+		expect(html).toContain(`${(12000).toLocaleString('pl-PL')} PLN`);
+		expect(html).toContain(`${(7500).toLocaleString('pl-PL')} PLN`);
+	});
+
+	it('tooltip formatter accepts a single (non-array) param', () => {
+		const option = buildRetirementProjectionOption([makeSimulation('IKE', [1000])]);
+		const tooltip = option.tooltip as unknown as {
+			formatter: (param: { name: number; seriesName: string; value: number }) => string;
+		};
+		const html = tooltip.formatter({ name: 2030, seriesName: 'IKE', value: 50000 });
+		expect(html).toContain('Rok 2030');
+		expect(html).toContain('IKE');
+	});
+
+	it('reuses the palette when there are more series than colors', () => {
+		const sims = Array.from({ length: 10 }, (_, i) => makeSimulation(`acc${i}`, [i * 100]));
+		const option = buildRetirementProjectionOption(sims);
+		const series = option.series as Array<{ itemStyle: { color: string } }>;
+		expect(series).toHaveLength(10);
+		// 7th item should wrap back to the first palette colour
+		expect(series[6].itemStyle.color).toBe(series[0].itemStyle.color);
+	});
 });

--- a/src/routes/salaries/page.test.ts
+++ b/src/routes/salaries/page.test.ts
@@ -232,6 +232,9 @@ describe('Salaries page — saveSalary validation & error display', () => {
 			company: 'Acme',
 			contract_type: 'UOP'
 		});
+
+		// Modal should have closed: the "Data wypłaty" input belongs to it.
+		await waitFor(() => expect(screen.queryByLabelText(/Data wypłaty/)).toBeNull());
 	});
 
 	it('blocks bonus save when amount is zero', async () => {

--- a/src/routes/salaries/page.test.ts
+++ b/src/routes/salaries/page.test.ts
@@ -203,6 +203,55 @@ describe('Salaries page — saveSalary validation & error display', () => {
 		);
 	});
 
+	it('POSTs a bonus and closes the modal on success', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: baseData } });
+		await fireEvent.click(screen.getByRole('button', { name: /Nowy bonus/i }));
+
+		const dateInput = screen.getByLabelText(/Data wypłaty/) as HTMLInputElement;
+		const amountInput = screen.getByLabelText(/Kwota/) as HTMLInputElement;
+		const companyInput = screen.getByLabelText(/Firma\*/) as HTMLInputElement;
+		await fireEvent.input(dateInput, { target: { value: '2026-05-01' } });
+		await fireEvent.input(amountInput, { target: { value: '12000' } });
+		await fireEvent.input(companyInput, { target: { value: 'Acme' } });
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe('http://localhost:8000/api/bonuses');
+		expect((init as RequestInit).method).toBe('POST');
+		const body = JSON.parse((init as RequestInit).body as string);
+		expect(body).toMatchObject({
+			date: '2026-05-01',
+			amount: 12000,
+			currency: 'PLN',
+			type: 'annual',
+			company: 'Acme',
+			contract_type: 'UOP'
+		});
+	});
+
+	it('blocks bonus save when amount is zero', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: baseData } });
+		await fireEvent.click(screen.getByRole('button', { name: /Nowy bonus/i }));
+
+		const dateInput = screen.getByLabelText(/Data wypłaty/) as HTMLInputElement;
+		const companyInput = screen.getByLabelText(/Firma\*/) as HTMLInputElement;
+		await fireEvent.input(dateInput, { target: { value: '2026-05-01' } });
+		await fireEvent.input(companyInput, { target: { value: 'Acme' } });
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() => expect(screen.getByText('Kwota musi być większa niż 0')).toBeTruthy());
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
 	it('POSTs to /api/salaries and invalidates on success', async () => {
 		const fetchMock = vi.fn().mockResolvedValue({
 			ok: true,

--- a/src/routes/simulations/page.test.ts
+++ b/src/routes/simulations/page.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, beforeAll, vi } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import Page from './+page.svelte';
 
 beforeAll(() => {
@@ -25,10 +25,10 @@ vi.mock('$env/dynamic/public', () => ({
 	}
 }));
 
-vi.mock('$app/environment', () => ({ browser: false }));
+vi.mock('$app/environment', () => ({ browser: true }));
 
 vi.mock('echarts', () => ({
-	init: vi.fn(() => ({ setOption: vi.fn(), resize: vi.fn(), dispose: vi.fn() }))
+	init: vi.fn(() => ({ setOption: vi.fn(), resize: vi.fn(), dispose: vi.fn(), clear: vi.fn() }))
 }));
 
 const mockData = {
@@ -38,13 +38,13 @@ const mockData = {
 		{ id: 1, name: 'Marcin' },
 		{ id: 2, name: 'Ewa' }
 	],
-	balances: {},
-	ppk_balances: {},
-	monthly_salaries: {},
-	ppk_rates: {}
+	balances: { ike_1: 1000, ikze_1: 2000, ike_2: 500, ikze_2: 800 },
+	ppk_balances: { '1': 5000, '2': 3000 },
+	monthly_salaries: { '1': 15000, '2': 12000 },
+	ppk_rates: { '1': { employee: 2.5, employer: 1.5 } }
 };
 
-describe('Simulations Page', () => {
+describe('Simulations Page — render', () => {
 	it('renders the main heading', () => {
 		render(Page, { props: { data: mockData } });
 		expect(screen.getByRole('heading', { name: 'Symulacje Emerytalne' })).toBeTruthy();
@@ -62,6 +62,97 @@ describe('Simulations Page', () => {
 
 	it('does not render results before a simulation is run', () => {
 		render(Page, { props: { data: mockData } });
+		expect(screen.queryByRole('heading', { name: 'Wyniki symulacji' })).toBeNull();
+	});
+
+	it('renders one IKE + IKZE checkbox per owner', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.getByText('IKE (Marcin)')).toBeTruthy();
+		expect(screen.getByText('IKZE (Marcin)')).toBeTruthy();
+		expect(screen.getByText('IKE (Ewa)')).toBeTruthy();
+		expect(screen.getByText('IKZE (Ewa)')).toBeTruthy();
+	});
+});
+
+describe('Simulations Page — run simulation', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('POSTs request body and renders the results section on success', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			statusText: 'OK',
+			json: async () => ({
+				simulations: [
+					{
+						account_name: 'IKE Marcin',
+						starting_balance: 1000,
+						total_contributions: 5000,
+						total_returns: 700,
+						total_tax_savings: 0,
+						final_balance: 6700,
+						yearly_projections: [
+							{
+								year: 2026,
+								age: 35,
+								annual_contribution: 1000,
+								balance_end_of_year: 2000,
+								cumulative_contributions: 1000,
+								cumulative_returns: 0,
+								annual_limit: 5000,
+								limit_utilized_pct: 20,
+								tax_savings: 0
+							}
+						]
+					}
+				],
+				summary: {
+					total_final_balance: 6700,
+					total_contributions: 5000,
+					total_returns: 700,
+					total_tax_savings: 0,
+					estimated_monthly_income: 200,
+					estimated_monthly_income_today: 150,
+					years_until_retirement: 30
+				}
+			})
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: mockData } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Uruchom symulację' }));
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe('http://localhost:8000/api/simulations/retirement');
+		expect((init as RequestInit).method).toBe('POST');
+		const body = JSON.parse((init as RequestInit).body as string);
+		expect(body.current_age).toBe(35);
+		expect(body.retirement_age).toBe(65);
+		expect(Array.isArray(body.ike_ikze_accounts)).toBe(true);
+
+		await waitFor(() =>
+			expect(screen.getByRole('heading', { name: 'Wyniki symulacji' })).toBeTruthy()
+		);
+	});
+
+	it('surfaces non-2xx response as an error', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: false,
+			statusText: 'Internal Server Error',
+			json: async () => ({})
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: mockData } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Uruchom symulację' }));
+
+		await waitFor(() => expect(screen.getByText(/Simulation failed/)).toBeTruthy());
 		expect(screen.queryByRole('heading', { name: 'Wyniki symulacji' })).toBeNull();
 	});
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,10 +16,10 @@ export default defineConfig({
 			reporter: ['text', 'json', 'html', 'lcov'],
 			exclude: ['node_modules/**', '.svelte-kit/**', 'build/**', '**/*.config.*', '**/.*rc.*'],
 			thresholds: {
-				statements: 56,
-				branches: 39,
-				functions: 56,
-				lines: 59
+				statements: 62,
+				branches: 43,
+				functions: 60,
+				lines: 64
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation

The tech-debt audit flagged frontend statement coverage at 57.28%, with `src/routes/salaries/+page.svelte` at 30.71% and `src/routes/simulations/+page.svelte` at 37.99%. The original goal was 70% statements / 60% branches; getting all the way there is a multi-day push that mostly depends on chipping at the 2,400-line salaries page.

This PR moves the needle and sets a higher coverage floor so future PRs can't regress what we just gained.

## Implementation information

New / extended tests:

- `src/lib/utils/charts/simulations.test.ts`: cover the tooltip formatter on both the array and single-param paths, the y-axis label formatter, and the palette wrap-around (more series than colours).
- `src/routes/simulations/page.test.ts`: render-only test extended with a real run-simulation happy path (POST body shape + results section appears) and a non-2xx error path.
- `src/routes/salaries/page.test.ts`: add a bonus-modal POST flow plus the amount-must-be-positive validation gate.
- `vite.config.ts`: thresholds raised from 56/39/56/59 to 62/43/60/64 so the new floor is enforced.

Coverage moves from 57.28% / 41.22% / 56.28% / 59.80% to **63.61% / 43.96% / 62.86% / 65.40%** (statements / branches / functions / lines).

### Open follow-ups

The original 70% / 60% target isn't fully reached here. Most of the remaining gap is in `salaries/+page.svelte` (now 38%, four big modals still mostly untested). Refactoring that file (the audit's #508) will make those flows easier to cover incrementally.

Closes #509

> Changelog: test(frontend): raise coverage and ratchet floor