### PR TITLE
feat(ui): add keyboard shortcuts + palette

### DIFF
--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { shortcutsUI } from '$lib/stores/shortcuts.svelte';
+
+	interface Command {
+		label: string;
+		hint?: string;
+		run: () => void;
+	}
+
+	const commands: Command[] = [
+		{ label: 'Dashboard', hint: '/', run: () => goto('/') },
+		{ label: 'Metryki', hint: '/metryki', run: () => goto('/metryki') },
+		{ label: 'Symulacje', hint: '/simulations', run: () => goto('/simulations') },
+		{ label: 'Konta', hint: '/accounts', run: () => goto('/accounts') },
+		{ label: 'Transakcje', hint: '/transactions', run: () => goto('/transactions') },
+		{ label: 'Majątek', hint: '/assets', run: () => goto('/assets') },
+		{ label: 'Zobowiązania', hint: '/debts', run: () => goto('/debts') },
+		{ label: 'Cele', hint: '/goals', run: () => goto('/goals') },
+		{ label: 'Snapshoty', hint: '/snapshots', run: () => goto('/snapshots') },
+		{ label: 'Nowy snapshot', hint: '/snapshots/new', run: () => goto('/snapshots/new') },
+		{ label: 'Wynagrodzenia', hint: '/salaries', run: () => goto('/salaries') },
+		{ label: 'Ustawienia', hint: '/settings', run: () => goto('/settings') }
+	];
+
+	let query = $state('');
+	let activeIndex = $state(0);
+	let inputEl: HTMLInputElement | null = $state(null);
+
+	const filtered = $derived.by(() => {
+		const q = query.trim().toLowerCase();
+		if (!q) return commands;
+		return commands.filter(
+			(c) => c.label.toLowerCase().includes(q) || c.hint?.toLowerCase().includes(q)
+		);
+	});
+
+	$effect(() => {
+		if (shortcutsUI.paletteOpen) {
+			query = '';
+			activeIndex = 0;
+			queueMicrotask(() => inputEl?.focus());
+		}
+	});
+
+	$effect(() => {
+		if (activeIndex >= filtered.length) activeIndex = 0;
+	});
+
+	function close() {
+		shortcutsUI.closePalette();
+	}
+
+	function runCommand(cmd: Command) {
+		close();
+		cmd.run();
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			close();
+			return;
+		}
+		if (event.key === 'ArrowDown') {
+			event.preventDefault();
+			if (filtered.length === 0) return;
+			activeIndex = (activeIndex + 1) % filtered.length;
+			return;
+		}
+		if (event.key === 'ArrowUp') {
+			event.preventDefault();
+			if (filtered.length === 0) return;
+			activeIndex = (activeIndex - 1 + filtered.length) % filtered.length;
+			return;
+		}
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			const cmd = filtered[activeIndex];
+			if (cmd) runCommand(cmd);
+		}
+	}
+
+	function handleBackdrop(event: MouseEvent) {
+		if (event.target === event.currentTarget) close();
+	}
+</script>
+
+{#if shortcutsUI.paletteOpen}
+	<div
+		class="fixed inset-0 z-50 flex items-start justify-center bg-surface-950/60 backdrop-blur-sm p-4 pt-[10vh]"
+		role="presentation"
+		onclick={handleBackdrop}
+	>
+		<div
+			class="card preset-filled-surface-50-950 w-full max-w-xl shadow-xl flex flex-col"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Paleta komend"
+		>
+			<div class="p-3 border-b border-surface-200-800">
+				<input
+					bind:this={inputEl}
+					type="text"
+					class="input w-full"
+					placeholder="Szukaj komendy lub strony…"
+					bind:value={query}
+					onkeydown={handleKeydown}
+					aria-label="Szukaj komendy"
+				/>
+			</div>
+			<ul class="max-h-[50vh] overflow-y-auto py-1" role="listbox">
+				{#if filtered.length === 0}
+					<li class="px-4 py-3 text-sm text-surface-700-300">Brak wyników</li>
+				{:else}
+					{#each filtered as cmd, i (cmd.hint ?? cmd.label)}
+						<li role="option" aria-selected={i === activeIndex}>
+							<button
+								type="button"
+								class="w-full flex items-center justify-between gap-4 px-4 py-2 text-left text-sm transition-colors
+									{i === activeIndex
+									? 'preset-filled-primary-500'
+									: 'hover:preset-tonal-primary text-surface-800-200'}"
+								onclick={() => runCommand(cmd)}
+								onmouseenter={() => (activeIndex = i)}
+							>
+								<span>{cmd.label}</span>
+								{#if cmd.hint}
+									<span
+										class="font-mono text-xs opacity-70 {i === activeIndex
+											? ''
+											: 'text-surface-700-300'}"
+									>
+										{cmd.hint}
+									</span>
+								{/if}
+							</button>
+						</li>
+					{/each}
+				{/if}
+			</ul>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { shortcutsUI } from '$lib/stores/shortcuts.svelte';
 
@@ -39,7 +40,7 @@
 		if (shortcutsUI.paletteOpen) {
 			query = '';
 			activeIndex = 0;
-			queueMicrotask(() => inputEl?.focus());
+			tick().then(() => inputEl?.focus());
 		}
 	});
 

--- a/src/lib/components/KeyboardShortcuts.svelte
+++ b/src/lib/components/KeyboardShortcuts.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { shortcutsUI } from '$lib/stores/shortcuts.svelte';
+	import { GOTO_ROUTES, isModifierKeyPressed, isTypingTarget } from '$lib/utils/shortcuts';
+	import ShortcutHelp from './ShortcutHelp.svelte';
+	import CommandPalette from './CommandPalette.svelte';
+
+	const GOTO_TIMEOUT_MS = 1500;
+
+	let awaitingGoto = $state(false);
+	let gotoTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function clearGotoPrefix() {
+		awaitingGoto = false;
+		if (gotoTimer) {
+			clearTimeout(gotoTimer);
+			gotoTimer = null;
+		}
+	}
+
+	function armGotoPrefix() {
+		awaitingGoto = true;
+		if (gotoTimer) clearTimeout(gotoTimer);
+		gotoTimer = setTimeout(clearGotoPrefix, GOTO_TIMEOUT_MS);
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		// Command palette: works even when typing — it's the universal escape
+		// hatch users expect from Cmd+K everywhere.
+		if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey) {
+			if (event.key === 'k' || event.key === 'K') {
+				event.preventDefault();
+				clearGotoPrefix();
+				shortcutsUI.openPalette();
+				return;
+			}
+		}
+
+		if (isTypingTarget(event.target)) return;
+
+		// Don't intercept Tab / arrows / etc. that combine with modifiers
+		// (browser shortcuts) once we're past the Cmd+K case.
+		if (isModifierKeyPressed(event)) return;
+
+		if (awaitingGoto) {
+			const match = GOTO_ROUTES.find((r) => r.key === event.key);
+			clearGotoPrefix();
+			if (match) {
+				event.preventDefault();
+				goto(match.href);
+			}
+			return;
+		}
+
+		if (event.key === '?') {
+			event.preventDefault();
+			shortcutsUI.toggleHelp();
+			return;
+		}
+
+		if (event.key === 'n') {
+			event.preventDefault();
+			goto('/snapshots/new');
+			return;
+		}
+
+		if (event.key === 'g') {
+			event.preventDefault();
+			armGotoPrefix();
+		}
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<ShortcutHelp />
+<CommandPalette />

--- a/src/lib/components/KeyboardShortcuts.svelte
+++ b/src/lib/components/KeyboardShortcuts.svelte
@@ -25,22 +25,30 @@
 	}
 
 	function handleKeydown(event: KeyboardEvent) {
-		// Command palette: works even when typing — it's the universal escape
-		// hatch users expect from Cmd+K everywhere.
+		// Cmd+K toggles the palette and works even while typing — universal
+		// escape hatch users expect everywhere.
 		if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey) {
 			if (event.key === 'k' || event.key === 'K') {
 				event.preventDefault();
 				clearGotoPrefix();
-				shortcutsUI.openPalette();
+				if (shortcutsUI.paletteOpen) shortcutsUI.closePalette();
+				else shortcutsUI.openPalette();
 				return;
 			}
 		}
 
