### PR TITLE
fix(ppk): generate government subsidies

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -4049,11 +4049,18 @@
               "application/json": {
                 "schema": {
                   "properties": {
+                    "annual_applied": {
+                      "type": "boolean"
+                    },
                     "employee_amount": {
                       "format": "double",
                       "type": "number"
                     },
                     "employer_amount": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "government_amount": {
                       "format": "double",
                       "type": "number"
                     },
@@ -4077,6 +4084,9 @@
                         "type": "integer"
                       },
                       "type": "array"
+                    },
+                    "welcome_applied": {
+                      "type": "boolean"
                     },
                     "year": {
                       "type": "integer"

--- a/backend-bb-tests/tests/test_retirement.py
+++ b/backend-bb-tests/tests/test_retirement.py
@@ -136,34 +136,43 @@ def _ppk_account_id(client: httpx.Client) -> int:
 
 @contextmanager
 def _clean_ppk_account(dsn: str, account_id: int) -> Iterator[None]:
-    """Soft-delete the account's existing transactions for the test, then
-    restore them so the session-scoped seed is intact for downstream
-    golden tests. Newly-inserted rows during the test are hard-deleted on
-    exit."""
+    """Capture every existing transaction id on the account (active or not),
+    soft-deactivate the active ones so eligibility checks fire, then on exit
+    delete only the rows that didn't exist before and restore the originals'
+    is_active flags. Session-scoped seed survives intact."""
     with closing(psycopg2.connect(dsn)) as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "SELECT id FROM transactions WHERE account_id = %s AND is_active = true",
+                "SELECT id, is_active FROM transactions WHERE account_id = %s",
                 (account_id,),
             )
-            existing_ids = [row[0] for row in cur.fetchall()]
+            preserved = {row[0]: row[1] for row in cur.fetchall()}
+            active_ids = [tid for tid, active in preserved.items() if active]
             cur.execute(
                 "UPDATE transactions SET is_active = false WHERE id = ANY(%s)",
-                (existing_ids,),
+                (active_ids,),
             )
         conn.commit()
         try:
             yield
         finally:
+            preserved_ids = list(preserved.keys())
             with conn.cursor() as cur:
-                cur.execute(
-                    "DELETE FROM transactions WHERE account_id = %s AND id <> ALL(%s)",
-                    (account_id, existing_ids),
-                )
-                cur.execute(
-                    "UPDATE transactions SET is_active = true WHERE id = ANY(%s)",
-                    (existing_ids,),
-                )
+                if preserved_ids:
+                    cur.execute(
+                        "DELETE FROM transactions WHERE account_id = %s AND id <> ALL(%s)",
+                        (account_id, preserved_ids),
+                    )
+                else:
+                    cur.execute(
+                        "DELETE FROM transactions WHERE account_id = %s",
+                        (account_id,),
+                    )
+                if active_ids:
+                    cur.execute(
+                        "UPDATE transactions SET is_active = true WHERE id = ANY(%s)",
+                        (active_ids,),
+                    )
             conn.commit()
 
 

--- a/backend-bb-tests/tests/test_retirement.py
+++ b/backend-bb-tests/tests/test_retirement.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import closing, contextmanager
+
 import httpx
+import psycopg2
 import pytest
 
 from fixtures.seed import PERSONA_MARCIN
@@ -119,3 +123,150 @@ def test_post_ppk_contributions_validation_error(
     response = client.post("/api/retirement/ppk-contributions/generate", json=payload)
     assert response.status_code >= 400, response.text
     assert "detail" in response.json()
+
+
+def _ppk_account_id(client: httpx.Client) -> int:
+    response = client.get("/api/accounts")
+    assert response.status_code == 200, response.text
+    for account in response.json()["assets"]:
+        if account["account_wrapper"] == "PPK":
+            return int(account["id"])
+    raise AssertionError("No PPK account found in /api/accounts response")
+
+
+@contextmanager
+def _clean_ppk_account(dsn: str, account_id: int) -> Iterator[None]:
+    """Soft-delete the account's existing transactions for the test, then
+    restore them so the session-scoped seed is intact for downstream
+    golden tests. Newly-inserted rows during the test are hard-deleted on
+    exit."""
+    with closing(psycopg2.connect(dsn)) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM transactions WHERE account_id = %s AND is_active = true",
+                (account_id,),
+            )
+            existing_ids = [row[0] for row in cur.fetchall()]
+            cur.execute(
+                "UPDATE transactions SET is_active = false WHERE id = ANY(%s)",
+                (existing_ids,),
+            )
+        conn.commit()
+        try:
+            yield
+        finally:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM transactions WHERE account_id = %s AND id <> ALL(%s)",
+                    (account_id, existing_ids),
+                )
+                cur.execute(
+                    "UPDATE transactions SET is_active = true WHERE id = ANY(%s)",
+                    (existing_ids,),
+                )
+            conn.commit()
+
+
+@pytest.mark.mutates
+def test_ppk_generation_includes_welcome_subsidy_when_opted_in(
+    client: httpx.Client, database_url: str, owner_ids: dict[str, int]
+) -> None:
+    account_id = _ppk_account_id(client)
+    # Seed has a prior 'government' transaction on this PPK account; the
+    # context manager soft-deletes it for the test (so welcome eligibility
+    # fires) and restores it after, so the golden suite isn't disturbed.
+    with _clean_ppk_account(database_url, account_id):
+        payload = {
+            "owner_user_id": owner_ids[PERSONA_MARCIN],
+            "month": 3,
+            "year": 2025,
+            "include_welcome_subsidy": True,
+        }
+        response = client.post("/api/retirement/ppk-contributions/generate", json=payload)
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["welcome_applied"] is True
+        assert body["government_amount"] == pytest.approx(250.0)
+        assert body["total_amount"] == pytest.approx(
+            body["employee_amount"] + body["employer_amount"] + body["government_amount"]
+        )
+        # Employee + employer + welcome government row.
+        assert len(body["transactions_created"]) >= 3
+
+
+@pytest.mark.mutates
+def test_ppk_welcome_is_idempotent_across_months(
+    client: httpx.Client, database_url: str, owner_ids: dict[str, int]
+) -> None:
+    account_id = _ppk_account_id(client)
+    with _clean_ppk_account(database_url, account_id):
+        base = {
+            "owner_user_id": owner_ids[PERSONA_MARCIN],
+            "year": 2025,
+            "include_welcome_subsidy": True,
+        }
+        first = client.post("/api/retirement/ppk-contributions/generate", json={**base, "month": 4})
+        assert first.status_code == 200, first.text
+        assert first.json()["welcome_applied"] is True
+
+        # Second call (different month) still requests the welcome; the store
+        # must skip it because a government txn already exists.
+        second = client.post(
+            "/api/retirement/ppk-contributions/generate", json={**base, "month": 5}
+        )
+        assert second.status_code == 200, second.text
+        assert second.json()["welcome_applied"] is False
+        assert second.json()["government_amount"] == pytest.approx(0.0)
+
+
+@pytest.mark.mutates
+def test_ppk_combined_welcome_and_annual_in_one_call(
+    client: httpx.Client, database_url: str, owner_ids: dict[str, int]
+) -> None:
+    # Both subsidies in a single generate call must both land. Welcome and
+    # annual share transaction_type='government', so the eligibility check
+    # must distinguish them (by amount) — otherwise the welcome inserted
+    # first masks the annual check.
+    account_id = _ppk_account_id(client)
+    with _clean_ppk_account(database_url, account_id):
+        response = client.post(
+            "/api/retirement/ppk-contributions/generate",
+            json={
+                "owner_user_id": owner_ids[PERSONA_MARCIN],
+                "month": 8,
+                "year": 2025,
+                "include_welcome_subsidy": True,
+                "include_annual_subsidy": True,
+            },
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["welcome_applied"] is True
+        assert body["annual_applied"] is True
+        assert body["government_amount"] == pytest.approx(250.0 + 240.0)
+        # Employee + employer + welcome + annual.
+        assert len(body["transactions_created"]) == 4
+
+
+@pytest.mark.mutates
+def test_ppk_annual_subsidy_idempotent_within_year(
+    client: httpx.Client, database_url: str, owner_ids: dict[str, int]
+) -> None:
+    account_id = _ppk_account_id(client)
+    with _clean_ppk_account(database_url, account_id):
+        base = {
+            "owner_user_id": owner_ids[PERSONA_MARCIN],
+            "year": 2025,
+            "include_annual_subsidy": True,
+        }
+        first = client.post("/api/retirement/ppk-contributions/generate", json={**base, "month": 6})
+        assert first.status_code == 200, first.text
+        assert first.json()["annual_applied"] is True
+        assert first.json()["government_amount"] == pytest.approx(240.0)
+
+        second = client.post(
+            "/api/retirement/ppk-contributions/generate", json={**base, "month": 7}
+        )
+        assert second.status_code == 200, second.text
+        assert second.json()["annual_applied"] is False
+        assert second.json()["government_amount"] == pytest.approx(0.0)

--- a/backend-go/internal/retirement/handler.go
+++ b/backend-go/internal/retirement/handler.go
@@ -543,22 +543,32 @@ func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) 
 	}
 	r.Year = year
 
