### PR TITLE
fix(api): centralize API URL resolution

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -43,17 +43,31 @@ describe('resolveApiUrl', () => {
 		expect(resolveApiUrl()).toBe('http://localhost:5174');
 	});
 
-	it('throws when the server variable is missing', async () => {
+	it('throws a 500 when the server variable is missing', async () => {
 		browserState.value = false;
 		envState.PUBLIC_API_URL_BROWSER = 'http://localhost:5174';
 		const { resolveApiUrl } = await freshImport();
-		expect(() => resolveApiUrl()).toThrowError(/PUBLIC_API_URL/);
+		try {
+			resolveApiUrl();
+			expect.fail('expected throw');
+		} catch (e) {
+			const err = e as { status: number; body: { message: string } };
+			expect(err.status).toBe(500);
+			expect(err.body.message).toMatch(/PUBLIC_API_URL/);
+		}
 	});
 
-	it('throws when the browser variable is missing', async () => {
+	it('throws a 500 when the browser variable is missing', async () => {
 		browserState.value = true;
 		envState.PUBLIC_API_URL = 'http://backend-go:8000';
 		const { resolveApiUrl } = await freshImport();
-		expect(() => resolveApiUrl()).toThrowError(/PUBLIC_API_URL_BROWSER/);
+		try {
+			resolveApiUrl();
+			expect.fail('expected throw');
+		} catch (e) {
+			const err = e as { status: number; body: { message: string } };
+			expect(err.status).toBe(500);
+			expect(err.body.message).toMatch(/PUBLIC_API_URL_BROWSER/);
+		}
 	});
 });

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const browserState = { value: false };
+const envState: { PUBLIC_API_URL?: string; PUBLIC_API_URL_BROWSER?: string } = {};
+
+vi.mock('$app/environment', () => ({
+	get browser() {
+		return browserState.value;
+	}
+}));
+
+vi.mock('$env/dynamic/public', () => ({
+	get env() {
+		return envState;
+	}
+}));
+
+async function freshImport() {
+	vi.resetModules();
+	return await import('./api');
+}
+
+describe('resolveApiUrl', () => {
+	beforeEach(() => {
+		browserState.value = false;
+		envState.PUBLIC_API_URL = undefined;
+		envState.PUBLIC_API_URL_BROWSER = undefined;
+	});
+
+	it('returns PUBLIC_API_URL on the server', async () => {
+		browserState.value = false;
+		envState.PUBLIC_API_URL = 'http://backend-go:8000';
+		envState.PUBLIC_API_URL_BROWSER = 'http://localhost:5174';
+		const { resolveApiUrl } = await freshImport();
+		expect(resolveApiUrl()).toBe('http://backend-go:8000');
+	});
+
+	it('returns PUBLIC_API_URL_BROWSER in the browser', async () => {
+		browserState.value = true;
+		envState.PUBLIC_API_URL = 'http://backend-go:8000';
+		envState.PUBLIC_API_URL_BROWSER = 'http://localhost:5174';
+		const { resolveApiUrl } = await freshImport();
+		expect(resolveApiUrl()).toBe('http://localhost:5174');
+	});
+
+	it('throws when the server variable is missing', async () => {
+		browserState.value = false;
+		envState.PUBLIC_API_URL_BROWSER = 'http://localhost:5174';
+		const { resolveApiUrl } = await freshImport();
+		expect(() => resolveApiUrl()).toThrowError(/PUBLIC_API_URL/);
+	});
+
+	it('throws when the browser variable is missing', async () => {
+		browserState.value = true;
+		envState.PUBLIC_API_URL = 'http://backend-go:8000';
+		const { resolveApiUrl } = await freshImport();
+		expect(() => resolveApiUrl()).toThrowError(/PUBLIC_API_URL_BROWSER/);
+	});
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { browser } from '$app/environment';
 import { env } from '$env/dynamic/public';
+import { error } from '@sveltejs/kit';
 
 // resolveApiUrl returns the API base URL for the current execution context.
 //
@@ -8,14 +9,15 @@ import { env } from '$env/dynamic/public';
 // server, e.g. during SSR for a universal load, returns PUBLIC_API_URL
 // (the backend's reachable hostname inside the Docker network).
 //
-// Throws when the relevant variable is not configured. Callers in load
-// functions can let it propagate — SvelteKit converts an uncaught throw
-// into a 500.
+// Throws a SvelteKit 500 when the relevant variable is unset. Load
+// functions that catch errors and rethrow only those with a `status`
+// preserve this actionable message instead of swallowing it as a
+// generic "Failed to load …".
 export function resolveApiUrl(): string {
 	const url = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
 	if (!url) {
 		const which = browser ? 'PUBLIC_API_URL_BROWSER' : 'PUBLIC_API_URL';
-		throw new Error(`${which} is not configured`);
+		error(500, `${which} is not configured`);
 	}
 	return url;
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,21 @@
+import { browser } from '$app/environment';
+import { env } from '$env/dynamic/public';
+
+// resolveApiUrl returns the API base URL for the current execution context.
+//
+// In the browser, returns PUBLIC_API_URL_BROWSER (the SvelteKit origin —
+// calls hit the /api proxy in routes/api/[...path]/+server.ts). On the
+// server, e.g. during SSR for a universal load, returns PUBLIC_API_URL
+// (the backend's reachable hostname inside the Docker network).
+//
+// Throws when the relevant variable is not configured. Callers in load
+// functions can let it propagate — SvelteKit converts an uncaught throw
+// into a 500.
+export function resolveApiUrl(): string {
+	const url = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+	if (!url) {
+		const which = browser ? 'PUBLIC_API_URL_BROWSER' : 'PUBLIC_API_URL';
+		throw new Error(`${which} is not configured`);
+	}
+	return url;
+}

--- a/src/lib/components/SnapshotForm.svelte
+++ b/src/lib/components/SnapshotForm.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { env } from '$env/dynamic/public';
+	import { resolveApiUrl } from '$lib/api';
 	import { Wallet, Umbrella, TrendingUp, Home, CreditCard } from 'lucide-svelte';
 	import type { Account, Asset, SnapshotResponse } from '$lib/types';
 	import type { OwnerOption } from '$lib/types/owners';
@@ -173,7 +173,7 @@
 				newAccountSection === 'retirement' && newAccountWrapper ? newAccountWrapper : null;
 			const purpose = newAccountSection === 'retirement' ? 'retirement' : 'general';
 
-			const response = await fetch(`${env.PUBLIC_API_URL_BROWSER}/api/accounts`, {
+			const response = await fetch(`${resolveApiUrl()}/api/accounts`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
@@ -253,7 +253,7 @@
 		error = '';
 
 		try {
-			const response = await fetch(`${env.PUBLIC_API_URL_BROWSER}/api/assets`, {
+			const response = await fetch(`${resolveApiUrl()}/api/assets`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
@@ -359,8 +359,8 @@
 
 			const method = editingSnapshot ? 'PUT' : 'POST';
 			const url = editingSnapshot
-				? `${env.PUBLIC_API_URL_BROWSER}/api/snapshots/${editingSnapshot.id}`
-				: `${env.PUBLIC_API_URL_BROWSER}/api/snapshots`;
+				? `${resolveApiUrl()}/api/snapshots/${editingSnapshot.id}`
+				: `${resolveApiUrl()}/api/snapshots`;
 
 			const response = await fetch(url, {
 				method,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,7 +14,7 @@
 		AlertTriangle,
 		PiggyBank
 	} from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
+	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
@@ -68,7 +68,7 @@
 	}
 
 	async function saveLimits() {
-		const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+		const apiUrl = resolveApiUrl();
 		try {
 			const requests = Object.entries(limits).map(([key, amount]) => {
 				const sep = key.indexOf('_');

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,12 +1,8 @@
 import { error, isHttpError } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { resolveApiUrl } from '$lib/api';
 
 export async function load({ fetch }) {
-	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-	if (!apiUrl) {
-		throw error(500, 'API URL is not configured');
-	}
+	const apiUrl = resolveApiUrl();
 
 	const currentYear = new Date().getFullYear();
 

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -3,7 +3,7 @@
 	import Skeleton from '$lib/components/Skeleton.svelte';
 	import { formatPLN } from '$lib/utils/format';
 	import { Wallet, TrendingDown, Pencil, Trash2, Plus, BarChart3 } from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
+	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
 	import { onMount, untrack } from 'svelte';
 	import { INVESTMENT_CATEGORIES } from '$lib/constants';
@@ -17,7 +17,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = resolveApiUrl();
 	let owners: OwnerOption[] = $state([]);
 	const defaultOwnerUserId = $derived(owners.length > 0 ? owners[0].id : null);
 

--- a/src/routes/accounts/+page.ts
+++ b/src/routes/accounts/+page.ts
@@ -1,6 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { resolveApiUrl } from '$lib/api';
 import type { PageLoad } from './$types';
 import type { Transaction, TransactionsData } from '$lib/types/transactions';
 import type { OwnerOption } from '$lib/types/owners';
@@ -29,10 +28,7 @@ export interface AccountsData {
 export type { Transaction, TransactionsData };
 
 export const load: PageLoad = async ({ fetch }) => {
-	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-	if (!apiUrl) {
-		throw error(500, 'API URL is not configured');
-	}
+	const apiUrl = resolveApiUrl();
 
 	const owners = (async (): Promise<OwnerOption[]> => {
 		const res = await fetch(`${apiUrl}/api/users`);

--- a/src/routes/assets/+page.svelte
+++ b/src/routes/assets/+page.svelte
@@ -2,7 +2,7 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import { formatPLN } from '$lib/utils/format';
 	import { Home, Pencil, Plus, Trash2 } from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
+	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
 	import type { Asset } from './+page';
 	import type { PageData } from './$types';
@@ -13,7 +13,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = resolveApiUrl();
 
 	let showForm = $state(false);
 	let editingAsset: Asset | null = $state(null);

--- a/src/routes/assets/+page.ts
+++ b/src/routes/assets/+page.ts
@@ -1,6 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { resolveApiUrl } from '$lib/api';
 import type { PageLoad } from './$types';
 
 export interface Asset {
@@ -17,10 +16,7 @@ export interface AssetsData {
 
 export const load: PageLoad = async ({ fetch }) => {
 	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API URL is not configured');
-		}
+		const apiUrl = resolveApiUrl();
 		const response = await fetch(`${apiUrl}/api/assets`);
 
 		if (!response.ok) {

--- a/src/routes/config/+page.svelte
+++ b/src/routes/config/+page.svelte
@@ -11,7 +11,7 @@
 		AlertTriangle,
 		Gauge
 	} from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
+	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
 	import { untrack } from 'svelte';
 	import type { PageData } from './$types';
@@ -22,7 +22,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = resolveApiUrl();
 
 	const defaults = {
 		birth_date: '1990-01-01',

--- a/src/routes/config/+page.ts
+++ b/src/routes/config/+page.ts
@@ -1,6 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { resolveApiUrl } from '$lib/api';
 import type { PageLoad } from './$types';
 import type { paths } from '$lib/types/api.generated';
 
@@ -10,10 +9,7 @@ type AppConfig = paths['/api/config']['get']['responses'][200]['content']['appli
 
 export const load: PageLoad = async ({ fetch }) => {
 	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API URL is not configured');
-		}
+		const apiUrl = resolveApiUrl();
 
 		const response = await fetch(`${apiUrl}/api/config`);
 

--- a/src/routes/debts/+page.svelte
+++ b/src/routes/debts/+page.svelte
@@ -2,7 +2,7 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import { formatPLN, formatDate } from '$lib/utils/format';
 	import { ClipboardList, Plus, Pencil, Trash2, Wallet, CircleDollarSign } from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
+	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
 	import { onMount, untrack } from 'svelte';
 	import type { Debt, DebtPayment } from './+page';
@@ -15,7 +15,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = resolveApiUrl();
 	const owners = $derived(data.owners as OwnerOption[]);
 	const defaultOwnerUserId = $derived(owners.length > 0 ? owners[0].id : null);
 

--- a/src/routes/debts/+page.ts
+++ b/src/routes/debts/+page.ts
@@ -1,6 +1,5 @@
-import { browser } from '$app/environment';
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
+import { resolveApiUrl } from '$lib/api';
 import type { PageLoad } from './$types';
 
 export interface Debt {
@@ -41,7 +40,7 @@ export interface DebtsListResponse {
 }
 
 export const load: PageLoad = async ({ fetch }) => {
-	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
+	const apiUrl = resolveApiUrl();
 	const [debtsResponse, ownersResponse] = await Promise.all([
 		fetch(`${apiUrl}/api/debts`),
 		fetch(`${apiUrl}/api/users`)

--- a/src/routes/goals/+page.svelte
+++ b/src/routes/goals/+page.svelte
@@ -2,7 +2,7 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import { formatPLN, formatDate } from '$lib/utils/format';
 	import { Target, Plus, Pencil, Trash2, CheckCircle2, Calendar } from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
+	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
 	import type { Goal, AccountOption } from './+page';
 	import type { PageData } from './$types';
@@ -13,7 +13,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = resolveApiUrl();
 
 	const goals = $derived(data.goals as Goal[]);
 	const accounts = $derived(data.accounts as AccountOption[]);

--- a/src/routes/goals/+page.ts
+++ b/src/routes/goals/+page.ts
@@ -1,6 +1,5 @@
-import { browser } from '$app/environment';
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
+import { resolveApiUrl } from '$lib/api';
 import type { PageLoad } from './$types';
 
 export interface Goal {
@@ -32,10 +31,7 @@ export interface AccountOption {
 }
 
 export const load: PageLoad = async ({ fetch }) => {
-	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-	if (!apiUrl) {
-		throw error(500, 'API URL is not configured');
-	}
+	const apiUrl = resolveApiUrl();
 	const [goalsResponse, accountsResponse] = await Promise.all([
 		fetch(`${apiUrl}/api/goals`),
 		fetch(`${apiUrl}/api/accounts`)

--- a/src/routes/metryki/+page.ts
+++ b/src/routes/metryki/+page.ts
@@ -1,13 +1,9 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { resolveApiUrl } from '$lib/api';
 
 export async function load({ fetch }) {
 	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API URL is not configured');
-		}
+		const apiUrl = resolveApiUrl();
 
 		const dashboardRes = await fetch(`${apiUrl}/api/dashboard`);
 

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -24,7 +24,7 @@
 		Building2,
 		Wallet
 	} from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
+	import { resolveApiUrl } from '$lib/api';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
 	import type {
@@ -49,7 +49,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = resolveApiUrl();
 	const owners = $derived(data.owners as OwnerOption[]);
 	const defaultOwnerId = $derived<number | null>(owners.length > 0 ? owners[0].id : null);
 	const cpiSeries = $derived(data.cpiSeries as CpiSeries);

--- a/src/routes/salaries/+page.ts
+++ b/src/routes/salaries/+page.ts
@@ -1,6 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { resolveApiUrl } from '$lib/api';
 import type { PageLoad } from './$types';
 import type {
 	BonusEventsData,
@@ -30,10 +29,7 @@ const EMPTY_VALUATIONS: CompanyValuationsData = {
 
 export const load: PageLoad = async ({ fetch, url }) => {
 	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API URL is not configured');
-		}
+		const apiUrl = resolveApiUrl();
 
 		const ownerUserId = url.searchParams.get('owner_user_id');
 		const dateFrom = url.searchParams.get('date_from');

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { onMount, untrack } from 'svelte';
-	import { browser } from '$app/environment';
-	import { env } from '$env/dynamic/public';
+	import { resolveApiUrl } from '$lib/api';
 	import * as echarts from 'echarts';
 	import type { PageData } from './$types';
 	import {
@@ -163,8 +162,7 @@
 				}
 			}
 
-			const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-			if (!apiUrl) throw new Error('API URL not configured');
+			const apiUrl = resolveApiUrl();
 
 			const requestBody = {
 				current_age: currentAge,

--- a/src/routes/simulations/+page.ts
+++ b/src/routes/simulations/+page.ts
@@ -1,13 +1,11 @@
 import { error } from '@sveltejs/kit';
-import { browser } from '$app/environment';
-import { env } from '$env/dynamic/public';
+import { resolveApiUrl } from '$lib/api';
 import type { PageLoad } from './$types';
 import type { OwnerOption } from '$lib/types/owners';
 
 export const load: PageLoad = async ({ fetch }) => {
 	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) throw error(500, 'API URL not configured');
+		const apiUrl = resolveApiUrl();
 
 		const [prefillRes, ownersRes] = await Promise.all([
 			fetch(`${apiUrl}/api/simulations/prefill`),

--- a/src/routes/simulations/kalkulator/+page.ts
+++ b/src/routes/simulations/kalkulator/+page.ts
@@ -1,13 +1,11 @@
-import { browser } from '$app/environment';
-import { env } from '$env/dynamic/public';
+import { resolveApiUrl } from '$lib/api';
 import type { PageLoad } from './$types';
 import type { SalaryRecord } from '$lib/types/salaries';
 import type { OwnerOption } from '$lib/types/owners';
 
 export const load: PageLoad = async ({ fetch }) => {
 	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) return { latestSalaries: [], owners: [] };
+		const apiUrl = resolveApiUrl();
 
 		const [res, ownersRes] = await Promise.all([
 			fetch(`${apiUrl}/api/salaries`),

--- a/src/routes/simulations/mortgage/+page.svelte
+++ b/src/routes/simulations/mortgage/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { onMount, tick } from 'svelte';
-	import { browser } from '$app/environment';
-	import { env } from '$env/dynamic/public';
+	import { resolveApiUrl } from '$lib/api';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
@@ -77,8 +76,7 @@
 		results = null;
 
 		try {
-			const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-			if (!apiUrl) throw new Error('API URL not configured');
+			const apiUrl = resolveApiUrl();
 
 			const response = await fetch(`${apiUrl}/api/simulations/mortgage-vs-invest`, {
 				method: 'POST',

--- a/src/routes/simulations/zus/+page.svelte
+++ b/src/routes/simulations/zus/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { onMount, tick, untrack } from 'svelte';
-	import { browser } from '$app/environment';
-	import { env } from '$env/dynamic/public';
+	import { resolveApiUrl } from '$lib/api';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
@@ -97,8 +96,7 @@
 		results = null;
 
 		try {
-			const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-			if (!apiUrl) throw new Error('API URL not configured');
+			const apiUrl = resolveApiUrl();
 
 			const response = await fetch(`${apiUrl}/api/zus/calculate`, {
 				method: 'POST',

--- a/src/routes/simulations/zus/+page.ts
+++ b/src/routes/simulations/zus/+page.ts
@@ -1,13 +1,11 @@
 import { error } from '@sveltejs/kit';
-import { browser } from '$app/environment';
-import { env } from '$env/dynamic/public';
+import { resolveApiUrl } from '$lib/api';
 import type { PageLoad } from './$types';
 import type { OwnerOption } from '$lib/types/owners';
 
 export const load: PageLoad = async ({ fetch }) => {
 	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) throw error(500, 'API URL not configured');
+		const apiUrl = resolveApiUrl();
 
 		const [prefillRes, ownersRes] = await Promise.all([
 			fetch(`${apiUrl}/api/zus/prefill`),

--- a/src/routes/snapshots/+page.ts
+++ b/src/routes/snapshots/+page.ts
@@ -1,6 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { resolveApiUrl } from '$lib/api';
 import type { PageLoad } from './$types';
 
 export interface SnapshotListItem {
@@ -11,10 +10,7 @@ export interface SnapshotListItem {
 }
 
 export const load: PageLoad = async ({ fetch }) => {
-	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-	if (!apiUrl) {
-		throw error(500, 'API URL is not configured');
-	}
+	const apiUrl = resolveApiUrl();
 
 	const snapshots = (async () => {
 		const response = await fetch(`${apiUrl}/api/snapshots`);

--- a/src/routes/snapshots/[id]/edit/+page.ts
+++ b/src/routes/snapshots/[id]/edit/+page.ts
@@ -1,15 +1,15 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
+import { resolveApiUrl } from '$lib/api';
 import type { SnapshotResponse } from '$lib/types';
 
 export async function load({ params, fetch }) {
-	const API_URL = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = resolveApiUrl();
 
 	const [snapshotRes, accountsRes, assetsRes, ownersRes] = await Promise.all([
-		fetch(`${API_URL}/api/snapshots/${params.id}`),
-		fetch(`${API_URL}/api/accounts`),
-		fetch(`${API_URL}/api/assets`),
-		fetch(`${API_URL}/api/users`)
+		fetch(`${apiUrl}/api/snapshots/${params.id}`),
+		fetch(`${apiUrl}/api/accounts`),
+		fetch(`${apiUrl}/api/assets`),
+		fetch(`${apiUrl}/api/users`)
 	]);
 
 	if (!snapshotRes.ok) {

--- a/src/routes/snapshots/[id]/edit/page.test.ts
+++ b/src/routes/snapshots/[id]/edit/page.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const browserState = { value: false };
+const envState: { PUBLIC_API_URL?: string; PUBLIC_API_URL_BROWSER?: string } = {};
+
+vi.mock('$app/environment', () => ({
+	get browser() {
+		return browserState.value;
+	}
+}));
+
+vi.mock('$env/dynamic/public', () => ({
+	get env() {
+		return envState;
+	}
+}));
+
+async function freshLoad() {
+	vi.resetModules();
+	return (await import('./+page')).load;
+}
+
+describe('snapshots/[id]/edit load', () => {
+	beforeEach(() => {
+		browserState.value = false;
+		envState.PUBLIC_API_URL = 'http://backend-go:8000';
+		envState.PUBLIC_API_URL_BROWSER = 'http://localhost:5174';
+	});
+
+	it('hits PUBLIC_API_URL during SSR (regression for #395)', async () => {
+		const load = await freshLoad();
+		const fetch = vi.fn(async () =>
+			Response.json({ assets: [], liabilities: [] })
+		) as unknown as typeof globalThis.fetch;
+		await load({ params: { id: '7' }, fetch } as Parameters<typeof load>[0]);
+
+		const urls = (fetch as unknown as { mock: { calls: [string][] } }).mock.calls.map((c) => c[0]);
+		for (const u of urls) {
+			expect(u).toMatch(/^http:\/\/backend-go:8000\//);
+		}
+		expect(urls).toContain('http://backend-go:8000/api/snapshots/7');
+		expect(urls).toContain('http://backend-go:8000/api/accounts');
+		expect(urls).toContain('http://backend-go:8000/api/assets');
+		expect(urls).toContain('http://backend-go:8000/api/users');
+	});
+});

--- a/src/routes/snapshots/new/+page.ts
+++ b/src/routes/snapshots/new/+page.ts
@@ -1,13 +1,9 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { resolveApiUrl } from '$lib/api';
 
 export async function load({ fetch }) {
 	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API base URL is not configured');
-		}
+		const apiUrl = resolveApiUrl();
 
 		// Fetch accounts, assets, and owners in parallel
 		const [accountsResponse, assetsResponse, ownersResponse] = await Promise.all([

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -2,7 +2,7 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import { formatPLN } from '$lib/utils/format';
 	import { Plus, Landmark, Search, BarChart3, Trash2 } from 'lucide-svelte';
-	import { env } from '$env/dynamic/public';
+	import { resolveApiUrl } from '$lib/api';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
@@ -15,7 +15,7 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = env.PUBLIC_API_URL_BROWSER || 'http://localhost:8000';
+	const apiUrl = resolveApiUrl();
 	const owners = $derived(data.owners as OwnerOption[]);
 	const defaultOwnerUserId = $derived(owners.length > 0 ? owners[0].id : null);
 	const defaultOwnerName = $derived(owners.length > 0 ? owners[0].name : '');

--- a/src/routes/transactions/+page.ts
+++ b/src/routes/transactions/+page.ts
@@ -1,6 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { resolveApiUrl } from '$lib/api';
 import type { PageLoad } from './$types';
 import type { Transaction, TransactionsData } from '$lib/types/transactions';
 import { INVESTMENT_CATEGORIES } from '$lib/constants';
@@ -15,10 +14,7 @@ export interface Account {
 
 export const load: PageLoad = async ({ fetch, url }) => {
 	try {
-		const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-		if (!apiUrl) {
-			throw error(500, 'API URL is not configured');
-		}
+		const apiUrl = resolveApiUrl();
 
 		// Build query params from URL
 		const accountId = url.searchParams.get('account_id');

--- a/src/routes/users/+page.svelte
+++ b/src/routes/users/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { env } from '$env/dynamic/public';
+	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
 	import Modal from '$lib/components/Modal.svelte';
@@ -18,7 +18,7 @@
 
 	let { data }: { data: PageData } = $props();
 	const users = $derived(data.users as AppUser[]);
-	const apiUrl = env.PUBLIC_API_URL_BROWSER ?? '';
+	const apiUrl = resolveApiUrl();
 
 	let username = $state('');
 	let password = $state('');

--- a/src/routes/users/+page.ts
+++ b/src/routes/users/+page.ts
@@ -1,6 +1,5 @@
 import { error, redirect } from '@sveltejs/kit';
-import { env } from '$env/dynamic/public';
-import { browser } from '$app/environment';
+import { resolveApiUrl } from '$lib/api';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ fetch, parent }) => {
@@ -9,10 +8,7 @@ export const load: PageLoad = async ({ fetch, parent }) => {
 		redirect(303, '/');
 	}
 
-	const apiUrl = browser ? env.PUBLIC_API_URL_BROWSER : env.PUBLIC_API_URL;
-	if (!apiUrl) {
-		throw error(500, 'API URL is not configured');
-	}
+	const apiUrl = resolveApiUrl();
 
 	const response = await fetch(`${apiUrl}/api/auth/users`);
 	if (!response.ok) {


### PR DESCRIPTION
## Motivation

Universal loads were mixing browser-only API URLs with localhost fallbacks. \`src/routes/snapshots/[id]/edit/+page.ts\` was the smoking gun: \`PUBLIC_API_URL_BROWSER || http://localhost:8000\` even during SSR, broken on Docker deploys where the browser URL isn't reachable from the SvelteKit server.

## Implementation information

- New helper \`src/lib/api.ts::resolveApiUrl\` reads \`browser\` from \`\$app/environment\` and returns \`PUBLIC_API_URL_BROWSER\` (browser) or \`PUBLIC_API_URL\` (server). Throws when the relevant variable is unset — SvelteKit's load functions convert an uncaught throw into a 500.
- Every \`+page.ts\` (13 files) and every \`.svelte\` API caller (10 files) now uses the helper. \`localhost:8000\` fallbacks are gone (kept only in \`routes/api/[...path]/+server.ts\` for the private \`API_PROXY_TARGET\`).
- Regression test \`src/routes/snapshots/[id]/edit/page.test.ts\` proves the broken path is fixed: with \`browser=false\` the load hits \`PUBLIC_API_URL\` exclusively.
- Helper unit tests cover both contexts + both missing-var branches.

Closes #395

> Changelog: fix(api): centralize API URL resolution