### PR TITLE
fix(transactions): allow same-day entries

### DIFF
--- a/backend-bb-tests/tests/test_transactions.py
+++ b/backend-bb-tests/tests/test_transactions.py
@@ -94,6 +94,15 @@ def test_create_transaction_validation_error(client: httpx.Client) -> None:
     assert "detail" in response.json()
 
 
+def _post_and_track(
+    client: httpx.Client, account_id: int, payload: dict, created_ids: list[int]
+) -> httpx.Response:
+    resp = client.post(f"/api/accounts/{account_id}/transactions", json=payload)
+    if resp.status_code == 201:
+        created_ids.append(resp.json()["id"])
+    return resp
+
+
 @pytest.mark.mutates
 def test_create_two_same_day_transactions_persist(
     client: httpx.Client, owner_ids: dict[str, int]
@@ -105,27 +114,30 @@ def test_create_two_same_day_transactions_persist(
         "date": "2025-09-12",
         "owner_user_id": owner_ids[PERSONA_MARCIN],
     }
-    first = client.post(
-        f"/api/accounts/{account_id}/transactions",
-        json={**base, "amount": 100.0, "transaction_type": "employee"},
-    )
-    assert first.status_code == 201, first.text
-    second = client.post(
-        f"/api/accounts/{account_id}/transactions",
-        json={**base, "amount": 250.0, "transaction_type": "employer"},
-    )
-    assert second.status_code == 201, second.text
+    created_ids: list[int] = []
     try:
+        first = _post_and_track(
+            client,
+            account_id,
+            {**base, "amount": 100.0, "transaction_type": "employee"},
+            created_ids,
+        )
+        assert first.status_code == 201, first.text
+        second = _post_and_track(
+            client,
+            account_id,
+            {**base, "amount": 250.0, "transaction_type": "employer"},
+            created_ids,
+        )
+        assert second.status_code == 201, second.text
         listing = client.get(f"/api/accounts/{account_id}/transactions")
         assert listing.status_code == 200, listing.text
         same_day = [t for t in listing.json()["transactions"] if t["date"] == "2025-09-12"]
         amounts = sorted(t["amount"] for t in same_day)
         assert amounts == [pytest.approx(100.0), pytest.approx(250.0)]
     finally:
-        for resp in (first, second):
-            tid = resp.json().get("id")
-            if tid is not None:
-                client.delete(f"/api/accounts/{account_id}/transactions/{tid}")
+        for tid in created_ids:
+            client.delete(f"/api/accounts/{account_id}/transactions/{tid}")
 
 
 @pytest.mark.mutates
@@ -140,23 +152,16 @@ def test_create_two_same_day_same_type_transactions_persist(
         "owner_user_id": owner_ids[PERSONA_MARCIN],
         "transaction_type": "employee",
     }
-    first = client.post(
-        f"/api/accounts/{account_id}/transactions",
-        json={**base, "amount": 50.0},
-    )
-    assert first.status_code == 201, first.text
-    second = client.post(
-        f"/api/accounts/{account_id}/transactions",
-        json={**base, "amount": 75.0},
-    )
-    assert second.status_code == 201, second.text
+    created_ids: list[int] = []
     try:
+        first = _post_and_track(client, account_id, {**base, "amount": 50.0}, created_ids)
+        assert first.status_code == 201, first.text
+        second = _post_and_track(client, account_id, {**base, "amount": 75.0}, created_ids)
+        assert second.status_code == 201, second.text
         assert first.json()["id"] != second.json()["id"]
     finally:
-        for resp in (first, second):
-            tid = resp.json().get("id")
-            if tid is not None:
-                client.delete(f"/api/accounts/{account_id}/transactions/{tid}")
+        for tid in created_ids:
+            client.delete(f"/api/accounts/{account_id}/transactions/{tid}")
 
 
 @pytest.mark.mutates

--- a/backend-bb-tests/tests/test_transactions.py
+++ b/backend-bb-tests/tests/test_transactions.py
@@ -95,6 +95,71 @@ def test_create_transaction_validation_error(client: httpx.Client) -> None:
 
 
 @pytest.mark.mutates
+def test_create_two_same_day_transactions_persist(
+    client: httpx.Client, owner_ids: dict[str, int]
+) -> None:
+    # Regression for #396: multiple active transactions may share
+    # (account_id, date) — e.g. same-day fees, dividends, split imports.
+    account_id = _account_id_by_name(client, ACCOUNT_MARCIN_IKE)
+    base = {
+        "date": "2025-09-12",
+        "owner_user_id": owner_ids[PERSONA_MARCIN],
+    }
+    first = client.post(
+        f"/api/accounts/{account_id}/transactions",
+        json={**base, "amount": 100.0, "transaction_type": "employee"},
+    )
+    assert first.status_code == 201, first.text
+    second = client.post(
+        f"/api/accounts/{account_id}/transactions",
+        json={**base, "amount": 250.0, "transaction_type": "employer"},
+    )
+    assert second.status_code == 201, second.text
+    try:
+        listing = client.get(f"/api/accounts/{account_id}/transactions")
+        assert listing.status_code == 200, listing.text
+        same_day = [t for t in listing.json()["transactions"] if t["date"] == "2025-09-12"]
+        amounts = sorted(t["amount"] for t in same_day)
+        assert amounts == [pytest.approx(100.0), pytest.approx(250.0)]
+    finally:
+        for resp in (first, second):
+            tid = resp.json().get("id")
+            if tid is not None:
+                client.delete(f"/api/accounts/{account_id}/transactions/{tid}")
+
+
+@pytest.mark.mutates
+def test_create_two_same_day_same_type_transactions_persist(
+    client: httpx.Client, owner_ids: dict[str, int]
+) -> None:
+    # Same (account_id, date) and same transaction_type — e.g. two same-day
+    # fees or two employee contributions split across imports.
+    account_id = _account_id_by_name(client, ACCOUNT_MARCIN_IKE)
+    base = {
+        "date": "2025-09-19",
+        "owner_user_id": owner_ids[PERSONA_MARCIN],
+        "transaction_type": "employee",
+    }
+    first = client.post(
+        f"/api/accounts/{account_id}/transactions",
+        json={**base, "amount": 50.0},
+    )
+    assert first.status_code == 201, first.text
+    second = client.post(
+        f"/api/accounts/{account_id}/transactions",
+        json={**base, "amount": 75.0},
+    )
+    assert second.status_code == 201, second.text
+    try:
+        assert first.json()["id"] != second.json()["id"]
+    finally:
+        for resp in (first, second):
+            tid = resp.json().get("id")
+            if tid is not None:
+                client.delete(f"/api/accounts/{account_id}/transactions/{tid}")
+
+
+@pytest.mark.mutates
 def test_delete_transaction_happy_path(client: httpx.Client, owner_ids: dict[str, int]) -> None:
     account_id = _account_id_by_name(client, ACCOUNT_MARCIN_IKE)
     create_resp = client.post(

--- a/backend-go/internal/transactions/handler.go
+++ b/backend-go/internal/transactions/handler.go
@@ -181,12 +181,6 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		TransactionType: req.TransactionType,
 	})
 	if err != nil {
-		if errors.Is(err, ErrDuplicate) {
-			writeDetailError(w, http.StatusConflict,
-				fmt.Sprintf("Transaction for account %d on %s already exists",
-					accountID, req.Date.Format("2006-01-02")))
-			return
-		}
 		h.logger.Error("create transaction", "err", err)
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return

--- a/backend-go/internal/transactions/store.go
+++ b/backend-go/internal/transactions/store.go
@@ -1,6 +1,8 @@
 // Package transactions implements transaction endpoints for investment +
-// retirement accounts. Soft-delete is the only delete; create enforces
-// one-per-day per account.
+// retirement accounts. Soft-delete is the only delete; multiple active
+// transactions per (account, date) are allowed (fees, dividends, splits,
+// employer/employee PPK rows). PPK generation has its own idempotency
+// guard in internal/retirement.
 package transactions
 
 import (
@@ -49,7 +51,6 @@ var (
 	ErrAccountNotFound      = errors.New("account not found")
 	ErrAccountNotInvestment = errors.New("account is not investment/retirement")
 	ErrNotFound             = errors.New("transaction not found")
-	ErrDuplicate            = errors.New("transaction for date already exists")
 	ErrCrossAccount         = errors.New("transaction does not belong to account")
 )
 
@@ -182,22 +183,10 @@ func (s *Store) ListAll(ctx context.Context, f ListFilter) ([]TxnWithAccount, er
 	return out, nil
 }
 
-// Create inserts a transaction. ErrDuplicate on same (account_id, date) for
-// an active row.
+// Create inserts a transaction. Multiple active transactions may share
+// (account_id, date) — real workflows include same-day fees, dividends,
+// PPK employer/employee rows, and split imports.
 func (s *Store) Create(ctx context.Context, t *Transaction) (*Transaction, error) {
-	var existing int
-	err := s.pool.QueryRow(ctx, `
-		SELECT id FROM transactions
-		WHERE account_id = $1 AND date = $2 AND is_active = true
-		LIMIT 1`,
-		t.AccountID, t.Date,
-	).Scan(&existing)
-	if err == nil {
-		return nil, ErrDuplicate
-	}
-	if !errors.Is(err, pgx.ErrNoRows) {
-		return nil, fmt.Errorf("check duplicate transaction: %w", err)
-	}
 	row := s.pool.QueryRow(ctx, `
 		INSERT INTO transactions (account_id, amount, date, owner_user_id, transaction_type, is_active, created_at)
 		VALUES ($1, $2, $3, $4, $5, true, $6)


### PR DESCRIPTION
## Motivation

`Store.Create` rejected any second active transaction for the same (account_id, date). Real workflows need multiple same-day rows: fees, dividends, split imports, and employer/employee PPK contributions. The Python original had the same bug; the Go port faithfully reproduced it.

## Implementation information

- Dropped the pre-check in `backend-go/internal/transactions/store.go`; bare INSERT.
- Removed `ErrDuplicate` sentinel + the 409 branch from the handler.
- Updated the package doc comment.
- PPK idempotency stays intact: `internal/retirement/store.go::InsertPPKContributions` uses a transaction-scoped advisory lock + active-row pre-check, independent of this path.
- Two black-box regressions: different-type same-day pair, same-type same-day pair.

The issue mentions an optional import idempotency key / source fingerprint as future protection. Deferred — no CSV-import endpoint exists yet, so the column would be unused. Add it together with the importer.

Closes #396

> Changelog: fix(transactions): allow same-day entries