### PR TITLE
feat(dashboard): FIRE number + runway badge

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -1962,7 +1962,9 @@
                     "retirement_monthly_salary": {
                       "type": "string"
                     },
-                    "withdrawal_rate": {}
+                    "withdrawal_rate": {
+                      "type": "string"
+                    }
                   },
                   "type": "object"
                 }
@@ -2064,7 +2066,9 @@
                     "retirement_monthly_salary": {
                       "type": "string"
                     },
-                    "withdrawal_rate": {}
+                    "withdrawal_rate": {
+                      "type": "string"
+                    }
                   },
                   "type": "object"
                 }

--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -1961,7 +1961,8 @@
                     },
                     "retirement_monthly_salary": {
                       "type": "string"
-                    }
+                    },
+                    "withdrawal_rate": {}
                   },
                   "type": "object"
                 }
@@ -2011,6 +2012,10 @@
                   },
                   "retirement_monthly_salary": {
                     "type": "string"
+                  },
+                  "withdrawal_rate": {
+                    "nullable": true,
+                    "type": "string"
                   }
                 },
                 "type": "object"
@@ -2058,7 +2063,8 @@
                     },
                     "retirement_monthly_salary": {
                       "type": "string"
-                    }
+                    },
+                    "withdrawal_rate": {}
                   },
                   "type": "object"
                 }
