### PR TITLE
feat(dashboard): net-worth waterfall chart

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -2057,9 +2057,20 @@
                     "net_worth_history": {
                       "items": {
                         "properties": {
+                          "assets": {
+                            "format": "double",
+                            "type": "number"
+                          },
                           "date": {
                             "format": "date",
                             "type": "string"
+                          },
+                          "liabilities": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "snapshot_id": {
+                            "type": "integer"
                           },
                           "value": {
                             "format": "double",

--- a/backend-go/internal/dashboard/dashboard.go
+++ b/backend-go/internal/dashboard/dashboard.go
@@ -6,10 +6,16 @@ import (
 	"time"
 )
 
-// netWorthPoint mirrors NetWorthPoint.
+// netWorthPoint mirrors NetWorthPoint. Assets and Liabilities are emitted
+// so the frontend can build a waterfall of month-over-month contributions
+// (asset-side delta vs liability-side delta). SnapshotID enables click
+// drill-down to the snapshot detail page.
 type netWorthPoint struct {
-	Date  time.Time
-	Value float64
+	Date        time.Time
+	Value       float64
+	Assets      float64
+	Liabilities float64
+	SnapshotID  int
 }
 
 // allocationItem mirrors AllocationItem.

--- a/backend-go/internal/dashboard/handler.go
+++ b/backend-go/internal/dashboard/handler.go
@@ -145,8 +145,11 @@ func (f pyFloat) MarshalJSON() ([]byte, error) {
 }
 
 type netWorthPointWire struct {
-	Date  isoDate `json:"date"`
-	Value pyFloat `json:"value"`
+	Date        isoDate `json:"date"`
+	Value       pyFloat `json:"value"`
+	Assets      pyFloat `json:"assets"`
+	Liabilities pyFloat `json:"liabilities"`
+	SnapshotID  int     `json:"snapshot_id"`
 }
 
 type allocationItemWire struct {
@@ -262,7 +265,11 @@ func toWire(res result) dashboardWire {
 	w.NetWorthHistory = make([]netWorthPointWire, 0, len(res.NetWorthHistory))
 	for _, p := range res.NetWorthHistory {
 		w.NetWorthHistory = append(w.NetWorthHistory, netWorthPointWire{
-			Date: isoDate(p.Date), Value: pyFloat(p.Value),
+			Date:        isoDate(p.Date),
+			Value:       pyFloat(p.Value),
+			Assets:      pyFloat(p.Assets),
+			Liabilities: pyFloat(p.Liabilities),
+			SnapshotID:  p.SnapshotID,
 		})
 	}
 	w.Allocation = make([]allocationItemWire, 0, len(res.Allocation))

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -48,7 +48,14 @@ func aggregatePointsBySnapshot(aggRows []AggregateRow, snapshotDate map[int]time
 			SnapshotID:  sid,
 		})
 	}
-	sort.Slice(points, func(i, j int) bool { return points[i].Date.Before(points[j].Date) })
+	// Date primary, SnapshotID tiebreaker — keeps order stable when two
+	// snapshots share a calendar day.
+	sort.Slice(points, func(i, j int) bool {
+		if !points[i].Date.Equal(points[j].Date) {
+			return points[i].Date.Before(points[j].Date)
+		}
+		return points[i].SnapshotID < points[j].SnapshotID
+	})
 	return points, nil
 }
 

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -12,6 +12,49 @@ var allocationGroupMap = map[string]string{
 	"bond": "bonds", "gold": "gold",
 }
 
+// aggregatePointsBySnapshot collapses snapshot_aggregates rows (which are
+// per-(snapshot, owner)) into per-snapshot net-worth/assets/liabilities
+// points sorted by date. Missing snapshot dates cause a fail-fast error.
+func aggregatePointsBySnapshot(aggRows []AggregateRow, snapshotDate map[int]time.Time) ([]netWorthPoint, error) {
+	type snapAgg struct {
+		nw, assets, liabs float64
+	}
+	bySnap := map[int]*snapAgg{}
+	for _, r := range aggRows {
+		nw, _ := r.NetWorth.Float64()
+		ta, _ := r.TotalAssets.Float64()
+		tl, _ := r.TotalLiabilities.Float64()
+		agg, ok := bySnap[r.SnapshotID]
+		if !ok {
+			agg = &snapAgg{}
+			bySnap[r.SnapshotID] = agg
+		}
+		agg.nw += nw
+		agg.assets += ta
+		agg.liabs += tl
+	}
+	points := make([]netWorthPoint, 0, len(bySnap))
+	for sid, agg := range bySnap {
+		date, ok := snapshotDate[sid]
+		if !ok {
+			// A snapshot_aggregates row references a snapshot that doesn't
+			// exist — partial restore / corruption. Fail fast, as Python's
+			// snap_date[sid] KeyError does, rather than skewing the history
+			// with a zero date.
+			return nil, fmt.Errorf("aggregate references missing snapshot %d", sid)
+		}
+		points = append(points, netWorthPoint{
+			Date:        date,
+			Value:       agg.nw,
+			Assets:      agg.assets,
+			Liabilities: agg.liabs,
+			SnapshotID:  sid,
+		})
+	}
+	sort.Slice(points, func(i, j int) bool { return points[i].Date.Before(points[j].Date) })
+	return points, nil
+}
+
 // computeFromAggregates ports _get_dashboard_data_from_aggregates.
 func computeFromAggregates(ctx context.Context, s *Store, aggRows []AggregateRow) (result, error) {
 	shared, err := loadShared(ctx, s)
@@ -19,42 +62,19 @@ func computeFromAggregates(ctx context.Context, s *Store, aggRows []AggregateRow
 		return result{}, err
 	}
 
-	// net worth per snapshot, sorted by date.
-	snapNW := map[int]float64{}
-	for _, r := range aggRows {
-		nw, _ := r.NetWorth.Float64()
-		snapNW[r.SnapshotID] += nw
+	points, err := aggregatePointsBySnapshot(aggRows, shared.snapshotDate)
+	if err != nil {
+		return result{}, err
 	}
-	type snapNWPoint struct {
-		id   int
-		date time.Time
-		nw   float64
-	}
-	points := make([]snapNWPoint, 0, len(snapNW))
-	for sid, nw := range snapNW {
-		date, ok := shared.snapshotDate[sid]
-		if !ok {
-			// A snapshot_aggregates row references a snapshot that doesn't
-			// exist — partial restore / corruption. Fail fast, as Python's
-			// snap_date[sid] KeyError does, rather than skewing the history
-			// with a zero date.
-			return result{}, fmt.Errorf("aggregate references missing snapshot %d", sid)
-		}
-		points = append(points, snapNWPoint{id: sid, date: date, nw: nw})
-	}
-	sort.Slice(points, func(i, j int) bool { return points[i].date.Before(points[j].date) })
 
 	res := emptyResult()
-	res.NetWorthHistory = make([]netWorthPoint, 0, len(points))
-	for _, p := range points {
-		res.NetWorthHistory = append(res.NetWorthHistory, netWorthPoint{Date: p.date, Value: p.nw})
-	}
+	res.NetWorthHistory = points
 	if len(points) > 0 {
-		res.CurrentNetWorth = points[len(points)-1].nw
+		res.CurrentNetWorth = points[len(points)-1].Value
 	}
 	lastMonthNW := 0.0
 	if len(points) > 1 {
-		lastMonthNW = points[len(points)-2].nw
+		lastMonthNW = points[len(points)-2].Value
 	}
 	res.ChangeVsLastMonth = res.CurrentNetWorth - lastMonthNW
 
@@ -129,19 +149,56 @@ func computeRaw(ctx context.Context, s *Store) (result, error) {
 		return res, nil
 	}
 
-	// net worth grouped by date.
-	nwByDate := map[time.Time]float64{}
-	for _, r := range rows {
-		nwByDate[r.Date] += r.signedValue()
+	// net worth grouped by date — track assets/liabilities separately so
+	// the waterfall chart can show per-month contribution by side.
+	type byDateAgg struct {
+		nw, assets, liabs float64
+		snapshotID        int
 	}
-	dates := make([]time.Time, 0, len(nwByDate))
-	for d := range nwByDate {
+	byDate := map[time.Time]*byDateAgg{}
+	for _, r := range rows {
+		agg, ok := byDate[r.Date]
+		if !ok {
+			agg = &byDateAgg{}
+			byDate[r.Date] = agg
+		}
+		if r.AccountID != nil && r.AccType != nil {
+			if *r.AccType == "asset" {
+				agg.assets += r.Value
+			} else {
+				agg.liabs += r.Value
+			}
+		} else if r.AssetID != nil && r.AssetName != nil {
+			agg.assets += r.Value
+		}
+		agg.nw += r.signedValue()
+		// Lowest snapshot_id for a given date wins — multiple snapshots on
+		// one date is unusual; the click-through points at the earliest-
+		// created of the duplicates.
+		if agg.snapshotID == 0 || r.SnapshotID < agg.snapshotID {
+			agg.snapshotID = r.SnapshotID
+		}
+	}
+	dates := make([]time.Time, 0, len(byDate))
+	for d := range byDate {
 		dates = append(dates, d)
 	}
 	sort.Slice(dates, func(i, j int) bool { return dates[i].Before(dates[j]) })
 	res.NetWorthHistory = make([]netWorthPoint, 0, len(dates))
 	for _, d := range dates {
-		res.NetWorthHistory = append(res.NetWorthHistory, netWorthPoint{Date: d, Value: nwByDate[d]})
+		agg := byDate[d]
+		res.NetWorthHistory = append(res.NetWorthHistory, netWorthPoint{
+			Date:        d,
+			Value:       agg.nw,
+			Assets:      agg.assets,
+			Liabilities: agg.liabs,
+			SnapshotID:  agg.snapshotID,
+		})
+	}
+	// Convenience alias for the old single-value lookup below.
+	nwByDate := map[time.Time]float64{}
+	for d, agg := range byDate {
+		nwByDate[d] = agg.nw
 	}
 	if len(dates) > 0 {
 		res.CurrentNetWorth = nwByDate[dates[len(dates)-1]]

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -19,19 +19,16 @@ func aggregatePointsBySnapshot(aggRows []AggregateRow, snapshotDate map[int]time
 	type snapAgg struct {
 		nw, assets, liabs float64
 	}
-	bySnap := map[int]*snapAgg{}
+	bySnap := map[int]snapAgg{}
 	for _, r := range aggRows {
 		nw, _ := r.NetWorth.Float64()
 		ta, _ := r.TotalAssets.Float64()
 		tl, _ := r.TotalLiabilities.Float64()
-		agg, ok := bySnap[r.SnapshotID]
-		if !ok {
-			agg = &snapAgg{}
-			bySnap[r.SnapshotID] = agg
-		}
+		agg := bySnap[r.SnapshotID]
 		agg.nw += nw
 		agg.assets += ta
 		agg.liabs += tl
+		bySnap[r.SnapshotID] = agg
 	}
 	points := make([]netWorthPoint, 0, len(bySnap))
 	for sid, agg := range bySnap {
@@ -155,13 +152,11 @@ func computeRaw(ctx context.Context, s *Store) (result, error) {
 		nw, assets, liabs float64
 		snapshotID        int
 	}
-	byDate := map[time.Time]*byDateAgg{}
+	// Value-typed map so nilaway can verify every read is non-nil — the
+	// aggregate is updated by reassignment after each row.
+	byDate := map[time.Time]byDateAgg{}
 	for _, r := range rows {
-		agg, ok := byDate[r.Date]
-		if !ok {
-			agg = &byDateAgg{}
-			byDate[r.Date] = agg
-		}
+		agg := byDate[r.Date]
 		if r.AccountID != nil && r.AccType != nil {
 			if *r.AccType == "asset" {
 				agg.assets += r.Value
@@ -178,6 +173,7 @@ func computeRaw(ctx context.Context, s *Store) (result, error) {
 		if agg.snapshotID == 0 || r.SnapshotID < agg.snapshotID {
 			agg.snapshotID = r.SnapshotID
 		}
+		byDate[r.Date] = agg
 	}
 	dates := make([]time.Time, 0, len(byDate))
 	for d := range byDate {

--- a/src/lib/components/DashboardCharts.svelte
+++ b/src/lib/components/DashboardCharts.svelte
@@ -1,15 +1,25 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
 	import * as echarts from 'echarts';
-	import type { EChartsOption } from 'echarts';
+	import type { ECElementEvent, EChartsOption } from 'echarts';
 	import { formatPLN } from '$lib/utils/format';
 	import { isMobile, isTablet } from '$lib/utils/viewport';
 	import { chartPalette, chartAccent, chartAccentGradient } from '$lib/utils/theme';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
 	import { createChart } from '$lib/utils/charts/lifecycle';
+	import { buildWaterfallOption, buildWaterfallSteps } from '$lib/utils/charts/waterfall';
+
+	interface NetWorthHistoryPoint {
+		date: string;
+		value: number;
+		assets?: number;
+		liabilities?: number;
+		snapshot_id?: number;
+	}
 
 	interface Props {
-		netWorthHistory: { date: string; value: number }[];
+		netWorthHistory: NetWorthHistoryPoint[];
 		allocation: { category: string; owner_user_id: number | null; value: number }[];
 		owners: OwnerOption[];
 	}
@@ -18,8 +28,29 @@
 
 	let chartContainer: HTMLDivElement | undefined;
 	let pieChartContainer: HTMLDivElement | undefined;
+	// Read inside an $effect, so must be $state.
+	let waterfallContainer: HTMLDivElement | undefined = $state();
 	let lineChart: echarts.ECharts | undefined = $state(undefined);
 	let pieChart: echarts.ECharts | undefined = $state(undefined);
+	let waterfallChart: echarts.ECharts | undefined = $state(undefined);
+
+	const waterfallSteps = $derived.by(() => {
+		const usable = netWorthHistory.filter(
+			(h) => typeof h.assets === 'number' && typeof h.liabilities === 'number'
+		);
+		return buildWaterfallSteps(
+			usable.map((h) => ({
+				date: h.date,
+				snapshotId: h.snapshot_id ?? 0,
+				value: h.value,
+				assets: h.assets!,
+				liabilities: h.liabilities!
+			}))
+		);
+	});
+
+	const waterfallMaxMonths = $derived($isMobile ? 6 : 12);
+	const waterfallSliced = $derived(waterfallSteps.slice(-waterfallMaxMonths));
 
 	const gridConfig = $derived(
 		$isMobile
@@ -116,6 +147,35 @@
 	$effect(() => {
 		if (pieChart) pieChart.setOption(pieOption);
 	});
+
+	// Waterfall chart lifecycle: the container only mounts when at least
+	// two snapshots exist (deltas need a previous baseline). Create the
+	// chart once via `handle` so the ResizeObserver from createChart() is
+	// disconnected on teardown — `chart.dispose()` alone would leak it.
+	$effect(() => {
+		if (!waterfallContainer) return;
+		const handle = createChart(waterfallContainer);
+		waterfallChart = handle.chart;
+		return () => {
+			handle.dispose();
+			waterfallChart = undefined;
+		};
+	});
+
+	$effect(() => {
+		if (!waterfallChart) return;
+		// Wipe any prior click handler — `setOption` is fine to call
+		// repeatedly, but click handlers stack across reactive runs.
+		waterfallChart.off('click');
+		waterfallChart.on('click', (event: ECElementEvent) => {
+			const idx = event.dataIndex as number;
+			const step = waterfallSliced[idx];
+			if (step && step.snapshotId) {
+				goto(`/snapshots/${step.snapshotId}/edit`);
+			}
+		});
+		waterfallChart.setOption(buildWaterfallOption(waterfallSliced));
+	});
 </script>
 
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
@@ -127,3 +187,9 @@
 		<div bind:this={pieChartContainer} class="w-full h-[400px]"></div>
 	</div>
 </div>
+
+{#if waterfallSteps.length > 0}
+	<div class="card preset-filled-surface-100-900 p-4 mt-4">
+		<div bind:this={waterfallContainer} class="w-full h-[360px] cursor-pointer"></div>
+	</div>
+{/if}

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -1429,8 +1429,13 @@ export interface paths {
                                 savings_rate?: number | null;
                             };
                             net_worth_history?: {
+                                /** Format: double */
+                                assets?: number;
                                 /** Format: date */
                                 date?: string;
+                                /** Format: double */
+                                liabilities?: number;
+                                snapshot_id?: number;
                                 /** Format: double */
                                 value?: number;
                             }[];

--- a/src/lib/utils/charts/waterfall.test.ts
+++ b/src/lib/utils/charts/waterfall.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { buildWaterfallOption, buildWaterfallSteps, type NetWorthPoint } from './waterfall';
+
+function point(
+	date: string,
+	snapshotId: number,
+	value: number,
+	assets: number,
+	liabilities: number
+): NetWorthPoint {
+	return { date, snapshotId, value, assets, liabilities };
+}
+
+describe('buildWaterfallSteps', () => {
+	it('returns empty for fewer than two points', () => {
+		expect(buildWaterfallSteps([])).toEqual([]);
+		expect(buildWaterfallSteps([point('2025-01-31', 1, 100, 150, 50)])).toEqual([]);
+	});
+
+	it('computes month-over-month deltas', () => {
+		const steps = buildWaterfallSteps([
+			point('2025-01-31', 1, 100, 200, 100),
+			point('2025-02-28', 2, 130, 240, 110),
+			point('2025-03-31', 3, 150, 250, 100)
+		]);
+		expect(steps).toHaveLength(2);
+		expect(steps[0]).toMatchObject({
+			snapshotId: 2,
+			startingNetWorth: 100,
+			endingNetWorth: 130,
+			assetDelta: 40,
+			liabilityDelta: 10
+		});
+		expect(steps[1]).toMatchObject({
+			snapshotId: 3,
+			startingNetWorth: 130,
+			endingNetWorth: 150,
+			assetDelta: 10,
+			liabilityDelta: -10
+		});
+	});
+});
+
+describe('buildWaterfallOption', () => {
+	const steps = buildWaterfallSteps([
+		point('2025-01-31', 1, 100, 200, 100),
+		point('2025-02-28', 2, 130, 240, 110), // assets +40, liab +10
+		point('2025-03-31', 3, 150, 250, 100) // assets +10, liab -10
+	]);
+
+	it('emits 3 series: asset delta, liability delta, net worth line', () => {
+		const opt = buildWaterfallOption(steps);
+		const series = opt.series as Array<{ name: string; type: string }>;
+		expect(series).toHaveLength(3);
+		expect(series.map((s) => s.name)).toEqual(['Δ Aktywa', 'Δ Zobowiązania', 'Wartość netto']);
+		expect(series[2].type).toBe('line');
+	});
+
+	it('liability series inverts the sign so an increase reads as a negative contribution', () => {
+		const opt = buildWaterfallOption(steps);
+		const series = opt.series as Array<{ data: Array<{ value: number }> }>;
+		expect(series[1].data[0].value).toBe(-10); // liability grew → drag
+		expect(series[1].data[1].value).toBe(10); // liability shrank → boost
+	});
+
+	it('green for positive asset delta, red for negative', () => {
+		const negSteps = buildWaterfallSteps([
+			point('2025-01-31', 1, 100, 200, 100),
+			point('2025-02-28', 2, 80, 180, 100) // assets -20
+		]);
+		const opt = buildWaterfallOption(negSteps);
+		const assetData = (opt.series as Array<{ data: Array<{ itemStyle: { color: string } }> }>)[0]
+			.data;
+		const liabData = (opt.series as Array<{ data: Array<{ itemStyle: { color: string } }> }>)[1]
+			.data;
+		expect(assetData[0].itemStyle.color).toBe('#BF616A'); // red
+		expect(liabData[0].itemStyle.color).toBe('#A3BE8C'); // no liab change → green branch
+	});
+
+	it('maxMonths crops to the most recent N steps', () => {
+		const many = buildWaterfallSteps([
+			point('2025-01-31', 1, 100, 200, 100),
+			point('2025-02-28', 2, 110, 210, 100),
+			point('2025-03-31', 3, 120, 220, 100),
+			point('2025-04-30', 4, 130, 230, 100),
+			point('2025-05-31', 5, 140, 240, 100),
+			point('2025-06-30', 6, 150, 250, 100),
+			point('2025-07-31', 7, 160, 260, 100)
+		]);
+		const opt = buildWaterfallOption(many, { maxMonths: 3 });
+		const xAxis = opt.xAxis as { data: string[] };
+		expect(xAxis.data).toHaveLength(3);
+		const series = opt.series as Array<{ data: unknown[] }>;
+		expect(series[0].data).toHaveLength(3);
+	});
+
+	it('tooltip renders monthly breakdown', () => {
+		const opt = buildWaterfallOption(steps);
+		const tooltip = opt.tooltip as unknown as {
+			formatter: (params: Array<{ dataIndex: number }>) => string;
+		};
+		const html = tooltip.formatter([{ dataIndex: 0 }]);
+		expect(html).toContain('Saldo początkowe');
+		expect(html).toContain('Δ Aktywa');
+		expect(html).toContain('Δ Zobowiązania');
+		expect(html).toContain('Saldo końcowe');
+	});
+});

--- a/src/lib/utils/charts/waterfall.ts
+++ b/src/lib/utils/charts/waterfall.ts
@@ -1,4 +1,4 @@
-import type { BarSeriesOption, EChartsOption } from 'echarts';
+import type { BarSeriesOption, EChartsOption, LineSeriesOption } from 'echarts';
 import type { TopLevelFormatterParams } from 'echarts/types/dist/shared';
 
 export interface NetWorthPoint {
@@ -98,7 +98,7 @@ export function buildWaterfallOption(
 			itemStyle: { color: s.liabilityDelta <= 0 ? COLOR_LIAB_NEG : COLOR_LIAB_POS }
 		}))
 	};
-	const netWorthLine: BarSeriesOption = {
+	const netWorthLine: LineSeriesOption = {
 		name: 'Wartość netto',
 		type: 'line',
 		yAxisIndex: 1,
@@ -107,7 +107,7 @@ export function buildWaterfallOption(
 		data: sliced.map((s) => s.endingNetWorth),
 		lineStyle: { color: COLOR_LINE, width: 2 },
 		itemStyle: { color: COLOR_LINE }
-	} as unknown as BarSeriesOption;
+	};
 
 	return {
 		title: { text: 'Wartość netto — wkład miesięczny' },

--- a/src/lib/utils/charts/waterfall.ts
+++ b/src/lib/utils/charts/waterfall.ts
@@ -1,0 +1,151 @@
+import type { BarSeriesOption, EChartsOption } from 'echarts';
+import type { TopLevelFormatterParams } from 'echarts/types/dist/shared';
+
+export interface NetWorthPoint {
+	date: string;
+	snapshotId: number;
+	value: number;
+	assets: number;
+	liabilities: number;
+}
+
+export interface WaterfallStep {
+	date: string;
+	snapshotId: number;
+	startingNetWorth: number;
+	endingNetWorth: number;
+	assetDelta: number;
+	liabilityDelta: number;
+}
+
+const COLOR_ASSET_POS = '#A3BE8C'; // green: assets grew
+const COLOR_ASSET_NEG = '#BF616A'; // red: assets fell
+const COLOR_LIAB_POS = '#BF616A'; // red: liabilities grew (worse)
+const COLOR_LIAB_NEG = '#A3BE8C'; // green: liabilities shrank (better)
+const COLOR_LINE = '#5E81AC';
+
+// Tooltips render as HTML; escape any interpolated string in case future
+// labels carry user content.
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}
+
+// buildWaterfallSteps derives month-over-month deltas from consecutive
+// snapshots. A history of N points yields N-1 steps.
+export function buildWaterfallSteps(history: NetWorthPoint[]): WaterfallStep[] {
+	const out: WaterfallStep[] = [];
+	for (let i = 1; i < history.length; i++) {
+		const prev = history[i - 1];
+		const curr = history[i];
+		out.push({
+			date: curr.date,
+			snapshotId: curr.snapshotId,
+			startingNetWorth: prev.value,
+			endingNetWorth: curr.value,
+			assetDelta: curr.assets - prev.assets,
+			liabilityDelta: curr.liabilities - prev.liabilities
+		});
+	}
+	return out;
+}
+
+function fmtPLN(value: number): string {
+	const sign = value > 0 ? '+' : value < 0 ? '−' : '';
+	const abs = Math.abs(value).toLocaleString('pl-PL', { maximumFractionDigits: 0 });
+	return `${sign}${abs} PLN`;
+}
+
+function formatMonth(dateISO: string): string {
+	const d = new Date(dateISO);
+	if (Number.isNaN(d.getTime())) return dateISO;
+	return d.toLocaleDateString('pl-PL', { year: '2-digit', month: 'short' });
+}
+
+export interface WaterfallChartOptions {
+	maxMonths?: number; // crop to the most recent N steps (mobile = 6)
+}
+
+// buildWaterfallOption renders a grouped bar chart: per month, an Asset Δ
+// bar and a Liability Δ bar, plus an overlaid line of running net worth.
+// Color-coded so positive contributions are green, negative are red.
+export function buildWaterfallOption(
+	steps: WaterfallStep[],
+	options: WaterfallChartOptions = {}
+): EChartsOption {
+	const sliced = options.maxMonths ? steps.slice(-options.maxMonths) : steps;
+
+	const months = sliced.map((s) => formatMonth(s.date));
+	const assetSeries: BarSeriesOption = {
+		name: 'Δ Aktywa',
+		type: 'bar',
+		data: sliced.map((s) => ({
+			value: s.assetDelta,
+			itemStyle: { color: s.assetDelta >= 0 ? COLOR_ASSET_POS : COLOR_ASSET_NEG }
+		}))
+	};
+	// Liability delta is shown as how it impacted net worth: a liability
+	// increase is a red drag, a decrease (paying down debt) is green.
+	const liabilitySeries: BarSeriesOption = {
+		name: 'Δ Zobowiązania',
+		type: 'bar',
+		data: sliced.map((s) => ({
+			value: -s.liabilityDelta,
+			itemStyle: { color: s.liabilityDelta <= 0 ? COLOR_LIAB_NEG : COLOR_LIAB_POS }
+		}))
+	};
+	const netWorthLine: BarSeriesOption = {
+		name: 'Wartość netto',
+		type: 'line',
+		yAxisIndex: 1,
+		smooth: true,
+		showSymbol: true,
+		data: sliced.map((s) => s.endingNetWorth),
+		lineStyle: { color: COLOR_LINE, width: 2 },
+		itemStyle: { color: COLOR_LINE }
+	} as unknown as BarSeriesOption;
+
+	return {
+		title: { text: 'Wartość netto — wkład miesięczny' },
+		tooltip: {
+			trigger: 'axis',
+			formatter: (params: TopLevelFormatterParams) => {
+				const items = Array.isArray(params) ? params : [params];
+				const idx = items[0].dataIndex as number;
+				const step = sliced[idx];
+				if (!step) return '';
+				const month = escapeHtml(formatMonth(step.date));
+				const netDelta = step.endingNetWorth - step.startingNetWorth;
+				return (
+					`<strong>${month}</strong><br/>` +
+					`Saldo początkowe: ${step.startingNetWorth.toLocaleString('pl-PL', { maximumFractionDigits: 0 })} PLN<br/>` +
+					`Δ Aktywa: ${fmtPLN(step.assetDelta)}<br/>` +
+					`Δ Zobowiązania: ${fmtPLN(step.liabilityDelta)}<br/>` +
+					`Saldo końcowe: ${step.endingNetWorth.toLocaleString('pl-PL', { maximumFractionDigits: 0 })} PLN<br/>` +
+					`<strong>Zmiana netto: ${fmtPLN(netDelta)}</strong>`
+				);
+			}
+		},
+		legend: { data: ['Δ Aktywa', 'Δ Zobowiązania', 'Wartość netto'], bottom: 0 },
+		grid: { left: '3%', right: '4%', bottom: '15%', containLabel: true },
+		xAxis: { type: 'category', data: months },
+		yAxis: [
+			{
+				type: 'value',
+				name: 'Wkład (PLN)',
+				axisLabel: { formatter: (v: number) => `${(v / 1000).toFixed(0)}k` }
+			},
+			{
+				type: 'value',
+				name: 'Saldo (PLN)',
+				position: 'right',
+				axisLabel: { formatter: (v: number) => `${(v / 1000).toFixed(0)}k` }
+			}
+		],
+		series: [assetSeries, liabilitySeries, netWorthLine]
+	};
+}


### PR DESCRIPTION
## Motivation

Single net-worth line tells you what but not why. Waterfall chart shows
"assets went up by X, liabilities went down by Y → net Δ Z" per month
(inspired by Monarch). Closes #379.

## Implementation information

**Backend (`backend-go/internal/dashboard/`):**
- `netWorthPoint` gains `Assets`, `Liabilities`, `SnapshotID` — the
  frontend can now compute month-over-month asset Δ vs liability Δ.
- `computeFromAggregates` factored into `aggregatePointsBySnapshot` (the
  body grew past golangci's funlen budget after adding the new fields).
- Raw fallback path tracks assets/liabilities separately per date and
  picks the lowest snapshot_id when duplicates share a date.

**Frontend (`src/`):**
- New `lib/utils/charts/waterfall.ts` — `buildWaterfallSteps` derives
  N-1 deltas from N points; `buildWaterfallOption` renders a grouped
  bar chart (Δ Assets + Δ Liabilities) with a running net-worth line
  on a secondary y-axis, with color coding (green = boost, red = drag).
- `DashboardCharts.svelte` mounts a third chart card below the existing
  line + pie when at least 2 snapshots exist. The viewport-dependent
  slice (`maxMonths = $isMobile ? 6 : 12`) is shared between the chart
  and the click handler, so dataIndex resolves to the same step both
  sides. Click navigates to `/snapshots/<id>/edit` (the breakdown view).
- Chart lifecycle split into two effects: handle creation once when the
  container mounts (cleanup disposes the handle's ResizeObserver), and
  click-handler + setOption when the data changes.

Alternatives considered: true Tufte-style waterfall with floating bars
(rejected — clearer as grouped bars + running line for non-finance
audiences); a separate `/dashboard/waterfall` page (rejected — issue
explicitly says "on dashboard").

## Supporting documentation

Issue #379 — subissue of #355.

> Changelog: feat(dashboard): net-worth waterfall chart