-	r.IncludeWelcome = optionalBool(raw, "include_welcome_subsidy")
-	r.IncludeAnnual = optionalBool(raw, "include_annual_subsidy")
+	welcome, vErr := optionalBool(raw, "include_welcome_subsidy")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.IncludeWelcome = welcome
+	annual, vErr := optionalBool(raw, "include_annual_subsidy")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.IncludeAnnual = annual
 	return r, nil
 }
 
-// optionalBool reads a boolean key; missing/null returns false.
-func optionalBool(raw map[string]json.RawMessage, key string) bool {
+// optionalBool reads a boolean key. Missing/null returns false; a present
+// non-bool value (e.g. "true" sent as a string) is rejected so the client
+// gets a 422 instead of silently degrading to false.
+func optionalBool(raw map[string]json.RawMessage, key string) (bool, *validationError) {
 	v, ok := raw[key]
 	if !ok || isNull(v) {
-		return false
+		return false, nil
 	}
 	var b bool
 	if err := json.Unmarshal(v, &b); err != nil {
-		return false
+		return false, &validationError{Field: key, Msg: "must be a boolean"}
 	}
-	return b
+	return b, nil
 }
 
 // --- helpers ---

--- a/backend-go/internal/retirement/handler.go
+++ b/backend-go/internal/retirement/handler.go
@@ -58,6 +58,9 @@ type ppkGenerateResponse struct {
 	GrossSalary         pyFloat `json:"gross_salary"`
 	EmployeeAmount      pyFloat `json:"employee_amount"`
 	EmployerAmount      pyFloat `json:"employer_amount"`
+	GovernmentAmount    pyFloat `json:"government_amount"`
+	WelcomeApplied      bool    `json:"welcome_applied"`
+	AnnualApplied       bool    `json:"annual_applied"`
 	TotalAmount         pyFloat `json:"total_amount"`
 	TransactionsCreated []int   `json:"transactions_created"`
 }
@@ -357,10 +360,18 @@ func (h *Handler) GeneratePPKContributions(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	lastDay := time.Date(req.Year, time.Month(req.Month)+1, 0, 0, 0, 0, 0, time.UTC)
-	ids, err := h.store.InsertPPKContributions(r.Context(), PPKContribution{
+	subsidy := SubsidyFor(req.Year)
+	contrib := PPKContribution{
 		AccountID: accountID, EmployeeAmt: employeeAmt, EmployerAmt: employerAmt,
 		Date: lastDay, OwnerUserID: req.OwnerUserID,
-	})
+	}
+	if req.IncludeWelcome {
+		contrib.WelcomeAmt = subsidy.WelcomeAmount
+	}
+	if req.IncludeAnnual {
+		contrib.AnnualAmt = subsidy.AnnualAmount
+	}
+	result, err := h.store.InsertPPKContributions(r.Context(), contrib)
 	if err != nil {
 		if errors.Is(err, ErrContributionsExist) {
 			writeDetailError(w, http.StatusConflict,
@@ -371,17 +382,49 @@ func (h *Handler) GeneratePPKContributions(w http.ResponseWriter, r *http.Reques
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
+	writeJSON(w, http.StatusOK, buildPPKGenerateResponse(req, gross, employeeAmt, employerAmt, subsidy, result))
+}
+
+func buildPPKGenerateResponse(
+	req generateRequest,
+	gross, employeeAmt, employerAmt decimal.Decimal,
+	subsidy SubsidyConfig,
+	result PPKContributionResult,
+) ppkGenerateResponse {
 	grossF, _ := gross.Float64()
 	empF, _ := employeeAmt.Float64()
 	emprF, _ := employerAmt.Float64()
-	writeJSON(w, http.StatusOK, ppkGenerateResponse{
-		OwnerUserID: req.OwnerUserID, Month: req.Month, Year: req.Year,
+	govF := 0.0
+	welcomeApplied := result.WelcomeID != nil
+	annualApplied := result.AnnualID != nil
+	if welcomeApplied {
+		w, _ := subsidy.WelcomeAmount.Float64()
+		govF += w
+	}
+	if annualApplied {
+		a, _ := subsidy.AnnualAmount.Float64()
+		govF += a
+	}
+	ids := []int{result.EmployeeID, result.EmployerID}
+	if result.WelcomeID != nil {
+		ids = append(ids, *result.WelcomeID)
+	}
+	if result.AnnualID != nil {
+		ids = append(ids, *result.AnnualID)
+	}
+	return ppkGenerateResponse{
+		OwnerUserID:         req.OwnerUserID,
+		Month:               req.Month,
+		Year:                req.Year,
 		GrossSalary:         pyFloat(grossF),
 		EmployeeAmount:      pyFloat(empF),
 		EmployerAmount:      pyFloat(emprF),
-		TotalAmount:         pyFloat(empF + emprF),
+		GovernmentAmount:    pyFloat(govF),
+		WelcomeApplied:      welcomeApplied,
+		AnnualApplied:       annualApplied,
+		TotalAmount:         pyFloat(empF + emprF + govF),
 		TransactionsCreated: ids,
-	})
+	}
 }
 
 // errBadOwnerParam marks a non-integer owner_user_id query value.
@@ -468,9 +511,11 @@ func buildLimitRequest(raw map[string]json.RawMessage, now func() time.Time) (li
 }
 
 type generateRequest struct {
-	OwnerUserID *int
-	Month       int
-	Year        int
+	OwnerUserID    *int
+	Month          int
+	Year           int
+	IncludeWelcome bool
+	IncludeAnnual  bool
 }
 
 func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) (generateRequest, *validationError) {
@@ -497,7 +542,23 @@ func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) 
 		return r, vErr
 	}
 	r.Year = year
+
+	r.IncludeWelcome = optionalBool(raw, "include_welcome_subsidy")
+	r.IncludeAnnual = optionalBool(raw, "include_annual_subsidy")
 	return r, nil
+}
+
+// optionalBool reads a boolean key; missing/null returns false.
+func optionalBool(raw map[string]json.RawMessage, key string) bool {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return false
+	}
+	var b bool
+	if err := json.Unmarshal(v, &b); err != nil {
+		return false
+	}
+	return b
 }
 
 // --- helpers ---

--- a/backend-go/internal/retirement/store.go
+++ b/backend-go/internal/retirement/store.go
@@ -327,23 +327,46 @@ func (s *Store) ActivePPKAccountForOwner(ctx context.Context, ownerUserID *int) 
 	return id, nil
 }
 