@@ -2386,6 +2392,11 @@
                     },
                     "metric_cards": {
                       "properties": {
+                        "annual_expenses": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
                         "debt_to_income_ratio": {
                           "format": "double",
                           "nullable": true,
@@ -2393,6 +2404,16 @@
                         },
                         "emergency_fund_months": {
                           "format": "double",
+                          "type": "number"
+                        },
+                        "fi_progress": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "fire_number": {
+                          "format": "double",
+                          "nullable": true,
                           "type": "number"
                         },
                         "hour_of_life_cost": {
@@ -2436,7 +2457,17 @@
                           "format": "double",
                           "type": "number"
                         },
+                        "runway_months": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
                         "savings_rate": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "withdrawal_rate": {
                           "format": "double",
                           "nullable": true,
                           "type": "number"

--- a/backend-bb-tests/golden/config_get.json
+++ b/backend-bb-tests/golden/config_get.json
@@ -9,5 +9,6 @@
   "monthly_expenses": "5000.00",
   "monthly_mortgage_payment": "2000.00",
   "retirement_age": 65,
-  "retirement_monthly_salary": "8000.00"
+  "retirement_monthly_salary": "8000.00",
+  "withdrawal_rate": "0.0400"
 }

--- a/backend-bb-tests/tests/test_dashboard.py
+++ b/backend-bb-tests/tests/test_dashboard.py
@@ -46,6 +46,11 @@ def test_dashboard_nested_keys_present(client: httpx.Client) -> None:
         "retirement_total",
         "investment_contributions",
         "investment_returns",
+        "fire_number",
+        "fi_progress",
+        "runway_months",
+        "annual_expenses",
+        "withdrawal_rate",
     }
     assert metric_card_keys.issubset(body["metric_cards"].keys())
 

--- a/backend-go/cmd/gen-openapi/main.go
+++ b/backend-go/cmd/gen-openapi/main.go
@@ -166,7 +166,7 @@ func customizeScalar(_ string, t reflect.Type, _ reflect.StructTag, schema *open
 	case "pyFloat":
 		schema.Type = &openapi3.Types{"number"}
 		schema.Properties = nil
-	case "moneyJSON", "ppkRate":
+	case "moneyJSON", "ppkRate", "rateJSON":
 		schema.Type = &openapi3.Types{"string"}
 		schema.Properties = nil
 	case "isoDate":

--- a/backend-go/internal/config/handler.go
+++ b/backend-go/internal/config/handler.go
@@ -28,21 +28,23 @@ type response struct {
 	AllocationCommodities   int       `json:"allocation_commodities"`
 	MonthlyExpenses         moneyJSON `json:"monthly_expenses"`
 	MonthlyMortgagePayment  moneyJSON `json:"monthly_mortgage_payment"`
+	WithdrawalRate          rateJSON  `json:"withdrawal_rate"`
 }
 
 // request is the PUT body. Date arrives as "YYYY-MM-DD" and money as either
 // a JSON number or string — pydantic on the Python side accepts both.
 type request struct {
-	BirthDate               isoDate         `json:"birth_date"`
-	RetirementAge           int             `json:"retirement_age"`
-	RetirementMonthlySalary decimal.Decimal `json:"retirement_monthly_salary"`
-	AllocationRealEstate    int             `json:"allocation_real_estate"`
-	AllocationStocks        int             `json:"allocation_stocks"`
-	AllocationBonds         int             `json:"allocation_bonds"`
-	AllocationGold          int             `json:"allocation_gold"`
-	AllocationCommodities   int             `json:"allocation_commodities"`
-	MonthlyExpenses         decimal.Decimal `json:"monthly_expenses"`
-	MonthlyMortgagePayment  decimal.Decimal `json:"monthly_mortgage_payment"`
+	BirthDate               isoDate          `json:"birth_date"`
+	RetirementAge           int              `json:"retirement_age"`
+	RetirementMonthlySalary decimal.Decimal  `json:"retirement_monthly_salary"`
+	AllocationRealEstate    int              `json:"allocation_real_estate"`
+	AllocationStocks        int              `json:"allocation_stocks"`
+	AllocationBonds         int              `json:"allocation_bonds"`
+	AllocationGold          int              `json:"allocation_gold"`
+	AllocationCommodities   int              `json:"allocation_commodities"`
+	MonthlyExpenses         decimal.Decimal  `json:"monthly_expenses"`
+	MonthlyMortgagePayment  decimal.Decimal  `json:"monthly_mortgage_payment"`
+	WithdrawalRate          *decimal.Decimal `json:"withdrawal_rate"`
 }
 
 func toResponse(c *Config) response {
@@ -58,6 +60,7 @@ func toResponse(c *Config) response {
 		AllocationCommodities:   c.AllocationCommodities,
 		MonthlyExpenses:         moneyJSON(c.MonthlyExpenses),
 		MonthlyMortgagePayment:  moneyJSON(c.MonthlyMortgagePayment),
+		WithdrawalRate:          rateJSON(c.WithdrawalRate),
 	}
 }
 
@@ -115,6 +118,10 @@ func (h *Handler) Put(w http.ResponseWriter, r *http.Request) {
 }
 
 func (r *request) toConfig() *Config {
+	rate := defaultWithdrawalRate
+	if r.WithdrawalRate != nil {
+		rate = *r.WithdrawalRate
+	}
 	return &Config{
 		BirthDate:               time.Time(r.BirthDate),
 		RetirementAge:           r.RetirementAge,
@@ -126,8 +133,13 @@ func (r *request) toConfig() *Config {
 		AllocationCommodities:   r.AllocationCommodities,
 		MonthlyExpenses:         r.MonthlyExpenses,
 		MonthlyMortgagePayment:  r.MonthlyMortgagePayment,
+		WithdrawalRate:          rate,
 	}
 }
+
+// defaultWithdrawalRate is the 4% Trinity-study safe-withdrawal default
+// — used when a PUT body omits withdrawal_rate (older clients).
+var defaultWithdrawalRate = decimal.NewFromFloat(0.04)
 
 // isoDate is a time.Time alias that JSON-marshals as "YYYY-MM-DD" and
 // unmarshals from the same. Matches Python's `date` field on the wire.
@@ -161,4 +173,13 @@ type moneyJSON decimal.Decimal
 func (m moneyJSON) MarshalJSON() ([]byte, error) {
 	d := decimal.Decimal(m)
 	return []byte(`"` + d.StringFixed(2) + `"`), nil
+}
+
+// rateJSON serializes withdrawal_rate as a 4-decimal JSON string — matches
+// the numeric(5,4) DB column (e.g. "0.0400" for the 4% default).
+type rateJSON decimal.Decimal
+
+func (r rateJSON) MarshalJSON() ([]byte, error) {
+	d := decimal.Decimal(r)
+	return []byte(`"` + d.StringFixed(4) + `"`), nil
 }

--- a/backend-go/internal/config/handler.go
+++ b/backend-go/internal/config/handler.go
@@ -139,7 +139,9 @@ func (r *request) toConfig() *Config {
 
 // defaultWithdrawalRate is the 4% Trinity-study safe-withdrawal default
 // — used when a PUT body omits withdrawal_rate (older clients).
-var defaultWithdrawalRate = decimal.NewFromFloat(0.04)
+// RequireFromString keeps the constant exact at the numeric(5,4) precision
+// the DB column expects.
+var defaultWithdrawalRate = decimal.RequireFromString("0.04")
 
 // isoDate is a time.Time alias that JSON-marshals as "YYYY-MM-DD" and
 // unmarshals from the same. Matches Python's `date` field on the wire.

--- a/backend-go/internal/config/store.go
+++ b/backend-go/internal/config/store.go
@@ -29,6 +29,7 @@ type Config struct {
 	AllocationCommodities   int             `json:"allocation_commodities"`
 	MonthlyExpenses         decimal.Decimal `json:"monthly_expenses"`
 	MonthlyMortgagePayment  decimal.Decimal `json:"monthly_mortgage_payment"`
+	WithdrawalRate          decimal.Decimal `json:"withdrawal_rate"`
 }
 
 // ErrNotFound is returned when no row exists at id=1.
@@ -48,7 +49,7 @@ const selectColumns = `
 	id, birth_date, retirement_age, retirement_monthly_salary,
 	allocation_real_estate, allocation_stocks, allocation_bonds,
 	allocation_gold, allocation_commodities,
-	monthly_expenses, monthly_mortgage_payment
+	monthly_expenses, monthly_mortgage_payment, withdrawal_rate
 `
 
 // Get returns the singleton config or ErrNotFound.
@@ -75,8 +76,8 @@ func (s *Store) Upsert(ctx context.Context, in *Config) (*Config, error) {
 			id, birth_date, retirement_age, retirement_monthly_salary,
 			allocation_real_estate, allocation_stocks, allocation_bonds,
 			allocation_gold, allocation_commodities,
-			monthly_expenses, monthly_mortgage_payment
-		) VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			monthly_expenses, monthly_mortgage_payment, withdrawal_rate
+		) VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		ON CONFLICT (id) DO UPDATE SET
 			birth_date = EXCLUDED.birth_date,
 			retirement_age = EXCLUDED.retirement_age,
@@ -87,7 +88,8 @@ func (s *Store) Upsert(ctx context.Context, in *Config) (*Config, error) {
 			allocation_gold = EXCLUDED.allocation_gold,
 			allocation_commodities = EXCLUDED.allocation_commodities,
 			monthly_expenses = EXCLUDED.monthly_expenses,
-			monthly_mortgage_payment = EXCLUDED.monthly_mortgage_payment
+			monthly_mortgage_payment = EXCLUDED.monthly_mortgage_payment,
+			withdrawal_rate = EXCLUDED.withdrawal_rate
 		RETURNING `+selectColumns,
 		in.BirthDate,
 		in.RetirementAge,
@@ -99,6 +101,7 @@ func (s *Store) Upsert(ctx context.Context, in *Config) (*Config, error) {
 		in.AllocationCommodities,
 		in.MonthlyExpenses,
 		in.MonthlyMortgagePayment,
+		in.WithdrawalRate,
 	)
 	c, err := scanConfig(row)
 	if err != nil {
@@ -121,6 +124,7 @@ func scanConfig(row pgx.Row) (*Config, error) {
 		&c.AllocationCommodities,
 		&c.MonthlyExpenses,
 		&c.MonthlyMortgagePayment,
+		&c.WithdrawalRate,
 	)
 	if err != nil {
 		return nil, err

--- a/backend-go/internal/config/validation.go
+++ b/backend-go/internal/config/validation.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -77,5 +78,25 @@ func (r *request) validate() *validationError {
 			),
 		}
 	}
+	if r.WithdrawalRate != nil && !isAllowedWithdrawalRate(*r.WithdrawalRate) {
+		return &validationError{
+			"withdrawal_rate",
+			"Withdrawal rate must be 0.03, 0.035, or 0.04",
+		}
+	}
 	return nil
+}
+
+// allowedWithdrawalRates are the three FIRE-research-backed safe-withdrawal
+// rates exposed in /settings. Stored as 4-decimal numerics; comparison runs
+// against the canonical decimal form so JSON-number and JSON-string inputs
+// (0.04 vs "0.04") both parse to the same accepted value.
+var allowedWithdrawalRates = []decimal.Decimal{
+	decimal.NewFromFloat(0.03),
+	decimal.NewFromFloat(0.035),
+	decimal.NewFromFloat(0.04),
+}
+
+func isAllowedWithdrawalRate(v decimal.Decimal) bool {
+	return slices.ContainsFunc(allowedWithdrawalRates, v.Equal)
 }

--- a/backend-go/internal/config/validation.go
+++ b/backend-go/internal/config/validation.go
@@ -88,13 +88,14 @@ func (r *request) validate() *validationError {
 }
 
 // allowedWithdrawalRates are the three FIRE-research-backed safe-withdrawal
-// rates exposed in /settings. Stored as 4-decimal numerics; comparison runs
-// against the canonical decimal form so JSON-number and JSON-string inputs
-// (0.04 vs "0.04") both parse to the same accepted value.
+// rates exposed in /settings. RequireFromString — not NewFromFloat — so the
+// constants stay exact: NewFromFloat(0.035) round-trips through a binary
+// float and can lose precision, which would make Decimal.Equal miss a
+// JSON "0.035" parsed exactly via shopspring's string path.
 var allowedWithdrawalRates = []decimal.Decimal{
-	decimal.NewFromFloat(0.03),
-	decimal.NewFromFloat(0.035),
-	decimal.NewFromFloat(0.04),
+	decimal.RequireFromString("0.03"),
+	decimal.RequireFromString("0.035"),
+	decimal.RequireFromString("0.04"),
 }
 
 func isAllowedWithdrawalRate(v decimal.Decimal) bool {

--- a/backend-go/internal/config/validation_test.go
+++ b/backend-go/internal/config/validation_test.go
@@ -114,3 +114,33 @@ func TestValidateRetirementAgeBeforeCurrent(t *testing.T) {
 		t.Fatalf("expected retirement_age (vs current age) error, got %+v", err)
 	}
 }
+
+func TestValidateWithdrawalRateAllowed(t *testing.T) {
+	for _, v := range []float64{0.03, 0.035, 0.04} {
+		r := validRequest()
+		d := decimal.NewFromFloat(v)
+		r.WithdrawalRate = &d
+		if err := r.validate(); err != nil {
+			t.Fatalf("expected %v to validate, got %+v", v, err)
+		}
+	}
+}
+
+func TestValidateWithdrawalRateRejected(t *testing.T) {
+	for _, v := range []float64{0.02, 0.05, 0.045, 0} {
+		r := validRequest()
+		d := decimal.NewFromFloat(v)
+		r.WithdrawalRate = &d
+		if err := r.validate(); err == nil || err.Field != "withdrawal_rate" {
+			t.Fatalf("expected withdrawal_rate error for %v, got %+v", v, err)
+		}
+	}
+}
+
+func TestValidateWithdrawalRateNilOK(t *testing.T) {
+	r := validRequest()
+	r.WithdrawalRate = nil
+	if err := r.validate(); err != nil {
+		t.Fatalf("nil withdrawal_rate should pass (backward compat), got %+v", err)
+	}
+}

--- a/backend-go/internal/config/validation_test.go
+++ b/backend-go/internal/config/validation_test.go
@@ -116,23 +116,43 @@ func TestValidateRetirementAgeBeforeCurrent(t *testing.T) {
 }
 
 func TestValidateWithdrawalRateAllowed(t *testing.T) {
-	for _, v := range []float64{0.03, 0.035, 0.04} {
+	// RequireFromString mirrors how shopspring's JSON decoder reads numeric
+	// literals — round-tripping through float64 would mask 0.035 precision
+	// loss and make the test pass for the wrong reason.
+	for _, s := range []string{"0.03", "0.035", "0.04"} {
 		r := validRequest()
-		d := decimal.NewFromFloat(v)
+		d := decimal.RequireFromString(s)
 		r.WithdrawalRate = &d
 		if err := r.validate(); err != nil {
-			t.Fatalf("expected %v to validate, got %+v", v, err)
+			t.Fatalf("expected %s to validate, got %+v", s, err)
 		}
 	}
 }
 
 func TestValidateWithdrawalRateRejected(t *testing.T) {
-	for _, v := range []float64{0.02, 0.05, 0.045, 0} {
+	for _, s := range []string{"0.02", "0.05", "0.045", "0"} {
 		r := validRequest()
-		d := decimal.NewFromFloat(v)
+		d := decimal.RequireFromString(s)
 		r.WithdrawalRate = &d
 		if err := r.validate(); err == nil || err.Field != "withdrawal_rate" {
-			t.Fatalf("expected withdrawal_rate error for %v, got %+v", v, err)
+			t.Fatalf("expected withdrawal_rate error for %s, got %+v", s, err)
+		}
+	}
+}
+
+// TestValidateWithdrawalRateFromJSON guards the actual wire path: a JSON
+// "0.035" must parse to a decimal that Equals the validation constant. If
+// either side ever switches back to NewFromFloat this regresses.
+func TestValidateWithdrawalRateFromJSON(t *testing.T) {
+	for _, raw := range []string{`0.035`, `"0.035"`, `0.04`, `"0.03"`} {
+		var d decimal.Decimal
+		if err := d.UnmarshalJSON([]byte(raw)); err != nil {
+			t.Fatalf("unmarshal %s: %v", raw, err)
+		}
+		r := validRequest()
+		r.WithdrawalRate = &d
+		if err := r.validate(); err != nil {
+			t.Fatalf("expected JSON %s to validate, got %+v", raw, err)
 		}
 	}
 }

--- a/backend-go/internal/dashboard/dashboard.go
+++ b/backend-go/internal/dashboard/dashboard.go
@@ -40,6 +40,11 @@ type metricCards struct {
 	DebtToIncomeRatio       *float64
 	HourOfWorkCost          *float64
 	HourOfLifeCost          *float64
+	FIRENumber              *float64
+	FIProgress              *float64
+	RunwayMonths            *float64
+	AnnualExpenses          *float64
+	WithdrawalRate          *float64
 }
 
 type allocationBreakdown struct {

--- a/backend-go/internal/dashboard/fire.go
+++ b/backend-go/internal/dashboard/fire.go
@@ -36,10 +36,6 @@ func computeFIRE(latestRows []mergedRow, cfg AppConfig, netWorth float64) fireMe
 
 	monthlyExpenses, _ := cfg.MonthlyExpenses.Float64()
 	withdrawalRate, _ := cfg.WithdrawalRate.Float64()
-	if withdrawalRate > 0 {
-		wr := withdrawalRate
-		out.WithdrawalRate = &wr
-	}
 	if monthlyExpenses <= 0 {
 		return out
 	}
@@ -48,6 +44,8 @@ func computeFIRE(latestRows []mergedRow, cfg AppConfig, netWorth float64) fireMe
 	out.AnnualExpenses = &annual
 
 	if withdrawalRate > 0 {
+		wr := withdrawalRate
+		out.WithdrawalRate = &wr
 		fire := annual / withdrawalRate
 		out.FIRENumber = &fire
 		if fire > 0 && netWorth > 0 {

--- a/backend-go/internal/dashboard/fire.go
+++ b/backend-go/internal/dashboard/fire.go
@@ -1,0 +1,74 @@
+package dashboard
+
+// liquidCategories is the set of account categories counted as liquid for
+// the runway metric — bank checking and savings only. Investments are
+// excluded: a true runway figure assumes assets that can cover next
+// month's bills without market timing or tax-event drag.
+var liquidCategories = map[string]struct{}{
+	"bank":           {},
+	"saving_account": {},
+}
+
+// fireMetrics is the FIRE-tile bundle computed from app_config and the
+// latest snapshot. Pointers are nil when the inputs aren't enough to
+// produce a meaningful number (monthly_expenses == 0, withdrawal_rate == 0,
+// or net_worth <= 0 for the progress percentage).
+type fireMetrics struct {
+	AnnualExpenses *float64
+	FIRENumber     *float64
+	FIProgress     *float64
+	RunwayMonths   *float64
+	WithdrawalRate *float64
+}
+
+// computeFIRE turns app_config + the latest snapshot's rows into the FIRE
+// + runway pair. Math:
+//
+//	annual_expenses = monthly_expenses × 12
+//	fire_number     = annual_expenses / withdrawal_rate
+//	fi_progress     = net_worth / fire_number × 100
+//	runway_months   = liquid_assets / monthly_expenses
+//
+// liquid_assets is the sum of active asset-account values whose category
+// is in liquidCategories at the latest snapshot.
+func computeFIRE(latestRows []mergedRow, cfg AppConfig, netWorth float64) fireMetrics {
+	var out fireMetrics
+
+	monthlyExpenses, _ := cfg.MonthlyExpenses.Float64()
+	withdrawalRate, _ := cfg.WithdrawalRate.Float64()
+	if withdrawalRate > 0 {
+		wr := withdrawalRate
+		out.WithdrawalRate = &wr
+	}
+	if monthlyExpenses <= 0 {
+		return out
+	}
+
+	annual := monthlyExpenses * 12
+	out.AnnualExpenses = &annual
+
+	if withdrawalRate > 0 {
+		fire := annual / withdrawalRate
+		out.FIRENumber = &fire
+		if fire > 0 && netWorth > 0 {
+			progress := netWorth / fire * 100
+			out.FIProgress = &progress
+		}
+	}
+
+	liquid := 0.0
+	for _, r := range latestRows {
+		if r.AccountID == nil || r.AccType == nil || r.Category == nil {
+			continue
+		}
+		if *r.AccType != "asset" {
+			continue
+		}
+		if _, ok := liquidCategories[*r.Category]; ok {
+			liquid += r.Value
+		}
+	}
+	runway := liquid / monthlyExpenses
+	out.RunwayMonths = &runway
+	return out
+}

--- a/backend-go/internal/dashboard/fire_test.go
+++ b/backend-go/internal/dashboard/fire_test.go
@@ -1,0 +1,139 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func newAccountRow(category, accType string, value float64) mergedRow {
+	c := category
+	t := accType
+	id := 1
+	return mergedRow{
+		AccountID: &id,
+		AccType:   &t,
+		Category:  &c,
+		Value:     value,
+	}
+}
+
+func TestComputeFIREHappyPath(t *testing.T) {
+	t.Parallel()
+	rows := []mergedRow{
+		newAccountRow("bank", "asset", 30000),
+		newAccountRow("saving_account", "asset", 20000),
+		newAccountRow("stock", "asset", 100000),
+	}
+	cfg := AppConfig{
+		MonthlyExpenses: decimal.NewFromInt(5000),
+		WithdrawalRate:  decimal.NewFromFloat(0.04),
+	}
+
+	got := computeFIRE(rows, cfg, 500_000)
+
+	if got.AnnualExpenses == nil || *got.AnnualExpenses != 60_000 {
+		t.Fatalf("annual_expenses = %v, want 60000", got.AnnualExpenses)
+	}
+	if got.FIRENumber == nil || *got.FIRENumber != 1_500_000 {
+		t.Fatalf("fire_number = %v, want 1500000", got.FIRENumber)
+	}
+	if got.FIProgress == nil {
+		t.Fatal("fi_progress should be set when net worth > 0")
+	}
+	// 500_000 / 1_500_000 * 100 ≈ 33.33%
+	if !approxEqual(*got.FIProgress, 33.333333, 0.0001) {
+		t.Errorf("fi_progress = %v, want ~33.33", *got.FIProgress)
+	}
+	// liquid = 30000 + 20000; stock excluded.
+	// runway = 50000 / 5000 = 10 months
+	if got.RunwayMonths == nil || *got.RunwayMonths != 10 {
+		t.Errorf("runway_months = %v, want 10", got.RunwayMonths)
+	}
+	if got.WithdrawalRate == nil || *got.WithdrawalRate != 0.04 {
+		t.Errorf("withdrawal_rate = %v, want 0.04", got.WithdrawalRate)
+	}
+}
+
+func TestComputeFIREThreePercentRate(t *testing.T) {
+	t.Parallel()
+	cfg := AppConfig{
+		MonthlyExpenses: decimal.NewFromInt(4000),
+		WithdrawalRate:  decimal.NewFromFloat(0.03),
+	}
+	got := computeFIRE(nil, cfg, 0)
+	// annual = 48000; fire = 48000 / 0.03 = 1_600_000
+	if got.FIRENumber == nil || *got.FIRENumber != 1_600_000 {
+		t.Errorf("fire_number = %v, want 1.6M", got.FIRENumber)
+	}
+}
+
+func TestComputeFIREZeroExpenses(t *testing.T) {
+	t.Parallel()
+	cfg := AppConfig{
+		MonthlyExpenses: decimal.Zero,
+		WithdrawalRate:  decimal.NewFromFloat(0.04),
+	}
+	got := computeFIRE(nil, cfg, 100_000)
+	if got.AnnualExpenses != nil || got.FIRENumber != nil ||
+		got.FIProgress != nil || got.RunwayMonths != nil {
+		t.Errorf("expected all-nil when monthly expenses == 0, got %+v", got)
+	}
+	if got.WithdrawalRate == nil {
+		t.Error("withdrawal_rate should still echo back when set")
+	}
+}
+
+func TestComputeFIREZeroWithdrawalRate(t *testing.T) {
+	t.Parallel()
+	cfg := AppConfig{
+		MonthlyExpenses: decimal.NewFromInt(5000),
+		WithdrawalRate:  decimal.Zero,
+	}
+	got := computeFIRE(nil, cfg, 100_000)
+	if got.FIRENumber != nil || got.FIProgress != nil {
+		t.Error("fire_number/fi_progress should be nil when withdrawal_rate == 0")
+	}
+	if got.AnnualExpenses == nil || got.RunwayMonths == nil {
+		t.Error("annual_expenses + runway_months should still compute")
+	}
+}
+
+func TestComputeFIRENegativeNetWorthSuppressesProgress(t *testing.T) {
+	t.Parallel()
+	cfg := AppConfig{
+		MonthlyExpenses: decimal.NewFromInt(5000),
+		WithdrawalRate:  decimal.NewFromFloat(0.04),
+	}
+	got := computeFIRE(nil, cfg, -10_000)
+	if got.FIProgress != nil {
+		t.Errorf("fi_progress should be nil for non-positive net worth, got %v", *got.FIProgress)
+	}
+}
+
+func TestComputeFIRELiquidExcludesNonBank(t *testing.T) {
+	t.Parallel()
+	rows := []mergedRow{
+		newAccountRow("bank", "asset", 10_000),
+		newAccountRow("stock", "asset", 50_000),
+		newAccountRow("real_estate", "asset", 500_000),
+		newAccountRow("bank", "liability", 5_000),
+	}
+	cfg := AppConfig{
+		MonthlyExpenses: decimal.NewFromInt(2_000),
+		WithdrawalRate:  decimal.NewFromFloat(0.04),
+	}
+	got := computeFIRE(rows, cfg, 0)
+	// Only the bank-asset row counts: 10000 / 2000 = 5.
+	if got.RunwayMonths == nil || *got.RunwayMonths != 5 {
+		t.Errorf("runway = %v, want 5", got.RunwayMonths)
+	}
+}
+
+func approxEqual(a, b, tol float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < tol
+}

--- a/backend-go/internal/dashboard/fire_test.go
+++ b/backend-go/internal/dashboard/fire_test.go
@@ -75,12 +75,12 @@ func TestComputeFIREZeroExpenses(t *testing.T) {
 		WithdrawalRate:  decimal.NewFromFloat(0.04),
 	}
 	got := computeFIRE(nil, cfg, 100_000)
+	// Zero monthly expenses → every FIRE-tile field is nil (the entire tile
+	// is hidden on the FE), including withdrawal_rate.
 	if got.AnnualExpenses != nil || got.FIRENumber != nil ||
-		got.FIProgress != nil || got.RunwayMonths != nil {
+		got.FIProgress != nil || got.RunwayMonths != nil ||
+		got.WithdrawalRate != nil {
 		t.Errorf("expected all-nil when monthly expenses == 0, got %+v", got)
-	}
-	if got.WithdrawalRate == nil {
-		t.Error("withdrawal_rate should still echo back when set")
 	}
 }
 

--- a/backend-go/internal/dashboard/handler.go
+++ b/backend-go/internal/dashboard/handler.go
@@ -188,6 +188,11 @@ type metricCardsWire struct {
 	DebtToIncomeRatio       *pyFloat `json:"debt_to_income_ratio"`
 	HourOfWorkCost          *pyFloat `json:"hour_of_work_cost"`
 	HourOfLifeCost          *pyFloat `json:"hour_of_life_cost"`
+	FIRENumber              *pyFloat `json:"fire_number"`
+	FIProgress              *pyFloat `json:"fi_progress"`
+	RunwayMonths            *pyFloat `json:"runway_months"`
+	AnnualExpenses          *pyFloat `json:"annual_expenses"`
+	WithdrawalRate          *pyFloat `json:"withdrawal_rate"`
 }
 
 type allocationBreakdownWire struct {
@@ -319,6 +324,11 @@ func metricCardsToWire(m metricCards) metricCardsWire {
 		DebtToIncomeRatio:       floatPtr(m.DebtToIncomeRatio),
 		HourOfWorkCost:          floatPtr(m.HourOfWorkCost),
 		HourOfLifeCost:          floatPtr(m.HourOfLifeCost),
+		FIRENumber:              floatPtr(m.FIRENumber),
+		FIProgress:              floatPtr(m.FIProgress),
+		RunwayMonths:            floatPtr(m.RunwayMonths),
+		AnnualExpenses:          floatPtr(m.AnnualExpenses),
+		WithdrawalRate:          floatPtr(m.WithdrawalRate),
 	}
 }
 

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -116,7 +116,7 @@ func computeFromAggregates(ctx context.Context, s *Store, aggRows []AggregateRow
 	if shared.hasConfig && len(latestRows) > 0 {
 		latestDate := shared.snapshotDate[latestSID]
 		nwForSavings := aggregateMonthlyNetWorths(aggRows)
-		res.MetricCards = buildMetricCards(latestRows, shared, res.RetirementAccountValue, latestDate, nwForSavings)
+		res.MetricCards = buildMetricCards(latestRows, shared, res.RetirementAccountValue, latestDate, nwForSavings, res.CurrentNetWorth)
 		res.AllocationAnalysis = buildAllocationAnalysis(latestRows, shared.config)
 	}
 
@@ -225,7 +225,7 @@ func computeRaw(ctx context.Context, s *Store) (result, error) {
 		res.RetirementAccountValue = retirementValueOf(latestRows)
 		if shared.hasConfig {
 			nwForSavings := rawMonthlyNetWorths(rows, shared.snapshots)
-			res.MetricCards = buildMetricCards(latestRows, shared, res.RetirementAccountValue, latestDate, nwForSavings)
+			res.MetricCards = buildMetricCards(latestRows, shared, res.RetirementAccountValue, latestDate, nwForSavings, res.CurrentNetWorth)
 			res.AllocationAnalysis = buildAllocationAnalysis(latestRows, shared.config)
 		}
 	}
@@ -388,6 +388,7 @@ func buildMetricCards(
 	retirementValue float64,
 	latestDate time.Time,
 	netWorthsForSavings []float64,
+	currentNetWorth float64,
 ) metricCards {
 	cfg := shared.config
 
@@ -469,6 +470,13 @@ func buildMetricCards(
 		mc.HourOfWorkCost = &work
 		mc.HourOfLifeCost = &life
 	}
+
+	fire := computeFIRE(latestRows, cfg, currentNetWorth)
+	mc.AnnualExpenses = fire.AnnualExpenses
+	mc.FIRENumber = fire.FIRENumber
+	mc.FIProgress = fire.FIProgress
+	mc.RunwayMonths = fire.RunwayMonths
+	mc.WithdrawalRate = fire.WithdrawalRate
 	return mc
 }
 

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -448,10 +448,14 @@ func buildMetricCards(
 		}
 	}
 
+	swr, _ := cfg.WithdrawalRate.Float64()
+	if swr <= 0 {
+		swr = 0.04
+	}
 	mc := metricCards{
 		PropertySQM:             propertySQM,
 		EmergencyFundMonths:     emergencyMonths,
-		RetirementIncomeMonthly: retirementValue * 0.04 / 12,
+		RetirementIncomeMonthly: retirementValue * swr / 12,
 		MortgageRemaining:       mortgageRemaining,
 		MortgageMonthsLeft:      mortgageMonthsLeft,
 		MortgageYearsLeft:       float64(mortgageMonthsLeft) / 12,

--- a/backend-go/internal/dashboard/store.go
+++ b/backend-go/internal/dashboard/store.go
@@ -77,6 +77,7 @@ type AppConfig struct {
 	AllocationStocks       int
 	AllocationBonds        int
 	AllocationGold         int
+	WithdrawalRate         decimal.Decimal
 }
 
 // SnapshotMeta is id+date.
@@ -290,13 +291,15 @@ func (s *Store) ActiveTransactions(ctx context.Context) ([]Transaction, error) {
 func (s *Store) LoadAppConfig(ctx context.Context) (AppConfig, bool, error) {
 	row := s.pool.QueryRow(ctx, `
 		SELECT monthly_expenses, monthly_mortgage_payment,
-		       allocation_stocks, allocation_bonds, allocation_gold
+		       allocation_stocks, allocation_bonds, allocation_gold,
+		       withdrawal_rate
 		FROM app_config WHERE id = 1`,
 	)
 	var c AppConfig
 	if err := row.Scan(
 		&c.MonthlyExpenses, &c.MonthlyMortgagePayment,
 		&c.AllocationStocks, &c.AllocationBonds, &c.AllocationGold,
+		&c.WithdrawalRate,
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return AppConfig{}, false, nil

--- a/backend-go/internal/db/migrate.go
+++ b/backend-go/internal/db/migrate.go
@@ -58,6 +58,22 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
 	if _, err := pool.Exec(ctx, `DROP TABLE IF EXISTS personas`); err != nil {
 		return fmt.Errorf("drop personas table: %w", err)
 	}
+	if err := addAppConfigWithdrawalRate(ctx, pool); err != nil {
+		return err
+	}
+	return nil
+}
+
+// addAppConfigWithdrawalRate adds the withdrawal_rate column to app_config
+// for FIRE number computation (issue #376). 0.04 (4 percent) is the
+// Trinity-study default; the column is created with that default so any
+// existing app_config row is backfilled without a separate UPDATE.
+func addAppConfigWithdrawalRate(ctx context.Context, pool *pgxpool.Pool) error {
+	if _, err := pool.Exec(ctx, `
+		ALTER TABLE app_config
+		ADD COLUMN IF NOT EXISTS withdrawal_rate numeric(5,4) NOT NULL DEFAULT 0.04`); err != nil {
+		return fmt.Errorf("add withdrawal_rate to app_config: %w", err)
+	}
 	return nil
 }
 

--- a/backend-go/internal/db/schema.sql
+++ b/backend-go/internal/db/schema.sql
@@ -95,6 +95,7 @@ CREATE TABLE public.app_config (
     allocation_commodities integer NOT NULL,
     monthly_expenses numeric(15,2) NOT NULL,
     monthly_mortgage_payment numeric(15,2) NOT NULL,
+    withdrawal_rate numeric(5,4) NOT NULL DEFAULT 0.04,
     CONSTRAINT single_row CHECK ((id = 1))
 );
 

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -1389,7 +1389,7 @@ export interface paths {
                             monthly_mortgage_payment?: string;
                             retirement_age?: number;
                             retirement_monthly_salary?: string;
-                            withdrawal_rate?: unknown;
+                            withdrawal_rate?: string;
                         };
                     };
                 };
@@ -1441,7 +1441,7 @@ export interface paths {
                             monthly_mortgage_payment?: string;
                             retirement_age?: number;
                             retirement_monthly_salary?: string;
-                            withdrawal_rate?: unknown;
+                            withdrawal_rate?: string;
                         };
                     };
                 };

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -1389,6 +1389,7 @@ export interface paths {
                             monthly_mortgage_payment?: string;
                             retirement_age?: number;
                             retirement_monthly_salary?: string;
+                            withdrawal_rate?: unknown;
                         };
                     };
                 };
@@ -1416,6 +1417,7 @@ export interface paths {
                         monthly_mortgage_payment?: string;
                         retirement_age?: number;
                         retirement_monthly_salary?: string;
+                        withdrawal_rate?: string | null;
                     };
                 };
             };
@@ -1439,6 +1441,7 @@ export interface paths {
                             monthly_mortgage_payment?: string;
                             retirement_age?: number;
                             retirement_monthly_salary?: string;
+                            withdrawal_rate?: unknown;
                         };
                     };
                 };
@@ -1681,9 +1684,15 @@ export interface paths {
                             }[];
                             metric_cards?: {
                                 /** Format: double */
+                                annual_expenses?: number | null;
+                                /** Format: double */
                                 debt_to_income_ratio?: number | null;
                                 /** Format: double */
                                 emergency_fund_months?: number;
+                                /** Format: double */
+                                fi_progress?: number | null;
+                                /** Format: double */
+                                fire_number?: number | null;
                                 /** Format: double */
                                 hour_of_life_cost?: number | null;
                                 /** Format: double */
@@ -1704,7 +1713,11 @@ export interface paths {
                                 /** Format: double */
                                 retirement_total?: number;
                                 /** Format: double */
+                                runway_months?: number | null;
+                                /** Format: double */
                                 savings_rate?: number | null;
+                                /** Format: double */
+                                withdrawal_rate?: number | null;
                             };
                             net_worth_history?: {
                                 /** Format: double */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,7 +14,8 @@
 		CheckCircle2,
 		AlertTriangle,
 		PiggyBank,
-		Coins
+		Coins,
+		Flame
 	} from 'lucide-svelte';
 	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
@@ -207,6 +208,50 @@
 				</div>
 			</div>
 		</div>
+
+		{#if dashboard.metric_cards?.fire_number != null && dashboard.metric_cards?.runway_months != null}
+			{@const fire = dashboard.metric_cards}
+			{@const progress = fire.fi_progress ?? 0}
+			{@const annualExpensesPLN = formatPLN(fire.annual_expenses ?? 0)}
+			{@const firePLN = formatPLN(fire.fire_number ?? 0)}
+			{@const wrPct = ((fire.withdrawal_rate ?? 0.04) * 100).toFixed(1)}
+			{@const runwayLabel = (fire.runway_months ?? 0).toFixed(1)}
+			<div class="card preset-filled-surface-100-900 p-4 space-y-3">
+				<header class="flex items-start justify-between gap-2 flex-wrap">
+					<h3 class="h4 flex items-center gap-2"><Flame size={18} /> FIRE i runway</h3>
+					<span
+						class="text-xs text-surface-700-300"
+						title="annual_expenses = miesięczne wydatki × 12&#10;FIRE = annual_expenses ÷ withdrawal_rate (np. ÷ 0.04 = ×25)&#10;FI = wartość netto ÷ FIRE × 100%&#10;runway = aktywa płynne (bank + saving_account) ÷ miesięczne wydatki"
+					>
+						SWR {wrPct}% · ø {annualExpensesPLN}/rok
+					</span>
+				</header>
+				<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+					<div class="space-y-1">
+						<div class="text-xs text-surface-700-300">FI progress</div>
+						<div class="text-2xl font-bold">{progress.toFixed(1)}%</div>
+						<div class="h-2 rounded-full bg-surface-200-800 overflow-hidden">
+							<div
+								class="h-full transition-all {progress >= 100
+									? 'bg-success-500'
+									: progress >= 50
+										? 'bg-warning-500'
+										: 'bg-primary-500'}"
+								style="width: {Math.min(progress, 100)}%"
+							></div>
+						</div>
+						<div class="text-xs text-surface-700-300">cel: {firePLN}</div>
+					</div>
+					<div class="space-y-1">
+						<div class="text-xs text-surface-700-300">Runway</div>
+						<div class="text-2xl font-bold">{runwayLabel} mies.</div>
+						<div class="text-xs text-surface-700-300">
+							ile miesięcy wydatków pokrywają aktywa płynne
+						</div>
+					</div>
+				</div>
+			</div>
+		{/if}
 
 		{#if dashboard.treasuryBondsCount > 0}
 			<a

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -211,7 +211,7 @@
 
 		{#if dashboard.metric_cards?.fire_number != null && dashboard.metric_cards?.runway_months != null}
 			{@const fire = dashboard.metric_cards}
-			{@const progress = fire.fi_progress ?? 0}
+			{@const progress = fire.fi_progress}
 			{@const annualExpensesPLN = formatPLN(fire.annual_expenses ?? 0)}
 			{@const firePLN = formatPLN(fire.fire_number ?? 0)}
 			{@const wrPct = ((fire.withdrawal_rate ?? 0.04) * 100).toFixed(1)}
@@ -229,15 +229,17 @@
 				<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
 					<div class="space-y-1">
 						<div class="text-xs text-surface-700-300">FI progress</div>
-						<div class="text-2xl font-bold">{progress.toFixed(1)}%</div>
+						<div class="text-2xl font-bold">
+							{progress != null ? `${progress.toFixed(1)}%` : '—'}
+						</div>
 						<div class="h-2 rounded-full bg-surface-200-800 overflow-hidden">
 							<div
-								class="h-full transition-all {progress >= 100
+								class="h-full transition-all {(progress ?? 0) >= 100
 									? 'bg-success-500'
-									: progress >= 50
+									: (progress ?? 0) >= 50
 										? 'bg-warning-500'
 										: 'bg-primary-500'}"
-								style="width: {Math.min(progress, 100)}%"
+								style="width: {Math.min(progress ?? 0, 100)}%"
 							></div>
 						</div>
 						<div class="text-xs text-surface-700-300">cel: {firePLN}</div>

--- a/src/routes/settings/config/+page.svelte
+++ b/src/routes/settings/config/+page.svelte
@@ -54,6 +54,7 @@
 	);
 	let monthlyExpenses = $state(Number(config?.monthly_expenses ?? 0));
 	let monthlyMortgagePayment = $state(Number(config?.monthly_mortgage_payment ?? 0));
+	let withdrawalRate = $state(Number(config?.withdrawal_rate ?? 0.04));
 
 	let error = $state('');
 	let saving = $state(false);
@@ -117,7 +118,8 @@
 					allocation_gold: allocationGold,
 					allocation_commodities: allocationCommodities,
 					monthly_expenses: monthlyExpenses,
-					monthly_mortgage_payment: monthlyMortgagePayment
+					monthly_mortgage_payment: monthlyMortgagePayment,
+					withdrawal_rate: withdrawalRate
 				})
 			});
 
@@ -329,6 +331,18 @@
 			/>
 			<span class="text-xs italic text-surface-700-300"
 				>Używane do obliczenia czasu spłaty hipoteki</span
+			>
+		</label>
+
+		<label class="label">
+			<span class="font-semibold text-sm">Bezpieczna stopa wypłaty (FIRE)</span>
+			<select id="withdrawal-rate" class="select" bind:value={withdrawalRate}>
+				<option value={0.03}>3% — bardzo ostrożna (~33× wydatków)</option>
+				<option value={0.035}>3.5% — ostrożna (~28.6× wydatków)</option>
+				<option value={0.04}>4% — klasyczna reguła Trinity (×25)</option>
+			</select>
+			<span class="text-xs italic text-surface-700-300"
+				>Wyznacza cel FIRE = roczne wydatki ÷ stopa wypłaty.</span
 			>
 		</label>
 	</div>


### PR DESCRIPTION
## Motivation

Closes #376. Inspired by Maybe Finance / Freenance — quick "am I free
yet?" read on the dashboard. FIRE = annual_expenses ÷ withdrawal_rate
(×25 at 4%); runway = liquid_assets ÷ monthly_expenses.

## Implementation information

- Backend `internal/dashboard/fire.go` computes annual_expenses
  (monthly_expenses × 12), fire_number, fi_progress, runway_months,
  withdrawal_rate. Liquid = `bank` + `saving_account` asset rows at
  the latest snapshot. Added to `metric_cards` as five nullable fields
  (no breaking change — existing keys preserved).
- `withdrawal_rate numeric(5,4) DEFAULT 0.04` added to `app_config`
  (`schema.sql` for fresh DBs + presence-guarded `ADD COLUMN IF NOT
  EXISTS` in `db.Migrate` for production). Config GET/PUT round-trip
  the field; validation accepts only `{0.03, 0.035, 0.04}`; a PUT
  with the field omitted defaults to 4% for backward compat with
  older frontend builds.
- `retirement_income_monthly` also switches from the hard-coded 0.04
  to `cfg.WithdrawalRate` so both retirement metrics agree.
- Frontend tile sits above the Treasury Bonds tile, with a `title`
  tooltip explaining all four formulas; 3% / 3.5% / 4% select on
  `/settings/config`.
- OpenAPI spec + generated TS types updated; `customizeScalar` taught
  about the new `rateJSON` wrapper.
- Black-box dashboard test now asserts the five new `metric_cards`
  keys are present.

Scope note: AC mentions transaction-based annual_expenses, gated on
#377 (transaction categories) which is still open. The implementation
uses the existing `app_config.monthly_expenses × 12` — same input as
the existing emergency-fund metric. Swapping to a 12-month sum of
expense-category transactions is a follow-up that won't touch the
wire.

## Supporting documentation

- Issue: #376
- Umbrella: #355

> Changelog: feat(dashboard): FIRE number + runway badge