### PR TITLE
fix(ui): replace native confirm dialogs

### DIFF
--- a/src/lib/components/Confirm.svelte
+++ b/src/lib/components/Confirm.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import Modal from './Modal.svelte';
+	import { confirmDialog } from '$lib/stores/confirm.svelte';
+
+	const req = $derived(confirmDialog.current);
+</script>
+
+{#if req}
+	<Modal
+		open
+		title={req.title}
+		confirmText={req.confirmText ?? 'OK'}
+		cancelText={req.cancelText ?? 'Anuluj'}
+		confirmVariant={req.danger ? 'danger' : 'primary'}
+		confirmDisabled={req.pending}
+		onConfirm={confirmDialog.confirm}
+		onCancel={confirmDialog.cancel}
+	>
+		<p class="whitespace-pre-line">{req.message}</p>
+	</Modal>
+{/if}

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -30,7 +30,29 @@
 	}
 
 	function handleKeydown(event: KeyboardEvent) {
-		if (event.key === 'Escape') onCancel?.();
+		if (!open) return;
+		if (event.key === 'Escape') {
+			onCancel?.();
+			return;
+		}
+		if (event.key === 'Enter' && !confirmDisabled) {
+			// Only confirm when Enter wouldn't lose the user input that's
+			// in focus: text inputs / selects are safe (single-line submit),
+			// textareas insert newlines, buttons handle their own activation,
+			// content-editable could have any meaning so we skip it.
+			const t = event.target as HTMLElement | null;
+			if (!t) {
+				onConfirm?.();
+				return;
+			}
+			const tag = t.tagName;
+			const editable = t.isContentEditable;
+			if (tag === 'TEXTAREA' || tag === 'BUTTON' || editable) return;
+			if (tag === 'INPUT' || tag === 'SELECT') {
+				event.preventDefault();
+			}
+			onConfirm?.();
+		}
 	}
 
 	const confirmClass = $derived(

--- a/src/lib/components/Modal.test.ts
+++ b/src/lib/components/Modal.test.ts
@@ -52,4 +52,31 @@ describe('Modal', () => {
 		await fireEvent.click(screen.getByText('Zapisz'));
 		expect(onConfirm).toHaveBeenCalledOnce();
 	});
+
+	it('confirms on Enter when focus is in dialog body', async () => {
+		const onConfirm = vi.fn();
+		render(Modal, { props: { open: true, title: 'Tytuł', onConfirm } });
+		await fireEvent.keyDown(window, { key: 'Enter' });
+		expect(onConfirm).toHaveBeenCalledOnce();
+	});
+
+	it('does not confirm on Enter inside a textarea', async () => {
+		const onConfirm = vi.fn();
+		render(Modal, { props: { open: true, title: 'Tytuł', onConfirm } });
+		const ta = document.createElement('textarea');
+		document.body.appendChild(ta);
+		ta.focus();
+		await fireEvent.keyDown(ta, { key: 'Enter' });
+		expect(onConfirm).not.toHaveBeenCalled();
+		document.body.removeChild(ta);
+	});
+
+	it('does not confirm on Enter when confirmDisabled', async () => {
+		const onConfirm = vi.fn();
+		render(Modal, {
+			props: { open: true, title: 'Tytuł', confirmDisabled: true, onConfirm }
+		});
+		await fireEvent.keyDown(window, { key: 'Enter' });
+		expect(onConfirm).not.toHaveBeenCalled();
+	});
 });

