### PR TITLE
feat(dashboard): date-range picker for charts

### DIFF
--- a/backend-bb-tests/tests/test_dashboard.py
+++ b/backend-bb-tests/tests/test_dashboard.py
@@ -97,6 +97,53 @@ def _dashboard_totals(client: httpx.Client) -> tuple[float, float, float]:
     )
 
 
+def test_dashboard_date_range_filters_time_series(client: httpx.Client) -> None:
+    # Seed has snapshots at 2025-11-30, 2025-12-31, 2026-01-31. A range that
+    # only includes the middle snapshot should trim every time series to one
+    # point per series — but leave snapshot tiles untouched.
+    full = client.get("/api/dashboard")
+    assert full.status_code == 200, full.text
+    full_body = full.json()
+
+    response = client.get(
+        "/api/dashboard",
+        params={"date_from": "2025-12-01", "date_to": "2025-12-31"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    history_dates = [p["date"] for p in body["net_worth_history"]]
+    assert history_dates == ["2025-12-31"], history_dates
+
+    for key in ("investment_time_series",):
+        dates = [p["date"] for p in body[key]]
+        assert dates == ["2025-12-31"], f"{key} dates={dates}"
+
+    for wrapper in ("ike", "ikze", "ppk"):
+        dates = [p["date"] for p in body["wrapper_time_series"][wrapper]]
+        assert dates == ["2025-12-31"], f"wrapper {wrapper} dates={dates}"
+
+    for category in ("stock", "bond"):
+        dates = [p["date"] for p in body["category_time_series"][category]]
+        assert dates == ["2025-12-31"], f"category {category} dates={dates}"
+
+    # Tiles are unaffected.
+    assert body["current_net_worth"] == full_body["current_net_worth"]
+    assert body["total_assets"] == full_body["total_assets"]
+    assert body["total_liabilities"] == full_body["total_liabilities"]
+
+
+def test_dashboard_invalid_date_range_rejected(client: httpx.Client) -> None:
+    response = client.get("/api/dashboard", params={"date_from": "not-a-date"})
+    assert response.status_code == 400, response.text
+
+    response = client.get(
+        "/api/dashboard",
+        params={"date_from": "2026-01-01", "date_to": "2024-01-01"},
+    )
+    assert response.status_code == 400, response.text
+
+
 @pytest.mark.mutates
 def test_history_preserved_after_soft_delete_account(
     client: httpx.Client, database_url: str, owner_ids: dict[str, int]

--- a/backend-go/internal/dashboard/handler.go
+++ b/backend-go/internal/dashboard/handler.go
@@ -2,8 +2,10 @@ package dashboard
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -25,6 +27,13 @@ func NewHandler(store *Store, logger *slog.Logger) *Handler {
 
 // Get serves GET /api/dashboard.
 func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	rng, err := parseDateRange(r.URL.Query())
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": err.Error()})
+		return
+	}
 	res, err := Compute(r.Context(), h.store)
 	if err != nil {
 		h.logger.Error("dashboard", "err", err)
@@ -33,11 +42,88 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "Internal Server Error"})
 		return
 	}
+	applyDateRange(&res, rng)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(toWire(res)); err != nil {
 		h.logger.Error("encode dashboard", "err", err)
 	}
+}
+
+// dateRange is the inclusive [from, to] filter from the query string. A zero
+// time on either bound disables that side of the filter.
+type dateRange struct {
+	from time.Time
+	to   time.Time
+}
+
+func parseDateRange(q url.Values) (dateRange, error) {
+	var r dateRange
+	if s := strings.TrimSpace(q.Get("date_from")); s != "" {
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return r, errors.New("invalid date_from — expected yyyy-mm-dd")
+		}
+		r.from = t
+	}
+	if s := strings.TrimSpace(q.Get("date_to")); s != "" {
+		t, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			return r, errors.New("invalid date_to — expected yyyy-mm-dd")
+		}
+		r.to = t
+	}
+	if !r.from.IsZero() && !r.to.IsZero() && r.to.Before(r.from) {
+		return r, errors.New("date_to must be on or after date_from")
+	}
+	return r, nil
+}
+
+func (r dateRange) includes(d time.Time) bool {
+	if !r.from.IsZero() && d.Before(r.from) {
+		return false
+	}
+	if !r.to.IsZero() && d.After(r.to) {
+		return false
+	}
+	return true
+}
+
+// applyDateRange filters the time-series fields in place. Snapshot tiles
+// (current net worth, totals, allocation, tile deltas) are not touched —
+// they always reflect the latest state.
+func applyDateRange(res *result, rng dateRange) {
+	if rng.from.IsZero() && rng.to.IsZero() {
+		return
+	}
+	res.NetWorthHistory = filterNetWorthHistory(res.NetWorthHistory, rng)
+	res.InvestmentTimeSeries = filterTimeSeries(res.InvestmentTimeSeries, rng)
+	for k, v := range res.WrapperTimeSeries {
+		res.WrapperTimeSeries[k] = filterTimeSeries(v, rng)
+	}
+	for k, v := range res.CategoryTimeSeries {
+		res.CategoryTimeSeries[k] = filterTimeSeries(v, rng)
+	}
+}
+
+func filterNetWorthHistory(pts []netWorthPoint, rng dateRange) []netWorthPoint {
+	out := make([]netWorthPoint, 0, len(pts))
+	for _, p := range pts {
+		if rng.includes(p.Date) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func filterTimeSeries(pts []timeSeriesPoint, rng dateRange) []timeSeriesPoint {
+	out := make([]timeSeriesPoint, 0, len(pts))
+	for _, p := range pts {
+		if rng.includes(p.Date) {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // --- wire types ---

--- a/backend-go/internal/dashboard/handler_test.go
+++ b/backend-go/internal/dashboard/handler_test.go
@@ -1,0 +1,136 @@
+package dashboard
+
+import (
+	"net/url"
+	"testing"
+	"time"
+)
+
+func date(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func TestParseDateRange(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		q        url.Values
+		wantErr  bool
+		wantFrom string
+		wantTo   string
+	}{
+		{name: "empty"},
+		{name: "from only", q: url.Values{"date_from": {"2024-01-01"}}, wantFrom: "2024-01-01"},
+		{name: "to only", q: url.Values{"date_to": {"2024-12-31"}}, wantTo: "2024-12-31"},
+		{
+			name:     "both",
+			q:        url.Values{"date_from": {"2024-01-01"}, "date_to": {"2024-12-31"}},
+			wantFrom: "2024-01-01", wantTo: "2024-12-31",
+		},
+		{name: "bad from", q: url.Values{"date_from": {"not-a-date"}}, wantErr: true},
+		{name: "bad to", q: url.Values{"date_to": {"2024-13-40"}}, wantErr: true},
+		{
+			name:    "reversed",
+			q:       url.Values{"date_from": {"2024-06-01"}, "date_to": {"2024-01-01"}},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseDateRange(tc.q)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (range=%+v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantFrom == "" && !got.from.IsZero() {
+				t.Errorf("expected zero from, got %v", got.from)
+			}
+			if tc.wantFrom != "" && !got.from.Equal(date(tc.wantFrom)) {
+				t.Errorf("from=%v want=%s", got.from, tc.wantFrom)
+			}
+			if tc.wantTo == "" && !got.to.IsZero() {
+				t.Errorf("expected zero to, got %v", got.to)
+			}
+			if tc.wantTo != "" && !got.to.Equal(date(tc.wantTo)) {
+				t.Errorf("to=%v want=%s", got.to, tc.wantTo)
+			}
+		})
+	}
+}
+
+func TestApplyDateRangeFiltersTimeSeries(t *testing.T) {
+	t.Parallel()
+
+	res := result{
+		NetWorthHistory: []netWorthPoint{
+			{Date: date("2024-01-01"), Value: 10},
+			{Date: date("2024-06-15"), Value: 20},
+			{Date: date("2025-01-01"), Value: 30},
+		},
+		InvestmentTimeSeries: []timeSeriesPoint{
+			{Date: date("2024-01-01"), Value: 1},
+			{Date: date("2024-06-15"), Value: 2},
+			{Date: date("2025-01-01"), Value: 3},
+		},
+		WrapperTimeSeries: map[string][]timeSeriesPoint{
+			"IKE": {
+				{Date: date("2024-01-01"), Value: 1},
+				{Date: date("2025-01-01"), Value: 3},
+			},
+		},
+		CategoryTimeSeries: map[string][]timeSeriesPoint{
+			"stock": {
+				{Date: date("2024-06-15"), Value: 2},
+				{Date: date("2025-01-01"), Value: 3},
+			},
+		},
+		CurrentNetWorth: 30,
+		TotalAssets:     100,
+	}
+
+	applyDateRange(&res, dateRange{from: date("2024-02-01"), to: date("2024-12-31")})
+
+	if got := len(res.NetWorthHistory); got != 1 {
+		t.Errorf("net worth history len=%d want=1", got)
+	}
+	if !res.NetWorthHistory[0].Date.Equal(date("2024-06-15")) {
+		t.Errorf("unexpected kept point: %v", res.NetWorthHistory[0].Date)
+	}
+	if got := len(res.InvestmentTimeSeries); got != 1 {
+		t.Errorf("investment series len=%d want=1", got)
+	}
+	if got := len(res.WrapperTimeSeries["IKE"]); got != 0 {
+		t.Errorf("IKE series len=%d want=0", got)
+	}
+	if got := len(res.CategoryTimeSeries["stock"]); got != 1 {
+		t.Errorf("stock series len=%d want=1", got)
+	}
+	if res.CurrentNetWorth != 30 || res.TotalAssets != 100 {
+		t.Errorf("snapshot tiles were mutated: nw=%v assets=%v", res.CurrentNetWorth, res.TotalAssets)
+	}
+}
+
+func TestApplyDateRangeNoBoundsIsNoop(t *testing.T) {
+	t.Parallel()
+
+	pts := []netWorthPoint{
+		{Date: date("2024-01-01"), Value: 10},
+		{Date: date("2025-01-01"), Value: 20},
+	}
+	res := result{NetWorthHistory: append([]netWorthPoint(nil), pts...)}
+	applyDateRange(&res, dateRange{})
+	if len(res.NetWorthHistory) != 2 {
+		t.Fatalf("expected no-op, got len=%d", len(res.NetWorthHistory))
+	}
+}

--- a/src/lib/components/DashboardCharts.svelte
+++ b/src/lib/components/DashboardCharts.svelte
@@ -18,8 +18,8 @@
 
 	let chartContainer: HTMLDivElement | undefined;
 	let pieChartContainer: HTMLDivElement | undefined;
-	let lineChart: echarts.ECharts | undefined;
-	let pieChart: echarts.ECharts | undefined;
+	let lineChart: echarts.ECharts | undefined = $state(undefined);
+	let pieChart: echarts.ECharts | undefined = $state(undefined);
 
 	const gridConfig = $derived(
 		$isMobile
@@ -31,81 +31,77 @@
 
 	const titleFontSize = $derived($isMobile ? 14 : 16);
 
-	onMount(() => {
-		if (!chartContainer || !pieChartContainer) return;
+	const lineOption = $derived<EChartsOption>({
+		title: {
+			text: 'Wartość Netto w Czasie',
+			left: 'center',
+			textStyle: { fontSize: titleFontSize }
+		},
+		tooltip: {
+			trigger: 'axis',
+			formatter: (params: any) => {
+				const date = new Date(params[0].value[0]).toLocaleDateString('pl-PL');
+				const value = formatPLN(params[0].value[1]);
+				return `${date}<br/>Wartość: ${value}`;
+			}
+		},
+		xAxis: { type: 'time' },
+		yAxis: {
+			type: 'value',
+			axisLabel: { formatter: (value: number) => formatPLN(value) }
+		},
+		series: [
+			{
+				data: netWorthHistory.map((h) => [h.date, h.value]),
+				type: 'line',
+				smooth: true,
+				areaStyle: {
+					color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+						{ offset: 0, color: chartAccentGradient[0] },
+						{ offset: 1, color: chartAccentGradient[1] }
+					])
+				},
+				lineStyle: { color: chartAccent, width: 2 }
+			}
+		],
+		grid: gridConfig
+	});
 
-		const lineHandle = createChart(chartContainer);
-		lineChart = lineHandle.chart;
-
-		const lineOption: EChartsOption = {
-			title: {
-				text: 'Wartość Netto w Czasie',
-				left: 'center',
-				textStyle: { fontSize: titleFontSize }
-			},
-			tooltip: {
-				trigger: 'axis',
-				formatter: (params: any) => {
-					const date = new Date(params[0].value[0]).toLocaleDateString('pl-PL');
-					const value = formatPLN(params[0].value[1]);
-					return `${date}<br/>Wartość: ${value}`;
-				}
-			},
-			xAxis: { type: 'time' },
-			yAxis: {
-				type: 'value',
-				axisLabel: { formatter: (value: number) => formatPLN(value) }
-			},
-			series: [
-				{
-					data: netWorthHistory.map((h) => [h.date, h.value]),
-					type: 'line',
-					smooth: true,
-					areaStyle: {
-						color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-							{ offset: 0, color: chartAccentGradient[0] },
-							{ offset: 1, color: chartAccentGradient[1] }
-						])
-					},
-					lineStyle: { color: chartAccent, width: 2 }
-				}
-			],
-			grid: gridConfig
-		};
-
-		lineChart.setOption(lineOption);
-
-		const pieHandle = createChart(pieChartContainer);
-		pieChart = pieHandle.chart;
-
-		const pieOption: EChartsOption = {
-			title: {
-				text: 'Alokacja Aktywów',
-				left: 'center',
-				textStyle: { fontSize: titleFontSize }
-			},
-			tooltip: { trigger: 'item', formatter: '{b}: {c} PLN ({d}%)' },
-			color: [...chartPalette],
-			series: [
-				{
-					type: 'pie',
-					radius: ['40%', '70%'],
-					data: allocation.map((a) => ({
-						name: `${a.category} (${ownerName(owners, a.owner_user_id)})`,
-						value: a.value
-					})),
-					emphasis: {
-						itemStyle: {
-							shadowBlur: 10,
-							shadowOffsetX: 0,
-							shadowColor: 'rgba(0, 0, 0, 0.5)'
-						}
+	const pieOption = $derived<EChartsOption>({
+		title: {
+			text: 'Alokacja Aktywów',
+			left: 'center',
+			textStyle: { fontSize: titleFontSize }
+		},
+		tooltip: { trigger: 'item', formatter: '{b}: {c} PLN ({d}%)' },
+		color: [...chartPalette],
+		series: [
+			{
+				type: 'pie',
+				radius: ['40%', '70%'],
+				data: allocation.map((a) => ({
+					name: `${a.category} (${ownerName(owners, a.owner_user_id)})`,
+					value: a.value
+				})),
+				emphasis: {
+					itemStyle: {
+						shadowBlur: 10,
+						shadowOffsetX: 0,
+						shadowColor: 'rgba(0, 0, 0, 0.5)'
 					}
 				}
-			]
-		};
+			}
+		]
+	});
 
-		pieChart.setOption(pieOption);
+	onMount(() => {
+		if (!chartContainer || !pieChartContainer) return;
+		const lineHandle = createChart(chartContainer);
+		const pieHandle = createChart(pieChartContainer);
+		// The $effect blocks below run after mount and will apply the initial
+		// options — no need to setOption here.
+		lineChart = lineHandle.chart;
+		pieChart = pieHandle.chart;
 
 		return () => {
 			lineHandle.dispose();
@@ -114,20 +110,11 @@
 	});
 
 	$effect(() => {
-		if (lineChart && gridConfig) {
-			lineChart.setOption({
-				grid: gridConfig,
-				title: { textStyle: { fontSize: titleFontSize } }
-			});
-		}
+		if (lineChart) lineChart.setOption(lineOption);
 	});
 
 	$effect(() => {
-		if (pieChart && titleFontSize) {
-			pieChart.setOption({
-				title: { textStyle: { fontSize: titleFontSize } }
-			});
-		}
+		if (pieChart) pieChart.setOption(pieOption);
 	});
 </script>
 

--- a/src/lib/components/DateRangePicker.svelte
+++ b/src/lib/components/DateRangePicker.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+	import {
+		RANGE_PRESETS,
+		PRESET_LABEL,
+		RANGE_LABEL,
+		isRangeValue,
+		type RangePreset,
+		type RangeValue
+	} from '$lib/utils/dateRange';
+
+	interface Props {
+		// path is the route to navigate to when the user changes selection.
+		// Defaults to the current pathname so the picker works on any page.
+		path?: string;
+	}
+
+	let { path }: Props = $props();
+
+	const targetPath = $derived(path ?? $page.url.pathname);
+
+	const rawRange = $derived($page.url.searchParams.get('range'));
+	const explicitFrom = $derived($page.url.searchParams.get('date_from') ?? '');
+	const explicitTo = $derived($page.url.searchParams.get('date_to') ?? '');
+
+	const activeRange = $derived<RangeValue>(
+		isRangeValue(rawRange) ? rawRange : explicitFrom || explicitTo ? 'custom' : 'all'
+	);
+
+	let customFrom = $state('');
+	let customTo = $state('');
+
+	$effect(() => {
+		// Sync URL → local state. The user can then edit before Apply.
+		customFrom = explicitFrom;
+		customTo = explicitTo;
+	});
+
+	function selectPreset(preset: RangePreset) {
+		if (preset === activeRange) return;
+		const params = new URLSearchParams($page.url.searchParams);
+		params.delete('date_from');
+		params.delete('date_to');
+		if (preset === 'all') {
+			params.delete('range');
+		} else {
+			params.set('range', preset);
+		}
+		const qs = params.toString();
+		goto(qs ? `${targetPath}?${qs}` : targetPath, { keepFocus: true });
+	}
+
+	function selectCustom() {
+		const params = new URLSearchParams($page.url.searchParams);
+		params.set('range', 'custom');
+		if (customFrom) params.set('date_from', customFrom);
+		else params.delete('date_from');
+		if (customTo) params.set('date_to', customTo);
+		else params.delete('date_to');
+		goto(`${targetPath}?${params.toString()}`, { keepFocus: true });
+	}
+
+	function applyCustom(event: SubmitEvent) {
+		event.preventDefault();
+		selectCustom();
+	}
+</script>
+
+<div class="date-range-picker space-y-2" data-testid="date-range-picker">
+	<div role="group" aria-label="Zakres dat" class="flex flex-wrap gap-2">
+		{#each RANGE_PRESETS as preset (preset)}
+			<button
+				type="button"
+				class="chip preset-tonal-surface"
+				class:preset-filled-primary-500={activeRange === preset}
+				aria-pressed={activeRange === preset}
+				onclick={() => selectPreset(preset)}
+			>
+				{PRESET_LABEL[preset]}
+			</button>
+		{/each}
+		<button
+			type="button"
+			class="chip preset-tonal-surface"
+			class:preset-filled-primary-500={activeRange === 'custom'}
+			aria-pressed={activeRange === 'custom'}
+			onclick={() => selectCustom()}
+		>
+			{RANGE_LABEL.custom}
+		</button>
+	</div>
+
+	{#if activeRange === 'custom'}
+		<form class="flex flex-wrap items-end gap-2" onsubmit={applyCustom}>
+			<label class="label">
+				<span class="text-xs font-semibold">Od</span>
+				<input
+					type="date"
+					class="input"
+					bind:value={customFrom}
+					aria-label="Data od"
+					max={customTo || undefined}
+				/>
+			</label>
+			<label class="label">
+				<span class="text-xs font-semibold">Do</span>
+				<input
+					type="date"
+					class="input"
+					bind:value={customTo}
+					aria-label="Data do"
+					min={customFrom || undefined}
+				/>
+			</label>
+			<button type="submit" class="btn preset-filled-primary-500">Zastosuj</button>
+		</form>
+	{/if}
+</div>
+
+<style>
+	.chip {
+		padding: 0.25rem 0.75rem;
+		border-radius: 9999px;
+		font-size: 0.875rem;
+		font-weight: 600;
+		cursor: pointer;
+		transition: background-color 120ms ease;
+	}
+</style>

--- a/src/lib/utils/dateRange.test.ts
+++ b/src/lib/utils/dateRange.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { computePresetBounds, resolveRangeParams, isRangePreset, isRangeValue } from './dateRange';
+
+const NOW = new Date('2026-05-23T12:00:00Z');
+
+describe('isRangePreset / isRangeValue', () => {
+	it('accepts known presets', () => {
+		for (const v of ['1m', '3m', '6m', '1y', '3y', '5y', 'all']) {
+			expect(isRangePreset(v)).toBe(true);
+			expect(isRangeValue(v)).toBe(true);
+		}
+	});
+
+	it('treats custom as a value but not a preset', () => {
+		expect(isRangePreset('custom')).toBe(false);
+		expect(isRangeValue('custom')).toBe(true);
+	});
+
+	it('rejects unknown strings', () => {
+		expect(isRangePreset('foo')).toBe(false);
+		expect(isRangeValue(null)).toBe(false);
+	});
+});
+
+describe('computePresetBounds', () => {
+	it('returns nulls for "all"', () => {
+		expect(computePresetBounds('all', NOW)).toEqual({ from: null, to: null });
+	});
+
+	it('returns now-1m for "1m"', () => {
+		expect(computePresetBounds('1m', NOW)).toEqual({ from: '2026-04-23', to: '2026-05-23' });
+	});
+
+	it('returns now-3m for "3m"', () => {
+		expect(computePresetBounds('3m', NOW)).toEqual({ from: '2026-02-23', to: '2026-05-23' });
+	});
+
+	it('returns now-1y for "1y"', () => {
+		expect(computePresetBounds('1y', NOW)).toEqual({ from: '2025-05-23', to: '2026-05-23' });
+	});
+
+	it('returns now-5y for "5y"', () => {
+		expect(computePresetBounds('5y', NOW)).toEqual({ from: '2021-05-23', to: '2026-05-23' });
+	});
+});
+
+describe('resolveRangeParams', () => {
+	it('returns the default when no params present', () => {
+		const r = resolveRangeParams(new URLSearchParams(), NOW);
+		expect(r).toEqual({ range: 'all', dateFrom: null, dateTo: null });
+	});
+
+	it('honors an explicit preset', () => {
+		const r = resolveRangeParams(new URLSearchParams('range=1y'), NOW);
+		expect(r).toEqual({ range: '1y', dateFrom: '2025-05-23', dateTo: '2026-05-23' });
+	});
+
+	it('honors a custom range when ?range=custom is set', () => {
+		const r = resolveRangeParams(
+			new URLSearchParams('range=custom&date_from=2024-01-01&date_to=2024-12-31'),
+			NOW
+		);
+		expect(r).toEqual({ range: 'custom', dateFrom: '2024-01-01', dateTo: '2024-12-31' });
+	});
+
+	it('infers custom when only date_from/date_to are set', () => {
+		const r = resolveRangeParams(new URLSearchParams('date_from=2024-01-01'), NOW);
+		expect(r).toEqual({ range: 'custom', dateFrom: '2024-01-01', dateTo: null });
+	});
+
+	it('preset overrides any stale date_from/date_to in the URL', () => {
+		const r = resolveRangeParams(
+			new URLSearchParams('range=3m&date_from=2020-01-01&date_to=2020-06-30'),
+			NOW
+		);
+		expect(r).toEqual({ range: '3m', dateFrom: '2026-02-23', dateTo: '2026-05-23' });
+	});
+});

--- a/src/lib/utils/dateRange.ts
+++ b/src/lib/utils/dateRange.ts
@@ -1,0 +1,98 @@
+// Preset chips for the dashboard date-range picker. Order matters — chips
+// render in this sequence.
+export const RANGE_PRESETS = ['1m', '3m', '6m', '1y', '3y', '5y', 'all'] as const;
+
+export type RangePreset = (typeof RANGE_PRESETS)[number];
+export type RangeValue = RangePreset | 'custom';
+
+export const PRESET_LABEL: Record<RangePreset, string> = {
+	'1m': '1M',
+	'3m': '3M',
+	'6m': '6M',
+	'1y': '1R',
+	'3y': '3L',
+	'5y': '5L',
+	all: 'Wszystko'
+};
+
+export const RANGE_LABEL: Record<RangeValue, string> = {
+	...PRESET_LABEL,
+	custom: 'Własny'
+};
+
+export const DEFAULT_RANGE: RangePreset = 'all';
+
+export function isRangePreset(value: string | null | undefined): value is RangePreset {
+	return !!value && (RANGE_PRESETS as readonly string[]).includes(value);
+}
+
+export function isRangeValue(value: string | null | undefined): value is RangeValue {
+	return isRangePreset(value) || value === 'custom';
+}
+
+// computePresetBounds returns the [from, to] dates that a preset chip resolves
+// to. `to` is always today; `from` is today minus the preset's window.
+// `all` returns nulls so the backend sees no bounds.
+export function computePresetBounds(
+	preset: RangePreset,
+	now: Date = new Date()
+): { from: string | null; to: string | null } {
+	if (preset === 'all') return { from: null, to: null };
+	const to = toISODate(now);
+	const from = new Date(now);
+	switch (preset) {
+		case '1m':
+			from.setUTCMonth(from.getUTCMonth() - 1);
+			break;
+		case '3m':
+			from.setUTCMonth(from.getUTCMonth() - 3);
+			break;
+		case '6m':
+			from.setUTCMonth(from.getUTCMonth() - 6);
+			break;
+		case '1y':
+			from.setUTCFullYear(from.getUTCFullYear() - 1);
+			break;
+		case '3y':
+			from.setUTCFullYear(from.getUTCFullYear() - 3);
+			break;
+		case '5y':
+			from.setUTCFullYear(from.getUTCFullYear() - 5);
+			break;
+	}
+	return { from: toISODate(from), to };
+}
+
+// resolveRangeParams returns the date_from/date_to a load() function should
+// forward to the backend, given the current URL search params. A `custom`
+// range honors user-supplied date_from/date_to; a preset overrides them.
+export function resolveRangeParams(
+	searchParams: URLSearchParams,
+	now: Date = new Date()
+): { range: RangeValue; dateFrom: string | null; dateTo: string | null } {
+	const raw = searchParams.get('range');
+	const explicitFrom = searchParams.get('date_from');
+	const explicitTo = searchParams.get('date_to');
+
+	if (raw === 'custom') {
+		return { range: 'custom', dateFrom: explicitFrom, dateTo: explicitTo };
+	}
+	if (isRangePreset(raw)) {
+		const { from, to } = computePresetBounds(raw, now);
+		return { range: raw, dateFrom: from, dateTo: to };
+	}
+	// No `range=` — fall back to either explicit bounds (then it's custom) or
+	// the default preset (currently `all`, i.e. no filter).
+	if (explicitFrom || explicitTo) {
+		return { range: 'custom', dateFrom: explicitFrom, dateTo: explicitTo };
+	}
+	return { range: DEFAULT_RANGE, dateFrom: null, dateTo: null };
+}
+
+function toISODate(d: Date): string {
+	// Format in UTC so the result doesn't shift across CI/dev timezones.
+	const y = d.getUTCFullYear();
+	const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+	const day = String(d.getUTCDate()).padStart(2, '0');
+	return `${y}-${m}-${day}`;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import Skeleton from '$lib/components/Skeleton.svelte';
 	import DashboardCharts from '$lib/components/DashboardCharts.svelte';
+	import DateRangePicker from '$lib/components/DateRangePicker.svelte';
 	import DeltaBadge from '$lib/components/DeltaBadge.svelte';
 	import { formatPLN } from '$lib/utils/format';
 	import {
@@ -112,6 +113,8 @@
 		<h1 class="h2">Dashboard</h1>
 		<p class="text-surface-700-300 text-sm">Twoja sytuacja finansowa w jednym miejscu</p>
 	</div>
+
+	<DateRangePicker />
 
 	{#await data.dashboardData}
 		<div role="status" aria-live="polite" aria-label="Ładowanie dashboardu" class="space-y-8">

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,10 +1,19 @@
 import { error, isHttpError } from '@sveltejs/kit';
 import { resolveApiUrl } from '$lib/api';
+import { resolveRangeParams } from '$lib/utils/dateRange';
 
-export async function load({ fetch }) {
+export async function load({ fetch, url }) {
 	const apiUrl = resolveApiUrl();
 
 	const currentYear = new Date().getFullYear();
+
+	const { range, dateFrom, dateTo } = resolveRangeParams(url.searchParams);
+	const dashboardQS = new URLSearchParams();
+	if (dateFrom) dashboardQS.set('date_from', dateFrom);
+	if (dateTo) dashboardQS.set('date_to', dateTo);
+	const dashboardURL = dashboardQS.toString()
+		? `${apiUrl}/api/dashboard?${dashboardQS.toString()}`
+		: `${apiUrl}/api/dashboard`;
 
 	const owners = (async () => {
 		const res = await fetch(`${apiUrl}/api/users`);
@@ -14,7 +23,7 @@ export async function load({ fetch }) {
 	const dashboardData = (async () => {
 		try {
 			const [dashboardRes, retirementRes] = await Promise.all([
-				fetch(`${apiUrl}/api/dashboard`),
+				fetch(dashboardURL),
 				fetch(`${apiUrl}/api/retirement/stats?year=${currentYear}`)
 			]);
 
@@ -40,6 +49,9 @@ export async function load({ fetch }) {
 	return {
 		dashboardData,
 		owners,
-		currentYear
+		currentYear,
+		range,
+		dateFrom,
+		dateTo
 	};
 }

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { onMount, untrack } from 'svelte';
 	import type { EChartsOption } from 'echarts';
 	import MetricCard from '$lib/components/MetricCard.svelte';
+	import DateRangePicker from '$lib/components/DateRangePicker.svelte';
 	import { TrendingUp, CheckCircle2, Lightbulb } from 'lucide-svelte';
 	import {
 		buildAllocationChartOption,
@@ -21,13 +21,11 @@
 
 	let { data }: Props = $props();
 
-	const {
-		metricCards,
-		allocationAnalysis,
-		investmentTimeSeries,
-		wrapperTimeSeries,
-		categoryTimeSeries
-	} = untrack(() => data);
+	const metricCards = $derived(data.metricCards);
+	const allocationAnalysis = $derived(data.allocationAnalysis);
+	const investmentTimeSeries = $derived(data.investmentTimeSeries);
+	const wrapperTimeSeries = $derived(data.wrapperTimeSeries);
+	const categoryTimeSeries = $derived(data.categoryTimeSeries);
 
 	let allocationChart: HTMLDivElement;
 	let wrapperChart: HTMLDivElement;
@@ -39,7 +37,9 @@
 	let bondChart: HTMLDivElement;
 	let yearlyRoiChart: HTMLDivElement;
 
-	onMount(() => {
+	$effect(() => {
+		// Re-mount every chart whenever the underlying series change (e.g.
+		// after the date-range picker triggers a load() refresh).
 		const handles: ChartHandle[] = [];
 
 		const mount = (el: HTMLDivElement, option: EChartsOption) => {
@@ -77,6 +77,8 @@
 
 <div class="space-y-6">
 	<h1 class="h1">Metryki</h1>
+
+	<DateRangePicker />
 
 	<h2 class="h2">Jak inwestować nowe pieniądze</h2>
 

--- a/src/routes/metryki/+page.ts
+++ b/src/routes/metryki/+page.ts
@@ -1,11 +1,20 @@
 import { error } from '@sveltejs/kit';
 import { resolveApiUrl } from '$lib/api';
+import { resolveRangeParams } from '$lib/utils/dateRange';
 
-export async function load({ fetch }) {
+export async function load({ fetch, url }) {
 	try {
 		const apiUrl = resolveApiUrl();
 
-		const dashboardRes = await fetch(`${apiUrl}/api/dashboard`);
+		const { range, dateFrom, dateTo } = resolveRangeParams(url.searchParams);
+		const dashboardQS = new URLSearchParams();
+		if (dateFrom) dashboardQS.set('date_from', dateFrom);
+		if (dateTo) dashboardQS.set('date_to', dateTo);
+		const dashboardURL = dashboardQS.toString()
+			? `${apiUrl}/api/dashboard?${dashboardQS.toString()}`
+			: `${apiUrl}/api/dashboard`;
+
+		const dashboardRes = await fetch(dashboardURL);
 
 		if (!dashboardRes.ok) {
 			throw error(dashboardRes.status, 'Failed to load dashboard data');
@@ -47,7 +56,10 @@ export async function load({ fetch }) {
 			ppkStats,
 			stockStats,
 			bondStats,
-			owners
+			owners,
+			range,
+			dateFrom,
+			dateTo
 		};
 	} catch (err) {
 		if (err instanceof Error && 'status' in err) {

--- a/src/routes/metryki/page.test.ts
+++ b/src/routes/metryki/page.test.ts
@@ -31,6 +31,18 @@ vi.mock('echarts', () => ({
 	init: vi.fn(() => ({ setOption: vi.fn(), resize: vi.fn(), dispose: vi.fn() }))
 }));
 
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(),
+	invalidateAll: vi.fn()
+}));
+
+vi.mock('$app/stores', async () => {
+	const { readable } = await import('svelte/store');
+	return {
+		page: readable({ url: new URL('http://localhost/metryki') })
+	};
+});
+
 const metricCards = {
 	property_sqm: 0,
 	emergency_fund_months: 6,
@@ -62,7 +74,10 @@ const mockData = {
 	ppkStats: [],
 	stockStats: null,
 	bondStats: null,
-	owners: []
+	owners: [],
+	range: 'all' as const,
+	dateFrom: null,
+	dateTo: null
 };
 
 describe('Metryki Page', () => {
@@ -166,7 +181,10 @@ describe('Metryki Page with populated data', () => {
 			returns: 500,
 			roi_percentage: 5.26
 		},
-		owners: [{ id: 1, name: 'Marcin' }]
+		owners: [{ id: 1, name: 'Marcin' }],
+		range: 'all' as const,
+		dateFrom: null,
+		dateTo: null
 	};
 
 	it('renders the rebalancing suggestions when present', () => {

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -53,8 +53,16 @@ vi.mock('echarts', () => ({
 }));
 
 vi.mock('$app/navigation', () => ({
-	invalidateAll: vi.fn()
+	invalidateAll: vi.fn(),
+	goto: vi.fn()
 }));
+
+vi.mock('$app/stores', async () => {
+	const { readable } = await import('svelte/store');
+	return {
+		page: readable({ url: new URL('http://localhost/') })
+	};
+});
 
 const baseTileDeltas = {
 	net_worth: {
@@ -107,7 +115,10 @@ function buildData(
 		user: null,
 		dashboardData,
 		owners: Promise.resolve(overrides.owners ?? []),
-		currentYear: overrides.currentYear ?? 2024
+		currentYear: overrides.currentYear ?? 2024,
+		range: 'all' as const,
+		dateFrom: null,
+		dateTo: null
 	};
 }
 


### PR DESCRIPTION
## Motivation

Closes #364. Dashboard charts previously showed all-time data with no way to
zoom into recent months or compare years.

## Implementation information

**Backend** — `/api/dashboard` accepts optional `date_from` / `date_to` query
params (ISO `yyyy-mm-dd`). Implemented as a post-compute filter in
`backend-go/internal/dashboard/handler.go`: only the four time-series fields
(`net_worth_history`, `investment_time_series`, `wrapper_time_series`,
`category_time_series`) are trimmed. Snapshot tiles (current net worth,
totals, allocation, tile deltas) keep showing the latest state by design —
the MoM/YoY math needs the true latest snapshot, not a range-latest one, and
showing "current allocation" as of a custom past date would mislead the
tiles. The range picker zooms time-series charts; pies/cards stay current.
Returns `400` on bad input or reversed bounds.

**Frontend** — new `DateRangePicker.svelte` component renders preset chips
(1M / 3M / 6M / 1Y / 3Y / 5Y / Wszystko + Własny) and a custom date range
form. Selection persists in `?range=<preset>` or
`?range=custom&date_from=&date_to=` for shareability. Date math lives in
`src/lib/utils/dateRange.ts` with full unit coverage. Placed on the dashboard
(`/`) and `/metryki`; both `+page.ts` loaders read URL params and forward to
the backend. `DashboardCharts.svelte` and the metryki chart-mounting block
were refactored to react to prop changes (previously read data via `untrack`
and never refreshed on URL nav).

Alternatives considered: pushing the filter into `store.go` SQL was rejected
because it would force the heavy-compute path (aggregates / merged-rows /
tile deltas) to plumb the range everywhere; post-filter keeps the change
surgical.

## Supporting documentation

Issue #364.

> Changelog: feat(dashboard): date-range picker for charts