### PR TITLE
feat(tax): IKZE PIT tax-deduction tracker

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -4201,11 +4201,21 @@
                         "nullable": true,
                         "type": "number"
                       },
+                      "marginal_tax_rate": {
+                        "format": "double",
+                        "nullable": true,
+                        "type": "number"
+                      },
                       "owner_user_id": {
                         "nullable": true,
                         "type": "integer"
                       },
                       "percentage_used": {
+                        "format": "double",
+                        "nullable": true,
+                        "type": "number"
+                      },
+                      "pit_savings": {
                         "format": "double",
                         "nullable": true,
                         "type": "number"

--- a/backend-bb-tests/golden/retirement_stats_2025.json
+++ b/backend-bb-tests/golden/retirement_stats_2025.json
@@ -5,8 +5,10 @@
     "employer_contributed": 0.0,
     "is_warning": false,
     "limit_amount": 23472.0,
+    "marginal_tax_rate": null,
     "owner_user_id": 2,
     "percentage_used": 6.4,
+    "pit_savings": null,
     "remaining": 21972.0,
     "total_contributed": 1500.0,
     "year": 2025

--- a/backend-go/internal/retirement/handler.go
+++ b/backend-go/internal/retirement/handler.go
@@ -29,6 +29,11 @@ type yearlyStat struct {
 	Remaining           *pyFloat `json:"remaining"`
 	PercentageUsed      *pyFloat `json:"percentage_used"`
 	IsWarning           bool     `json:"is_warning"`
+	// IKZE-only: marginal PIT rate at the owner's annualized salary and
+	// the estimated PIT savings from this year's contributions. Nil when
+	// the wrapper is not IKZE or the owner has no salary record.
+	MarginalTaxRate *pyFloat `json:"marginal_tax_rate"`
+	PITSavings      *pyFloat `json:"pit_savings"`
 }
 
 type ppkStat struct {
@@ -156,7 +161,7 @@ func (h *Handler) buildYearlyStat(ctx context.Context, year int, wrapper string,
 	lAmt := pyFloat(limitF)
 	rem := pyFloat(remaining)
 	pct := pyFloat(math.Round(percentage*10) / 10)
-	return yearlyStat{
+	stat := yearlyStat{
 		Year: year, AccountWrapper: wrapper, OwnerUserID: ownerUserID,
 		LimitAmount:         &lAmt,
 		TotalContributed:    pyFloat(totalF),
@@ -168,7 +173,39 @@ func (h *Handler) buildYearlyStat(ctx context.Context, year int, wrapper string,
 		// the raw value, so 89.95% must NOT flip the flag even though it
 		// rounds to 90.0 in percentage_used.
 		IsWarning: percentage >= 90,
-	}, true, nil
+	}
+	if wrapper == "IKZE" && totalF > 0 {
+		if rate, savings, ok := h.estimateIKZEPITSavings(ctx, ownerUserID, year, totalF); ok {
+			r := pyFloat(rate)
+			s := pyFloat(savings)
+			stat.MarginalTaxRate = &r
+			stat.PITSavings = &s
+		}
+	}
+	return stat, true, nil
+}
+
+// estimateIKZEPITSavings derives the owner's marginal PIT rate from their
+// latest salary record on or before year-end, then approximates the tax
+// saved by deducting the year's IKZE contributions. Returns ok=false when
+// the owner has no salary on record.
+func (h *Handler) estimateIKZEPITSavings(ctx context.Context, ownerUserID *int, year int, contribution float64) (float64, float64, bool) {
+	asOf := time.Date(year, 12, 31, 0, 0, 0, 0, time.UTC)
+	monthlyGross, err := h.store.CurrentSalaryFor(ctx, ownerUserID, asOf)
+	if err != nil {
+		// Skip the PIT card for owners with no salary. Anything else is an
+		// infra error that shouldn't silently degrade the UI — log it.
+		if !errors.Is(err, ErrNoSalary) {
+			h.logger.Warn("ikze pit salary lookup", "owner", ownerUserID, "err", err)
+		}
+		return 0, 0, false
+	}
+	monthly, _ := monthlyGross.Float64()
+	if monthly <= 0 {
+		return 0, 0, false
+	}
+	annualGross := monthly * 12
+	return MarginalPITRate(annualGross), EstimatePITSavings(contribution, annualGross), true
 }
 
 // PPKStats serves GET /api/retirement/ppk-stats.

--- a/backend-go/internal/retirement/pit.go
+++ b/backend-go/internal/retirement/pit.go
@@ -1,0 +1,43 @@
+package retirement
+
+// Polish PIT brackets (2024+ — kwota wolna 30k, próg 120k, plus solidarity
+// surcharge on annual income above PLN 1M). Mirrors src/lib/utils/pl_tax.ts.
+const (
+	pitFreeAmount       = 30_000.0
+	pitThresholdAnnual  = 120_000.0
+	pitLowRate          = 0.12
+	pitHighRate         = 0.32
+	solidarityThreshold = 1_000_000.0
+	solidarityRate      = 0.04
+)
+
+// MarginalPITRate returns the applicable marginal rate for the next zloty
+// earned at a given annual gross income. Below the kwota wolna (PLN 30k)
+// the rate is zero; above PLN 1M the 4% solidarity surcharge is added.
+func MarginalPITRate(annualGross float64) float64 {
+	if annualGross <= pitFreeAmount {
+		return 0
+	}
+	rate := pitLowRate
+	if annualGross > pitThresholdAnnual {
+		rate = pitHighRate
+	}
+	if annualGross > solidarityThreshold {
+		rate += solidarityRate
+	}
+	return rate
+}
+
+// EstimatePITSavings approximates the income-tax saved by deducting a
+// year's IKZE contributions from taxable income. Uses the marginal rate
+// at the *pre*-deduction income level — accurate when the contribution
+// doesn't straddle a bracket boundary, slightly overstates savings when
+// it does (the part of the deduction below the next bracket would
+// actually save at the lower rate). Display estimate, not a filing.
+func EstimatePITSavings(contribution, annualGross float64) float64 {
+	if contribution <= 0 || annualGross <= 0 {
+		return 0
+	}
+	rate := MarginalPITRate(annualGross)
+	return contribution * rate
+}

--- a/backend-go/internal/retirement/pit_test.go
+++ b/backend-go/internal/retirement/pit_test.go
@@ -1,0 +1,57 @@
+package retirement
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMarginalPITRate(t *testing.T) {
+	cases := []struct {
+		name        string
+		annualGross float64
+		want        float64
+	}{
+		{"below kwota wolna is zero", 25_000, 0},
+		{"at kwota wolna boundary stays zero", 30_000, 0},
+		{"just above kwota wolna is 12%", 30_001, 0.12},
+		{"at threshold stays 12%", 120_000, 0.12},
+		{"just above threshold is 32%", 120_001, 0.32},
+		{"between threshold and 1M is 32%", 250_000, 0.32},
+		{"at 1M solidarity boundary stays 32%", 1_000_000, 0.32},
+		{"above 1M adds 4% solidarity", 1_500_000, 0.36},
+		{"negative income treated as below kwota wolna", -100, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MarginalPITRate(tc.annualGross)
+			if math.Abs(got-tc.want) > 1e-9 {
+				t.Errorf("MarginalPITRate(%v) = %v, want %v", tc.annualGross, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEstimatePITSavings(t *testing.T) {
+	cases := []struct {
+		name         string
+		contribution float64
+		annualGross  float64
+		want         float64
+	}{
+		{"low bracket: 12% of contribution", 10_000, 80_000, 1200},
+		{"high bracket: 32% of contribution", 10_000, 150_000, 3200},
+		{"with solidarity: 36% of contribution", 10_000, 1_500_000, 3600},
+		{"zero contribution returns zero", 0, 150_000, 0},
+		{"negative contribution returns zero", -5_000, 150_000, 0},
+		{"zero gross returns zero", 10_000, 0, 0},
+		{"income below kwota wolna returns zero savings", 5_000, 25_000, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EstimatePITSavings(tc.contribution, tc.annualGross)
+			if math.Abs(got-tc.want) > 1e-6 {
+				t.Errorf("EstimatePITSavings(%v, %v) = %v, want %v", tc.contribution, tc.annualGross, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/lib/components/IKZEPITTracker.svelte
+++ b/src/lib/components/IKZEPITTracker.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { resolveApiUrl } from '$lib/api';
+	import { formatPLN, formatPercent } from '$lib/utils/format';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
 	import { ShieldCheck, Receipt } from 'lucide-svelte';
 
@@ -42,23 +43,17 @@
 		}
 	});
 
-	function fmtPLN(value: number | null | undefined): string {
-		if (value === null || value === undefined) return '—';
-		return value.toLocaleString('pl-PL', { maximumFractionDigits: 0 }) + ' PLN';
-	}
-
-	function fmtPct(value: number | null | undefined): string {
-		if (value === null || value === undefined) return '—';
-		return `${value.toFixed(1)}%`;
-	}
-
+	// marginal_tax_rate ships as a decimal (0.32), but formatPercent expects
+	// percent units — scale up first.
 	function fmtRate(value: number | null | undefined): string {
-		if (value === null || value === undefined) return '—';
-		return `${(value * 100).toFixed(0)}%`;
+		if (value == null) return '—';
+		return formatPercent(value * 100);
 	}
 
 	function progressClass(pct: number | null | undefined): string {
-		if (!pct) return 'bg-surface-300-700';
+		// `== null` matches both null and undefined but not 0 — important so
+		// "no data" (no aggregate at all) stays distinct from "0% used".
+		if (pct == null) return 'bg-surface-300-700';
 		// Order matters: ≥100 must check first or the ≥90 branch shadows it.
 		if (pct >= 100) return 'bg-success-500';
 		if (pct >= 90) return 'bg-warning-500';
@@ -88,8 +83,8 @@
 	{:else}
 		<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 			{#each ikzeRows as row (row.owner_user_id ?? 'shared')}
-				{@const label = row.owner_user_id ? ownerName(owners, row.owner_user_id) : 'Wspólne'}
-				{@const pct = row.percentage_used ?? 0}
+				{@const label = ownerName(owners, row.owner_user_id)}
+				{@const pct = row.percentage_used}
 				<article class="card preset-tonal-surface p-4 space-y-3">
 					<div class="flex items-center justify-between gap-2">
 						<div class="font-semibold flex items-center gap-2">
@@ -105,15 +100,18 @@
 						<div class="flex justify-between text-sm">
 							<span class="text-surface-700-300">Wpłacono</span>
 							<span class="font-semibold">
-								{fmtPLN(row.total_contributed)} / {fmtPLN(row.limit_amount)}
+								{formatPLN(row.total_contributed)} / {formatPLN(row.limit_amount)}
 							</span>
 						</div>
 						<div class="h-2 w-full bg-surface-300-700 rounded-full overflow-hidden">
-							<div class="h-full {progressClass(pct)}" style="width: {Math.min(pct, 100)}%"></div>
+							<div
+								class="h-full {progressClass(pct)}"
+								style="width: {Math.min(pct ?? 0, 100)}%"
+							></div>
 						</div>
 						<div class="flex justify-between text-xs text-surface-600-400">
-							<span>{fmtPct(row.percentage_used)} limitu</span>
-							<span>Pozostało {fmtPLN(row.remaining)}</span>
+							<span>{formatPercent(row.percentage_used)} limitu</span>
+							<span>Pozostało {formatPLN(row.remaining)}</span>
 						</div>
 					</div>
 
@@ -124,7 +122,7 @@
 						</div>
 						<div>
 							<div class="text-xs text-surface-600-400">Szac. oszczędność PIT</div>
-							<div class="font-bold text-success-600-400">{fmtPLN(row.pit_savings)}</div>
+							<div class="font-bold text-success-600-400">{formatPLN(row.pit_savings)}</div>
 						</div>
 					</div>
 				</article>

--- a/src/lib/components/IKZEPITTracker.svelte
+++ b/src/lib/components/IKZEPITTracker.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { resolveApiUrl } from '$lib/api';
+	import { ownerName, type OwnerOption } from '$lib/types/owners';
+	import { ShieldCheck, Receipt } from 'lucide-svelte';
+
+	interface YearlyStat {
+		year: number;
+		account_wrapper: string;
+		owner_user_id: number | null;
+		limit_amount: number | null;
+		total_contributed: number;
+		remaining: number | null;
+		percentage_used: number | null;
+		marginal_tax_rate: number | null;
+		pit_savings: number | null;
+		is_warning: boolean;
+	}
+
+	let stats = $state<YearlyStat[]>([]);
+	let owners = $state<OwnerOption[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	const currentYear = new Date().getFullYear();
+	const ikzeRows = $derived(stats.filter((s) => s.account_wrapper === 'IKZE'));
+
+	onMount(async () => {
+		try {
+			const apiUrl = resolveApiUrl();
+			const [statsRes, ownersRes] = await Promise.all([
+				fetch(`${apiUrl}/api/retirement/stats?year=${currentYear}`),
+				fetch(`${apiUrl}/api/users`)
+			]);
+			if (!statsRes.ok) throw new Error(`Stats failed: ${statsRes.statusText}`);
+			stats = await statsRes.json();
+			owners = ownersRes.ok ? await ownersRes.json() : [];
+		} catch (err) {
+			if (err instanceof Error) error = err.message;
+		} finally {
+			loading = false;
+		}
+	});
+
+	function fmtPLN(value: number | null | undefined): string {
+		if (value === null || value === undefined) return '—';
+		return value.toLocaleString('pl-PL', { maximumFractionDigits: 0 }) + ' PLN';
+	}
+
+	function fmtPct(value: number | null | undefined): string {
+		if (value === null || value === undefined) return '—';
+		return `${value.toFixed(1)}%`;
+	}
+
+	function fmtRate(value: number | null | undefined): string {
+		if (value === null || value === undefined) return '—';
+		return `${(value * 100).toFixed(0)}%`;
+	}
+
+	function progressClass(pct: number | null | undefined): string {
+		if (!pct) return 'bg-surface-300-700';
+		// Order matters: ≥100 must check first or the ≥90 branch shadows it.
+		if (pct >= 100) return 'bg-success-500';
+		if (pct >= 90) return 'bg-warning-500';
+		return 'bg-primary-500';
+	}
+</script>
+
+<section class="card preset-filled-surface-100-900 p-5 space-y-4">
+	<header class="space-y-1">
+		<h2 class="h4 flex items-center gap-2">
+			<Receipt size={20} class="text-primary-500" />
+			IKZE — oszczędność na PIT
+		</h2>
+		<p class="text-sm text-surface-700-300">
+			Wpłaty na IKZE odliczasz od dochodu — szacunek oszczędności podatkowej w {currentYear}.
+		</p>
+	</header>
+
+	{#if loading}
+		<p class="text-sm text-surface-700-300">Ładowanie…</p>
+	{:else if error}
+		<div class="card preset-tonal-error p-3 text-sm">{error}</div>
+	{:else if ikzeRows.length === 0}
+		<p class="text-sm text-surface-700-300">
+			Brak kont IKZE w bieżącym roku — dodaj konto i transakcje, aby zobaczyć oszczędność na PIT.
+		</p>
+	{:else}
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+			{#each ikzeRows as row (row.owner_user_id ?? 'shared')}
+				{@const label = row.owner_user_id ? ownerName(owners, row.owner_user_id) : 'Wspólne'}
+				{@const pct = row.percentage_used ?? 0}
+				<article class="card preset-tonal-surface p-4 space-y-3">
+					<div class="flex items-center justify-between gap-2">
+						<div class="font-semibold flex items-center gap-2">
+							<ShieldCheck size={16} class="text-primary-500" />
+							{label}
+						</div>
+						{#if row.is_warning}
+							<span class="badge preset-filled-warning-500 text-xs">Limit blisko</span>
+						{/if}
+					</div>
+
+					<div class="space-y-1">
+						<div class="flex justify-between text-sm">
+							<span class="text-surface-700-300">Wpłacono</span>
+							<span class="font-semibold">
+								{fmtPLN(row.total_contributed)} / {fmtPLN(row.limit_amount)}
+							</span>
+						</div>
+						<div class="h-2 w-full bg-surface-300-700 rounded-full overflow-hidden">
+							<div class="h-full {progressClass(pct)}" style="width: {Math.min(pct, 100)}%"></div>
+						</div>
+						<div class="flex justify-between text-xs text-surface-600-400">
+							<span>{fmtPct(row.percentage_used)} limitu</span>
+							<span>Pozostało {fmtPLN(row.remaining)}</span>
+						</div>
+					</div>
+
+					<div class="grid grid-cols-2 gap-2 pt-2 border-t border-surface-200-800">
+						<div>
+							<div class="text-xs text-surface-600-400">Stawka krańcowa</div>
+							<div class="font-bold">{fmtRate(row.marginal_tax_rate)}</div>
+						</div>
+						<div>
+							<div class="text-xs text-surface-600-400">Szac. oszczędność PIT</div>
+							<div class="font-bold text-success-600-400">{fmtPLN(row.pit_savings)}</div>
+						</div>
+					</div>
+				</article>
+			{/each}
+		</div>
+	{/if}
+</section>

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -2782,9 +2782,13 @@ export interface paths {
                             is_warning?: boolean;
                             /** Format: double */
                             limit_amount?: number | null;
+                            /** Format: double */
+                            marginal_tax_rate?: number | null;
                             owner_user_id?: number | null;
                             /** Format: double */
                             percentage_used?: number | null;
+                            /** Format: double */
+                            pit_savings?: number | null;
                             /** Format: double */
                             remaining?: number | null;
                             /** Format: double */

--- a/src/routes/retirement/+page.svelte
+++ b/src/routes/retirement/+page.svelte
@@ -4,6 +4,7 @@
 	import { buildMonteCarloFanOption, type MonteCarloResult } from '$lib/utils/charts/montecarlo';
 	import { Info, Sparkles } from 'lucide-svelte';
 	import * as echarts from 'echarts';
+	import IKZEPITTracker from '$lib/components/IKZEPITTracker.svelte';
 
 	let currentPortfolio = $state(100000);
 	let annualContribution = $state(20000);
@@ -117,6 +118,8 @@
 			Tysiąc losowych ścieżek emerytalnych zamiast jednego deterministycznego planu.
 		</p>
 	</header>
+
+	<IKZEPITTracker />
 
 	<section class="card preset-filled-surface-100-900 p-5 space-y-4">
 		<h2 class="h4">Parametry</h2>


### PR DESCRIPTION
## Motivation

IKZE contributions reduce PIT taxable income but the dashboard has no
"how much tax did this save" view. Users have been asking for a
contribution-vs-limit progress bar plus an estimated savings figure.
Closes #370.

## Implementation information

**Backend (`backend-go/internal/retirement/`):**
- `pit.go` — Polish PIT bracket constants (12% / 32% with +4% solidarity
  surcharge above PLN 1M; PLN 30k kwota wolna), `MarginalPITRate` and
  `EstimatePITSavings`.
- `handler.go` — extends `yearlyStat` with `marginal_tax_rate` and
  `pit_savings` (nil except for IKZE rows with a salary on file).
  `estimateIKZEPITSavings` reads `CurrentSalaryFor` (already in the
  retirement store), annualizes monthly × 12, logs unexpected store
  errors instead of swallowing them.
- Annual sum from Transactions and limit lookup reuse the existing
  `YearlyContributions` + `LimitConfigured` plumbing — no new SQL.
- API spec + TS types regenerated.

**Frontend:**
- `src/lib/components/IKZEPITTracker.svelte` — per-persona card with
  progress bar (warning ≥90%, success ≥100%), marginal rate, and
  estimated savings.
- Mounted above the Monte Carlo card on `/retirement`.

Approximation notes (also commented in `pit.go`):
- Uses pre-deduction marginal rate; slightly overstates when the
  deduction crosses a bracket boundary. Display estimate, not a filing.
- Bonus/equity income isn't folded into the marginal-rate calc — issue
  scope says "from SalaryRecord".

## Supporting documentation

Issue #370.

> Changelog: feat(tax): IKZE PIT tax-deduction tracker