### PR TITLE
feat(retirement): chart balances at 60/65/70

### DIFF
--- a/src/lib/utils/charts/simulations.test.ts
+++ b/src/lib/utils/charts/simulations.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { buildRetirementProjectionOption, type AccountSimulation } from './simulations';
+import {
+	aggregateByWrapperOverAges,
+	buildRetirementByWrapperOption,
+	buildRetirementProjectionOption,
+	getTotalBalanceAtAge,
+	wrapperFromAccountName,
+	type AccountSimulation
+} from './simulations';
 
-function makeSimulation(name: string, balances: number[]): AccountSimulation {
+function makeSimulation(name: string, balances: number[], startAge = 30): AccountSimulation {
 	return {
 		account_name: name,
 		starting_balance: balances[0] ?? 0,
@@ -11,7 +18,7 @@ function makeSimulation(name: string, balances: number[]): AccountSimulation {
 		final_balance: balances[balances.length - 1] ?? 0,
 		yearly_projections: balances.map((balance, idx) => ({
 			year: 2025 + idx,
-			age: 30 + idx,
+			age: startAge + idx,
 			annual_contribution: 0,
 			balance_end_of_year: balance,
 			cumulative_contributions: 0,
@@ -112,5 +119,160 @@ describe('buildRetirementProjectionOption', () => {
 		expect(series).toHaveLength(10);
 		// 7th item should wrap back to the first palette colour
 		expect(series[6].itemStyle.color).toBe(series[0].itemStyle.color);
+	});
+});
+
+describe('wrapperFromAccountName', () => {
+	it('maps IKE/IKZE/PPK prefixes correctly', () => {
+		expect(wrapperFromAccountName('IKE (Marcin)')).toBe('IKE');
+		expect(wrapperFromAccountName('IKZE (Marcin)')).toBe('IKZE');
+		expect(wrapperFromAccountName('PPK (Marcin)')).toBe('PPK');
+	});
+
+	it('returns null for non-retirement accounts', () => {
+		expect(wrapperFromAccountName('Rachunek maklerski (Marcin)')).toBeNull();
+		expect(wrapperFromAccountName('')).toBeNull();
+	});
+
+	it('disambiguates IKZE before IKE so the longer prefix wins', () => {
+		expect(wrapperFromAccountName('IKZE (Ewa)')).toBe('IKZE');
+	});
+});
+
+describe('aggregateByWrapperOverAges', () => {
+	it('sums balances per wrapper at each age across owners', () => {
+		const sims: AccountSimulation[] = [
+			makeSimulation('IKE (Marcin)', [100, 200, 300], 60),
+			makeSimulation('IKE (Ewa)', [50, 100, 150], 60),
+			makeSimulation('IKZE (Marcin)', [1000, 2000, 3000], 60),
+			makeSimulation('PPK (Marcin)', [10, 20, 30], 60)
+		];
+		const out = aggregateByWrapperOverAges(sims);
+		expect(out.ages).toEqual([60, 61, 62]);
+		expect(out.IKE).toEqual([150, 300, 450]);
+		expect(out.IKZE).toEqual([1000, 2000, 3000]);
+		expect(out.PPK).toEqual([10, 20, 30]);
+	});
+
+	it('ignores non-retirement accounts', () => {
+		const sims: AccountSimulation[] = [
+			makeSimulation('Rachunek maklerski (Marcin)', [9999], 60),
+			makeSimulation('IKE (Marcin)', [100], 60)
+		];
+		const out = aggregateByWrapperOverAges(sims);
+		expect(out.IKE).toEqual([100]);
+		expect(out.IKZE).toEqual([0]);
+		expect(out.PPK).toEqual([0]);
+	});
+
+	it('returns empty arrays for an empty input', () => {
+		const out = aggregateByWrapperOverAges([]);
+		expect(out.ages).toEqual([]);
+		expect(out.IKE).toEqual([]);
+		expect(out.IKZE).toEqual([]);
+		expect(out.PPK).toEqual([]);
+	});
+
+	it('uses zero when a wrapper has no entry at an age', () => {
+		// IKE present at 60, PPK only at 61 — both ages should show.
+		const sims: AccountSimulation[] = [
+			{
+				account_name: 'IKE (Marcin)',
+				starting_balance: 0,
+				total_contributions: 0,
+				total_returns: 0,
+				total_tax_savings: 0,
+				final_balance: 0,
+				yearly_projections: [
+					{
+						year: 2025,
+						age: 60,
+						annual_contribution: 0,
+						balance_end_of_year: 100,
+						cumulative_contributions: 0,
+						cumulative_returns: 0,
+						annual_limit: 0,
+						limit_utilized_pct: 0,
+						tax_savings: 0
+					}
+				]
+			},
+			{
+				account_name: 'PPK (Marcin)',
+				starting_balance: 0,
+				total_contributions: 0,
+				total_returns: 0,
+				total_tax_savings: 0,
+				final_balance: 0,
+				yearly_projections: [
+					{
+						year: 2026,
+						age: 61,
+						annual_contribution: 0,
+						balance_end_of_year: 50,
+						cumulative_contributions: 0,
+						cumulative_returns: 0,
+						annual_limit: 0,
+						limit_utilized_pct: 0,
+						tax_savings: 0
+					}
+				]
+			}
+		];
+		const out = aggregateByWrapperOverAges(sims);
+		expect(out.ages).toEqual([60, 61]);
+		expect(out.IKE).toEqual([100, 0]);
+		expect(out.PPK).toEqual([0, 50]);
+	});
+});
+
+describe('getTotalBalanceAtAge', () => {
+	it('returns the sum of retirement balances at a given age', () => {
+		const sims: AccountSimulation[] = [
+			makeSimulation('IKE (Marcin)', [100, 200], 60),
+			makeSimulation('IKZE (Marcin)', [500, 700], 60),
+			makeSimulation('PPK (Marcin)', [50, 80], 60),
+			makeSimulation('Rachunek maklerski (Marcin)', [9999, 9999], 60)
+		];
+		expect(getTotalBalanceAtAge(sims, 60)).toBe(650);
+		expect(getTotalBalanceAtAge(sims, 61)).toBe(980);
+	});
+
+	it('returns null when no projection covers the age', () => {
+		const sims = [makeSimulation('IKE (Marcin)', [100, 200], 60)];
+		expect(getTotalBalanceAtAge(sims, 70)).toBeNull();
+	});
+});
+
+describe('buildRetirementByWrapperOption', () => {
+	it('emits three stacked series for IKE/IKZE/PPK', () => {
+		const sims = [
+			makeSimulation('IKE (Marcin)', [100, 200], 60),
+			makeSimulation('IKZE (Marcin)', [50, 75], 60),
+			makeSimulation('PPK (Marcin)', [10, 20], 60)
+		];
+		const option = buildRetirementByWrapperOption(sims, []);
+		const series = option.series as Array<{ name: string; stack: string; data: number[] }>;
+		expect(series).toHaveLength(3);
+		expect(series.map((s) => s.name)).toEqual(['IKE', 'IKZE', 'PPK']);
+		expect(series.every((s) => s.stack === 'total')).toBe(true);
+		expect(series[0].data).toEqual([100, 200]);
+	});
+
+	it('adds markLines only for milestone ages within the projection range', () => {
+		const sims = [makeSimulation('IKE (Marcin)', [100, 200, 300], 60)];
+		const option = buildRetirementByWrapperOption(sims, [60, 65, 70]);
+		const series = option.series as Array<{ markLine?: { data: Array<{ xAxis: string }> } }>;
+		const lines = series[0].markLine?.data ?? [];
+		// Only age 60 falls inside [60, 62]; 65 and 70 must be dropped.
+		expect(lines.map((l) => l.xAxis)).toEqual(['60']);
+	});
+
+	it('uses age as x-axis category', () => {
+		const sims = [makeSimulation('IKE (Marcin)', [100, 200], 60)];
+		const option = buildRetirementByWrapperOption(sims, []);
+		const xAxis = option.xAxis as { data: string[]; name: string };
+		expect(xAxis.data).toEqual(['60', '61']);
+		expect(xAxis.name).toBe('Wiek');
 	});
 });

--- a/src/lib/utils/charts/simulations.ts
+++ b/src/lib/utils/charts/simulations.ts
@@ -70,3 +70,141 @@ export function buildRetirementProjectionOption(simulations: AccountSimulation[]
 		series
 	};
 }
+
+export type WrapperKey = 'IKE' | 'IKZE' | 'PPK';
+
+const WRAPPER_PREFIX: Record<WrapperKey, string> = {
+	IKE: 'IKE ',
+	IKZE: 'IKZE ',
+	PPK: 'PPK '
+};
+
+export function wrapperFromAccountName(name: string): WrapperKey | null {
+	if (name.startsWith(WRAPPER_PREFIX.IKZE)) return 'IKZE';
+	if (name.startsWith(WRAPPER_PREFIX.IKE)) return 'IKE';
+	if (name.startsWith(WRAPPER_PREFIX.PPK)) return 'PPK';
+	return null;
+}
+
+export interface WrapperAggregates {
+	ages: number[];
+	IKE: number[];
+	IKZE: number[];
+	PPK: number[];
+}
+
+export function aggregateByWrapperOverAges(simulations: AccountSimulation[]): WrapperAggregates {
+	const byAge = new Map<number, { IKE: number; IKZE: number; PPK: number }>();
+	for (const sim of simulations) {
+		const wrapper = wrapperFromAccountName(sim.account_name);
+		if (!wrapper) continue;
+		for (const p of sim.yearly_projections) {
+			const bucket = byAge.get(p.age) ?? { IKE: 0, IKZE: 0, PPK: 0 };
+			bucket[wrapper] += p.balance_end_of_year;
+			byAge.set(p.age, bucket);
+		}
+	}
+	const ages = Array.from(byAge.keys()).sort((a, b) => a - b);
+	return {
+		ages,
+		IKE: ages.map((a) => byAge.get(a)?.IKE ?? 0),
+		IKZE: ages.map((a) => byAge.get(a)?.IKZE ?? 0),
+		PPK: ages.map((a) => byAge.get(a)?.PPK ?? 0)
+	};
+}
+
+export function getTotalBalanceAtAge(simulations: AccountSimulation[], age: number): number | null {
+	let total = 0;
+	let found = false;
+	for (const sim of simulations) {
+		if (!wrapperFromAccountName(sim.account_name)) continue;
+		const proj = sim.yearly_projections.find((p) => p.age === age);
+		if (proj) {
+			total += proj.balance_end_of_year;
+			found = true;
+		}
+	}
+	return found ? total : null;
+}
+
+const WRAPPER_COLORS: Record<WrapperKey, string> = {
+	IKE: '#5E81AC',
+	IKZE: '#88C0D0',
+	PPK: '#A3BE8C'
+};
+
+export function buildRetirementByWrapperOption(
+	simulations: AccountSimulation[],
+	milestoneAges: number[]
+): EChartsOption {
+	const data = aggregateByWrapperOverAges(simulations);
+
+	interface MilestoneMarkLine {
+		xAxis: string;
+		label: { formatter: string; position: 'insideEndTop' };
+	}
+	const markLineData: MilestoneMarkLine[] = milestoneAges
+		.map((age) => {
+			const idx = data.ages.indexOf(age);
+			if (idx === -1) return null;
+			const total = data.IKE[idx] + data.IKZE[idx] + data.PPK[idx];
+			return {
+				xAxis: String(age),
+				label: {
+					formatter: `${age} lat\n${(total / 1000).toFixed(0)}k`,
+					position: 'insideEndTop' as const
+				}
+			};
+		})
+		.filter((d): d is MilestoneMarkLine => d !== null);
+
+	const wrappers: WrapperKey[] = ['IKE', 'IKZE', 'PPK'];
+	const series: LineSeriesOption[] = wrappers.map((w) => ({
+		name: w,
+		type: 'line',
+		stack: 'total',
+		areaStyle: {},
+		smooth: true,
+		showSymbol: false,
+		data: data[w],
+		itemStyle: { color: WRAPPER_COLORS[w] }
+	}));
+
+	if (series.length > 0 && markLineData.length > 0) {
+		series[0].markLine = {
+			symbol: ['none', 'none'],
+			lineStyle: { type: 'dashed', color: '#B48EAD' },
+			data: markLineData
+		};
+	}
+
+	return {
+		title: { text: 'Projekcja IKE + IKZE + PPK wg wieku' },
+		tooltip: {
+			trigger: 'axis',
+			formatter: (params: TopLevelFormatterParams) => {
+				const items = Array.isArray(params) ? params : [params];
+				let total = 0;
+				let result = `<strong>Wiek ${items[0].name}</strong><br/>`;
+				items.forEach((p) => {
+					const value = (p.value as number) || 0;
+					total += value;
+					result += `${p.seriesName}: ${value.toLocaleString('pl-PL', { maximumFractionDigits: 0 })} PLN<br/>`;
+				});
+				result += `<strong>Razem: ${total.toLocaleString('pl-PL', { maximumFractionDigits: 0 })} PLN</strong>`;
+				return result;
+			}
+		},
+		legend: { data: wrappers, bottom: 0 },
+		grid: { left: '3%', right: '4%', bottom: '15%', containLabel: true },
+		xAxis: { type: 'category', data: data.ages.map(String), name: 'Wiek' },
+		yAxis: {
+			type: 'value',
+			name: 'Wartość (PLN)',
+			axisLabel: {
+				formatter: (value: number) => `${(value / 1000).toFixed(0)}k`
+			}
+		},
+		series
+	};
+}

--- a/src/lib/utils/charts/simulations.ts
+++ b/src/lib/utils/charts/simulations.ts
@@ -29,6 +29,18 @@ export interface AccountSimulation {
 
 const SERIES_COLORS = ['#5E81AC', '#81A1C1', '#88C0D0', '#8FBCBB', '#B48EAD', '#A3BE8C'];
 
+// Tooltip HTML escape: account names come from the database (user-set
+// owner labels can flow in) and Echarts' default tooltip renderer treats
+// the returned string as HTML.
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}
+
 export function buildRetirementProjectionOption(simulations: AccountSimulation[]): EChartsOption {
 	const years = simulations.length > 0 ? simulations[0].yearly_projections.map((p) => p.year) : [];
 
@@ -46,10 +58,10 @@ export function buildRetirementProjectionOption(simulations: AccountSimulation[]
 			trigger: 'axis',
 			formatter: (params: TopLevelFormatterParams) => {
 				const items = Array.isArray(params) ? params : [params];
-				let result = `<strong>Rok ${items[0].name}</strong><br/>`;
+				let result = `<strong>Rok ${escapeHtml(String(items[0].name))}</strong><br/>`;
 				items.forEach((param) => {
 					const value = (param.value as number).toLocaleString('pl-PL');
-					result += `${param.seriesName}: ${value} PLN<br/>`;
+					result += `${escapeHtml(String(param.seriesName))}: ${value} PLN<br/>`;
 				});
 				return result;
 			}
@@ -185,11 +197,11 @@ export function buildRetirementByWrapperOption(
 			formatter: (params: TopLevelFormatterParams) => {
 				const items = Array.isArray(params) ? params : [params];
 				let total = 0;
-				let result = `<strong>Wiek ${items[0].name}</strong><br/>`;
+				let result = `<strong>Wiek ${escapeHtml(String(items[0].name))}</strong><br/>`;
 				items.forEach((p) => {
 					const value = (p.value as number) || 0;
 					total += value;
-					result += `${p.seriesName}: ${value.toLocaleString('pl-PL', { maximumFractionDigits: 0 })} PLN<br/>`;
+					result += `${escapeHtml(String(p.seriesName))}: ${value.toLocaleString('pl-PL', { maximumFractionDigits: 0 })} PLN<br/>`;
 				});
 				result += `<strong>Razem: ${total.toLocaleString('pl-PL', { maximumFractionDigits: 0 })} PLN</strong>`;
 				return result;

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -4,7 +4,9 @@
 	import * as echarts from 'echarts';
 	import type { PageData } from './$types';
 	import {
+		buildRetirementByWrapperOption,
 		buildRetirementProjectionOption,
+		getTotalBalanceAtAge,
 		type AccountSimulation
 	} from '$lib/utils/charts/simulations';
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
@@ -130,10 +132,23 @@
 	let loading = $state(false);
 	let error = $state('');
 
-	// Chart
+	// Charts
+	const MILESTONE_AGES = [60, 65, 70];
 	let chartContainer: HTMLDivElement | undefined = $state();
+	let wrapperChartContainer: HTMLDivElement | undefined = $state();
 	let chart: echarts.ECharts | null = null;
 	let chartHandle: ChartHandle | null = null;
+	let wrapperChart: echarts.ECharts | null = null;
+	let wrapperChartHandle: ChartHandle | null = null;
+
+	const milestoneBalances = $derived.by(() => {
+		const r = results;
+		if (!r) return [];
+		return MILESTONE_AGES.map((age) => ({
+			age,
+			balance: getTotalBalanceAtAge(r.simulations, age)
+		}));
+	});
 
 	async function runSimulation() {
 		loading = true;
@@ -240,11 +255,33 @@
 		chart?.setOption(buildRetirementProjectionOption(results.simulations));
 	}
 
+	// Render the wrapper-aggregate chart reactively: it only mounts after the
+	// milestone cards reveal, so we can't draw it synchronously when results
+	// arrive — wait for the container to bind.
+	$effect(() => {
+		if (!results || !wrapperChartContainer) return;
+
+		if (!wrapperChartHandle) {
+			wrapperChartHandle = createChart(wrapperChartContainer);
+			wrapperChart = wrapperChartHandle.chart;
+		}
+
+		if (results.simulations.length === 0) {
+			wrapperChart?.clear();
+			return;
+		}
+
+		wrapperChart?.setOption(buildRetirementByWrapperOption(results.simulations, MILESTONE_AGES));
+	});
+
 	onMount(() => {
 		return () => {
 			chartHandle?.dispose();
 			chartHandle = null;
 			chart = null;
+			wrapperChartHandle?.dispose();
+			wrapperChartHandle = null;
+			wrapperChart = null;
 		};
 	});
 
@@ -572,6 +609,25 @@
 				</div>
 
 				<div bind:this={chartContainer} class="w-full h-[280px] sm:h-[400px]"></div>
+
+				{#if milestoneBalances.some((m) => m.balance !== null)}
+					<h3 class="h4">Saldo IKE + IKZE + PPK w wieku emerytalnym</h3>
+					<div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+						{#each milestoneBalances as milestone (milestone.age)}
+							<div class="card preset-tonal-surface p-4">
+								<div class="text-xs text-surface-600-400 mb-2">Wiek {milestone.age}</div>
+								<div class="text-xl font-bold">
+									{#if milestone.balance === null}
+										—
+									{:else}
+										{formatCurrency(milestone.balance)} PLN
+									{/if}
+								</div>
+							</div>
+						{/each}
+					</div>
+					<div bind:this={wrapperChartContainer} class="w-full h-[280px] sm:h-[400px]"></div>
+				{/if}
 
 				<h3 class="h4">Szczegóły projekcji</h3>
 				{#each results.simulations as simulation}

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -257,9 +257,18 @@
 
 	// Render the wrapper-aggregate chart reactively: it only mounts after the
 	// milestone cards reveal, so we can't draw it synchronously when results
-	// arrive — wait for the container to bind.
+	// arrive — wait for the container to bind. When the {#if} unmounts the
+	// container (e.g. user re-runs with a sub-60 retirement age), dispose the
+	// handle so a later remount creates a fresh chart instead of writing to
+	// a detached canvas.
 	$effect(() => {
-		if (!results || !wrapperChartContainer) return;
+		if (!wrapperChartContainer) {
+			wrapperChartHandle?.dispose();
+			wrapperChartHandle = null;
+			wrapperChart = null;
+			return;
+		}
+		if (!results) return;
 
 		if (!wrapperChartHandle) {
 			wrapperChartHandle = createChart(wrapperChartContainer);

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -228,7 +228,6 @@
 
 			const responseData = await response.json();
 			results = responseData;
-			renderChart();
 		} catch (err) {
 			console.error('Simulation failed:', err);
 			if (err instanceof Error) {
@@ -239,8 +238,17 @@
 		}
 	}
 
-	function renderChart() {
-		if (!results || !chartContainer) return;
+	// Main per-account chart. Driven by $effect so it renders on the tick
+	// after `results = ...` flushes the DOM (the {#if results} container
+	// isn't bound until then).
+	$effect(() => {
+		if (!chartContainer) {
+			chartHandle?.dispose();
+			chartHandle = null;
+			chart = null;
+			return;
+		}
+		if (!results) return;
 
 		if (!chartHandle) {
 			chartHandle = createChart(chartContainer);
@@ -253,7 +261,7 @@
 		}
 
 		chart?.setOption(buildRetirementProjectionOption(results.simulations));
-	}
+	});
 
 	// Render the wrapper-aggregate chart reactively: it only mounts after the
 	// milestone cards reveal, so we can't draw it synchronously when results


### PR DESCRIPTION
## Motivation

Most-requested feature in Polish FI tools: project IKE/IKZE/PPK balance at
retirement age. Backend already ships `POST /api/simulations/retirement`
(post-Go-migration); this PR is the frontend chart users have been asking
for. Closes #369.

## Implementation information

- `src/lib/utils/charts/simulations.ts` — added `wrapperFromAccountName`,
  `aggregateByWrapperOverAges`, `getTotalBalanceAtAge`, and
  `buildRetirementByWrapperOption` (stacked-area Echarts option, with
  vertical markLines at ages within the projection range).
- `src/routes/simulations/+page.svelte` — after the existing per-account
  chart, render a second stacked-area chart aggregated by wrapper
  (IKE + IKZE + PPK) with summary cards showing the total balance at
  ages 60/65/70 read out of `yearly_projections`. Charts dispose
  correctly on remount when the milestone block hides.

Alternatives considered: a dedicated `/retirement` page (rejected — the
simulation form already exists on `/simulations`, duplicating it would
fork inputs; the new chart sits below the existing one). Conservative /
Base / Optimistic scenario buttons (deferred — the existing
`annualReturnRate` input is already the scenario knob, per the issue
owner's rescope comment).

## Supporting documentation

Issue #369 (rescoped — backend is already in `backend-go/internal/simulations/`).

> Changelog: feat(retirement): chart balances at 60/65/70