--- a/src/lib/stores/confirm.svelte.ts
+++ b/src/lib/stores/confirm.svelte.ts
@@ -1,0 +1,79 @@
+// Programmatic confirm dialog: await confirm(...) anywhere in
+// browser code, get back a boolean. A single <Confirm /> instance
+// mounted in the root layout renders the modal driven by this store.
+//
+// Two patterns supported:
+//
+//   // 1. Simple — modal closes immediately, caller handles work itself.
+//   if (!(await confirm({ title, message }))) return;
+//   await doDelete();
+//
+//   // 2. With loading state — modal stays open + confirm button disabled
+//   // while the async handler runs, then closes. Promise resolves true
+//   // when the handler settled, false on cancel or if it threw.
+//   await confirm({ title, message, onConfirm: () => doDelete() });
+
+export interface ConfirmOptions {
+	title: string;
+	message: string;
+	confirmText?: string;
+	cancelText?: string;
+	danger?: boolean;
+	onConfirm?: () => void | Promise<void>;
+}
+
+export interface ConfirmRequest extends ConfirmOptions {
+	pending: boolean;
+	resolve: (ok: boolean) => void;
+}
+
+let current = $state<ConfirmRequest | null>(null);
+
+function open(options: ConfirmOptions): Promise<boolean> {
+	if (current && !current.pending) {
+		// A second confirm before the first resolved cancels the first.
+		current.resolve(false);
+		current = null;
+	}
+	return new Promise<boolean>((resolve) => {
+		current = { ...options, pending: false, resolve };
+	});
+}
+
+async function confirmAction(): Promise<void> {
+	if (!current || current.pending) return;
+	const req = current;
+	if (!req.onConfirm) {
+		current = null;
+		req.resolve(true);
+		return;
+	}
+	req.pending = true;
+	try {
+		await req.onConfirm();
+		current = null;
+		req.resolve(true);
+	} catch {
+		current = null;
+		req.resolve(false);
+	}
+}
+
+function cancelAction(): void {
+	if (!current || current.pending) return;
+	const req = current;
+	current = null;
+	req.resolve(false);
+}
+
+export const confirmDialog = {
+	get current(): ConfirmRequest | null {
+		return current;
+	},
+	confirm: confirmAction,
+	cancel: cancelAction
+};
+
+export function confirm(options: ConfirmOptions): Promise<boolean> {
+	return open(options);
+}