-// PPKContribution is the writeback shape — two transactions per call.
+// PPKContribution is the writeback shape — two transactions per call,
+// plus optional one-time welcome and yearly annual government subsidies
+// when the caller requests them. WelcomeAmt/AnnualAmt are zero when the
+// caller didn't opt in; the store skips inserting a row when the amount
+// is zero or a matching subsidy already exists for the eligibility
+// window (welcome: per account, ever; annual: per (account, year)).
 type PPKContribution struct {
 	AccountID   int
 	EmployeeAmt decimal.Decimal
 	EmployerAmt decimal.Decimal
+	WelcomeAmt  decimal.Decimal
+	AnnualAmt   decimal.Decimal
 	Date        time.Time
 	OwnerUserID *int
 }
 
+// PPKContributionResult names the inserted transaction IDs so the handler
+// can echo which subsidies were actually written (vs. skipped due to
+// idempotency).
+type PPKContributionResult struct {
+	EmployeeID  int
+	EmployerID  int
+	WelcomeID   *int
+	AnnualID    *int
+	WelcomeSkip bool
+	AnnualSkip  bool
+}
+
 // InsertPPKContributions writes the employee + employer transactions
-// atomically. ErrContributionsExist when a row already exists for the
-// (account_id, date, employee|employer) tuple — guarded both by a
-// pre-check and by a UniqueViolation catch.
-func (s *Store) InsertPPKContributions(ctx context.Context, c PPKContribution) ([]int, error) {
+// atomically, plus any opted-in government subsidies. ErrContributionsExist
+// when a (account_id, date, employee|employer) row already exists — guarded
+// both by a pre-check and by a UniqueViolation catch. Welcome / annual
+// subsidies are independently idempotent: an existing welcome (any prior
+// government txn) skips the new one; an existing annual government txn in
+// the same year skips that one too.
+func (s *Store) InsertPPKContributions(ctx context.Context, c PPKContribution) (PPKContributionResult, error) {
+	var res PPKContributionResult
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("begin ppk tx: %w", err)
+		return res, fmt.Errorf("begin ppk tx: %w", err)
 	}
 	committed := false
 	defer func() {
@@ -361,7 +384,7 @@ func (s *Store) InsertPPKContributions(ctx context.Context, c PPKContribution) (
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock($1)`, lockKey,
 	); err != nil {
-		return nil, fmt.Errorf("ppk advisory lock: %w", err)
+		return res, fmt.Errorf("ppk advisory lock: %w", err)
 	}
 	var existing int
 	err = tx.QueryRow(ctx, `
@@ -372,40 +395,137 @@ func (s *Store) InsertPPKContributions(ctx context.Context, c PPKContribution) (
 		c.AccountID, c.Date,
 	).Scan(&existing)
 	if err != nil {
-		return nil, fmt.Errorf("count ppk existing: %w", err)
+		return res, fmt.Errorf("count ppk existing: %w", err)
 	}
 	if existing > 0 {
-		return nil, ErrContributionsExist
+		return res, ErrContributionsExist
 	}
 	now := time.Now().UTC()
-	var empID, emprID int
 	if err := tx.QueryRow(ctx, `
 		INSERT INTO transactions (account_id, amount, date, owner_user_id, transaction_type, is_active, created_at)
 		VALUES ($1, $2, $3, $4, 'employee', true, $5)
 		RETURNING id`,
 		c.AccountID, c.EmployeeAmt, c.Date, c.OwnerUserID, now,
-	).Scan(&empID); err != nil {
+	).Scan(&res.EmployeeID); err != nil {
 		if isUniqueViolation(err) {
-			return nil, ErrContributionsExist
+			return res, ErrContributionsExist
 		}
-		return nil, fmt.Errorf("insert employee txn: %w", err)
+		return res, fmt.Errorf("insert employee txn: %w", err)
 	}
 	if err := tx.QueryRow(ctx, `
 		INSERT INTO transactions (account_id, amount, date, owner_user_id, transaction_type, is_active, created_at)
 		VALUES ($1, $2, $3, $4, 'employer', true, $5)
 		RETURNING id`,
 		c.AccountID, c.EmployerAmt, c.Date, c.OwnerUserID, now,
-	).Scan(&emprID); err != nil {
+	).Scan(&res.EmployerID); err != nil {
 		if isUniqueViolation(err) {
-			return nil, ErrContributionsExist
+			return res, ErrContributionsExist
 		}
-		return nil, fmt.Errorf("insert employer txn: %w", err)
+		return res, fmt.Errorf("insert employer txn: %w", err)
+	}
+	if c.WelcomeAmt.IsPositive() {
+		welcomeID, skipped, err := maybeInsertSubsidy(ctx, tx, subsidyInsert{
+			accountID: c.AccountID, ownerUserID: c.OwnerUserID,
+			amount: c.WelcomeAmt, date: c.Date, now: now,
+			scope: welcomeScope{amount: c.WelcomeAmt},
+		})
+		if err != nil {
+			return res, err
+		}
+		res.WelcomeSkip = skipped
+		if !skipped {
+			res.WelcomeID = &welcomeID
+		}
+	}
+	if c.AnnualAmt.IsPositive() {
+		annualID, skipped, err := maybeInsertSubsidy(ctx, tx, subsidyInsert{
+			accountID: c.AccountID, ownerUserID: c.OwnerUserID,
+			amount: c.AnnualAmt, date: c.Date, now: now,
+			scope: annualScope{amount: c.AnnualAmt, year: c.Date.Year()},
+		})
+		if err != nil {
+			return res, err
+		}
+		res.AnnualSkip = skipped
+		if !skipped {
+			res.AnnualID = &annualID
+		}
 	}
 	if err := tx.Commit(ctx); err != nil {
-		return nil, fmt.Errorf("commit ppk tx: %w", err)
+		return res, fmt.Errorf("commit ppk tx: %w", err)
 	}
 	committed = true
-	return []int{empID, emprID}, nil
+	return res, nil
+}
+
+// welcomeScope / annualScope name the eligibility windows. Both filter by
+// `amount` because welcome (250 PLN) and annual (240 PLN) are written with
+// the same `transaction_type='government'` — without distinguishing on
+// amount, a welcome inserted earlier in the same transaction would mask
+// the annual check (and vice-versa).
+type welcomeScope struct{ amount decimal.Decimal }
+
+type annualScope struct {
+	amount decimal.Decimal
+	year   int
+}
+
+type subsidyInsert struct {
+	accountID   int
+	ownerUserID *int
+	amount      decimal.Decimal
+	date, now   time.Time
+	scope       any
+}
+
+func maybeInsertSubsidy(ctx context.Context, tx pgx.Tx, s subsidyInsert) (int, bool, error) {
+	exists, err := subsidyExists(ctx, tx, s.accountID, s.scope)
+	if err != nil {
+		return 0, false, err
+	}
+	if exists {
+		return 0, true, nil
+	}
+	var id int
+	if err := tx.QueryRow(ctx, `
+		INSERT INTO transactions (account_id, amount, date, owner_user_id, transaction_type, is_active, created_at)
+		VALUES ($1, $2, $3, $4, 'government', true, $5)
+		RETURNING id`,
+		s.accountID, s.amount, s.date, s.ownerUserID, s.now,
+	).Scan(&id); err != nil {
+		return 0, false, fmt.Errorf("insert government subsidy: %w", err)
+	}
+	return id, false, nil
+}
+
+func subsidyExists(ctx context.Context, tx pgx.Tx, accountID int, scope any) (bool, error) {
+	switch s := scope.(type) {
+	case welcomeScope:
+		var n int
+		if err := tx.QueryRow(ctx, `
+			SELECT COUNT(*) FROM transactions
+			WHERE account_id = $1 AND transaction_type = 'government'
+			  AND is_active = true AND amount = $2`,
+			accountID, s.amount,
+		).Scan(&n); err != nil {
+			return false, fmt.Errorf("count welcome subsidy: %w", err)
+		}
+		return n > 0, nil
+	case annualScope:
+		var n int
+		if err := tx.QueryRow(ctx, `
+			SELECT COUNT(*) FROM transactions
+			WHERE account_id = $1 AND transaction_type = 'government'
+			  AND is_active = true AND amount = $2
+			  AND EXTRACT(YEAR FROM date) = $3`,
+			accountID, s.amount, s.year,
+		).Scan(&n); err != nil {
+			return false, fmt.Errorf("count annual subsidy: %w", err)
+		}
+		return n > 0, nil
+	default:
+		return false, fmt.Errorf("unknown subsidy scope: %T", scope)
+	}
 }
 
 func isUniqueViolation(err error) bool {

--- a/backend-go/internal/retirement/store.go
+++ b/backend-go/internal/retirement/store.go
@@ -359,9 +359,10 @@ type PPKContributionResult struct {
 // atomically, plus any opted-in government subsidies. ErrContributionsExist
 // when a (account_id, date, employee|employer) row already exists — guarded
 // both by a pre-check and by a UniqueViolation catch. Welcome / annual
-// subsidies are independently idempotent: an existing welcome (any prior
-// government txn) skips the new one; an existing annual government txn in
-// the same year skips that one too.
+// subsidies are independently idempotent and keyed by amount (welcome and
+// annual share transaction_type='government'): a new welcome is skipped if
+// any prior welcome-amount government row exists on the account; a new
+// annual is skipped if a same-year, annual-amount government row exists.
 func (s *Store) InsertPPKContributions(ctx context.Context, c PPKContribution) (PPKContributionResult, error) {
 	var res PPKContributionResult
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})

--- a/backend-go/internal/retirement/subsidies.go
+++ b/backend-go/internal/retirement/subsidies.go
@@ -1,0 +1,33 @@
+package retirement
+
+import "github.com/shopspring/decimal"
+
+// SubsidyConfig is the PPK government subsidy amount table for one year.
+// Polish PPK pays a one-time welcome payment and an annual subsidy when the
+// participant meets contribution thresholds. The amounts are set by
+// regulation; thresholds shift with the minimum wage. Configurable per
+// year by editing this file.
+type SubsidyConfig struct {
+	WelcomeAmount decimal.Decimal
+	AnnualAmount  decimal.Decimal
+}
+
+// defaultSubsidy is the stable PPK regulation: 250 PLN welcome (one-time)
+// and 240 PLN annual subsidy. Used for any year not explicitly listed in
+// subsidiesByYear.
+var defaultSubsidy = SubsidyConfig{
+	WelcomeAmount: decimal.NewFromInt(250),
+	AnnualAmount:  decimal.NewFromInt(240),
+}
+
+// subsidiesByYear holds year-specific overrides. Add an entry when
+// regulation changes — defaultSubsidy applies for missing years.
+var subsidiesByYear = map[int]SubsidyConfig{}
+
+// SubsidyFor returns the configured subsidy amounts for a given year.
+func SubsidyFor(year int) SubsidyConfig {
+	if cfg, ok := subsidiesByYear[year]; ok {
+		return cfg
+	}
+	return defaultSubsidy
+}

--- a/backend-go/internal/retirement/subsidies_test.go
+++ b/backend-go/internal/retirement/subsidies_test.go
@@ -1,0 +1,33 @@
+package retirement
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestSubsidyForReturnsDefault(t *testing.T) {
+	cfg := SubsidyFor(2030)
+	if !cfg.WelcomeAmount.Equal(decimal.NewFromInt(250)) {
+		t.Fatalf("welcome want 250, got %s", cfg.WelcomeAmount)
+	}
+	if !cfg.AnnualAmount.Equal(decimal.NewFromInt(240)) {
+		t.Fatalf("annual want 240, got %s", cfg.AnnualAmount)
+	}
+}
+
+func TestSubsidyForRespectsYearOverride(t *testing.T) {
+	subsidiesByYear[1999] = SubsidyConfig{
+		WelcomeAmount: decimal.NewFromInt(123),
+		AnnualAmount:  decimal.NewFromInt(456),
+	}
+	t.Cleanup(func() { delete(subsidiesByYear, 1999) })
+
+	cfg := SubsidyFor(1999)
+	if !cfg.WelcomeAmount.Equal(decimal.NewFromInt(123)) {
+		t.Fatalf("override welcome got %s", cfg.WelcomeAmount)
+	}
+	if !cfg.AnnualAmount.Equal(decimal.NewFromInt(456)) {
+		t.Fatalf("override annual got %s", cfg.AnnualAmount)
+	}
+}

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -2666,10 +2666,13 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            annual_applied?: boolean;
                             /** Format: double */
                             employee_amount?: number;
                             /** Format: double */
                             employer_amount?: number;
+                            /** Format: double */
+                            government_amount?: number;
                             /** Format: double */
                             gross_salary?: number;
                             month?: number;
@@ -2677,6 +2680,7 @@ export interface paths {
                             /** Format: double */
                             total_amount?: number;
                             transactions_created?: number[];
+                            welcome_applied?: boolean;
                             year?: number;
                         };
                     };


### PR DESCRIPTION
## Motivation

PPK stats already split government contributions from employee + employer, but the PPK generator only wrote the latter two. Welcome payment (250 PLN, one-time) and annual subsidy (240 PLN, once per year) had to be tracked manually.

## Implementation information

- New \`subsidies.go\` exposes a per-year config table. Default amounts apply to every year; year-specific entries override.
- Generator request gains \`include_welcome_subsidy\` and \`include_annual_subsidy\` flags (opt-in — caller decides when eligibility holds). When set, the store inserts a third / fourth \`transaction_type='government'\` row inside the same advisory-locked transaction.
- Eligibility query distinguishes welcome from annual by \`amount\`. Required because both share \`transaction_type='government'\`: inserting welcome first would otherwise mask the annual check inside the same transaction (own-tx visibility). Welcome scope is per account, ever; annual scope is per (account, year).
- Response gains \`government_amount\`, \`welcome_applied\`, \`annual_applied\` so the UI can show what was actually applied vs skipped.
- Stats query was already government-aware — no change.

Tests (bb): welcome happy path; welcome idempotent across months; annual idempotent within year; combined welcome + annual in one call (regression for the own-tx-visibility bug). Plus a Go unit test for the subsidy config (default + year override).

Closes #405

> Changelog: fix(ppk): generate government subsidies