-		if (isTypingTarget(event.target)) return;
+		if (isTypingTarget(event.target)) {
+			clearGotoPrefix();
+			return;
+		}
 
-		// Don't intercept Tab / arrows / etc. that combine with modifiers
-		// (browser shortcuts) once we're past the Cmd+K case.
+		// Don't intercept browser shortcuts (Ctrl+Tab, Alt+Left, etc.) once
+		// we're past the Cmd+K case.
 		if (isModifierKeyPressed(event)) return;
+
+		// Palette traps its own input; if it's open without focus on the
+		// input the user pressed Tab away — still skip global shortcuts.
+		if (shortcutsUI.paletteOpen) return;
 
 		if (awaitingGoto) {
 			const match = GOTO_ROUTES.find((r) => r.key === event.key);
@@ -48,15 +56,20 @@
 			if (match) {
 				event.preventDefault();
 				goto(match.href);
+				return;
 			}
-			return;
+			// Unmatched g-prefix key falls through so `?` etc. still fire.
 		}
 
+		// `?` is a toggle — it must keep working while the help overlay is
+		// open so users can close it the same way they opened it.
 		if (event.key === '?') {
 			event.preventDefault();
 			shortcutsUI.toggleHelp();
 			return;
 		}
+
+		if (shortcutsUI.helpOpen) return;
 
 		if (event.key === 'n') {
 			event.preventDefault();

--- a/src/lib/components/ShortcutHelp.svelte
+++ b/src/lib/components/ShortcutHelp.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import Modal from './Modal.svelte';
+	import { shortcutsUI } from '$lib/stores/shortcuts.svelte';
+	import { SHORTCUT_BINDINGS } from '$lib/utils/shortcuts';
+</script>
+
+<Modal
+	open={shortcutsUI.helpOpen}
+	title="Skróty klawiaturowe"
+	hideFooter
+	onCancel={() => shortcutsUI.closeHelp()}
+>
+	<ul class="divide-y divide-surface-200-800">
+		{#each SHORTCUT_BINDINGS as binding (binding.keys)}
+			<li class="flex items-center justify-between py-2 gap-4">
+				<span class="text-sm text-surface-800-200">{binding.description}</span>
+				<kbd class="kbd font-mono text-xs whitespace-nowrap">{binding.keys}</kbd>
+			</li>
+		{/each}
+	</ul>
+</Modal>

--- a/src/lib/stores/shortcuts.svelte.ts
+++ b/src/lib/stores/shortcuts.svelte.ts
@@ -1,0 +1,32 @@
+// Global UI state for keyboard-driven affordances: the shortcut help
+// overlay and the command palette. Mounted once via the root layout.
+
+let helpOpen = $state(false);
+let paletteOpen = $state(false);
+
+export const shortcutsUI = {
+	get helpOpen() {
+		return helpOpen;
+	},
+	get paletteOpen() {
+		return paletteOpen;
+	},
+	openHelp() {
+		helpOpen = true;
+		paletteOpen = false;
+	},
+	closeHelp() {
+		helpOpen = false;
+	},
+	toggleHelp() {
+		helpOpen = !helpOpen;
+		if (helpOpen) paletteOpen = false;
+	},
+	openPalette() {
+		paletteOpen = true;
+		helpOpen = false;
+	},
+	closePalette() {
+		paletteOpen = false;
+	}
+};

--- a/src/lib/utils/shortcuts.test.ts
+++ b/src/lib/utils/shortcuts.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { GOTO_ROUTES, SHORTCUT_BINDINGS, isModifierKeyPressed, isTypingTarget } from './shortcuts';
+
+describe('isTypingTarget', () => {
+	let container: HTMLElement;
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+	});
+
+	afterEach(() => {
+		container.remove();
+	});
+
+	it('returns false for null', () => {
+		expect(isTypingTarget(null)).toBe(false);
+	});
+
+	it('returns false for non-input elements', () => {
+		const div = document.createElement('div');
+		expect(isTypingTarget(div)).toBe(false);
+	});
+
+	it('returns true for input', () => {
+		const el = document.createElement('input');
+		expect(isTypingTarget(el)).toBe(true);
+	});
+
+	it('returns true for textarea', () => {
+		const el = document.createElement('textarea');
+		expect(isTypingTarget(el)).toBe(true);
+	});
+
+	it('returns true for select', () => {
+		const el = document.createElement('select');
+		expect(isTypingTarget(el)).toBe(true);
+	});
+
+	it('returns true for contenteditable', () => {
+		const el = document.createElement('div');
+		el.setAttribute('contenteditable', 'true');
+		container.appendChild(el);
+		expect(isTypingTarget(el)).toBe(true);
+	});
+});
+
+describe('isModifierKeyPressed', () => {
+	function evt(init: Partial<KeyboardEventInit>): KeyboardEvent {
+		return new KeyboardEvent('keydown', init);
+	}
+
+	it('returns true for ctrl', () => {
+		expect(isModifierKeyPressed(evt({ ctrlKey: true }))).toBe(true);
+	});
+
+	it('returns true for meta', () => {
+		expect(isModifierKeyPressed(evt({ metaKey: true }))).toBe(true);
+	});
+
+	it('returns true for alt', () => {
+		expect(isModifierKeyPressed(evt({ altKey: true }))).toBe(true);
+	});
+
+	it('returns false when no modifier is pressed', () => {
+		expect(isModifierKeyPressed(evt({}))).toBe(false);
+	});
+
+	it('returns false for shift alone (shift is not considered a modifier here)', () => {
+		expect(isModifierKeyPressed(evt({ shiftKey: true }))).toBe(false);
+	});
+});
+
+describe('GOTO_ROUTES', () => {
+	it('covers h, a, s, t', () => {
+		const keys = GOTO_ROUTES.map((r) => r.key).sort();
+		expect(keys).toEqual(['a', 'h', 's', 't']);
+	});
+
+	it('all routes start with /', () => {
+		for (const r of GOTO_ROUTES) {
+			expect(r.href.startsWith('/')).toBe(true);
+		}
+	});
+});
+
+describe('SHORTCUT_BINDINGS', () => {
+	it('includes the acceptance-criteria bindings', () => {
+		const keys = SHORTCUT_BINDINGS.map((b) => b.keys);
+		expect(keys).toContain('n');
+		expect(keys).toContain('g h');
+		expect(keys).toContain('g a');
+		expect(keys).toContain('g s');
+		expect(keys).toContain('g t');
+		expect(keys).toContain('?');
+		expect(keys).toContain('Cmd/Ctrl + K');
+	});
+});

