### PR TITLE
feat(tables): sticky headers + column sort

### DIFF
--- a/src/lib/components/SortableTable.component.test.ts
+++ b/src/lib/components/SortableTable.component.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import SortableTable, { type SortableColumn } from './SortableTable.svelte';
+
+beforeAll(() => {
+	(globalThis as { IntersectionObserver?: unknown }).IntersectionObserver = class {
+		observe(): void {}
+		disconnect(): void {}
+		unobserve(): void {}
+		takeRecords(): unknown[] {
+			return [];
+		}
+		readonly root = null;
+		readonly rootMargin = '';
+		readonly thresholds: ReadonlyArray<number> = [];
+	};
+});
+
+interface Row {
+	id: number;
+	name: string;
+	amount: number;
+}
+
+interface PageState {
+	url: URL;
+	state: Record<string, unknown>;
+}
+
+const { pageStore, replaceStateSpy } = vi.hoisted(() => {
+	let value: PageState = { url: new URL('http://localhost/test'), state: {} };
+	const subs = new Set<(v: PageState) => void>();
+	const store = {
+		subscribe(fn: (v: PageState) => void): () => void {
+			subs.add(fn);
+			fn(value);
+			return () => subs.delete(fn);
+		},
+		set(next: PageState): void {
+			value = next;
+			subs.forEach((fn) => fn(value));
+		}
+	};
+	const spy = vi.fn();
+	return { pageStore: store, replaceStateSpy: spy };
+});
+
+vi.mock('$app/navigation', () => ({
+	replaceState: (url: URL | string, state: unknown) => {
+		const nextUrl = typeof url === 'string' ? new URL(url) : url;
+		replaceStateSpy(nextUrl, state);
+		pageStore.set({ url: nextUrl, state: (state ?? {}) as Record<string, unknown> });
+	}
+}));
+
+vi.mock('$app/stores', () => ({
+	page: pageStore
+}));
+
+const columns: SortableColumn<Row>[] = [
+	{ key: 'name', label: 'Nazwa', sortable: true, accessor: (r) => r.name },
+	{ key: 'amount', label: 'Kwota', sortable: true, accessor: (r) => r.amount },
+	{ key: 'actions', label: 'Akcje', align: 'right' }
+];
+
+const items: Row[] = [
+	{ id: 1, name: 'B', amount: 20 },
+	{ id: 2, name: 'A', amount: 30 },
+	{ id: 3, name: 'C', amount: 10 }
+];
+
+const rowSnippet = createRawSnippet<[Row]>((getRow) => ({
+	render: () => {
+		const r = getRow();
+		return `<tr data-testid="row-${r.id}"><td>${r.name}</td><td>${r.amount}</td><td>x</td></tr>`;
+	}
+}));
+
+function setUrl(search: string) {
+	pageStore.set({
+		url: new URL(`http://localhost/test${search}`),
+		state: {}
+	});
+}
+
+describe('SortableTable component', () => {
+	it('renders all column headers', () => {
+		setUrl('');
+		const { getByText } = render(SortableTable<Row>, {
+			props: { columns, items, row: rowSnippet }
+		});
+		expect(getByText('Nazwa')).toBeTruthy();
+		expect(getByText('Kwota')).toBeTruthy();
+		expect(getByText('Akcje')).toBeTruthy();
+	});
+
+	it('renders sortable headers as buttons and non-sortable as plain th', () => {
+		setUrl('');
+		const { container } = render(SortableTable<Row>, {
+			props: { columns, items, row: rowSnippet }
+		});
+		const buttons = container.querySelectorAll('thead button.sort-header');
+		expect(buttons.length).toBe(2);
+		const ths = container.querySelectorAll('thead th');
+		expect(ths.length).toBe(3);
+	});
+
+	it('renders rows in original order when no sort param', () => {
+		setUrl('');
+		const { container } = render(SortableTable<Row>, {
+			props: { columns, items, row: rowSnippet }
+		});
+		const rows = container.querySelectorAll('tbody tr');
+		expect(rows[0].getAttribute('data-testid')).toBe('row-1');
+		expect(rows[1].getAttribute('data-testid')).toBe('row-2');
+		expect(rows[2].getAttribute('data-testid')).toBe('row-3');
+	});
+
+	it('applies asc sort from URL param', () => {
+		setUrl('?sort=name:asc');
+		const { container } = render(SortableTable<Row>, {
+			props: { columns, items, row: rowSnippet }
+		});
+		const rows = container.querySelectorAll('tbody tr');
+		expect(rows[0].getAttribute('data-testid')).toBe('row-2'); // A
+		expect(rows[1].getAttribute('data-testid')).toBe('row-1'); // B
+		expect(rows[2].getAttribute('data-testid')).toBe('row-3'); // C
+	});
+
+	it('applies desc sort from URL param', () => {
+		setUrl('?sort=amount:desc');
+		const { container } = render(SortableTable<Row>, {
+			props: { columns, items, row: rowSnippet }
+		});
+		const rows = container.querySelectorAll('tbody tr');
+		expect(rows[0].getAttribute('data-testid')).toBe('row-2'); // 30
+		expect(rows[1].getAttribute('data-testid')).toBe('row-1'); // 20
+		expect(rows[2].getAttribute('data-testid')).toBe('row-3'); // 10
+	});
+
+	it('respects a custom paramName', () => {
+		setUrl('?sortA=name:asc&sort=amount:desc');
+		const { container } = render(SortableTable<Row>, {
+			props: { columns, items, row: rowSnippet, paramName: 'sortA' }
+		});
+		const rows = container.querySelectorAll('tbody tr');
+		expect(rows[0].getAttribute('data-testid')).toBe('row-2'); // A
+	});
+
+	it('cycles sort state via replaceState on header click', async () => {
+		setUrl('');
+		replaceStateSpy.mockClear();
+		const { container } = render(SortableTable<Row>, {
+			props: { columns, items, row: rowSnippet }
+		});
+		const nameButton = container.querySelector('thead button.sort-header') as HTMLButtonElement;
+		expect(nameButton).toBeTruthy();
+
+		await fireEvent.click(nameButton);
+		expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+		expect((replaceStateSpy.mock.calls[0][0] as URL).searchParams.get('sort')).toBe('name:asc');
+
+		await fireEvent.click(nameButton);
+		expect((replaceStateSpy.mock.calls[1][0] as URL).searchParams.get('sort')).toBe('name:desc');
+
+		await fireEvent.click(nameButton);
+		expect((replaceStateSpy.mock.calls[2][0] as URL).searchParams.get('sort')).toBeNull();
+	});
+
+	it('sets aria-sort on sorted column', () => {
+		setUrl('?sort=name:asc');
+		const { container } = render(SortableTable<Row>, {
+			props: { columns, items, row: rowSnippet }
+		});
+		const ths = container.querySelectorAll('thead th');
+		expect(ths[0].getAttribute('aria-sort')).toBe('ascending');
+		expect(ths[1].getAttribute('aria-sort')).toBe('none');
+		expect(ths[2].getAttribute('aria-sort')).toBeNull();
+	});
+
+	it('renders emptyMessage when items are empty', () => {
+		setUrl('');
+		const { getByText } = render(SortableTable<Row>, {
+			props: { columns, items: [], row: rowSnippet, emptyMessage: 'Brak danych' }
+		});
+		expect(getByText('Brak danych')).toBeTruthy();
+	});
+});

