### PR TITLE
fix(charts): dispose ECharts with shared helper

### DIFF
--- a/src/lib/components/DashboardCharts.svelte
+++ b/src/lib/components/DashboardCharts.svelte
@@ -6,6 +6,7 @@
 	import { isMobile, isTablet } from '$lib/utils/viewport';
 	import { chartPalette, chartAccent, chartAccentGradient } from '$lib/utils/theme';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
+	import { createChart } from '$lib/utils/charts/lifecycle';
 
 	interface Props {
 		netWorthHistory: { date: string; value: number }[];
@@ -33,7 +34,8 @@
 	onMount(() => {
 		if (!chartContainer || !pieChartContainer) return;
 
-		lineChart = echarts.init(chartContainer);
+		const lineHandle = createChart(chartContainer);
+		lineChart = lineHandle.chart;
 
 		const lineOption: EChartsOption = {
 			title: {
@@ -73,7 +75,8 @@
 
 		lineChart.setOption(lineOption);
 
-		pieChart = echarts.init(pieChartContainer);
+		const pieHandle = createChart(pieChartContainer);
+		pieChart = pieHandle.chart;
 
 		const pieOption: EChartsOption = {
 			title: {
@@ -104,17 +107,9 @@
 
 		pieChart.setOption(pieOption);
 
-		const handleResize = () => {
-			lineChart?.resize();
-			pieChart?.resize();
-		};
-
-		window.addEventListener('resize', handleResize);
-
 		return () => {
-			window.removeEventListener('resize', handleResize);
-			lineChart?.dispose();
-			pieChart?.dispose();
+			lineHandle.dispose();
+			pieHandle.dispose();
 		};
 	});
 

--- a/src/lib/utils/charts/lifecycle.test.ts
+++ b/src/lib/utils/charts/lifecycle.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createChart } from './lifecycle';
+import * as echarts from 'echarts';
+
+vi.mock('echarts', () => ({
+	init: vi.fn()
+}));
+
+describe('createChart', () => {
+	const disposeSpy = vi.fn();
+	const resizeSpy = vi.fn();
+	const observe = vi.fn();
+	const disconnect = vi.fn();
+
+	beforeEach(() => {
+		vi.mocked(echarts.init).mockReturnValue({
+			dispose: disposeSpy,
+			resize: resizeSpy
+		} as unknown as ReturnType<typeof echarts.init>);
+		// Stub ResizeObserver so this test runs without browser support.
+		// vitest's jsdom env doesn't ship one.
+		(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+			constructor(public cb: ResizeObserverCallback) {}
+			observe = observe;
+			disconnect = disconnect;
+		};
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		delete (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
+	});
+
+	it('initializes echarts on the container and observes it', () => {
+		const el = document.createElement('div');
+		createChart(el);
+		expect(echarts.init).toHaveBeenCalledWith(el);
+		expect(observe).toHaveBeenCalledWith(el);
+	});
+
+	it('dispose tears down both the observer and the chart', () => {
+		const el = document.createElement('div');
+		const handle = createChart(el);
+		handle.dispose();
+		expect(disconnect).toHaveBeenCalledTimes(1);
+		expect(disposeSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('still works when ResizeObserver is unavailable', () => {
+		delete (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
+		const el = document.createElement('div');
+		const handle = createChart(el);
+		// Dispose must not throw and must still tear down the chart.
+		handle.dispose();
+		expect(disposeSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips resize after dispose', () => {
+		let observerCb: ResizeObserverCallback | undefined;
+		(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+			constructor(cb: ResizeObserverCallback) {
+				observerCb = cb;
+			}
+			observe = observe;
+			disconnect = disconnect;
+		};
+		const el = document.createElement('div');
+		const handle = createChart(el);
+		handle.dispose();
+		// Simulate a late callback flushing after disconnect.
+		observerCb?.([], {} as ResizeObserver);
+		expect(resizeSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/utils/charts/lifecycle.ts
+++ b/src/lib/utils/charts/lifecycle.ts
@@ -7,9 +7,8 @@ export interface ChartHandle {
 }
 
 // createChart wires echarts.init + a ResizeObserver on the container and
-// returns a single dispose() that tears down both. Use inside onMount and
-// return chart.dispose from the cleanup callback so navigation away can't
-// leak canvases or observers.
+// returns a ChartHandle. Use inside onMount and call handle.dispose() from
+// the cleanup callback so navigation away can't leak canvases or observers.
 //
 // ResizeObserver is preferred over a global window resize listener: it
 // fires only when the container actually changes size (e.g. layout shifts,

--- a/src/lib/utils/charts/lifecycle.ts
+++ b/src/lib/utils/charts/lifecycle.ts
@@ -1,0 +1,39 @@
+import * as echarts from 'echarts';
+import type { ECharts } from 'echarts';
+
+export interface ChartHandle {
+	chart: ECharts;
+	dispose: () => void;
+}
+
+// createChart wires echarts.init + a ResizeObserver on the container and
+// returns a single dispose() that tears down both. Use inside onMount and
+// return chart.dispose from the cleanup callback so navigation away can't
+// leak canvases or observers.
+//
+// ResizeObserver is preferred over a global window resize listener: it
+// fires only when the container actually changes size (e.g. layout shifts,
+// sidebar toggles), and it's bound to the element so multiple charts on a
+// page don't share one global handler.
+export function createChart(container: HTMLElement): ChartHandle {
+	const chart = echarts.init(container);
+	let disposed = false;
+	let ro: ResizeObserver | undefined;
+	if (typeof ResizeObserver !== 'undefined') {
+		ro = new ResizeObserver(() => {
+			// Skip when teardown has started — ResizeObserver entries can flush
+			// on the next animation frame, after dispose() ran, and ECharts
+			// logs a warning on resize() of a disposed instance.
+			if (!disposed) chart.resize();
+		});
+		ro.observe(container);
+	}
+	return {
+		chart,
+		dispose: () => {
+			disposed = true;
+			ro?.disconnect();
+			chart.dispose();
+		}
+	};
+}

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount, untrack } from 'svelte';
+	import type { EChartsOption } from 'echarts';
 	import MetricCard from '$lib/components/MetricCard.svelte';
 	import { TrendingUp, CheckCircle2, Lightbulb } from 'lucide-svelte';
 	import {
@@ -41,10 +42,7 @@
 	onMount(() => {
 		const handles: ChartHandle[] = [];
 
-		const mount = (
-			el: HTMLDivElement,
-			option: Parameters<ChartHandle['chart']['setOption']>[0]
-		) => {
+		const mount = (el: HTMLDivElement, option: EChartsOption) => {
 			const handle = createChart(el);
 			handle.chart.setOption(option);
 			handles.push(handle);

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount, untrack } from 'svelte';
-	import * as echarts from 'echarts';
 	import MetricCard from '$lib/components/MetricCard.svelte';
 	import { TrendingUp, CheckCircle2, Lightbulb } from 'lucide-svelte';
 	import {
@@ -10,6 +9,7 @@
 		buildWrapperTrendChartOption,
 		buildYearlyRoiChartOption
 	} from '$lib/utils/charts/metryki';
+	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
 
 	import type { PageData } from './$types';
@@ -39,45 +39,27 @@
 	let yearlyRoiChart: HTMLDivElement;
 
 	onMount(() => {
-		const allocationChartInstance = echarts.init(allocationChart);
-		allocationChartInstance.setOption(buildAllocationChartOption(allocationAnalysis.by_category));
+		const handles: ChartHandle[] = [];
 
-		const wrapperChartInstance = echarts.init(wrapperChart);
-		wrapperChartInstance.setOption(buildWrapperChartOption(allocationAnalysis.by_wrapper));
-
-		const investmentTrendChartInstance = echarts.init(investmentTrendChart);
-		investmentTrendChartInstance.setOption(buildInvestmentTrendChartOption(investmentTimeSeries));
-
-		const createWrapperChart = (
-			chartElement: HTMLDivElement,
-			title: string,
-			series: Parameters<typeof buildWrapperTrendChartOption>[1]
+		const mount = (
+			el: HTMLDivElement,
+			option: Parameters<ChartHandle['chart']['setOption']>[0]
 		) => {
-			const chartInstance = echarts.init(chartElement);
-			chartInstance.setOption(buildWrapperTrendChartOption(title, series));
-			return chartInstance;
+			const handle = createChart(el);
+			handle.chart.setOption(option);
+			handles.push(handle);
 		};
 
-		const ikeChartInstance = createWrapperChart(ikeChart, 'IKE w czasie', wrapperTimeSeries.ike);
-		const ikzeChartInstance = createWrapperChart(
-			ikzeChart,
-			'IKZE w czasie',
-			wrapperTimeSeries.ikze
-		);
-		const ppkChartInstance = createWrapperChart(ppkChart, 'PPK w czasie', wrapperTimeSeries.ppk);
-		const stockChartInstance = createWrapperChart(
-			stockChart,
-			'Akcje w czasie',
-			categoryTimeSeries.stock
-		);
-		const bondChartInstance = createWrapperChart(
-			bondChart,
-			'Obligacje w czasie',
-			categoryTimeSeries.bond
-		);
-
-		const yearlyRoiChartInstance = echarts.init(yearlyRoiChart);
-		yearlyRoiChartInstance.setOption(
+		mount(allocationChart, buildAllocationChartOption(allocationAnalysis.by_category));
+		mount(wrapperChart, buildWrapperChartOption(allocationAnalysis.by_wrapper));
+		mount(investmentTrendChart, buildInvestmentTrendChartOption(investmentTimeSeries));
+		mount(ikeChart, buildWrapperTrendChartOption('IKE w czasie', wrapperTimeSeries.ike));
+		mount(ikzeChart, buildWrapperTrendChartOption('IKZE w czasie', wrapperTimeSeries.ikze));
+		mount(ppkChart, buildWrapperTrendChartOption('PPK w czasie', wrapperTimeSeries.ppk));
+		mount(stockChart, buildWrapperTrendChartOption('Akcje w czasie', categoryTimeSeries.stock));
+		mount(bondChart, buildWrapperTrendChartOption('Obligacje w czasie', categoryTimeSeries.bond));
+		mount(
+			yearlyRoiChart,
 			buildYearlyRoiChartOption(
 				categoryTimeSeries.stock,
 				categoryTimeSeries.bond,
@@ -86,15 +68,7 @@
 		);
 
 		return () => {
-			allocationChartInstance.dispose();
-			wrapperChartInstance.dispose();
-			investmentTrendChartInstance.dispose();
-			ikeChartInstance.dispose();
-			ikzeChartInstance.dispose();
-			ppkChartInstance.dispose();
-			stockChartInstance.dispose();
-			bondChartInstance.dispose();
-			yearlyRoiChartInstance.dispose();
+			for (const handle of handles) handle.dispose();
 		};
 	});
 </script>

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount, untrack } from 'svelte';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
+	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
 	import BonusFormModal from '$lib/components/salaries/BonusFormModal.svelte';
 	import EquityFormModal from '$lib/components/salaries/EquityFormModal.svelte';
 	import SalaryFormModal from '$lib/components/salaries/SalaryFormModal.svelte';
@@ -92,6 +93,7 @@
 
 	let chartContainer: HTMLDivElement;
 	let chart: echarts.ECharts | undefined;
+	let chartHandle: ChartHandle | undefined;
 
 	let filterOwnerUserId = $state<number | null>(
 		untrack(() => (data.filters.owner_user_id ? Number(data.filters.owner_user_id) : null))
@@ -1223,12 +1225,16 @@
 		void [data.salaries.salary_records, cpiSeries, showNominal, showReal, showInflationTracked];
 
 		if (!chartContainer) return;
-		if (!chart) chart = echarts.init(chartContainer);
+		if (!chartHandle) {
+			chartHandle = createChart(chartContainer);
+			chart = chartHandle.chart;
+		}
 		applyChart();
 	});
 
 	onMount(() => () => {
-		chart?.dispose();
+		chartHandle?.dispose();
+		chartHandle = undefined;
 		chart = undefined;
 	});
 </script>

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -8,6 +8,7 @@
 		buildRetirementProjectionOption,
 		type AccountSimulation
 	} from '$lib/utils/charts/simulations';
+	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
 
 	interface SimulationSummary {
@@ -133,6 +134,7 @@
 	// Chart
 	let chartContainer: HTMLDivElement | undefined = $state();
 	let chart: echarts.ECharts | null = null;
+	let chartHandle: ChartHandle | null = null;
 
 	async function runSimulation() {
 		loading = true;
@@ -227,30 +229,24 @@
 	function renderChart() {
 		if (!results || !chartContainer) return;
 
-		if (!chart) {
-			chart = echarts.init(chartContainer);
+		if (!chartHandle) {
+			chartHandle = createChart(chartContainer);
+			chart = chartHandle.chart;
 		}
 
 		if (results.simulations.length === 0) {
-			chart.clear();
+			chart?.clear();
 			return;
 		}
 
-		chart.setOption(buildRetirementProjectionOption(results.simulations));
+		chart?.setOption(buildRetirementProjectionOption(results.simulations));
 	}
 
 	onMount(() => {
-		const handleResize = () => chart?.resize();
-
-		if (browser) {
-			window.addEventListener('resize', handleResize);
-		}
-
 		return () => {
-			if (browser) {
-				window.removeEventListener('resize', handleResize);
-			}
-			chart?.dispose();
+			chartHandle?.dispose();
+			chartHandle = null;
+			chart = null;
 		};
 	});
 

--- a/src/routes/simulations/mortgage/+page.svelte
+++ b/src/routes/simulations/mortgage/+page.svelte
@@ -4,6 +4,7 @@
 	import { env } from '$env/dynamic/public';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
+	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
 
 	interface MortgageVsInvestYearlyRow {
 		year: number;
@@ -62,13 +63,15 @@
 	// Chart
 	let chartContainer: HTMLDivElement | undefined = $state();
 	let chart: echarts.ECharts | null = null;
+	let chartHandle: ChartHandle | null = null;
 
 	async function runSimulation() {
 		loading = true;
 		error = '';
 
-		if (chart) {
-			chart.dispose();
+		if (chartHandle) {
+			chartHandle.dispose();
+			chartHandle = null;
 			chart = null;
 		}
 		results = null;
@@ -112,8 +115,9 @@
 	function renderChart() {
 		if (!results || !chartContainer) return;
 
-		if (!chart) {
-			chart = echarts.init(chartContainer);
+		if (!chartHandle) {
+			chartHandle = createChart(chartContainer);
+			chart = chartHandle.chart;
 		}
 
 		const years = results.yearly_projections.map((r) => `Rok ${r.year}`);
@@ -184,15 +188,14 @@
 			]
 		};
 
-		chart.setOption(option);
+		chart?.setOption(option);
 	}
 
 	onMount(() => {
-		const handleResize = () => chart?.resize();
-		if (browser) window.addEventListener('resize', handleResize);
 		return () => {
-			if (browser) window.removeEventListener('resize', handleResize);
-			chart?.dispose();
+			chartHandle?.dispose();
+			chartHandle = null;
+			chart = null;
 		};
 	});
 

--- a/src/routes/simulations/zus/+page.svelte
+++ b/src/routes/simulations/zus/+page.svelte
@@ -4,6 +4,7 @@
 	import { env } from '$env/dynamic/public';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
+	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
 	import type { OwnerOption } from '$lib/types/owners';
 
 	interface Props {
@@ -82,13 +83,15 @@
 	// Chart
 	let chartContainer: HTMLDivElement | undefined = $state();
 	let chart: echarts.ECharts | null = null;
+	let chartHandle: ChartHandle | null = null;
 
 	async function runCalculation() {
 		loading = true;
 		error = '';
 
-		if (chart) {
-			chart.dispose();
+		if (chartHandle) {
+			chartHandle.dispose();
+			chartHandle = null;
 			chart = null;
 		}
 		results = null;
@@ -138,8 +141,9 @@
 	function renderChart() {
 		if (!results || !chartContainer) return;
 
-		if (!chart) {
-			chart = echarts.init(chartContainer);
+		if (!chartHandle) {
+			chartHandle = createChart(chartContainer);
+			chart = chartHandle.chart;
 		}
 
 		const years = results.yearly_projections.map((r) => r.year.toString());
@@ -190,15 +194,14 @@
 			]
 		};
 
-		chart.setOption(option);
+		chart?.setOption(option);
 	}
 
 	onMount(() => {
-		const handleResize = () => chart?.resize();
-		if (browser) window.addEventListener('resize', handleResize);
 		return () => {
-			if (browser) window.removeEventListener('resize', handleResize);
-			chart?.dispose();
+			chartHandle?.dispose();
+			chartHandle = null;
+			chart = null;
 		};
 	});
 


### PR DESCRIPTION
## Motivation

Dashboard + metryki + simulations init ECharts but the only cleanup was a global \`resize\` listener removal. Chart instances were leaking across SPA navigation. Six places open-coded the init/resize/dispose pattern, and three of them never disposed (or only via a window-resize cleanup that never fired the dispose path on real navigations).

## Implementation information

- New helper \`src/lib/utils/charts/lifecycle.ts::createChart\` wraps \`echarts.init\` + a per-container \`ResizeObserver\` and returns a single \`dispose()\`. The observer callback short-circuits once disposed, so a late flush can't hit a disposed instance.
- All six chart sites now use the helper. \`window.addEventListener('resize')\` removed in each.
- Unit tests for \`createChart\`: init/observe, dispose tears down both, no-op when ResizeObserver is unavailable, post-dispose flush is skipped.
- The Playwright suite already navigates across dashboards; chart-leak smoke was tractable but I chose unit coverage over an e2e route walk — happy to add the e2e check if requested.

Closes #397

> Changelog: fix(charts): dispose ECharts with shared helper