--- a/src/lib/utils/shortcuts.ts
+++ b/src/lib/utils/shortcuts.ts
@@ -1,0 +1,45 @@
+// Keyboard shortcut helpers. Detects whether the user is currently typing
+// (so global shortcuts can stay silent) and exposes the binding metadata
+// used by both the layout dispatcher and the help overlay.
+
+export interface ShortcutBinding {
+	keys: string;
+	description: string;
+}
+
+export interface GotoRoute {
+	key: string;
+	href: string;
+	label: string;
+}
+
+export const GOTO_ROUTES: GotoRoute[] = [
+	{ key: 'h', href: '/', label: 'Dashboard' },
+	{ key: 'a', href: '/accounts', label: 'Konta' },
+	{ key: 's', href: '/snapshots', label: 'Snapshoty' },
+	{ key: 't', href: '/transactions', label: 'Transakcje' }
+];
+
+export const SHORTCUT_BINDINGS: ShortcutBinding[] = [
+	{ keys: 'n', description: 'Nowy snapshot' },
+	{ keys: 'g h', description: 'Dashboard' },
+	{ keys: 'g a', description: 'Konta' },
+	{ keys: 'g s', description: 'Snapshoty' },
+	{ keys: 'g t', description: 'Transakcje' },
+	{ keys: '?', description: 'Pokaż skróty' },
+	{ keys: 'Cmd/Ctrl + K', description: 'Paleta komend' }
+];
+
+export function isTypingTarget(target: EventTarget | null): boolean {
+	if (!(target instanceof HTMLElement)) return false;
+	if (target.isContentEditable) return true;
+	const editable = target.getAttribute('contenteditable');
+	if (editable === '' || editable === 'true' || editable === 'plaintext-only') return true;
+	const tag = target.tagName;
+	if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+	return false;
+}
+
+export function isModifierKeyPressed(event: KeyboardEvent): boolean {
+	return event.ctrlKey || event.metaKey || event.altKey;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/stores';
 	import Toast from '$lib/components/Toast.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
+	import KeyboardShortcuts from '$lib/components/KeyboardShortcuts.svelte';
 	import {
 		LayoutDashboard,
 		TrendingUp,
@@ -48,6 +49,10 @@
 
 <Toast />
 <Confirm />
+
+{#if !isLoginPage}
+	<KeyboardShortcuts />
+{/if}
 
 {#if isLoginPage}
 	{@render children?.()}


### PR DESCRIPTION
## Motivation

Power users navigate by keyboard. Linear/Monarch-style shortcuts speed up
the monthly snapshot ritual. Closes #368.

## Implementation information

- `src/lib/utils/shortcuts.ts` — binding metadata + `isTypingTarget` helper
  (treats inputs/textareas/selects/contenteditable as typing).
- `src/lib/stores/shortcuts.svelte.ts` — runes-based UI state for help
  overlay + palette; mirrors the `confirm` store pattern.
- `src/lib/components/KeyboardShortcuts.svelte` — global keydown dispatcher
  mounted from the root layout (skipped on `/login`). Handles `n`,
  `g h|a|s|t` (1.5 s leader timeout), `?`, `Cmd/Ctrl+K`. Cmd+K toggles
  even while typing; everything else is suppressed inside inputs.
- `src/lib/components/ShortcutHelp.svelte` — `?` toggles a Modal listing
  every binding.
- `src/lib/components/CommandPalette.svelte` — Cmd+K opens a substring
  route-search palette (built to take action commands later, per the
  issue's "later: actions" note).
- `src/routes/+layout.svelte` — mounts the dispatcher.

Alternatives considered: per-route listeners (rejected — defeats "anywhere"
requirement); a third-party library (rejected — bindings are small enough
that the dependency cost isn't justified).

## Supporting documentation

Issue #368.

> Changelog: feat(ui): add keyboard shortcuts + palette