--- a/src/lib/components/SortableTable.svelte
+++ b/src/lib/components/SortableTable.svelte
@@ -1,0 +1,239 @@
+<script lang="ts" module>
+	export type SortDirection = 'asc' | 'desc';
+
+	export interface SortableColumn<T> {
+		key: string;
+		label: string;
+		sortable?: boolean;
+		accessor?: (row: T) => string | number | Date | null | undefined;
+		align?: 'left' | 'right' | 'center';
+		thClass?: string;
+	}
+
+	export interface SortState {
+		key: string;
+		direction: SortDirection;
+	}
+
+	export function parseSortParam(raw: string | null): SortState | null {
+		if (!raw) return null;
+		const [key, dir] = raw.split(':');
+		if (!key || (dir !== 'asc' && dir !== 'desc')) return null;
+		return { key, direction: dir };
+	}
+
+	export function formatSortParam(sort: SortState | null): string {
+		return sort ? `${sort.key}:${sort.direction}` : '';
+	}
+
+	export function nextSortDirection(current: SortState | null, key: string): SortState | null {
+		if (!current || current.key !== key) return { key, direction: 'asc' };
+		if (current.direction === 'asc') return { key, direction: 'desc' };
+		return null;
+	}
+
+	export function compareValues(a: unknown, b: unknown): number {
+		const aNull = a === null || a === undefined || (typeof a === 'number' && Number.isNaN(a));
+		const bNull = b === null || b === undefined || (typeof b === 'number' && Number.isNaN(b));
+		if (aNull && bNull) return 0;
+		if (aNull) return 1;
+		if (bNull) return -1;
+		if (typeof a === 'number' && typeof b === 'number') return a - b;
+		if (a instanceof Date && b instanceof Date) return a.getTime() - b.getTime();
+		return String(a).localeCompare(String(b), 'pl');
+	}
+
+	export function sortRows<T>(
+		items: T[],
+		columns: SortableColumn<T>[],
+		sort: SortState | null
+	): T[] {
+		if (!sort) return items;
+		const col = columns.find((c) => c.key === sort.key);
+		if (!col?.accessor) return items;
+		const accessor = col.accessor;
+		const factor = sort.direction === 'asc' ? 1 : -1;
+		return [...items].sort((a, b) => factor * compareValues(accessor(a), accessor(b)));
+	}
+</script>
+
+<script lang="ts" generics="T">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		columns: SortableColumn<T>[];
+		items: T[];
+		row: Snippet<[T]>;
+		paramName?: string;
+		emptyMessage?: string;
+		tableClass?: string;
+		getKey?: (item: T, index: number) => string | number;
+	}
+
+	let {
+		columns,
+		items,
+		row,
+		paramName = 'sort',
+		emptyMessage,
+		tableClass = 'table table-hover',
+		getKey
+	}: Props = $props();
+
+	const sort = $derived(parseSortParam($page.url.searchParams.get(paramName)));
+	const sortedItems = $derived(sortRows(items, columns, sort));
+
+	function cycleSort(key: string): void {
+		const params = new URLSearchParams($page.url.searchParams);
+		const next = nextSortDirection(sort, key);
+		if (next) params.set(paramName, formatSortParam(next));
+		else params.delete(paramName);
+		const qs = params.toString();
+		const path = $page.url.pathname;
+		goto(qs ? `${path}?${qs}` : path, { keepFocus: true, replaceState: true, noScroll: true });
+	}
+
+	let sentinel: HTMLDivElement;
+	let stuck = $state(false);
+
+	$effect(() => {
+		if (!sentinel) return;
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) stuck = !entry.isIntersecting;
+			},
+			{ threshold: 0 }
+		);
+		observer.observe(sentinel);
+		return () => observer.disconnect();
+	});
+</script>
+
+<div class="sortable-table">
+	<div bind:this={sentinel} class="sticky-sentinel" aria-hidden="true"></div>
+	<table class={tableClass}>
+		<thead class:is-stuck={stuck}>
+			<tr>
+				{#each columns as col (col.key)}
+					{@const isSorted = sort?.key === col.key}
+					{@const ariaSort = isSorted
+						? sort?.direction === 'asc'
+							? 'ascending'
+							: 'descending'
+						: 'none'}
+					<th
+						class={col.thClass}
+						class:text-right={col.align === 'right'}
+						class:text-center={col.align === 'center'}
+						aria-sort={col.sortable ? ariaSort : undefined}
+						scope="col"
+					>
+						{#if col.sortable}
+							<button
+								type="button"
+								class="sort-header"
+								class:is-sorted={isSorted}
+								class:align-right={col.align === 'right'}
+								class:align-center={col.align === 'center'}
+								onclick={() => cycleSort(col.key)}
+							>
+								<span>{col.label}</span>
+								<span class="sort-indicator" aria-hidden="true">
+									{#if isSorted && sort?.direction === 'asc'}
+										▲
+									{:else if isSorted && sort?.direction === 'desc'}
+										▼
+									{:else}
+										<span class="sort-placeholder">⇅</span>
+									{/if}
+								</span>
+							</button>
+						{:else}
+							{col.label}
+						{/if}
+					</th>
+				{/each}
+			</tr>
+		</thead>
+		<tbody>
+			{#if sortedItems.length === 0 && emptyMessage}
+				<tr>
+					<td colspan={columns.length} class="text-center py-8 text-surface-700-300">
+						{emptyMessage}
+					</td>
+				</tr>
+			{:else}
+				{#each sortedItems as item, i (getKey ? getKey(item, i) : i)}
+					{@render row(item)}
+				{/each}
+			{/if}
+		</tbody>
+	</table>
+</div>
+
+<style>
+	.sortable-table {
+		position: relative;
+		width: 100%;
+	}
+
+	.sticky-sentinel {
+		height: 1px;
+		width: 100%;
+	}
+
+	thead {
+		position: sticky;
+		top: 0;
+		z-index: 10;
+		background-color: var(--color-surface-100-900);
+		transition: box-shadow 150ms ease;
+	}
+
+	thead.is-stuck {
+		box-shadow: 0 2px 4px rgb(0 0 0 / 0.18);
+	}
+
+	.sort-header {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		cursor: pointer;
+		background: transparent;
+		border: 0;
+		padding: 0;
+		font: inherit;
+		color: inherit;
+		text-align: inherit;
+	}
+
+	.sort-header.align-right {
+		flex-direction: row-reverse;
+	}
+
+	.sort-header.align-center {
+		justify-content: center;
+	}
+
+	.sort-indicator {
+		display: inline-flex;
+		min-width: 0.85em;
+		justify-content: center;
+	}
+
+	.sort-placeholder {
+		opacity: 0.35;
+	}
+
+	.sort-header:hover .sort-placeholder {
+		opacity: 0.7;
+	}
+
+	.sort-header:focus-visible {
+		outline: 2px solid var(--color-primary-500);
+		outline-offset: 2px;
+		border-radius: 2px;
+	}
+</style>

--- a/src/lib/components/SortableTable.svelte
+++ b/src/lib/components/SortableTable.svelte
@@ -58,7 +58,7 @@
 </script>
 
 <script lang="ts" generics="T">
-	import { goto } from '$app/navigation';
+	import { replaceState } from '$app/navigation';
 	import { page } from '$app/stores';
 	import type { Snippet } from 'svelte';
 
@@ -86,13 +86,11 @@
 	const sortedItems = $derived(sortRows(items, columns, sort));
 
 	function cycleSort(key: string): void {
-		const params = new URLSearchParams($page.url.searchParams);
+		const url = new URL($page.url);
 		const next = nextSortDirection(sort, key);
-		if (next) params.set(paramName, formatSortParam(next));
-		else params.delete(paramName);
-		const qs = params.toString();
-		const path = $page.url.pathname;
-		goto(qs ? `${path}?${qs}` : path, { keepFocus: true, replaceState: true, noScroll: true });
+		if (next) url.searchParams.set(paramName, formatSortParam(next));
+		else url.searchParams.delete(paramName);
+		replaceState(url, $page.state);
 	}
 
 	let sentinel: HTMLDivElement;

--- a/src/lib/components/SortableTable.test.ts
+++ b/src/lib/components/SortableTable.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import {
+	parseSortParam,
+	formatSortParam,
+	nextSortDirection,
+	compareValues,
+	sortRows,
+	type SortableColumn
+} from './SortableTable.svelte';
+
+describe('parseSortParam', () => {
+	it('returns null for empty input', () => {
+		expect(parseSortParam(null)).toBeNull();
+		expect(parseSortParam('')).toBeNull();
+	});
+
+	it('parses key:asc', () => {
+		expect(parseSortParam('name:asc')).toEqual({ key: 'name', direction: 'asc' });
+	});
+
+	it('parses key:desc', () => {
+		expect(parseSortParam('value:desc')).toEqual({ key: 'value', direction: 'desc' });
+	});
+
+	it('returns null for invalid direction', () => {
+		expect(parseSortParam('name:bogus')).toBeNull();
+		expect(parseSortParam('name')).toBeNull();
+	});
+});
+
+describe('formatSortParam', () => {
+	it('returns empty string for null', () => {
+		expect(formatSortParam(null)).toBe('');
+	});
+
+	it('serializes sort state to key:direction', () => {
+		expect(formatSortParam({ key: 'amount', direction: 'desc' })).toBe('amount:desc');
+	});
+});
+
+describe('nextSortDirection', () => {
+	it('starts at asc for a new column', () => {
+		expect(nextSortDirection(null, 'name')).toEqual({ key: 'name', direction: 'asc' });
+	});
+
+	it('switches to a different column at asc', () => {
+		expect(nextSortDirection({ key: 'name', direction: 'desc' }, 'value')).toEqual({
+			key: 'value',
+			direction: 'asc'
+		});
+	});
+
+	it('cycles asc → desc on same column', () => {
+		expect(nextSortDirection({ key: 'name', direction: 'asc' }, 'name')).toEqual({
+			key: 'name',
+			direction: 'desc'
+		});
+	});
+
+	it('cycles desc → none on same column', () => {
+		expect(nextSortDirection({ key: 'name', direction: 'desc' }, 'name')).toBeNull();
+	});
+});
+
+describe('compareValues', () => {
+	it('compares numbers numerically', () => {
+		expect(compareValues(2, 10)).toBeLessThan(0);
+		expect(compareValues(10, 2)).toBeGreaterThan(0);
+	});
+
+	it('compares strings with Polish collation', () => {
+		expect(compareValues('Ąla', 'Bla')).toBeLessThan(0);
+	});
+
+	it('compares dates by timestamp', () => {
+		const a = new Date('2024-01-01');
+		const b = new Date('2024-06-01');
+		expect(compareValues(a, b)).toBeLessThan(0);
+	});
+
+	it('puts nullish values last', () => {
+		expect(compareValues(null, 1)).toBeGreaterThan(0);
+		expect(compareValues(1, null)).toBeLessThan(0);
+		expect(compareValues(null, null)).toBe(0);
+	});
+
+	it('treats NaN as nullish (sorts last)', () => {
+		expect(compareValues(NaN, 1)).toBeGreaterThan(0);
+		expect(compareValues(1, NaN)).toBeLessThan(0);
+		expect(compareValues(NaN, NaN)).toBe(0);
+	});
+});
+
+describe('sortRows', () => {
+	interface Row {
+		name: string;
+		amount: number;
+	}
+	const columns: SortableColumn<Row>[] = [
+		{ key: 'name', label: 'Nazwa', sortable: true, accessor: (r) => r.name },
+		{ key: 'amount', label: 'Kwota', sortable: true, accessor: (r) => r.amount }
+	];
+	const rows: Row[] = [
+		{ name: 'B', amount: 2 },
+		{ name: 'A', amount: 3 },
+		{ name: 'C', amount: 1 }
+	];
+
+	it('returns original order when sort is null', () => {
+		expect(sortRows(rows, columns, null)).toEqual(rows);
+	});
+
+	it('sorts ascending by accessor', () => {
+		const sorted = sortRows(rows, columns, { key: 'name', direction: 'asc' });
+		expect(sorted.map((r) => r.name)).toEqual(['A', 'B', 'C']);
+	});
+
+	it('sorts descending by accessor', () => {
+		const sorted = sortRows(rows, columns, { key: 'amount', direction: 'desc' });
+		expect(sorted.map((r) => r.amount)).toEqual([3, 2, 1]);
+	});
+
+	it('does not mutate the input array', () => {
+		const copy = [...rows];
+		sortRows(rows, columns, { key: 'name', direction: 'asc' });
+		expect(rows).toEqual(copy);
+	});
+
+	it('returns original order when column has no accessor', () => {
+		const cols: SortableColumn<Row>[] = [{ key: 'name', label: 'Nazwa', sortable: true }];
+		expect(sortRows(rows, cols, { key: 'name', direction: 'asc' })).toEqual(rows);
+	});
+
+	it('returns original order for unknown sort key', () => {
+		expect(sortRows(rows, columns, { key: 'unknown', direction: 'asc' })).toEqual(rows);
+	});
+});

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Modal from '$lib/components/Modal.svelte';
 	import Skeleton from '$lib/components/Skeleton.svelte';
+	import SortableTable, { type SortableColumn } from '$lib/components/SortableTable.svelte';
 	import { formatPLN } from '$lib/utils/format';
 	import { Wallet, TrendingDown, Pencil, Trash2, Plus, BarChart3 } from 'lucide-svelte';
 	import { resolveApiUrl } from '$lib/api';
@@ -99,6 +100,24 @@
 		installment: 'Raty',
 		other: 'Inne'
 	};
+
+	const accountColumns = $derived<SortableColumn<Account>[]>([
+		{ key: 'name', label: 'Nazwa', sortable: true, accessor: (a) => a.name },
+		{
+			key: 'category',
+			label: 'Kategoria',
+			sortable: true,
+			accessor: (a) => categoryLabels[a.category] ?? a.category
+		},
+		{
+			key: 'owner',
+			label: 'Właściciel',
+			sortable: true,
+			accessor: (a) => ownerName(owners, a.owner_user_id)
+		},
+		{ key: 'value', label: 'Wartość', sortable: true, accessor: (a) => a.current_value },
+		{ key: 'actions', label: 'Akcje', align: 'right' }
+	]);
 
 	function startCreate() {
 		editingAccount = null;
@@ -351,6 +370,71 @@
 	<title>Konta | Finansowa Forteca</title>
 </svelte:head>
 
+{#snippet assetRow(account: Account)}
+	<tr>
+		<td class="font-medium">{account.name}</td>
+		<td>{categoryLabels[account.category] || account.category}</td>
+		<td>{ownerName(owners, account.owner_user_id)}</td>
+		<td class="font-semibold text-primary-600-400">{formatPLN(account.current_value)}</td>
+		<td class="text-right whitespace-nowrap">
+			<button
+				type="button"
+				class="btn-icon btn-icon-sm"
+				aria-label="Edytuj"
+				onclick={() => startEdit(account)}
+			>
+				<Pencil size={16} />
+			</button>
+			{#if INVESTMENT_CATEGORIES.has(account.category) || account.account_wrapper}
+				<button
+					type="button"
+					class="btn preset-tonal-surface btn-sm gap-1"
+					aria-label="Transakcje"
+					onclick={() => openTransactions(account.id, account.name, account.account_wrapper)}
+				>
+					<BarChart3 size={14} />
+					<span>{transactionCounts[account.id] || 0}</span>
+				</button>
+			{/if}
+			<button
+				type="button"
+				class="btn-icon btn-icon-sm"
+				aria-label="Usuń"
+				onclick={() => handleDelete(account.id)}
+			>
+				<Trash2 size={16} />
+			</button>
+		</td>
+	</tr>
+{/snippet}
+
+{#snippet liabilityRow(account: Account)}
+	<tr>
+		<td class="font-medium">{account.name}</td>
+		<td>{categoryLabels[account.category] || account.category}</td>
+		<td>{ownerName(owners, account.owner_user_id)}</td>
+		<td class="font-semibold text-error-600-400">{formatPLN(account.current_value)}</td>
+		<td class="text-right whitespace-nowrap">
+			<button
+				type="button"
+				class="btn-icon btn-icon-sm"
+				aria-label="Edytuj"
+				onclick={() => startEdit(account)}
+			>
+				<Pencil size={16} />
+			</button>
+			<button
+				type="button"
+				class="btn-icon btn-icon-sm"
+				aria-label="Usuń"
+				onclick={() => handleDelete(account.id)}
+			>
+				<Trash2 size={16} />
+			</button>
+		</td>
+	</tr>
+{/snippet}
+
 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
 	<div class="space-y-1">
 		<h1 class="h2">Konta</h1>
@@ -417,61 +501,13 @@
 			{#if accounts.assets.length === 0}
 				<div class="text-center py-12 text-surface-700-300"><p>Brak aktywów</p></div>
 			{:else}
-				<div class="table-wrap">
-					<table class="table table-hover">
-						<thead>
-							<tr>
-								<th>Nazwa</th>
-								<th>Kategoria</th>
-								<th>Właściciel</th>
-								<th>Wartość</th>
-								<th class="text-right">Akcje</th>
-							</tr>
-						</thead>
-						<tbody>
-							{#each accounts.assets as account}
-								<tr>
-									<td class="font-medium">{account.name}</td>
-									<td>{categoryLabels[account.category] || account.category}</td>
-									<td>{ownerName(owners, account.owner_user_id)}</td>
-									<td class="font-semibold text-primary-600-400"
-										>{formatPLN(account.current_value)}</td
-									>
-									<td class="text-right whitespace-nowrap">
-										<button
-											type="button"
-											class="btn-icon btn-icon-sm"
-											aria-label="Edytuj"
-											onclick={() => startEdit(account)}
-										>
-											<Pencil size={16} />
-										</button>
-										{#if INVESTMENT_CATEGORIES.has(account.category) || account.account_wrapper}
-											<button
-												type="button"
-												class="btn preset-tonal-surface btn-sm gap-1"
-												aria-label="Transakcje"
-												onclick={() =>
-													openTransactions(account.id, account.name, account.account_wrapper)}
-											>
-												<BarChart3 size={14} />
-												<span>{transactionCounts[account.id] || 0}</span>
-											</button>
-										{/if}
-										<button
-											type="button"
-											class="btn-icon btn-icon-sm"
-											aria-label="Usuń"
-											onclick={() => handleDelete(account.id)}
-										>
-											<Trash2 size={16} />
-										</button>
-									</td>
-								</tr>
-							{/each}
-						</tbody>
-					</table>
-				</div>
+				<SortableTable
+					columns={accountColumns}
+					items={accounts.assets}
+					row={assetRow}
+					paramName="sortA"
+					getKey={(a) => a.id}
+				/>
 			{/if}
 		</div>
 
@@ -482,49 +518,13 @@
 			{#if accounts.liabilities.length === 0}
 				<div class="text-center py-12 text-surface-700-300"><p>Brak pasywów</p></div>
 			{:else}
-				<div class="table-wrap">
-					<table class="table table-hover">
-						<thead>
-							<tr>
-								<th>Nazwa</th>
-								<th>Kategoria</th>
-								<th>Właściciel</th>
-								<th>Wartość</th>
-								<th class="text-right">Akcje</th>
-							</tr>
-						</thead>
-						<tbody>
-							{#each accounts.liabilities as account}
-								<tr>
-									<td class="font-medium">{account.name}</td>
-									<td>{categoryLabels[account.category] || account.category}</td>
-									<td>{ownerName(owners, account.owner_user_id)}</td>
-									<td class="font-semibold text-error-600-400"
-										>{formatPLN(account.current_value)}</td
-									>
-									<td class="text-right whitespace-nowrap">
-										<button
-											type="button"
-											class="btn-icon btn-icon-sm"
-											aria-label="Edytuj"
-											onclick={() => startEdit(account)}
-										>
-											<Pencil size={16} />
-										</button>
-										<button
-											type="button"
-											class="btn-icon btn-icon-sm"
-											aria-label="Usuń"
-											onclick={() => handleDelete(account.id)}
-										>
-											<Trash2 size={16} />
-										</button>
-									</td>
-								</tr>
-							{/each}
-						</tbody>
-					</table>
-				</div>
+				<SortableTable
+					columns={accountColumns}
+					items={accounts.liabilities}
+					row={liabilityRow}
+					paramName="sortL"
+					getKey={(a) => a.id}
+				/>
 			{/if}
 		</div>
 	</div>

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Modal from '$lib/components/Modal.svelte';
+	import SortableTable, { type SortableColumn } from '$lib/components/SortableTable.svelte';
 	import { formatPLN } from '$lib/utils/format';
 	import { Plus, Landmark, Search, BarChart3, Trash2 } from 'lucide-svelte';
 	import { resolveApiUrl } from '$lib/api';
@@ -8,6 +9,7 @@
 	import { confirm } from '$lib/stores/confirm.svelte';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
 	import { untrack } from 'svelte';
+	import type { Transaction } from '$lib/types/transactions';
 	import type { PageData } from './$types';
 
 	interface Props {
@@ -20,6 +22,19 @@
 	const owners = $derived(data.owners as OwnerOption[]);
 	const defaultOwnerUserId = $derived(owners.length > 0 ? owners[0].id : null);
 	const defaultOwnerName = $derived(owners.length > 0 ? owners[0].name : '');
+
+	const transactionColumns = $derived<SortableColumn<Transaction>[]>([
+		{ key: 'date', label: 'Data zakupu', sortable: true, accessor: (t) => t.date },
+		{ key: 'account', label: 'Konto', sortable: true, accessor: (t) => t.account_name },
+		{
+			key: 'owner',
+			label: 'Właściciel',
+			sortable: true,
+			accessor: (t) => ownerName(owners, t.owner_user_id)
+		},
+		{ key: 'amount', label: 'Kwota', sortable: true, accessor: (t) => t.amount },
+		{ key: 'actions', label: 'Akcje', align: 'right' }
+	]);
 
 	let filterAccountId = $state(untrack(() => data.filters.account_id || ''));
 	let filterOwnerUserId = $state(untrack(() => data.filters.owner_user_id || ''));
@@ -196,6 +211,25 @@
 	<title>Transakcje | Finansowa Forteca</title>
 </svelte:head>
 
+{#snippet transactionRow(transaction: Transaction)}
+	<tr>
+		<td>{new Date(transaction.date).toLocaleDateString('pl-PL')}</td>
+		<td class="font-medium">{transaction.account_name}</td>
+		<td>{ownerName(owners, transaction.owner_user_id)}</td>
+		<td class="font-semibold text-primary-600-400">{formatPLN(transaction.amount)}</td>
+		<td class="text-right">
+			<button
+				type="button"
+				class="btn-icon btn-icon-sm"
+				aria-label="Usuń"
+				onclick={() => deleteTransaction(transaction.account_id, transaction.id)}
+			>
+				<Trash2 size={16} />
+			</button>
+		</td>
+	</tr>
+{/snippet}
+
 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
 	<div class="space-y-1">
 		<h1 class="h2">Wszystkie transakcje</h1>
@@ -285,39 +319,12 @@
 				<p>Brak transakcji</p>
 			</div>
 		{:else}
-			<div class="table-wrap">
-				<table class="table table-hover">
-					<thead>
-						<tr>
-							<th>Data zakupu</th>
-							<th>Konto</th>
-							<th>Właściciel</th>
-							<th>Kwota</th>
-							<th class="text-right">Akcje</th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each data.transactions.transactions as transaction}
-							<tr>
-								<td>{new Date(transaction.date).toLocaleDateString('pl-PL')}</td>
-								<td class="font-medium">{transaction.account_name}</td>
-								<td>{ownerName(owners, transaction.owner_user_id)}</td>
-								<td class="font-semibold text-primary-600-400">{formatPLN(transaction.amount)}</td>
-								<td class="text-right">
-									<button
-										type="button"
-										class="btn-icon btn-icon-sm"
-										aria-label="Usuń"
-										onclick={() => deleteTransaction(transaction.account_id, transaction.id)}
-									>
-										<Trash2 size={16} />
-									</button>
-								</td>
-							</tr>
-						{/each}
-					</tbody>
-				</table>
-			</div>
+			<SortableTable
+				columns={transactionColumns}
+				items={data.transactions.transactions}
+				row={transactionRow}
+				getKey={(t) => t.id}
+			/>
 		{/if}
 	</div>
 </div>

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -24,7 +24,7 @@
 	const defaultOwnerName = $derived(owners.length > 0 ? owners[0].name : '');
 
 	const transactionColumns = $derived<SortableColumn<Transaction>[]>([
-		{ key: 'date', label: 'Data zakupu', sortable: true, accessor: (t) => t.date },
+		{ key: 'date', label: 'Data zakupu', sortable: true, accessor: (t) => new Date(t.date) },
 		{ key: 'account', label: 'Konto', sortable: true, accessor: (t) => t.account_name },
 		{
 			key: 'owner',


### PR DESCRIPTION
## Motivation

Long account / transaction tables lose context once headers scroll out of view, and there is no way to sort by name, owner, value, or date. Adds sticky thead + a reusable click-to-sort header pattern to address both.

Closes #367

## Implementation information

- New reusable `src/lib/components/SortableTable.svelte` (Svelte 5, generic `<script lang=\"ts\" generics=\"T\">`).
- Sticky behaviour: `position: sticky; top: 0` on `<thead>` + `IntersectionObserver` sentinel for the on-scroll box-shadow.
- Three-state sort cycle: `none → asc → desc → none`. Clicking a column header rewrites the URL via `goto(..., { replaceState: true, noScroll: true })`, so sort state survives reload and is shareable.
- Param name is configurable; `accounts` uses `sortA` / `sortL` so the two stacked tables stay independent. `transactions` uses the default `sort`.
- Sort is parsed as `key:asc | key:desc`. Unknown / malformed values fall back to unsorted.
- Pure helpers (`parseSortParam`, `formatSortParam`, `nextSortDirection`, `compareValues`, `sortRows`) live in `<script module>` and are unit-tested. `compareValues` supports number / Date / locale-aware string compare, with null/undefined/NaN sorted last.
- `aria-sort` on each `<th>` reflects current state; the click target is a real `<button>` (focusable, Enter/Space activate).
- Caller passes a row snippet (full `<tr>`) plus an optional `getKey` for stable keying across sorts.

Alternative considered: re-using Skeleton's `.table-wrap` (`overflow: auto`). Dropped because it makes the wrap the nearest scroll container and prevents sticky from referencing the viewport.

## Supporting documentation

GitHub issue #367.

## Open questions

- Mobile horizontal overflow: previously handled by Skeleton's `.table-wrap`. With page-level sticky we drop that wrapper, so very wide tables may clip on narrow viewports (body has `overflow-x: hidden`). Acceptable for the desktop-primary dashboard; can be revisited if it bites.

> Changelog: feat(tables): sticky headers + column sort