### PR TITLE
chore(lint): add noctx misspell unparam gofumpt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - nilerr
     - nilnesserr
     - nilnil
+    - noctx
     - nonamedreturns
     - reassign
     - recvcheck
@@ -39,6 +40,7 @@ linters:
     - gocritic
     - goprintffuncname
     - gosec
+    - misspell
     - modernize
     - nolintlint
     - nosprintfhostport
@@ -47,11 +49,14 @@ linters:
     - testableexamples
     - thelper
     - unconvert
+    - unparam
     - usestdlibvars
     - usetesting
+    - whitespace
 
     # dependency hygiene
     - depguard
+    - gomodguard_v2
 
   settings:
     depguard:
@@ -158,6 +163,27 @@ linters:
     sloglint:
       no-mixed-args: true
 
+    misspell:
+      locale: US
+
+    gomodguard_v2:
+      blocked:
+        - module: github.com/pkg/errors
+          recommendations:
+            - errors
+          reason: stdlib errors covers wrapping since Go 1.13
+        - module: golang.org/x/exp/maps
+          recommendations:
+            - maps
+        - module: golang.org/x/exp/slices
+          recommendations:
+            - slices
+        - module: io/ioutil
+          recommendations:
+            - io
+            - os
+          reason: deprecated since Go 1.16
+
   exclusions:
     warn-unused: true
     presets:
@@ -174,5 +200,12 @@ linters:
 
 formatters:
   enable:
-    - gofmt
-    - goimports
+    - gci
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/Automaat/finance-buddy/backend-go)
+      custom-order: true

--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -47,7 +47,14 @@ func healthcheck() int {
 	}
 	url := "http://" + net.JoinHostPort(host, port) + "/health"
 	client := &http.Client{Timeout: 3 * time.Second}
-	resp, err := client.Get(url)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "healthcheck:", err)
+		return 1
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "healthcheck:", err)
 		return 1
