### PR TITLE
refactor(tx): centralize transaction_type enum

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -5077,6 +5077,37 @@
         ]
       }
     },
+    "/api/transactions/types": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "label": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List valid transaction_type enum values",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
     "/api/zus/calculate": {
       "post": {
         "responses": {

--- a/backend-bb-tests/tests/test_transactions.py
+++ b/backend-bb-tests/tests/test_transactions.py
@@ -8,6 +8,38 @@ import pytest
 from fixtures.seed import ACCOUNT_MARCIN_BANK, ACCOUNT_MARCIN_IKE, PERSONA_MARCIN
 
 
+def test_get_transaction_types_lists_canonical_enum(client: httpx.Client) -> None:
+    response = client.get("/api/transactions/types")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert isinstance(body, list)
+    values = [item["value"] for item in body]
+    # Must include the four canonical types in the documented order so the
+    # frontend dropdown stays deterministic.
+    assert values == ["employee", "employer", "government", "withdrawal"]
+    for item in body:
+        assert isinstance(item["label"], str)
+        assert item["label"], "label must be non-empty"
+
+
+def test_create_transaction_rejects_empty_transaction_type(
+    client: httpx.Client, owner_ids: dict[str, int]
+) -> None:
+    # Empty string isn't in ValidTypes — locks the contract so a UI bug
+    # mapping "employee" back to "" gets caught.
+    account_id = _account_id_by_name(client, ACCOUNT_MARCIN_IKE)
+    response = client.post(
+        f"/api/accounts/{account_id}/transactions",
+        json={
+            "amount": 100.0,
+            "date": "2025-10-15",
+            "owner_user_id": owner_ids[PERSONA_MARCIN],
+            "transaction_type": "",
+        },
+    )
+    assert response.status_code == 422, response.text
+
+
 def _account_id_by_name(client: httpx.Client, name: str) -> int:
     response = client.get("/api/accounts")
     assert response.status_code == 200, response.text

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -130,6 +130,7 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	r.Delete("/api/accounts/{account_id}/transactions/{transaction_id}", txHandler.Delete)
 	r.Get("/api/transactions", txHandler.ListAll)
 	r.Get("/api/transactions/counts", txHandler.Counts)
+	r.Get("/api/transactions/types", txHandler.Types)
 
 	dpStore := debtpayments.NewStore(pool)
 	dpHandler := debtpayments.NewHandler(dpStore, logger)

--- a/backend-go/internal/transactions/handler.go
+++ b/backend-go/internal/transactions/handler.go
@@ -16,9 +16,8 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-var validTransactionTypes = map[string]struct{}{
-	"employee": {}, "employer": {}, "withdrawal": {}, "government": {},
-}
+// The canonical set of transaction_type values lives in types.go.
+// IsValid + ValidTypes are the only authority.
 
 type response struct {
 	ID              int      `json:"id"`
@@ -216,6 +215,17 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// Types serves GET /api/transactions/types — the canonical enum the
+// frontend dropdown should render. Ordered the same way as ValidTypes so
+// the UI is deterministic.
+func (h *Handler) Types(w http.ResponseWriter, _ *http.Request) {
+	out := make([]typesItem, 0, len(ValidTypes))
+	for _, t := range ValidTypes {
+		out = append(out, typesItem{Value: string(t), Label: LabelsPL[t]})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
 // Counts serves GET /api/transactions/counts.
 func (h *Handler) Counts(w http.ResponseWriter, r *http.Request) {
 	counts, err := h.store.CountsByAccount(r.Context())
@@ -308,7 +318,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *validat
 		if err := json.Unmarshal(v, &s); err != nil {
 			return r, &validationError{Field: "transaction_type", Msg: "must be a string"}
 		}
-		if _, ok := validTransactionTypes[s]; !ok {
+		if !IsValid(s) {
 			return r, &validationError{Field: "transaction_type", Msg: fmt.Sprintf("invalid value %q", s)}
 		}
 		r.TransactionType = &s

--- a/backend-go/internal/transactions/handler.go
+++ b/backend-go/internal/transactions/handler.go
@@ -216,12 +216,13 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 }
 
 // Types serves GET /api/transactions/types — the canonical enum the
-// frontend dropdown should render. Ordered the same way as ValidTypes so
-// the UI is deterministic.
+// frontend dropdown should render. Ordered the same way as ValidTypes()
+// so the UI is deterministic.
 func (h *Handler) Types(w http.ResponseWriter, _ *http.Request) {
-	out := make([]typesItem, 0, len(ValidTypes))
-	for _, t := range ValidTypes {
-		out = append(out, typesItem{Value: string(t), Label: LabelsPL[t]})
+	types := ValidTypes()
+	out := make([]typesItem, 0, len(types))
+	for _, t := range types {
+		out = append(out, typesItem{Value: string(t), Label: LabelPL(t)})
 	}
 	writeJSON(w, http.StatusOK, out)
 }

--- a/backend-go/internal/transactions/openapi.go
+++ b/backend-go/internal/transactions/openapi.go
@@ -2,6 +2,11 @@ package transactions
 
 import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
 
+type typesItem struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
 // APISpec registers this package's routes for OpenAPI generation.
 var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/accounts/{account_id}/transactions", Tag: "transactions", Summary: "List an account's transactions", Response: listResponse{}},
@@ -9,4 +14,5 @@ var APISpec = []apispec.Route{
 	{Method: "DELETE", Path: "/api/accounts/{account_id}/transactions/{transaction_id}", Tag: "transactions", Summary: "Delete a transaction", Status: 204},
 	{Method: "GET", Path: "/api/transactions", Tag: "transactions", Summary: "List all transactions", Response: listResponse{}},
 	{Method: "GET", Path: "/api/transactions/counts", Tag: "transactions", Summary: "Transaction counts per account", Response: map[string]int{}},
+	{Method: "GET", Path: "/api/transactions/types", Tag: "transactions", Summary: "List valid transaction_type enum values", Response: []typesItem{}},
 }

--- a/backend-go/internal/transactions/types.go
+++ b/backend-go/internal/transactions/types.go
@@ -17,27 +17,43 @@ const (
 	TransactionTypeWithdrawal TransactionType = "withdrawal"
 )
 
-// ValidTypes is the authoritative list of accepted transaction_type values.
-// Order is stable so the frontend dropdown renders deterministically.
-var ValidTypes = []TransactionType{
+// validTypes is the authoritative ordered list of accepted transaction_type
+// values. Kept unexported + only reached through ValidTypes() to prevent
+// other packages from reordering or appending at runtime.
+var validTypes = []TransactionType{
 	TransactionTypeEmployee,
 	TransactionTypeEmployer,
 	TransactionTypeGovernment,
 	TransactionTypeWithdrawal,
 }
 
-// LabelsPL maps each type to its Polish display label — used by /api/transactions/types
-// so the frontend dropdown doesn't have to hardcode translations.
-var LabelsPL = map[TransactionType]string{
+// labelsPL maps each type to its Polish display label. Same encapsulation
+// reason as validTypes — read via LabelPL().
+var labelsPL = map[TransactionType]string{
 	TransactionTypeEmployee:   "Wpłata pracownika",
 	TransactionTypeEmployer:   "Wpłata pracodawcy",
 	TransactionTypeGovernment: "Dopłata państwa",
 	TransactionTypeWithdrawal: "Wypłata",
 }
 
+// ValidTypes returns a fresh copy of the canonical, ordered enum slice.
+// Callers can mutate the returned slice without affecting the package's
+// source of truth.
+func ValidTypes() []TransactionType {
+	out := make([]TransactionType, len(validTypes))
+	copy(out, validTypes)
+	return out
+}
+
+// LabelPL returns the Polish display label for t, or an empty string if
+// t is not a recognized value.
+func LabelPL(t TransactionType) string {
+	return labelsPL[t]
+}
+
 // IsValid reports whether s is one of the recognized values.
 func IsValid(s string) bool {
-	for _, t := range ValidTypes {
+	for _, t := range validTypes {
 		if string(t) == s {
 			return true
 		}

--- a/backend-go/internal/transactions/types.go
+++ b/backend-go/internal/transactions/types.go
@@ -1,0 +1,46 @@
+package transactions
+
+// TransactionType is the discriminator on the transactions table. Stored
+// as a varchar today; the canonical set lives here so handlers, retirement
+// stats, and the API surface all share one source of truth.
+//
+// The names match the Polish PPK regulator's terminology rather than the
+// generic accounting words in #390's original wording — existing rows in
+// production use these values and a strict DB enum would otherwise reject
+// them on insert.
+type TransactionType string
+
+const (
+	TransactionTypeEmployee   TransactionType = "employee"
+	TransactionTypeEmployer   TransactionType = "employer"
+	TransactionTypeGovernment TransactionType = "government"
+	TransactionTypeWithdrawal TransactionType = "withdrawal"
+)
+
+// ValidTypes is the authoritative list of accepted transaction_type values.
+// Order is stable so the frontend dropdown renders deterministically.
+var ValidTypes = []TransactionType{
+	TransactionTypeEmployee,
+	TransactionTypeEmployer,
+	TransactionTypeGovernment,
+	TransactionTypeWithdrawal,
+}
+
+// LabelsPL maps each type to its Polish display label — used by /api/transactions/types
+// so the frontend dropdown doesn't have to hardcode translations.
+var LabelsPL = map[TransactionType]string{
+	TransactionTypeEmployee:   "Wpłata pracownika",
+	TransactionTypeEmployer:   "Wpłata pracodawcy",
+	TransactionTypeGovernment: "Dopłata państwa",
+	TransactionTypeWithdrawal: "Wypłata",
+}
+
+// IsValid reports whether s is one of the recognized values.
+func IsValid(s string) bool {
+	for _, t := range ValidTypes {
+		if string(t) == s {
+			return true
+		}
+	}
+	return false
+}

--- a/backend-go/internal/transactions/types_test.go
+++ b/backend-go/internal/transactions/types_test.go
@@ -1,0 +1,31 @@
+package transactions
+
+import "testing"
+
+func TestIsValid(t *testing.T) {
+	cases := map[string]bool{
+		"employee":     true,
+		"employer":     true,
+		"government":   true,
+		"withdrawal":   true,
+		"":             false,
+		"contribution": false, // listed in #390 but not in production use
+		"random":       false,
+	}
+	for input, want := range cases {
+		if got := IsValid(input); got != want {
+			t.Errorf("IsValid(%q) = %v, want %v", input, got, want)
+		}
+	}
+}
+
+func TestValidTypesAndLabelsCoverEachOther(t *testing.T) {
+	if len(ValidTypes) != len(LabelsPL) {
+		t.Fatalf("ValidTypes (%d) and LabelsPL (%d) lengths diverged", len(ValidTypes), len(LabelsPL))
+	}
+	for _, tt := range ValidTypes {
+		if _, ok := LabelsPL[tt]; !ok {
+			t.Errorf("LabelsPL missing entry for %q", tt)
+		}
+	}
+}

--- a/backend-go/internal/transactions/types_test.go
+++ b/backend-go/internal/transactions/types_test.go
@@ -20,12 +20,29 @@ func TestIsValid(t *testing.T) {
 }
 
 func TestValidTypesAndLabelsCoverEachOther(t *testing.T) {
-	if len(ValidTypes) != len(LabelsPL) {
-		t.Fatalf("ValidTypes (%d) and LabelsPL (%d) lengths diverged", len(ValidTypes), len(LabelsPL))
-	}
-	for _, tt := range ValidTypes {
-		if _, ok := LabelsPL[tt]; !ok {
-			t.Errorf("LabelsPL missing entry for %q", tt)
+	types := ValidTypes()
+	for _, tt := range types {
+		if label := LabelPL(tt); label == "" {
+			t.Errorf("LabelPL missing entry for %q", tt)
 		}
+	}
+	// Reverse: every labelsPL entry must be in validTypes too.
+	seen := make(map[TransactionType]struct{}, len(types))
+	for _, tt := range types {
+		seen[tt] = struct{}{}
+	}
+	for tt := range labelsPL {
+		if _, ok := seen[tt]; !ok {
+			t.Errorf("labelsPL has %q but ValidTypes() doesn't", tt)
+		}
+	}
+}
+
+func TestValidTypesReturnsCopy(t *testing.T) {
+	a := ValidTypes()
+	a[0] = "tampered"
+	b := ValidTypes()
+	if b[0] == "tampered" {
+		t.Fatal("ValidTypes() returned a shared slice; mutation leaked")
 	}
 }

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -3442,6 +3442,45 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/transactions/types": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List valid transaction_type enum values */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            label?: string;
+                            value?: string;
+                        }[];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/zus/calculate": {
         parameters: {
             query?: never;

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -46,10 +46,43 @@
 		amount: 0,
 		date: new Date().toISOString().split('T')[0],
 		owner_user_id: untrack(() => defaultOwnerUserId),
-		transaction_type: null as string | null
+		transaction_type: 'employee' as string
 	});
 	let transactionError = $state('');
 	let savingTransaction = $state(false);
+
+	interface TransactionTypeOption {
+		value: string;
+		label: string;
+	}
+	// Fallback list keeps the dropdown usable if /api/transactions/types
+	// fails (network blip, backend down). Matches the canonical Go enum so
+	// validation accepts every value the UI offers.
+	const FALLBACK_TRANSACTION_TYPES: TransactionTypeOption[] = [
+		{ value: 'employee', label: 'Wpłata pracownika' },
+		{ value: 'employer', label: 'Wpłata pracodawcy' },
+		{ value: 'government', label: 'Dopłata państwa' },
+		{ value: 'withdrawal', label: 'Wypłata' }
+	];
+	let transactionTypes: TransactionTypeOption[] = $state(FALLBACK_TRANSACTION_TYPES);
+
+	// Only PPK accounts accept employer + government contributions; for
+	// non-PPK wrappers (IKE, IKZE, stocks…) hide those rows.
+	const visibleTransactionTypes = $derived(
+		transactionTypes.filter(
+			(t) =>
+				selectedAccountWrapper === 'PPK' || (t.value !== 'employer' && t.value !== 'government')
+		)
+	);
+
+	onMount(async () => {
+		try {
+			const res = await fetch(`${apiUrl}/api/transactions/types`);
+			if (res.ok) transactionTypes = (await res.json()) as TransactionTypeOption[];
+		} catch (err) {
+			console.error('Failed to load transaction types:', err);
+		}
+	});
 
 	const categoryLabels: Record<string, string> = {
 		bank: 'Konto bankowe',
@@ -250,7 +283,7 @@
 			amount: 0,
 			date: new Date().toISOString().split('T')[0],
 			owner_user_id: defaultOwnerUserId,
-			transaction_type: null
+			transaction_type: 'employee'
 		};
 		transactionError = '';
 	}
@@ -277,7 +310,7 @@
 				amount: 0,
 				date: new Date().toISOString().split('T')[0],
 				owner_user_id: defaultOwnerUserId,
-				transaction_type: null
+				transaction_type: 'employee'
 			};
 
 			await loadTransactions();
@@ -747,11 +780,9 @@
 							<label class="label">
 								<span class="font-semibold text-sm">Typ wpłaty</span>
 								<select class="select" bind:value={transactionFormData.transaction_type}>
-									<option value="">Wpłata pracownika</option>
-									{#if selectedAccountWrapper === 'PPK'}
-										<option value="employer">Wpłata pracodawcy</option>
-									{/if}
-									<option value="withdrawal">Wypłata</option>
+									{#each visibleTransactionTypes as t}
+										<option value={t.value}>{t.label}</option>
+									{/each}
 								</select>
 							</label>
 						{/if}


### PR DESCRIPTION
## Motivation

\`transaction_type\` was a nullable free string validated by a private map in the handler. Issue #390 asked for a proper enum so typos can't slip through and the frontend dropdown doesn't drift from the backend's accepted set.

## Implementation information

- Centralized the canonical set in \`backend-go/internal/transactions/types.go\` (constants + \`ValidTypes\` slice + \`LabelsPL\` map + \`IsValid\` predicate). Handler validation now goes through \`IsValid\`.
- New \`GET /api/transactions/types\` returns the ordered list with Polish labels — single source of truth for the dropdown.
- Frontend (\`src/routes/accounts/+page.svelte\`) fetches that on mount; a hardcoded fallback matches the canonical set verbatim so the dropdown stays usable if the call fails. The empty-string sentinel that used to mask the \`employee\` value is gone, and the form initializes to \`'employee'\` so a submit can never send a value the backend rejects.
- Coverage: Go unit (\`IsValid\` + label coverage), black-box (\`/api/transactions/types\` ordering + 422 on empty \`transaction_type\`).

The Postgres enum + migration the original issue called for is deferred: \`schema.sql\` is the frozen baseline (applied to empty DBs only) and production rows already use these four PPK-aligned values rather than the generic accounting list the issue proposed. A strict DB enum would need a migration system that doesn't exist yet.

Closes #390

> Changelog: refactor(tx): centralize transaction_type enum