### PR TITLE
fix(snapshots): preserve history after soft delete

### DIFF
--- a/backend-bb-tests/tests/test_dashboard.py
+++ b/backend-bb-tests/tests/test_dashboard.py
@@ -82,10 +82,14 @@ def _restore_account(dsn: str, account_id: int) -> None:
         cur.execute("UPDATE accounts SET is_active = true WHERE id = %s", (account_id,))
 
 
-def _dashboard_totals(client: httpx.Client) -> tuple[float, float, float]:
+def _dashboard_body(client: httpx.Client) -> dict:
     response = client.get("/api/dashboard")
     assert response.status_code == 200, response.text
-    body = response.json()
+    return response.json()
+
+
+def _dashboard_totals(client: httpx.Client) -> tuple[float, float, float]:
+    body = _dashboard_body(client)
     return (
         float(body["total_assets"]),
         float(body["total_liabilities"]),
@@ -102,17 +106,25 @@ def test_history_preserved_after_soft_delete_account(
     # every snapshot row it was already part of.
     _ = owner_ids[PERSONA_MARCIN]  # ensure seed is loaded
     account_id = _account_id_by_name(client, ACCOUNT_MARCIN_BANK)
-    before_assets, before_liab, before_nw = _dashboard_totals(client)
-    before_history = client.get("/api/dashboard").json()["net_worth_history"]
+    before = _dashboard_body(client)
+    before_assets = float(before["total_assets"])
+    before_liab = float(before["total_liabilities"])
+    before_nw = float(before["current_net_worth"])
+    before_history = before["net_worth_history"]
 
     response = client.delete(f"/api/accounts/{account_id}")
     assert response.status_code == 204, response.text
     try:
-        after_assets, after_liab, after_nw = _dashboard_totals(client)
-        after_history = client.get("/api/dashboard").json()["net_worth_history"]
+        after = _dashboard_body(client)
+        after_assets = float(after["total_assets"])
+        after_liab = float(after["total_liabilities"])
+        after_nw = float(after["current_net_worth"])
+        after_history = after["net_worth_history"]
 
         # /api/accounts hides the soft-deleted row.
-        listing = client.get("/api/accounts").json()
+        listing_resp = client.get("/api/accounts")
+        assert listing_resp.status_code == 200, listing_resp.text
+        listing = listing_resp.json()
         live_names = {a["name"] for a in (*listing["assets"], *listing["liabilities"])}
         assert ACCOUNT_MARCIN_BANK not in live_names
 

--- a/backend-bb-tests/tests/test_dashboard.py
+++ b/backend-bb-tests/tests/test_dashboard.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import httpx
+import psycopg2
+import pytest
+
+from fixtures.seed import ACCOUNT_MARCIN_BANK, PERSONA_MARCIN
 
 
 def test_get_dashboard_returns_documented_shape(client: httpx.Client) -> None:
@@ -61,3 +65,68 @@ def test_dashboard_nested_keys_present(client: httpx.Client) -> None:
 
     category_ts_keys = {"stock", "bond"}
     assert category_ts_keys.issubset(body["category_time_series"].keys())
+
+
+def _account_id_by_name(client: httpx.Client, name: str) -> int:
+    response = client.get("/api/accounts")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    for account in (*body["assets"], *body["liabilities"]):
+        if account["name"] == name:
+            return int(account["id"])
+    raise AssertionError(f"Account {name!r} not found in /api/accounts response")
+
+
+def _restore_account(dsn: str, account_id: int) -> None:
+    with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute("UPDATE accounts SET is_active = true WHERE id = %s", (account_id,))
+
+
+def _dashboard_totals(client: httpx.Client) -> tuple[float, float, float]:
+    response = client.get("/api/dashboard")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    return (
+        float(body["total_assets"]),
+        float(body["total_liabilities"]),
+        float(body["current_net_worth"]),
+    )
+
+
+@pytest.mark.mutates
+def test_history_preserved_after_soft_delete_account(
+    client: httpx.Client, database_url: str, owner_ids: dict[str, int]
+) -> None:
+    # Regression for #394: soft-deleting an account must not retroactively
+    # change historical net worth. The account's value still contributes to
+    # every snapshot row it was already part of.
+    _ = owner_ids[PERSONA_MARCIN]  # ensure seed is loaded
+    account_id = _account_id_by_name(client, ACCOUNT_MARCIN_BANK)
+    before_assets, before_liab, before_nw = _dashboard_totals(client)
+    before_history = client.get("/api/dashboard").json()["net_worth_history"]
+
+    response = client.delete(f"/api/accounts/{account_id}")
+    assert response.status_code == 204, response.text
+    try:
+        after_assets, after_liab, after_nw = _dashboard_totals(client)
+        after_history = client.get("/api/dashboard").json()["net_worth_history"]
+
+        # /api/accounts hides the soft-deleted row.
+        listing = client.get("/api/accounts").json()
+        live_names = {a["name"] for a in (*listing["assets"], *listing["liabilities"])}
+        assert ACCOUNT_MARCIN_BANK not in live_names
+
+        # Aggregate totals across the full history must be unchanged — the
+        # soft-deleted account still contributes to every snapshot it was
+        # in before the delete.
+        assert after_assets == pytest.approx(before_assets), (
+            "total_assets shifted after soft-delete — history regressed"
+        )
+        assert after_liab == pytest.approx(before_liab)
+        assert after_nw == pytest.approx(before_nw)
+        assert len(after_history) == len(before_history)
+        for b, a in zip(before_history, after_history, strict=True):
+            assert a["date"] == b["date"]
+            assert a["value"] == pytest.approx(b["value"])
+    finally:
+        _restore_account(database_url, account_id)

--- a/backend-go/internal/aggregates/spec.go
+++ b/backend-go/internal/aggregates/spec.go
@@ -73,12 +73,14 @@ func (k ownerKey) ownerUserID() *int {
 }
 
 // ComputeAggregates is the pure-math port of aggregate_spec.compute_aggregates.
-// Caller must filter accounts/assets to is_active=true rows before calling.
+// Pass accounts and asset ids including soft-deleted rows — aggregates are
+// the historical reporting view (issue #394) and need their original
+// type/category metadata to survive a soft delete.
 func ComputeAggregates(
 	snap SnapshotInput,
 	values []SnapshotValueInput,
 	accounts []AccountInput,
-	activeAssetIDs map[int]struct{},
+	knownAssetIDs map[int]struct{},
 ) []AggregateRow {
 	accountMap := map[int]AccountInput{}
 	for _, a := range accounts {
@@ -104,7 +106,7 @@ func ComputeAggregates(
 		v := sv.Value
 		switch {
 		case sv.AssetID != nil:
-			if _, active := activeAssetIDs[*sv.AssetID]; active {
+			if _, known := knownAssetIDs[*sv.AssetID]; known {
 				b := getBucket(ownerKey{shared: true})
 				b.assets = b.assets.Add(v)
 			}

--- a/backend-go/internal/aggregates/store.go
+++ b/backend-go/internal/aggregates/store.go
@@ -60,15 +60,15 @@ func (s *Store) RecomputeForSnapshot(ctx context.Context, tx pgx.Tx, snapshotID 
 			assetIDs = append(assetIDs, *v.AssetID)
 		}
 	}
-	accounts, err := loadActiveAccounts(ctx, tx, accountIDs)
+	accounts, err := loadAccountsByID(ctx, tx, accountIDs)
 	if err != nil {
 		return err
 	}
-	activeAssets, err := loadActiveAssetIDs(ctx, tx, assetIDs)
+	knownAssets, err := loadAssetIDs(ctx, tx, assetIDs)
 	if err != nil {
 		return err
 	}
-	rows := ComputeAggregates(snap, values, accounts, activeAssets)
+	rows := ComputeAggregates(snap, values, accounts, knownAssets)
 	now := time.Now().UTC()
 	for _, r := range rows {
 		alloc := make([]map[string]any, 0, len(r.Allocation))
@@ -197,17 +197,21 @@ func loadSnapshotValues(ctx context.Context, tx pgx.Tx, snapshotID int) ([]Snaps
 	return out, nil
 }
 
-func loadActiveAccounts(ctx context.Context, tx pgx.Tx, ids []int) ([]AccountInput, error) {
+// loadAccountsByID loads every account referenced by the snapshots being
+// recomputed, regardless of is_active. Aggregates are the historical
+// reporting view (issue #394): soft-deleting an account must not retroactively
+// drop its contribution from old snapshots.
+func loadAccountsByID(ctx context.Context, tx pgx.Tx, ids []int) ([]AccountInput, error) {
 	if len(ids) == 0 {
 		return []AccountInput{}, nil
 	}
 	rows, err := tx.Query(ctx, `
 		SELECT id, owner_user_id, type, category
-		FROM accounts WHERE id = ANY($1) AND is_active = true`,
+		FROM accounts WHERE id = ANY($1)`,
 		ids,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("load active accounts: %w", err)
+		return nil, fmt.Errorf("load accounts for aggregates: %w", err)
 	}
 	defer rows.Close()
 	out := []AccountInput{}
@@ -224,16 +228,18 @@ func loadActiveAccounts(ctx context.Context, tx pgx.Tx, ids []int) ([]AccountInp
 	return out, nil
 }
 
-func loadActiveAssetIDs(ctx context.Context, tx pgx.Tx, ids []int) (map[int]struct{}, error) {
+// loadAssetIDs loads every asset id referenced by the snapshots being
+// recomputed, regardless of is_active. See loadAccountsByID for the why.
+func loadAssetIDs(ctx context.Context, tx pgx.Tx, ids []int) (map[int]struct{}, error) {
 	if len(ids) == 0 {
 		return map[int]struct{}{}, nil
 	}
 	rows, err := tx.Query(ctx, `
-		SELECT id FROM assets WHERE id = ANY($1) AND is_active = true`,
+		SELECT id FROM assets WHERE id = ANY($1)`,
 		ids,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("load active assets: %w", err)
+		return nil, fmt.Errorf("load assets for aggregates: %w", err)
 	}
 	defer rows.Close()
 	out := map[int]struct{}{}

--- a/backend-go/internal/dashboard/compute.go
+++ b/backend-go/internal/dashboard/compute.go
@@ -47,14 +47,15 @@ func (r mergedRow) signedValue() float64 {
 }
 
 // buildMergedRows joins snapshot_values to assets + accounts + snapshots,
-// mirroring _build_merged_df / the raw-path merge. Accounts are the active
-// set; an account_id pointing at an inactive account leaves the account
-// columns nil (LEFT JOIN miss).
+// mirroring _build_merged_df / the raw-path merge. Accounts/assets include
+// soft-deleted rows so historical snapshots keep their metadata after a
+// delete (issue #394); current-state checks filter on Account.IsActive at
+// the call site instead.
 func buildMergedRows(
 	values []SnapshotValue,
 	snapshotDate map[int]time.Time,
 	accounts map[int]Account,
-	activeAssetIDs map[int]struct{},
+	assetIDs map[int]struct{},
 ) []mergedRow {
 	out := make([]mergedRow, 0, len(values))
 	for _, v := range values {
@@ -71,7 +72,7 @@ func buildMergedRows(
 			Value:      val,
 		}
 		if v.AssetID != nil {
-			if _, active := activeAssetIDs[*v.AssetID]; active {
+			if _, known := assetIDs[*v.AssetID]; known {
 				name := "asset" // any non-nil name marks "asset join hit"
 				row.AssetName = &name
 			}

--- a/backend-go/internal/dashboard/dashboard.go
+++ b/backend-go/internal/dashboard/dashboard.go
@@ -105,30 +105,38 @@ func emptyResult() result {
 }
 
 // sharedInputs bundles the tables both paths need.
+//
+// accounts/assetIDs intentionally include soft-deleted rows so historical
+// snapshot values keep their metadata after delete (issue #394). accountList
+// is the active-only slice for "current state" reads (real-estate property
+// counts, hasInvestment, allocation totals).
 type sharedInputs struct {
-	accounts       map[int]Account
-	accountList    []Account
-	activeAssetIDs map[int]struct{}
-	snapshots      []SnapshotMeta
-	snapshotDate   map[int]time.Time
-	config         AppConfig
-	hasConfig      bool
-	txns           []txnWithAccount
-	salaries       []float64
+	accounts     map[int]Account
+	accountList  []Account
+	assetIDs     map[int]struct{}
+	snapshots    []SnapshotMeta
+	snapshotDate map[int]time.Time
+	config       AppConfig
+	hasConfig    bool
+	txns         []txnWithAccount
+	salaries     []float64
 }
 
 func loadShared(ctx context.Context, s *Store) (sharedInputs, error) {
 	var in sharedInputs
-	accList, err := s.ActiveAccounts(ctx)
+	allAccs, err := s.AllAccounts(ctx)
 	if err != nil {
 		return in, err
 	}
-	in.accountList = accList
 	in.accounts = map[int]Account{}
-	for _, a := range accList {
+	in.accountList = make([]Account, 0, len(allAccs))
+	for _, a := range allAccs {
 		in.accounts[a.ID] = a
+		if a.IsActive {
+			in.accountList = append(in.accountList, a)
+		}
 	}
-	in.activeAssetIDs, err = s.ActiveAssetIDs(ctx)
+	in.assetIDs, err = s.AllAssetIDs(ctx)
 	if err != nil {
 		return in, err
 	}

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -86,7 +86,7 @@ func computeFromAggregates(ctx context.Context, s *Store, aggRows []AggregateRow
 	if err != nil {
 		return result{}, err
 	}
-	latestRows := buildMergedRows(latestValues, shared.snapshotDate, shared.accounts, shared.activeAssetIDs)
+	latestRows := buildMergedRows(latestValues, shared.snapshotDate, shared.accounts, shared.assetIDs)
 	res.RetirementAccountValue = retirementValueOf(latestRows)
 
 	if shared.hasConfig && len(latestRows) > 0 {
@@ -102,7 +102,7 @@ func computeFromAggregates(ctx context.Context, s *Store, aggRows []AggregateRow
 		if err != nil {
 			return result{}, err
 		}
-		allRows := buildMergedRows(allValues, shared.snapshotDate, shared.accounts, shared.activeAssetIDs)
+		allRows := buildMergedRows(allValues, shared.snapshotDate, shared.accounts, shared.assetIDs)
 		res.InvestmentTimeSeries = buildInvestmentTimeSeries(allRows, shared.snapshots, shared.txns)
 		res.WrapperTimeSeries = buildWrapperTimeSeries(allRows, shared.snapshots, shared.txns)
 		res.CategoryTimeSeries = buildCategoryTimeSeries(allRows, shared.snapshots, shared.txns)
@@ -123,7 +123,7 @@ func computeRaw(ctx context.Context, s *Store) (result, error) {
 	if err != nil {
 		return result{}, err
 	}
-	rows := buildMergedRows(allValues, shared.snapshotDate, shared.accounts, shared.activeAssetIDs)
+	rows := buildMergedRows(allValues, shared.snapshotDate, shared.accounts, shared.assetIDs)
 	res := emptyResult()
 	if len(rows) == 0 {
 		return res, nil

--- a/backend-go/internal/dashboard/store.go
+++ b/backend-go/internal/dashboard/store.go
@@ -39,7 +39,9 @@ type AllocationJSONItem struct {
 }
 
 // Account mirrors the columns the dashboard reads from accounts.
-// OwnerUserID is nil for jointly-owned accounts.
+// OwnerUserID is nil for jointly-owned accounts. IsActive lets the
+// dashboard preserve historical snapshot values from soft-deleted
+// accounts while keeping "current state" reads filtered.
 type Account struct {
 	ID             int
 	Name           string
@@ -49,6 +51,7 @@ type Account struct {
 	AccountWrapper *string
 	Purpose        string
 	SquareMeters   *decimal.Decimal
+	IsActive       bool
 }
 
 // SnapshotValue is one snapshot_values row.
@@ -162,14 +165,18 @@ func (s *Store) AllSnapshots(ctx context.Context) ([]SnapshotMeta, error) {
 	return out, nil
 }
 
-// ActiveAccounts returns every active account.
-func (s *Store) ActiveAccounts(ctx context.Context) ([]Account, error) {
+// AllAccounts returns every account (active + soft-deleted). Historical
+// snapshot values that reference a soft-deleted account need the original
+// type/category to keep their contribution to net worth correct; callers
+// that want only the active set filter on Account.IsActive.
+func (s *Store) AllAccounts(ctx context.Context) ([]Account, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, name, type, category, owner_user_id, account_wrapper, purpose, square_meters
-		FROM accounts WHERE is_active = true`,
+		SELECT id, name, type, category, owner_user_id, account_wrapper,
+		       purpose, square_meters, is_active
+		FROM accounts`,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("active accounts: %w", err)
+		return nil, fmt.Errorf("all accounts: %w", err)
 	}
 	defer rows.Close()
 	out := []Account{}
@@ -177,7 +184,7 @@ func (s *Store) ActiveAccounts(ctx context.Context) ([]Account, error) {
 		var a Account
 		if err := rows.Scan(
 			&a.ID, &a.Name, &a.Type, &a.Category, &a.OwnerUserID,
-			&a.AccountWrapper, &a.Purpose, &a.SquareMeters,
+			&a.AccountWrapper, &a.Purpose, &a.SquareMeters, &a.IsActive,
 		); err != nil {
 			return nil, fmt.Errorf("scan account: %w", err)
 		}
@@ -189,11 +196,13 @@ func (s *Store) ActiveAccounts(ctx context.Context) ([]Account, error) {
 	return out, nil
 }
 
-// ActiveAssetIDs returns the set of active asset ids.
-func (s *Store) ActiveAssetIDs(ctx context.Context) (map[int]struct{}, error) {
-	rows, err := s.pool.Query(ctx, `SELECT id FROM assets WHERE is_active = true`)
+// AllAssetIDs returns the set of asset ids (active + soft-deleted), used
+// to mark historical snapshot rows that point at the assets table even
+// when the underlying asset is soft-deleted.
+func (s *Store) AllAssetIDs(ctx context.Context) (map[int]struct{}, error) {
+	rows, err := s.pool.Query(ctx, `SELECT id FROM assets`)
 	if err != nil {
-		return nil, fmt.Errorf("active assets: %w", err)
+		return nil, fmt.Errorf("all assets: %w", err)
 	}
 	defer rows.Close()
 	out := map[int]struct{}{}

--- a/backend-go/internal/snapshots/store.go
+++ b/backend-go/internal/snapshots/store.go
@@ -85,16 +85,18 @@ func NewStore(pool *pgxpool.Pool, aggs *aggregates.Store) *Store {
 	return &Store{pool: pool, aggregates: aggs}
 }
 
-// List returns all snapshots ordered by date desc, each with its total_net_worth
-// computed from active accounts + active assets only (inactive contribute 0).
+// List returns all snapshots ordered by date desc, each with its total_net_worth.
+// Soft-deleted accounts/assets still contribute to historical snapshots they
+// belong to — see issue #394. The active flag governs current-management
+// views, not historical totals.
 func (s *Store) List(ctx context.Context) ([]ListItem, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT s.id, s.date, s.notes,
 			COALESCE(SUM(
 				CASE
-					WHEN a.id IS NOT NULL AND a.is_active = true THEN sv.value
-					WHEN acc.id IS NOT NULL AND acc.is_active = true AND acc.type = 'asset' THEN sv.value
-					WHEN acc.id IS NOT NULL AND acc.is_active = true AND acc.type = 'liability' THEN -sv.value
+					WHEN a.id IS NOT NULL THEN sv.value
+					WHEN acc.id IS NOT NULL AND acc.type = 'asset' THEN sv.value
+					WHEN acc.id IS NOT NULL AND acc.type = 'liability' THEN -sv.value
 					ELSE 0
 				END
 			), 0) AS total_net_worth


### PR DESCRIPTION
## Motivation

The dashboard, the snapshot list, and the aggregates recompute path all stripped soft-deleted accounts/assets from their joins. After a soft delete, the matching snapshot values lost their type/category metadata and silently stopped contributing to historical net worth — the past changed retroactively.

## Implementation information

Took option 1 from the issue ("include inactive rows in history joins"). Avoided denormalizing type/name/category into snapshot_values, which is a much bigger schema change.

- \`dashboard.loadShared\` now loads every account/asset (\`AllAccounts\` / \`AllAssetIDs\`). Active rows are split into \`accountList\` for "current state" reads (real-estate property counts, \`hasInvestment\`, allocation totals); the lookup map \`accounts\` keeps every row so historical snapshot joins keep metadata.
- \`aggregates.RecomputeForSnapshot\` no longer filters \`is_active=true\`. Same reasoning: aggregates are the historical reporting view.
- \`snapshots.Store.List\` (which computes \`total_net_worth\` per snapshot) drops its \`is_active\` filter so the list view agrees with the dashboard.
- \`/api/accounts\` and \`/api/assets\` still filter active rows — unchanged.

Black-box regression test \`test_history_preserved_after_soft_delete_account\`: snapshot totals + \`net_worth_history\` are byte-identical before and after a soft-delete, while the deleted account is hidden from \`/api/accounts\`.

Closes #394

> Changelog: fix(snapshots): preserve history after soft delete