@@ -179,7 +186,7 @@ func envOr(key, fallback string) string {
 
 // envOrPresent returns the env value if the key is set (even if empty),
 // else fallback. Use for values where an explicit empty string is a
-// legitimate signal — e.g. CORS_ORIGINS="" matching Python's behaviour
+// legitimate signal — e.g. CORS_ORIGINS="" matching Python's behavior
 // of trusting whatever Settings parsed from the environment.
 func envOrPresent(key, fallback string) string {
 	if v, ok := os.LookupEnv(key); ok {

--- a/backend-go/internal/accounts/handler_test.go
+++ b/backend-go/internal/accounts/handler_test.go
@@ -94,7 +94,7 @@ func TestToResponseSquareMetersForwarded(t *testing.T) {
 
 func TestParseIDParamValid(t *testing.T) {
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/accounts/42", http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/accounts/42", http.NoBody)
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", "42")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
@@ -107,7 +107,7 @@ func TestParseIDParamValid(t *testing.T) {
 
 func TestParseIDParamInvalidWrites422(t *testing.T) {
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/accounts/abc", http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/accounts/abc", http.NoBody)
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", "abc")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))

--- a/backend-go/internal/accounts/validation.go
+++ b/backend-go/internal/accounts/validation.go
@@ -72,7 +72,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *validat
 	}
 	r.SquareMeters = sq
 
-	recv, vErr := optionalBool(raw, "receives_contributions", true)
+	recv, vErr := optionalBoolDefaultTrue(raw, "receives_contributions")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -250,10 +250,10 @@ func optionalDecimal(raw map[string]json.RawMessage, key string) (*decimal.Decim
 	return &d, nil
 }
 
-func optionalBool(raw map[string]json.RawMessage, key string, fallback bool) (bool, *validationError) {
+func optionalBoolDefaultTrue(raw map[string]json.RawMessage, key string) (bool, *validationError) {
 	v, ok := raw[key]
 	if !ok {
-		return fallback, nil
+		return true, nil
 	}
 	if isNull(v) {
 		return false, &validationError{Field: key, Msg: "must be a boolean"}

--- a/backend-go/internal/accounts/validation_test.go
+++ b/backend-go/internal/accounts/validation_test.go
@@ -264,13 +264,13 @@ func TestOptionalDecimalParsesAndFails(t *testing.T) {
 }
 
 func TestOptionalBoolFallbacks(t *testing.T) {
-	if b, vErr := optionalBool(map[string]json.RawMessage{}, "x", true); !b || vErr != nil {
+	if b, vErr := optionalBoolDefaultTrue(map[string]json.RawMessage{}, "x"); !b || vErr != nil {
 		t.Fatalf("missing should fall back to true")
 	}
-	if _, vErr := optionalBool(rawJSON(t, map[string]any{"x": nil}), "x", true); vErr == nil {
+	if _, vErr := optionalBoolDefaultTrue(rawJSON(t, map[string]any{"x": nil}), "x"); vErr == nil {
 		t.Fatalf("null should be a validation error")
 	}
-	b, vErr := optionalBool(rawJSON(t, map[string]any{"x": false}), "x", true)
+	b, vErr := optionalBoolDefaultTrue(rawJSON(t, map[string]any{"x": false}), "x")
 	if vErr != nil || b {
 		t.Fatalf("explicit false should pass through")
 	}

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -91,7 +91,7 @@ func computeFromAggregates(ctx context.Context, s *Store, aggRows []AggregateRow
 
 	if shared.hasConfig && len(latestRows) > 0 {
 		latestDate := shared.snapshotDate[latestSID]
-		nwForSavings := aggregateMonthlyNetWorths(aggRows, shared.snapshotDate)
+		nwForSavings := aggregateMonthlyNetWorths(aggRows)
 		res.MetricCards = buildMetricCards(latestRows, shared, res.RetirementAccountValue, latestDate, nwForSavings)
 		res.AllocationAnalysis = buildAllocationAnalysis(latestRows, shared.config)
 	}
@@ -246,7 +246,7 @@ func rawAllocation(latestRows []mergedRow) []allocationItem {
 
 // aggregateMonthlyNetWorths ports _compute_savings_rate_from_aggregates'
 // month-bucketing: latest snapshot per month, sorted chronologically.
-func aggregateMonthlyNetWorths(aggRows []AggregateRow, snapshotDate map[int]time.Time) []float64 {
+func aggregateMonthlyNetWorths(aggRows []AggregateRow) []float64 {
 	snapNW := map[int]float64{}
 	snapMonth := map[int]time.Time{}
 	for _, r := range aggRows {

--- a/backend-go/internal/goals/validation.go
+++ b/backend-go/internal/goals/validation.go
@@ -43,7 +43,7 @@ func validateCreate(req *createRequest) *validationError {
 }
 
 // buildUpdatePatch reads a raw JSON object and decides, per field, whether
-// it was omitted, explicitly null, or set to a value. This is the Go analogue
+// it was omitted, explicitly null, or set to a value. This is the Go analog
 // of Pydantic's model_fields_set used in update_goal.
 func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *validationError) {
 	var p UpdatePatch

--- a/backend-go/internal/salaries/handler.go
+++ b/backend-go/internal/salaries/handler.go
@@ -18,11 +18,9 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 )
 
-var (
-	validContractTypes = map[string]struct{}{
-		"UOP": {}, "UZ": {}, "UoD": {}, "B2B": {},
-	}
-)
+var validContractTypes = map[string]struct{}{
+	"UOP": {}, "UZ": {}, "UoD": {}, "B2B": {},
+}
 
 // response mirrors backend/app/schemas/salary_records.SalaryRecordResponse.
 // OwnerUserID is the owning household member; nil means jointly owned.
@@ -51,7 +49,7 @@ type inflationContext struct {
 }
 
 // listResponse keys current_salaries and inflation_context by owner_user_id
-// (JSON serialises the integer keys as strings).
+// (JSON serializes the integer keys as strings).
 type listResponse struct {
 	SalaryRecords      []response               `json:"salary_records"`
 	TotalCount         int                      `json:"total_count"`

--- a/backend-go/internal/scheduler/scheduler.go
+++ b/backend-go/internal/scheduler/scheduler.go
@@ -54,7 +54,7 @@ func NewCPIScheduler(store *cpi.Store, fetcher *cpi.GUSFetcher, logger *slog.Log
 }
 
 // Run does the startup staleness check, then loops firing the monthly
-// refresh until ctx is cancelled. Intended to run in its own goroutine.
+// refresh until ctx is canceled. Intended to run in its own goroutine.
 func (s *CPIScheduler) Run(ctx context.Context) {
 	s.startupRefresh(ctx)
 	for {

--- a/backend-go/internal/server/server_test.go
+++ b/backend-go/internal/server/server_test.go
@@ -13,7 +13,11 @@ func TestHealthEndpoint(t *testing.T) {
 	srv := httptest.NewServer(New(Config{CORSOrigins: "*"}, slog.New(slog.DiscardHandler), Deps{}))
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/health")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/health", http.NoBody)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("get /health: %v", err)
 	}


### PR DESCRIPTION
## Motivation

Ported missing linters from kuma's golangci-lint config. FB's config
was already strict on bug-catching but missing HTTP hygiene checks
and formatter strictness.

## Implementation information

**Added linters:**
- `noctx` — flags HTTP calls without context
- `misspell` — US-locale spelling
- `unparam` — unused function parameters
- `whitespace` — blank-line checks
- `gomodguard_v2` — blocks deprecated modules (`pkg/errors`,
  `golang.org/x/exp/{maps,slices}`, `io/ioutil`)

**Switched formatters:**
- `gofmt` → `gofumpt` (stricter superset)
- `goimports` → `gci` (deterministic import grouping with
  stdlib / default / prefix sections)

**Skipped:** `importas` (no aliasing convention to enforce),
`forbidigo` (no project-specific banned patterns),
`ginkgolinter` (FB has no Ginkgo).

**Fixed all 11 findings:**
- noctx (4): added context to `client.Get`, `http.Get`,
  `httptest.NewRequest` calls
- misspell (4): `behaviour`/`analogue`/`serialises`/`cancelled`
- unparam (2): dropped unused `fallback` from `optionalBool`
  (now `optionalBoolDefaultTrue`); dropped unused `snapshotDate`
  from `aggregateMonthlyNetWorths`
- gofumpt (1+): formatted across 9 files

Verified: `golangci-lint run ./...` → 0 issues; `go test ./...`
→ all pass.

## Supporting documentation

Source config: `~/kong/kuma/.golangci.yml`