--- a/src/lib/stores/confirm.svelte.ts
+++ b/src/lib/stores/confirm.svelte.ts
@@ -30,7 +30,13 @@ export interface ConfirmRequest extends ConfirmOptions {
 let current = $state<ConfirmRequest | null>(null);
 
 function open(options: ConfirmOptions): Promise<boolean> {
-	if (current && !current.pending) {
+	if (current) {
+		if (current.pending) {
+			// The first request is mid-flight handler — clobbering it would
+			// orphan its Promise and race confirmAction()'s post-await null
+			// write. Reject the newcomer instead.
+			return Promise.resolve(false);
+		}
 		// A second confirm before the first resolved cancels the first.
 		current.resolve(false);
 		current = null;

--- a/src/lib/stores/confirm.test.ts
+++ b/src/lib/stores/confirm.test.ts
@@ -60,28 +60,32 @@ describe('confirm store', () => {
 
 	it('with onConfirm: flips pending, awaits, then resolves true', async () => {
 		let resolveHandler: () => void = () => {};
-		const handlerStarted = new Promise<void>((started) => {
-			const p = confirm({
-				title: 't',
-				message: 'm',
-				onConfirm: () =>
-					new Promise<void>((resolveOnConfirm) => {
-						resolveHandler = resolveOnConfirm;
-						started();
-					})
-			});
-			confirmDialog.confirm();
-			void p.then((ok) => {
-				expect(ok).toBe(true);
-				expect(confirmDialog.current).toBeNull();
-			});
+		let handlerStarted!: () => void;
+		const started = new Promise<void>((res) => {
+			handlerStarted = res;
 		});
-		await handlerStarted;
+		const p = confirm({
+			title: 't',
+			message: 'm',
+			onConfirm: () =>
+				new Promise<void>((resolveOnConfirm) => {
+					resolveHandler = resolveOnConfirm;
+					handlerStarted();
+				})
+		});
+		confirmDialog.confirm();
+		await started;
 		expect(confirmDialog.current?.pending).toBe(true);
 		// Cancel during pending is a no-op.
 		confirmDialog.cancel();
 		expect(confirmDialog.current).not.toBeNull();
+		// Opening a second confirm while one is pending must not clobber.
+		const ignored = confirm({ title: 'x', message: 'x' });
+		await expect(ignored).resolves.toBe(false);
+		expect(confirmDialog.current?.title).toBe('t');
 		resolveHandler();
+		await expect(p).resolves.toBe(true);
+		expect(confirmDialog.current).toBeNull();
 	});
 
 	it('with onConfirm that throws: resolves false and closes', async () => {

--- a/src/lib/stores/confirm.test.ts
+++ b/src/lib/stores/confirm.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { confirm, confirmDialog } from './confirm.svelte';
+
+describe('confirm store', () => {
+	beforeEach(() => {
+		// Drain any prior request.
+		if (confirmDialog.current && !confirmDialog.current.pending) {
+			confirmDialog.cancel();
+		}
+	});
+
+	it('exposes the open request', () => {
+		const p = confirm({ title: 'Delete', message: 'Sure?' });
+		expect(confirmDialog.current).not.toBeNull();
+		expect(confirmDialog.current?.title).toBe('Delete');
+		expect(confirmDialog.current?.message).toBe('Sure?');
+		expect(confirmDialog.current?.pending).toBe(false);
+		confirmDialog.cancel();
+		return p;
+	});
+
+	it('resolves true when confirm() called (no handler)', async () => {
+		const p = confirm({ title: 't', message: 'm' });
+		confirmDialog.confirm();
+		await expect(p).resolves.toBe(true);
+		expect(confirmDialog.current).toBeNull();
+	});
+
+	it('resolves false when cancel() called', async () => {
+		const p = confirm({ title: 't', message: 'm' });
+		confirmDialog.cancel();
+		await expect(p).resolves.toBe(false);
+		expect(confirmDialog.current).toBeNull();
+	});
+
+	it('opening a second request cancels the first', async () => {
+		const first = confirm({ title: 'a', message: 'a' });
+		const second = confirm({ title: 'b', message: 'b' });
+		await expect(first).resolves.toBe(false);
+		expect(confirmDialog.current?.title).toBe('b');
+		confirmDialog.confirm();
+		await expect(second).resolves.toBe(true);
+	});
+
+	it('passes options through unchanged', () => {
+		const p = confirm({
+			title: 'X',
+			message: 'Y',
+			confirmText: 'Yes',
+			cancelText: 'No',
+			danger: true
+		});
+		const req = confirmDialog.current;
+		expect(req?.confirmText).toBe('Yes');
+		expect(req?.cancelText).toBe('No');
+		expect(req?.danger).toBe(true);
+		confirmDialog.cancel();
+		return p;
+	});
+
+	it('with onConfirm: flips pending, awaits, then resolves true', async () => {
+		let resolveHandler: () => void = () => {};
+		const handlerStarted = new Promise<void>((started) => {
+			const p = confirm({
+				title: 't',
+				message: 'm',
+				onConfirm: () =>
+					new Promise<void>((resolveOnConfirm) => {
+						resolveHandler = resolveOnConfirm;
+						started();
+					})
+			});
+			confirmDialog.confirm();
+			void p.then((ok) => {
+				expect(ok).toBe(true);
+				expect(confirmDialog.current).toBeNull();
+			});
+		});
+		await handlerStarted;
+		expect(confirmDialog.current?.pending).toBe(true);
+		// Cancel during pending is a no-op.
+		confirmDialog.cancel();
+		expect(confirmDialog.current).not.toBeNull();
+		resolveHandler();
+	});
+
+	it('with onConfirm that throws: resolves false and closes', async () => {
+		const p = confirm({
+			title: 't',
+			message: 'm',
+			onConfirm: () => {
+				throw new Error('boom');
+			}
+		});
+		confirmDialog.confirm();
+		await expect(p).resolves.toBe(false);
+		expect(confirmDialog.current).toBeNull();
+	});
+});

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import '../app.css';
 	import { page } from '$app/stores';
 	import Toast from '$lib/components/Toast.svelte';
+	import Confirm from '$lib/components/Confirm.svelte';
 	import {
 		LayoutDashboard,
 		TrendingUp,
@@ -55,6 +56,7 @@
 </script>
 
 <Toast />
+<Confirm />
 
 {#if isLoginPage}
 	{@render children?.()}

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -27,6 +27,7 @@
 	import { resolveApiUrl } from '$lib/api';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
+	import { confirm } from '$lib/stores/confirm.svelte';
 	import type {
 		BonusEvent,
 		BonusType,
@@ -417,9 +418,13 @@
 	}
 
 	async function deleteBonus(id: number) {
-		if (!confirm('Czy na pewno chcesz usunąć ten bonus?')) {
-			return;
-		}
+		const ok = await confirm({
+			title: 'Usuń bonus',
+			message: 'Czy na pewno chcesz usunąć ten bonus?',
+			confirmText: 'Usuń',
+			danger: true
+		});
+		if (!ok) return;
 
 		try {
 			const response = await fetch(`${apiUrl}/api/bonuses/${id}`, { method: 'DELETE' });
@@ -759,7 +764,13 @@
 	}
 
 	async function deleteEquityGrant(id: number) {
-		if (!confirm('Czy na pewno chcesz usunąć ten grant?')) return;
+		const ok = await confirm({
+			title: 'Usuń grant',
+			message: 'Czy na pewno chcesz usunąć ten grant?',
+			confirmText: 'Usuń',
+			danger: true
+		});
+		if (!ok) return;
 		try {
 			const response = await fetch(`${apiUrl}/api/equity-grants/${id}`, { method: 'DELETE' });
 			if (!response.ok) throw new Error('Failed to delete grant');
@@ -925,7 +936,13 @@
 	}
 
 	async function deleteValuation(id: number) {
-		if (!confirm('Czy na pewno chcesz usunąć tę wycenę?')) return;
+		const ok = await confirm({
+			title: 'Usuń wycenę',
+			message: 'Czy na pewno chcesz usunąć tę wycenę?',
+			confirmText: 'Usuń',
+			danger: true
+		});
+		if (!ok) return;
 		try {
 			const response = await fetch(`${apiUrl}/api/company-valuations/${id}`, {
 				method: 'DELETE'
@@ -1066,9 +1083,13 @@
 	}
 
 	async function deleteSalary(id: number) {
-		if (!confirm('Czy na pewno chcesz usunąć ten rekord wynagrodzenia?')) {
-			return;
-		}
+		const ok = await confirm({
+			title: 'Usuń wynagrodzenie',
+			message: 'Czy na pewno chcesz usunąć ten rekord wynagrodzenia?',
+			confirmText: 'Usuń',
+			danger: true
+		});
+		if (!ok) return;
 
 		try {
 			const response = await fetch(`${apiUrl}/api/salaries/${id}`, {

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -5,6 +5,7 @@
 	import { resolveApiUrl } from '$lib/api';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
+	import { confirm } from '$lib/stores/confirm.svelte';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
 	import { untrack } from 'svelte';
 	import type { PageData } from './$types';
@@ -63,7 +64,13 @@
 	}
 
 	async function deleteTransaction(accountId: number, transactionId: number) {
-		if (!confirm('Czy na pewno chcesz usunąć tę transakcję?')) return;
+		const ok = await confirm({
+			title: 'Usuń transakcję',
+			message: 'Czy na pewno chcesz usunąć tę transakcję?',
+			confirmText: 'Usuń',
+			danger: true
+		});
+		if (!ok) return;
 
 		try {
 			const response = await fetch(


### PR DESCRIPTION
## Motivation

Five destructive actions in salaries + transactions still used browser \`confirm()\`. Inconsistent with the rest of the app (which uses the in-app Modal), unstylable, hard to test on mobile.

## Implementation information

- New \`src/lib/stores/confirm.svelte.ts\`: a programmatic \`await confirm({ title, message, danger, confirmText, cancelText, onConfirm? })\` returning \`Promise<boolean>\`. Pass \`onConfirm\` for true loading-state semantics — the modal stays open with the confirm button disabled while the async handler runs, then closes; the Promise resolves \`true\` on success, \`false\` on cancel or thrown.
- New \`src/lib/components/Confirm.svelte\`: a singleton driven by the store. Mounted once in the root layout next to the existing Toast.
- Modal gains Enter-to-confirm. Skipped inside \`<textarea>\`, on focused buttons, on contentEditable, and when \`confirmDisabled\`. Escape was already wired.
- Replaced all 5 native \`confirm()\` calls (1 in transactions, 4 in salaries).
- Tests: store API (confirm/cancel/pending/throw/second-open), Modal keyboard (Enter / Enter-in-textarea / Enter-when-disabled / Escape).

Closes #404

> Changelog: fix(ui): replace native confirm dialogs