### PR TITLE
feat(allocation): target allocation + drift alerts

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -716,6 +716,365 @@
         ]
       }
     },
+    "/api/allocation/drift": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "scopes": {
+                      "items": {
+                        "properties": {
+                          "has_complete_target": {
+                            "type": "boolean"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "category": {
+                                  "type": "string"
+                                },
+                                "current_percentage": {
+                                  "format": "double",
+                                  "type": "number"
+                                },
+                                "current_value": {
+                                  "format": "double",
+                                  "type": "number"
+                                },
+                                "drift_pp": {
+                                  "format": "double",
+                                  "type": "number"
+                                },
+                                "owner_user_id": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "rebalance_amount": {
+                                  "format": "double",
+                                  "type": "number"
+                                },
+                                "severity": {
+                                  "type": "string"
+                                },
+                                "target_percentage": {
+                                  "format": "double",
+                                  "type": "number"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "owner_user_id": {
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "target_sum_pct": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "total_value": {
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Actual vs target allocation drift",
+        "tags": [
+          "allocation"
+        ]
+      }
+    },
+    "/api/allocation/targets": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "targets": {
+                      "items": {
+                        "properties": {
+                          "category": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "owner_user_id": {
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "target_pct": {
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List allocation targets",
+        "tags": [
+          "allocation"
+        ]
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "category": {
+                    "type": "string"
+                  },
+                  "owner_user_id": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "target_pct": {
+                    "format": "double",
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "category": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "target_pct": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create allocation target",
+        "tags": [
+          "allocation"
+        ]
+      }
+    },
+    "/api/allocation/targets/replace": {
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "owner_user_id": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "targets": {
+                    "items": {
+                      "properties": {
+                        "category": {
+                          "type": "string"
+                        },
+                        "target_pct": {
+                          "format": "double",
+                          "type": "number"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "targets": {
+                      "items": {
+                        "properties": {
+                          "category": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "owner_user_id": {
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "target_pct": {
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Replace all targets for one owner scope",
+        "tags": [
+          "allocation"
+        ]
+      }
+    },
+    "/api/allocation/targets/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete allocation target",
+        "tags": [
+          "allocation"
+        ]
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "target_pct": {
+                    "format": "double",
+                    "nullable": true,
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "category": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "target_pct": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Update allocation target",
+        "tags": [
+          "allocation"
+        ]
+      }
+    },
     "/api/assets": {
       "get": {
         "responses": {

--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Automaat/finance-buddy/backend-go/internal/allocation"
 	"github.com/Automaat/finance-buddy/backend-go/internal/auth"
 	"github.com/Automaat/finance-buddy/backend-go/internal/bonds"
 	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
@@ -188,6 +189,11 @@ func initDB(ctx context.Context, dsn string, logger *slog.Logger, adminUsername,
 	}
 	if err := bonds.NewStore(pool).EnsureSchema(ctx); err != nil {
 		logger.Error("ensure treasury_bonds schema", "err", err)
+		pool.Close()
+		return nil, 2
+	}
+	if err := allocation.NewStore(pool).EnsureSchema(ctx); err != nil {
+		logger.Error("ensure allocation_targets schema", "err", err)
 		pool.Close()
 		return nil, 2
 	}

--- a/backend-go/cmd/gen-openapi/routes.go
+++ b/backend-go/cmd/gen-openapi/routes.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/accounts"
+	"github.com/Automaat/finance-buddy/backend-go/internal/allocation"
 	"github.com/Automaat/finance-buddy/backend-go/internal/apispec"
 	"github.com/Automaat/finance-buddy/backend-go/internal/assets"
 	"github.com/Automaat/finance-buddy/backend-go/internal/bonds"
@@ -59,6 +60,7 @@ func allRoutes() []apispec.Route {
 		transactions.APISpec,
 		debtpayments.APISpec,
 		debts.APISpec,
+		allocation.APISpec,
 	}
 	for _, s := range specs {
 		routes = append(routes, s...)

--- a/backend-go/internal/allocation/compute.go
+++ b/backend-go/internal/allocation/compute.go
@@ -1,0 +1,194 @@
+package allocation
+
+import (
+	"sort"
+)
+
+// driftThresholdPP is the drift magnitude (percentage points) above which
+// a category triggers the dashboard warning badge. Mirrors the threshold
+// called out in the issue acceptance criteria.
+const driftThresholdPP = 5.0
+
+// CategoryAllocation is one (category, owner) holding from the latest
+// snapshot. Value is in PLN.
+type CategoryAllocation struct {
+	Category    string
+	OwnerUserID *int
+	Value       float64
+}
+
+// DriftItem is one row of the actual-vs-target widget.
+type DriftItem struct {
+	Category          string
+	OwnerUserID       *int
+	CurrentValue      float64
+	CurrentPercentage float64
+	TargetPercentage  float64
+	DriftPP           float64
+	Severity          string // "ok" | "warning" | "missing_target"
+	RebalanceAmount   float64
+}
+
+// DriftAnalysis is the dashboard widget payload, grouped by scope.
+type DriftAnalysis struct {
+	Scopes []DriftScope
+}
+
+// DriftScope is one owner_user_id bucket (nil = household).
+type DriftScope struct {
+	OwnerUserID       *int
+	TotalValue        float64
+	Items             []DriftItem
+	TargetSumPct      float64
+	HasCompleteTarget bool
+}
+
+// ComputeDrift bucket-sums the latest-snapshot holdings against the
+// declared targets and tags each row with the per-scope drift severity.
+//
+// Behavior:
+//   - For each (owner_user_id) scope that has any target row, render the
+//     full target set as DriftItems. Holdings whose category isn't in the
+//     target set show under that scope with target_pct=0 (so the user can
+//     see they're holding something they didn't plan for).
+//   - For each scope, HasCompleteTarget is true iff the configured targets
+//     sum to exactly 100 (within 0.01 tolerance).
+//   - Rebalance amount = (target_pct - current_pct) / 100 * total_value.
+//     Positive = buy, negative = sell.
+func ComputeDrift(holdings []CategoryAllocation, targets []Target) DriftAnalysis {
+	type scopeKey struct {
+		owner    int
+		isShared bool
+	}
+	holdingsByScope := map[scopeKey]map[string]float64{}
+	for _, h := range holdings {
+		k := scopeKey{isShared: h.OwnerUserID == nil}
+		if h.OwnerUserID != nil {
+			k.owner = *h.OwnerUserID
+		}
+		if holdingsByScope[k] == nil {
+			holdingsByScope[k] = map[string]float64{}
+		}
+		holdingsByScope[k][h.Category] += h.Value
+	}
+
+	targetsByScope := map[scopeKey][]Target{}
+	scopeOwner := map[scopeKey]*int{}
+	for _, t := range targets {
+		k := scopeKey{isShared: t.OwnerUserID == nil}
+		if t.OwnerUserID != nil {
+			k.owner = *t.OwnerUserID
+		}
+		targetsByScope[k] = append(targetsByScope[k], t)
+		owner := t.OwnerUserID
+		scopeOwner[k] = owner
+	}
+
+	allKeys := map[scopeKey]struct{}{}
+	for k := range targetsByScope {
+		allKeys[k] = struct{}{}
+	}
+	for k := range holdingsByScope {
+		if _, hasTarget := targetsByScope[k]; !hasTarget {
+			continue
+		}
+		allKeys[k] = struct{}{}
+	}
+
+	keys := make([]scopeKey, 0, len(allKeys))
+	for k := range allKeys {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].isShared != keys[j].isShared {
+			return keys[i].isShared
+		}
+		return keys[i].owner < keys[j].owner
+	})
+
+	out := DriftAnalysis{Scopes: make([]DriftScope, 0, len(keys))}
+	for _, k := range keys {
+		scope := buildScope(holdingsByScope[k], targetsByScope[k], scopeOwner[k])
+		out.Scopes = append(out.Scopes, scope)
+	}
+	return out
+}
+
+func buildScope(holdings map[string]float64, targets []Target, owner *int) DriftScope {
+	total := 0.0
+	for _, v := range holdings {
+		total += v
+	}
+	scope := DriftScope{OwnerUserID: owner, TotalValue: total}
+
+	covered := map[string]struct{}{}
+	for _, t := range targets {
+		tgt, _ := t.TargetPct.Float64()
+		scope.TargetSumPct += tgt
+		current := holdings[t.Category]
+		currentPct := 0.0
+		if total > 0 {
+			currentPct = current / total * 100
+		}
+		drift := currentPct - tgt
+		rebalance := 0.0
+		if total > 0 {
+			rebalance = (tgt - currentPct) / 100 * total
+		}
+		scope.Items = append(scope.Items, DriftItem{
+			Category:          t.Category,
+			OwnerUserID:       owner,
+			CurrentValue:      current,
+			CurrentPercentage: currentPct,
+			TargetPercentage:  tgt,
+			DriftPP:           drift,
+			Severity:          driftSeverity(drift),
+			RebalanceAmount:   rebalance,
+		})
+		covered[t.Category] = struct{}{}
+	}
+	categories := make([]string, 0, len(holdings))
+	for cat := range holdings {
+		if _, ok := covered[cat]; ok {
+			continue
+		}
+		categories = append(categories, cat)
+	}
+	sort.Strings(categories)
+	for _, cat := range categories {
+		current := holdings[cat]
+		currentPct := 0.0
+		if total > 0 {
+			currentPct = current / total * 100
+		}
+		scope.Items = append(scope.Items, DriftItem{
+			Category:          cat,
+			OwnerUserID:       owner,
+			CurrentValue:      current,
+			CurrentPercentage: currentPct,
+			TargetPercentage:  0,
+			DriftPP:           currentPct,
+			Severity:          "missing_target",
+			RebalanceAmount:   -current,
+		})
+	}
+	sort.SliceStable(scope.Items, func(i, j int) bool {
+		return scope.Items[i].Category < scope.Items[j].Category
+	})
+	scope.HasCompleteTarget = absFloat(scope.TargetSumPct-100) < 0.01
+	return scope
+}
+
+func driftSeverity(driftPP float64) string {
+	if absFloat(driftPP) > driftThresholdPP {
+		return "warning"
+	}
+	return "ok"
+}
+
+func absFloat(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/backend-go/internal/allocation/compute_test.go
+++ b/backend-go/internal/allocation/compute_test.go
@@ -1,0 +1,147 @@
+package allocation
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func pct(v float64) decimal.Decimal { return decimal.NewFromFloat(v) }
+
+func TestComputeDriftBalancedPortfolio(t *testing.T) {
+	holdings := []CategoryAllocation{
+		{Category: "stock", Value: 60000},
+		{Category: "bond", Value: 30000},
+		{Category: "gold", Value: 10000},
+	}
+	targets := []Target{
+		{Category: "stock", TargetPct: pct(60)},
+		{Category: "bond", TargetPct: pct(30)},
+		{Category: "gold", TargetPct: pct(10)},
+	}
+	got := ComputeDrift(holdings, targets)
+	if len(got.Scopes) != 1 {
+		t.Fatalf("expected 1 scope, got %d", len(got.Scopes))
+	}
+	scope := got.Scopes[0]
+	if !scope.HasCompleteTarget {
+		t.Fatalf("expected complete targets")
+	}
+	for _, it := range scope.Items {
+		if it.Severity != "ok" {
+			t.Fatalf("category %q expected ok severity, got %q", it.Category, it.Severity)
+		}
+		if absFloat(it.RebalanceAmount) > 0.01 {
+			t.Fatalf("category %q expected near-zero rebalance, got %v", it.Category, it.RebalanceAmount)
+		}
+	}
+}
+
+func TestComputeDriftWarningAboveThreshold(t *testing.T) {
+	holdings := []CategoryAllocation{
+		{Category: "stock", Value: 80000}, // 80% actual vs 60% target = +20pp drift
+		{Category: "bond", Value: 20000},
+	}
+	targets := []Target{
+		{Category: "stock", TargetPct: pct(60)},
+		{Category: "bond", TargetPct: pct(40)},
+	}
+	got := ComputeDrift(holdings, targets)
+	stock := findItem(t, got.Scopes[0].Items, "stock")
+	if stock.Severity != "warning" {
+		t.Fatalf("expected warning, got %q", stock.Severity)
+	}
+	if stock.RebalanceAmount > 0 {
+		t.Fatalf("over-allocated stock should suggest selling (negative), got %v", stock.RebalanceAmount)
+	}
+}
+
+func TestComputeDriftMissingTargetTagsHolding(t *testing.T) {
+	holdings := []CategoryAllocation{
+		{Category: "stock", Value: 50000},
+		{Category: "crypto", Value: 5000},
+	}
+	targets := []Target{
+		{Category: "stock", TargetPct: pct(100)},
+	}
+	got := ComputeDrift(holdings, targets)
+	if len(got.Scopes[0].Items) != 2 {
+		t.Fatalf("expected 2 items (stock target + untargeted crypto), got %d", len(got.Scopes[0].Items))
+	}
+	crypto := findItem(t, got.Scopes[0].Items, "crypto")
+	if crypto.Severity != "missing_target" {
+		t.Fatalf("untargeted holding should be missing_target, got %q", crypto.Severity)
+	}
+}
+
+func TestComputeDriftPerOwnerScopes(t *testing.T) {
+	o1, o2 := 1, 2
+	holdings := []CategoryAllocation{
+		{Category: "stock", OwnerUserID: &o1, Value: 30000},
+		{Category: "bond", OwnerUserID: &o1, Value: 20000},
+		{Category: "stock", OwnerUserID: &o2, Value: 40000},
+	}
+	targets := []Target{
+		{Category: "stock", OwnerUserID: &o1, TargetPct: pct(60)},
+		{Category: "bond", OwnerUserID: &o1, TargetPct: pct(40)},
+		{Category: "stock", OwnerUserID: &o2, TargetPct: pct(100)},
+	}
+	got := ComputeDrift(holdings, targets)
+	if len(got.Scopes) != 2 {
+		t.Fatalf("expected 2 owner scopes, got %d", len(got.Scopes))
+	}
+}
+
+func TestComputeDriftIncompleteTargets(t *testing.T) {
+	holdings := []CategoryAllocation{
+		{Category: "stock", Value: 50000},
+		{Category: "bond", Value: 50000},
+	}
+	targets := []Target{
+		{Category: "stock", TargetPct: pct(60)},
+		{Category: "bond", TargetPct: pct(30)},
+	}
+	got := ComputeDrift(holdings, targets)
+	if got.Scopes[0].HasCompleteTarget {
+		t.Fatalf("expected incomplete (sum=90)")
+	}
+}
+
+func TestComputeDriftRebalanceAmount(t *testing.T) {
+	holdings := []CategoryAllocation{
+		{Category: "stock", Value: 50000}, // 50% actual
+		{Category: "bond", Value: 50000},  // 50% actual
+	}
+	targets := []Target{
+		{Category: "stock", TargetPct: pct(70)},
+		{Category: "bond", TargetPct: pct(30)},
+	}
+	got := ComputeDrift(holdings, targets)
+	stock := findItem(t, got.Scopes[0].Items, "stock")
+	// stock: 20pp short on 100k = 20k buy
+	if absFloat(stock.RebalanceAmount-20000) > 0.5 {
+		t.Fatalf("stock rebalance: want ~+20000, got %v", stock.RebalanceAmount)
+	}
+	bond := findItem(t, got.Scopes[0].Items, "bond")
+	if absFloat(bond.RebalanceAmount+20000) > 0.5 {
+		t.Fatalf("bond rebalance: want ~-20000, got %v", bond.RebalanceAmount)
+	}
+}
+
+func TestComputeDriftEmptyNoTargetsNoScopes(t *testing.T) {
+	got := ComputeDrift([]CategoryAllocation{{Category: "stock", Value: 1000}}, []Target{})
+	if len(got.Scopes) != 0 {
+		t.Fatalf("no targets configured should produce no scopes; got %d", len(got.Scopes))
+	}
+}
+
+func findItem(t *testing.T, items []DriftItem, category string) DriftItem {
+	t.Helper()
+	for _, it := range items {
+		if it.Category == category {
+			return it
+		}
+	}
+	t.Fatalf("category %q not in items", category)
+	return DriftItem{}
+}

--- a/backend-go/internal/allocation/errors.go
+++ b/backend-go/internal/allocation/errors.go
@@ -1,0 +1,41 @@
+package allocation
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{
+				"type":  "value_error",
+				"loc":   []string{"body", field},
+				"msg":   msg,
+				"input": input,
+			},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/allocation/handler.go
+++ b/backend-go/internal/allocation/handler.go
@@ -1,0 +1,345 @@
+package allocation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// response is the wire shape for a single allocation_targets row.
+type response struct {
+	ID          int      `json:"id"`
+	Category    string   `json:"category"`
+	OwnerUserID *int     `json:"owner_user_id"`
+	TargetPct   float64  `json:"target_pct"`
+	CreatedAt   isoNaive `json:"created_at"`
+}
+
+type listResponse struct {
+	Targets []response `json:"targets"`
+}
+
+type createRequest struct {
+	Category    string  `json:"category"`
+	OwnerUserID *int    `json:"owner_user_id"`
+	TargetPct   float64 `json:"target_pct"`
+}
+
+type updateRequest struct {
+	TargetPct *float64 `json:"target_pct"`
+}
+
+type replaceItem struct {
+	Category  string  `json:"category"`
+	TargetPct float64 `json:"target_pct"`
+}
+
+type replaceRequest struct {
+	OwnerUserID *int          `json:"owner_user_id"`
+	Targets     []replaceItem `json:"targets"`
+}
+
+type driftItemWire struct {
+	Category          string  `json:"category"`
+	OwnerUserID       *int    `json:"owner_user_id"`
+	CurrentValue      float64 `json:"current_value"`
+	CurrentPercentage float64 `json:"current_percentage"`
+	TargetPercentage  float64 `json:"target_percentage"`
+	DriftPp           float64 `json:"drift_pp"`
+	Severity          string  `json:"severity"`
+	RebalanceAmount   float64 `json:"rebalance_amount"`
+}
+
+type driftScopeWire struct {
+	OwnerUserID       *int            `json:"owner_user_id"`
+	TotalValue        float64         `json:"total_value"`
+	TargetSumPct      float64         `json:"target_sum_pct"`
+	HasCompleteTarget bool            `json:"has_complete_target"`
+	Items             []driftItemWire `json:"items"`
+}
+
+type driftResponse struct {
+	Scopes []driftScopeWire `json:"scopes"`
+}
+
+// HoldingsProvider is what the handler needs to render drift — the source
+// of latest-snapshot (category, owner, value) buckets. Implemented by the
+// real store + injected from server wiring so the handler does not depend
+// on the dashboard package's internals.
+type HoldingsProvider interface {
+	LatestHoldings(ctx context.Context) ([]CategoryAllocation, error)
+}
+
+// Handler is the HTTP boundary for /api/allocation.
+type Handler struct {
+	store    *Store
+	holdings HoldingsProvider
+	logger   *slog.Logger
+}
+
+// NewHandler wires the store, holdings source and logger.
+func NewHandler(store *Store, holdings HoldingsProvider, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, holdings: holdings, logger: logger}
+}
+
+func toResponse(t *Target) response {
+	pct, _ := t.TargetPct.Float64()
+	return response{
+		ID:          t.ID,
+		Category:    t.Category,
+		OwnerUserID: t.OwnerUserID,
+		TargetPct:   pct,
+		CreatedAt:   isoNaive(t.CreatedAt),
+	}
+}
+
+// List serves GET /api/allocation/targets.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.store.List(r.Context())
+	if err != nil {
+		h.logger.Error("list allocation targets", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := listResponse{Targets: make([]response, 0, len(rows))}
+	for i := range rows {
+		out.Targets = append(out.Targets, toResponse(&rows[i]))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Create serves POST /api/allocation/targets.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	var req createRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	if vErr := validateCreate(&req); vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	t := &Target{
+		Category:    req.Category,
+		OwnerUserID: req.OwnerUserID,
+		TargetPct:   decimal.NewFromFloat(req.TargetPct),
+	}
+	created, err := h.store.Create(r.Context(), t)
+	if err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, toResponse(created))
+}
+
+// Update serves PUT /api/allocation/targets/{id}. Only target_pct is
+// patchable (changing scope is delete + create).
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	patch, vErr := buildUpdatePatch(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	t, err := h.store.Update(r.Context(), id, patch)
+	if err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toResponse(t))
+}
+
+// Delete serves DELETE /api/allocation/targets/{id}.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseIDParam(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.Delete(r.Context(), id); err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Replace serves PUT /api/allocation/targets/replace — atomic replace of
+// every target for one owner scope. The payload's targets must sum to 100.
+func (h *Handler) Replace(w http.ResponseWriter, r *http.Request) {
+	var req replaceRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	if vErr := validateReplaceBatch(req.Targets); vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	toInsert := make([]Target, 0, len(req.Targets))
+	for _, it := range req.Targets {
+		toInsert = append(toInsert, Target{
+			Category:  it.Category,
+			TargetPct: decimal.NewFromFloat(it.TargetPct),
+		})
+	}
+	inserted, err := h.store.Replace(r.Context(), req.OwnerUserID, toInsert)
+	if err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	out := listResponse{Targets: make([]response, 0, len(inserted))}
+	for i := range inserted {
+		out.Targets = append(out.Targets, toResponse(&inserted[i]))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// Drift serves GET /api/allocation/drift — the dashboard widget payload.
+func (h *Handler) Drift(w http.ResponseWriter, r *http.Request) {
+	targets, err := h.store.List(r.Context())
+	if err != nil {
+		h.logger.Error("drift: list targets", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	holdings, err := h.holdings.LatestHoldings(r.Context())
+	if err != nil {
+		h.logger.Error("drift: load holdings", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	analysis := ComputeDrift(holdings, targets)
+	out := driftResponse{Scopes: make([]driftScopeWire, 0, len(analysis.Scopes))}
+	for _, scope := range analysis.Scopes {
+		s := driftScopeWire{
+			OwnerUserID:       scope.OwnerUserID,
+			TotalValue:        scope.TotalValue,
+			TargetSumPct:      scope.TargetSumPct,
+			HasCompleteTarget: scope.HasCompleteTarget,
+			Items:             make([]driftItemWire, 0, len(scope.Items)),
+		}
+		for _, it := range scope.Items {
+			s.Items = append(s.Items, driftItemWire{
+				Category:          it.Category,
+				OwnerUserID:       it.OwnerUserID,
+				CurrentValue:      it.CurrentValue,
+				CurrentPercentage: it.CurrentPercentage,
+				TargetPercentage:  it.TargetPercentage,
+				DriftPp:           it.DriftPP,
+				Severity:          it.Severity,
+				RebalanceAmount:   it.RebalanceAmount,
+			})
+		}
+		out.Scopes = append(out.Scopes, s)
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) writeStoreError(w http.ResponseWriter, err error) {
+	var ownerMissing *OwnerMissingError
+	var dupScope *DuplicateScopeError
+	switch {
+	case errors.Is(err, ErrNotFound):
+		writeDetailError(w, http.StatusNotFound, "Allocation target not found")
+	case errors.As(err, &ownerMissing):
+		writeDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("User with id %d not found", ownerMissing.OwnerUserID))
+	case errors.As(err, &dupScope):
+		writeDetailError(w, http.StatusConflict, dupScope.Error())
+	default:
+		h.logger.Error("allocation store", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+	}
+}
+
+func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		writeValidationError(w, "target_id", "must be an integer", raw)
+		return 0, false
+	}
+	return id, true
+}
+
+// HoldingsFromSnapshots is a default HoldingsProvider — pulls the latest
+// snapshot, joins to accounts for category + owner, and returns one
+// CategoryAllocation per (owner, category) holding. Liabilities and
+// non-asset categories are excluded.
+type HoldingsFromSnapshots struct {
+	pool *pgxpool.Pool
+}
+
+// NewHoldingsFromSnapshots wraps a pool.
+func NewHoldingsFromSnapshots(pool *pgxpool.Pool) *HoldingsFromSnapshots {
+	return &HoldingsFromSnapshots{pool: pool}
+}
+
+// LatestHoldings reads the most recent snapshot's values and rolls them
+// up by (owner_user_id, category) for active asset accounts only.
+// Soft-deleted accounts are excluded — drift is forward-looking, unlike
+// dashboard net worth which keeps historical accounts for trend math.
+func (h *HoldingsFromSnapshots) LatestHoldings(ctx context.Context) ([]CategoryAllocation, error) {
+	var latestID int
+	err := h.pool.QueryRow(ctx, `SELECT id FROM snapshots ORDER BY date DESC, id DESC LIMIT 1`).Scan(&latestID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return []CategoryAllocation{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("latest snapshot id: %w", err)
+	}
+	rows, err := h.pool.Query(ctx, `
+		SELECT a.owner_user_id, a.category, sv.value
+		FROM snapshot_values sv
+		JOIN accounts a ON a.id = sv.account_id
+		WHERE sv.snapshot_id = $1 AND a.type = 'asset' AND a.is_active = true
+	`, latestID)
+	if err != nil {
+		return nil, fmt.Errorf("query latest snapshot values: %w", err)
+	}
+	defer rows.Close()
+	out := []CategoryAllocation{}
+	for rows.Next() {
+		var owner *int
+		var category string
+		var value decimal.Decimal
+		if err := rows.Scan(&owner, &category, &value); err != nil {
+			return nil, fmt.Errorf("scan snapshot value: %w", err)
+		}
+		f, _ := value.Float64()
+		out = append(out, CategoryAllocation{OwnerUserID: owner, Category: category, Value: f})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshot values: %w", err)
+	}
+	return out, nil
+}
+
+// isoNaive serializes a time.Time as ISO without a timezone suffix; mirrors
+// Python's datetime.isoformat() on naive datetimes.
+type isoNaive time.Time
+
+func (t isoNaive) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
+}

--- a/backend-go/internal/allocation/openapi.go
+++ b/backend-go/internal/allocation/openapi.go
@@ -1,0 +1,13 @@
+package allocation
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "GET", Path: "/api/allocation/targets", Tag: "allocation", Summary: "List allocation targets", Response: listResponse{}},
+	{Method: "POST", Path: "/api/allocation/targets", Tag: "allocation", Summary: "Create allocation target", Request: createRequest{}, Response: response{}, Status: 201},
+	{Method: "PUT", Path: "/api/allocation/targets/replace", Tag: "allocation", Summary: "Replace all targets for one owner scope", Request: replaceRequest{}, Response: listResponse{}},
+	{Method: "PUT", Path: "/api/allocation/targets/{id}", Tag: "allocation", Summary: "Update allocation target", Request: updateRequest{}, Response: response{}},
+	{Method: "DELETE", Path: "/api/allocation/targets/{id}", Tag: "allocation", Summary: "Delete allocation target", Status: 204},
+	{Method: "GET", Path: "/api/allocation/drift", Tag: "allocation", Summary: "Actual vs target allocation drift", Response: driftResponse{}},
+}

--- a/backend-go/internal/allocation/store.go
+++ b/backend-go/internal/allocation/store.go
@@ -1,0 +1,303 @@
+// Package allocation implements the /api/allocation/targets endpoints +
+// the actual-vs-target drift compute that powers the dashboard widget.
+//
+// A target is one (owner_user_id, category) pair carrying a target_pct.
+// owner_user_id NULL = household-level target (jointly owned). Per-owner
+// targets must sum to exactly 100 before they are usable for drift; the
+// store accepts partial sets so the UI can edit incrementally and the
+// bulk Replace endpoint enforces the sum.
+package allocation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Target is one allocation_targets row.
+type Target struct {
+	ID          int
+	Category    string
+	OwnerUserID *int
+	TargetPct   decimal.Decimal
+	CreatedAt   time.Time
+}
+
+// ErrNotFound is returned when no row matches the supplied id.
+var ErrNotFound = errors.New("allocation target not found")
+
+// OwnerMissingError is returned when create/update references a
+// non-existent owner_user_id; mapped to a 404.
+type OwnerMissingError struct {
+	OwnerUserID int
+}
+
+func (e *OwnerMissingError) Error() string {
+	return fmt.Sprintf("user with id %d not found", e.OwnerUserID)
+}
+
+// DuplicateScopeError is returned when (owner_user_id, category) collides
+// with an existing row; mapped to a 409.
+type DuplicateScopeError struct {
+	Category    string
+	OwnerUserID *int
+}
+
+func (e *DuplicateScopeError) Error() string {
+	return fmt.Sprintf("target for category %q in this scope already exists", e.Category)
+}
+
+// Store is the persistence boundary for allocation_targets.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const selectColumns = `id, category, owner_user_id, target_pct, created_at`
+
+// EnsureSchema creates the allocation_targets table if missing. Idempotent
+// so it can run on every backend start — schema.sql only seeds empty
+// databases, so existing prod installs need the additive DDL here too.
+func (s *Store) EnsureSchema(ctx context.Context) error {
+	if _, err := s.pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS allocation_targets (
+			id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+			category varchar(50) NOT NULL,
+			owner_user_id integer,
+			target_pct numeric(5,2) NOT NULL,
+			created_at timestamp without time zone NOT NULL DEFAULT (now() AT TIME ZONE 'utc'),
+			CONSTRAINT allocation_targets_pct_range CHECK (target_pct >= 0 AND target_pct <= 100),
+			CONSTRAINT allocation_targets_owner_user_id_fkey FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE
+		)`); err != nil {
+		return fmt.Errorf("ensure allocation_targets table: %w", err)
+	}
+	if _, err := s.pool.Exec(ctx, `
+		CREATE UNIQUE INDEX IF NOT EXISTS allocation_targets_scope_category_uniq
+			ON allocation_targets (COALESCE(owner_user_id, -1), category)`); err != nil {
+		return fmt.Errorf("ensure allocation_targets uniq index: %w", err)
+	}
+	return nil
+}
+
+// List returns every target ordered by (owner_user_id NULLS FIRST, category).
+func (s *Store) List(ctx context.Context) ([]Target, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+selectColumns+` FROM allocation_targets
+		 ORDER BY owner_user_id NULLS FIRST, category`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list allocation targets: %w", err)
+	}
+	defer rows.Close()
+	out := []Target{}
+	for rows.Next() {
+		t, err := scanTarget(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan allocation target: %w", err)
+		}
+		out = append(out, *t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate allocation targets: %w", err)
+	}
+	return out, nil
+}
+
+// Get returns one target by id; ErrNotFound when missing.
+func (s *Store) Get(ctx context.Context, id int) (*Target, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+selectColumns+` FROM allocation_targets WHERE id = $1`, id,
+	)
+	t, err := scanTarget(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get allocation target: %w", err)
+	}
+	return t, nil
+}
+
+// Create inserts a new target. Returns OwnerMissingError when owner_user_id
+// references a non-existent user, DuplicateScopeError when the (owner,
+// category) pair is already taken.
+func (s *Store) Create(ctx context.Context, t *Target) (*Target, error) {
+	if err := s.validateOwner(ctx, t.OwnerUserID); err != nil {
+		return nil, err
+	}
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO allocation_targets (category, owner_user_id, target_pct, created_at)
+		VALUES ($1, $2, $3, $4)
+		RETURNING `+selectColumns,
+		t.Category, t.OwnerUserID, t.TargetPct, time.Now().UTC(),
+	)
+	created, err := scanTarget(row)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return nil, &DuplicateScopeError{Category: t.Category, OwnerUserID: t.OwnerUserID}
+		}
+		if isForeignKeyViolation(err) && t.OwnerUserID != nil {
+			// Race: user was deleted between validateOwner and the INSERT.
+			return nil, &OwnerMissingError{OwnerUserID: *t.OwnerUserID}
+		}
+		return nil, fmt.Errorf("insert allocation target: %w", err)
+	}
+	return created, nil
+}
+
+// UpdatePatch is a sparse update; only set fields apply. Scope (category +
+// owner_user_id) is immutable — moving a target between scopes is a
+// delete + create.
+type UpdatePatch struct {
+	TargetPct *decimal.Decimal
+}
+
+// Update applies the patch and returns the refreshed target.
+func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Target, error) {
+	if p.TargetPct == nil {
+		return s.Get(ctx, id)
+	}
+	row := s.pool.QueryRow(ctx, `
+		UPDATE allocation_targets SET target_pct = $1
+		WHERE id = $2
+		RETURNING `+selectColumns,
+		*p.TargetPct, id,
+	)
+	updated, err := scanTarget(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("update allocation target: %w", err)
+	}
+	return updated, nil
+}
+
+// Delete removes the target by id.
+func (s *Store) Delete(ctx context.Context, id int) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM allocation_targets WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete allocation target: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// Replace atomically replaces every target for one owner scope (NULL = all
+// household-level rows). The caller validates sum-to-100 before calling.
+// A per-scope pg_advisory_xact_lock serializes concurrent replaces so two
+// in-flight payloads cannot leave the scope in a torn state.
+func (s *Store) Replace(ctx context.Context, ownerUserID *int, targets []Target) ([]Target, error) {
+	if err := s.validateOwner(ctx, ownerUserID); err != nil {
+		return nil, err
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin replace tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	scopeLockKey := -1
+	if ownerUserID != nil {
+		scopeLockKey = *ownerUserID
+	}
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtext('alloc_scope_' || $1::text))`, scopeLockKey,
+	); err != nil {
+		return nil, fmt.Errorf("acquire scope lock: %w", err)
+	}
+	if ownerUserID == nil {
+		if _, err := tx.Exec(ctx, `DELETE FROM allocation_targets WHERE owner_user_id IS NULL`); err != nil {
+			return nil, fmt.Errorf("clear household targets: %w", err)
+		}
+	} else {
+		if _, err := tx.Exec(ctx, `DELETE FROM allocation_targets WHERE owner_user_id = $1`, *ownerUserID); err != nil {
+			return nil, fmt.Errorf("clear owner targets: %w", err)
+		}
+	}
+	now := time.Now().UTC()
+	out := make([]Target, 0, len(targets))
+	for _, t := range targets {
+		row := tx.QueryRow(ctx, `
+			INSERT INTO allocation_targets (category, owner_user_id, target_pct, created_at)
+			VALUES ($1, $2, $3, $4)
+			RETURNING `+selectColumns,
+			t.Category, ownerUserID, t.TargetPct, now,
+		)
+		inserted, err := scanTarget(row)
+		if err != nil {
+			if isUniqueViolation(err) {
+				return nil, &DuplicateScopeError{Category: t.Category, OwnerUserID: ownerUserID}
+			}
+			return nil, fmt.Errorf("insert replacement target: %w", err)
+		}
+		out = append(out, *inserted)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit replace tx: %w", err)
+	}
+	committed = true
+	return out, nil
+}
+
+func (s *Store) validateOwner(ctx context.Context, ownerUserID *int) error {
+	if ownerUserID == nil {
+		return nil
+	}
+	var exists bool
+	err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM users WHERE id = $1)`, *ownerUserID,
+	).Scan(&exists)
+	if err != nil {
+		return fmt.Errorf("check user: %w", err)
+	}
+	if !exists {
+		return &OwnerMissingError{OwnerUserID: *ownerUserID}
+	}
+	return nil
+}
+
+// isUniqueViolation reports whether err is a Postgres 23505. Concurrent
+// inserts can race past the pre-check, so the caller converts the
+// resulting error into a 409.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr == nil {
+		return false
+	}
+	return pgErr.Code == pgerrcode.UniqueViolation
+}
+
+// isForeignKeyViolation reports whether err is a Postgres 23503.
+func isForeignKeyViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr == nil {
+		return false
+	}
+	return pgErr.Code == pgerrcode.ForeignKeyViolation
+}
+
+func scanTarget(row pgx.Row) (*Target, error) {
+	var t Target
+	if err := row.Scan(&t.ID, &t.Category, &t.OwnerUserID, &t.TargetPct, &t.CreatedAt); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}

--- a/backend-go/internal/allocation/validation.go
+++ b/backend-go/internal/allocation/validation.go
@@ -1,0 +1,89 @@
+package allocation
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/shopspring/decimal"
+)
+
+// validAllocationCategories are the asset-side categories users can target.
+// Mirrors accounts.validCategories minus the liability ones (mortgage,
+// installment) — targeting a liability percentage doesn't make sense.
+var validAllocationCategories = map[string]struct{}{
+	"bank": {}, "saving_account": {}, "stock": {}, "bond": {}, "gold": {},
+	"real_estate": {}, "ppk": {}, "fund": {}, "etf": {}, "vehicle": {},
+}
+
+func validateCreate(req *createRequest) *validationError {
+	if _, ok := validAllocationCategories[req.Category]; !ok {
+		return &validationError{Field: "category", Msg: fmt.Sprintf("invalid category %q", req.Category)}
+	}
+	if req.TargetPct < 0 || req.TargetPct > 100 {
+		return &validationError{Field: "target_pct", Msg: "Target percentage must be between 0 and 100"}
+	}
+	return nil
+}
+
+// buildUpdatePatch reads a raw JSON object and decides, per field, whether
+// it was omitted vs set. Only target_pct is mutable on PUT; changing scope
+// (owner_user_id / category) is delete + create.
+func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *validationError) {
+	var p UpdatePatch
+	if v, ok := raw["target_pct"]; ok && !isNull(v) {
+		var f float64
+		if err := json.Unmarshal(v, &f); err != nil {
+			return p, &validationError{Field: "target_pct", Msg: "must be a number"}
+		}
+		if f < 0 || f > 100 {
+			return p, &validationError{Field: "target_pct", Msg: "Target percentage must be between 0 and 100"}
+		}
+		d := decimal.NewFromFloat(f)
+		p.TargetPct = &d
+	}
+	return p, nil
+}
+
+// validateReplaceBatch enforces the sum-to-100 invariant + per-category
+// uniqueness within one bulk-replace payload.
+func validateReplaceBatch(items []replaceItem) *validationError {
+	seen := map[string]struct{}{}
+	sum := 0.0
+	for i, it := range items {
+		if _, ok := validAllocationCategories[it.Category]; !ok {
+			return &validationError{
+				Field: fmt.Sprintf("targets[%d].category", i),
+				Msg:   fmt.Sprintf("invalid category %q", it.Category),
+			}
+		}
+		if _, dup := seen[it.Category]; dup {
+			return &validationError{
+				Field: fmt.Sprintf("targets[%d].category", i),
+				Msg:   fmt.Sprintf("duplicate category %q in payload", it.Category),
+			}
+		}
+		seen[it.Category] = struct{}{}
+		if it.TargetPct < 0 || it.TargetPct > 100 {
+			return &validationError{
+				Field: fmt.Sprintf("targets[%d].target_pct", i),
+				Msg:   "Target percentage must be between 0 and 100",
+			}
+		}
+		sum += it.TargetPct
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	if absFloat(sum-100) > 0.01 {
+		return &validationError{
+			Field: "targets",
+			Msg:   fmt.Sprintf("Target percentages must sum to 100 (got %.2f)", sum),
+		}
+	}
+	return nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}

--- a/backend-go/internal/allocation/validation_test.go
+++ b/backend-go/internal/allocation/validation_test.go
@@ -1,0 +1,120 @@
+package allocation
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func rawJSON(t *testing.T, m map[string]any) map[string]json.RawMessage {
+	t.Helper()
+	out := make(map[string]json.RawMessage, len(m))
+	for k, v := range m {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", k, err)
+		}
+		out[k] = b
+	}
+	return out
+}
+
+func TestValidateCreateOK(t *testing.T) {
+	if err := validateCreate(&createRequest{Category: "stock", TargetPct: 60}); err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+}
+
+func TestValidateCreateUnknownCategory(t *testing.T) {
+	err := validateCreate(&createRequest{Category: "crypto", TargetPct: 10})
+	if err == nil || err.Field != "category" {
+		t.Fatalf("expected category error, got %+v", err)
+	}
+}
+
+func TestValidateCreateNegativePct(t *testing.T) {
+	err := validateCreate(&createRequest{Category: "stock", TargetPct: -1})
+	if err == nil || err.Field != "target_pct" {
+		t.Fatalf("expected target_pct error, got %+v", err)
+	}
+}
+
+func TestValidateCreatePctOver100(t *testing.T) {
+	err := validateCreate(&createRequest{Category: "stock", TargetPct: 100.5})
+	if err == nil || err.Field != "target_pct" {
+		t.Fatalf("expected target_pct error, got %+v", err)
+	}
+}
+
+func TestValidateCreateLiabilityCategoryRejected(t *testing.T) {
+	err := validateCreate(&createRequest{Category: "mortgage", TargetPct: 50})
+	if err == nil || err.Field != "category" {
+		t.Fatalf("liability category should be rejected, got %+v", err)
+	}
+}
+
+func TestReplaceBatchSumsTo100(t *testing.T) {
+	err := validateReplaceBatch([]replaceItem{
+		{Category: "stock", TargetPct: 60},
+		{Category: "bond", TargetPct: 30},
+		{Category: "gold", TargetPct: 10},
+	})
+	if err != nil {
+		t.Fatalf("expected ok, got %+v", err)
+	}
+}
+
+func TestReplaceBatchSumMismatch(t *testing.T) {
+	err := validateReplaceBatch([]replaceItem{
+		{Category: "stock", TargetPct: 60},
+		{Category: "bond", TargetPct: 30},
+	})
+	if err == nil || err.Field != "targets" {
+		t.Fatalf("expected sum error, got %+v", err)
+	}
+}
+
+func TestReplaceBatchDuplicateCategory(t *testing.T) {
+	err := validateReplaceBatch([]replaceItem{
+		{Category: "stock", TargetPct: 60},
+		{Category: "stock", TargetPct: 40},
+	})
+	if err == nil {
+		t.Fatalf("expected duplicate error, got nil")
+	}
+}
+
+func TestReplaceBatchEmptyOK(t *testing.T) {
+	if err := validateReplaceBatch([]replaceItem{}); err != nil {
+		t.Fatalf("empty payload should clear targets, got %+v", err)
+	}
+}
+
+func TestBuildUpdatePatchTargetPct(t *testing.T) {
+	patch, err := buildUpdatePatch(rawJSON(t, map[string]any{"target_pct": 42.5}))
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+	if patch.TargetPct == nil {
+		t.Fatalf("target_pct not parsed")
+	}
+	got, _ := patch.TargetPct.Float64()
+	if got != 42.5 {
+		t.Fatalf("target_pct = %v, want 42.5", got)
+	}
+}
+
+func TestBuildUpdatePatchOmittedNoChange(t *testing.T) {
+	patch, err := buildUpdatePatch(rawJSON(t, map[string]any{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+	if patch.TargetPct != nil {
+		t.Fatalf("target_pct should be nil when omitted")
+	}
+}
+
+func TestBuildUpdatePatchInvalidRange(t *testing.T) {
+	if _, err := buildUpdatePatch(rawJSON(t, map[string]any{"target_pct": 150})); err == nil {
+		t.Fatalf("expected range error")
+	}
+}

--- a/backend-go/internal/db/schema.sql
+++ b/backend-go/internal/db/schema.sql
@@ -1123,6 +1123,29 @@ ALTER TABLE ONLY public.treasury_bonds
 
 
 --
+-- Name: allocation_targets; Type: TABLE; Schema: public; Owner: -
+--
+-- Kept in sync with allocation.Store.EnsureSchema, which runs the same CREATE
+-- TABLE IF NOT EXISTS against pre-existing databases. Per-owner target asset
+-- allocations; owner_user_id NULL = household-level target.
+
+CREATE TABLE public.allocation_targets (
+    id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    category character varying(50) NOT NULL,
+    owner_user_id integer,
+    target_pct numeric(5,2) NOT NULL,
+    created_at timestamp without time zone NOT NULL DEFAULT (now() AT TIME ZONE 'utc'),
+    CONSTRAINT allocation_targets_pct_range CHECK (target_pct >= 0 AND target_pct <= 100)
+);
+
+CREATE UNIQUE INDEX allocation_targets_scope_category_uniq
+    ON public.allocation_targets (COALESCE(owner_user_id, -1), category);
+
+ALTER TABLE ONLY public.allocation_targets
+    ADD CONSTRAINT allocation_targets_owner_user_id_fkey FOREIGN KEY (owner_user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
 -- PostgreSQL database dump complete
 --
 

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/accounts"
 	"github.com/Automaat/finance-buddy/backend-go/internal/aggregates"
+	"github.com/Automaat/finance-buddy/backend-go/internal/allocation"
 	"github.com/Automaat/finance-buddy/backend-go/internal/assets"
 	"github.com/Automaat/finance-buddy/backend-go/internal/auth"
 	"github.com/Automaat/finance-buddy/backend-go/internal/bonds"
@@ -282,6 +283,18 @@ func registerPortfolioRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logg
 		r.Get("/{id}/ytm", bondsHandler.YTM)
 		r.Put("/{id}", bondsHandler.Update)
 		r.Delete("/{id}", bondsHandler.Delete)
+	})
+
+	allocStore := allocation.NewStore(pool)
+	allocHoldings := allocation.NewHoldingsFromSnapshots(pool)
+	allocHandler := allocation.NewHandler(allocStore, allocHoldings, logger)
+	r.Route("/api/allocation", func(r chi.Router) {
+		r.Get("/targets", allocHandler.List)
+		r.Post("/targets", allocHandler.Create)
+		r.Put("/targets/replace", allocHandler.Replace)
+		r.Put("/targets/{id}", allocHandler.Update)
+		r.Delete("/targets/{id}", allocHandler.Delete)
+		r.Get("/drift", allocHandler.Drift)
 	})
 }
 

--- a/src/lib/components/AllocationDriftWidget.svelte
+++ b/src/lib/components/AllocationDriftWidget.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+	import { formatPLN, formatSignedPLN } from '$lib/utils/format';
+	import { ownerName, type OwnerOption } from '$lib/types/owners';
+	import { Scale, AlertTriangle, CheckCircle2, ArrowUp, ArrowDown } from 'lucide-svelte';
+
+	interface DriftItem {
+		category: string;
+		owner_user_id: number | null;
+		current_value: number;
+		current_percentage: number;
+		target_percentage: number;
+		drift_pp: number;
+		severity: 'ok' | 'warning' | 'missing_target';
+		rebalance_amount: number;
+	}
+
+	interface DriftScope {
+		owner_user_id: number | null;
+		total_value: number;
+		target_sum_pct: number;
+		has_complete_target: boolean;
+		items: DriftItem[];
+	}
+
+	interface Props {
+		drift: { scopes: DriftScope[] };
+		owners: OwnerOption[];
+	}
+
+	const CATEGORY_LABELS: Record<string, string> = {
+		bank: 'Bank',
+		saving_account: 'Konto oszczędn.',
+		stock: 'Akcje',
+		bond: 'Obligacje',
+		gold: 'Złoto',
+		real_estate: 'Nieruchomości',
+		ppk: 'PPK',
+		fund: 'Fundusze',
+		etf: 'ETF',
+		vehicle: 'Pojazdy'
+	};
+
+	let { drift, owners }: Props = $props();
+
+	function scopeLabel(ownerId: number | null): string {
+		if (ownerId === null) return 'Wspólne';
+		return ownerName(owners, ownerId);
+	}
+
+	function categoryLabel(value: string): string {
+		return CATEGORY_LABELS[value] ?? value;
+	}
+
+	function barWidth(pct: number): string {
+		return `${Math.max(0, Math.min(100, pct))}%`;
+	}
+</script>
+
+{#if drift.scopes.length > 0}
+	<div class="card preset-filled-surface-100-900 p-4 space-y-4">
+		<header class="flex items-center gap-2">
+			<Scale size={20} />
+			<h3 class="h3">Dryft alokacji</h3>
+		</header>
+
+		{#each drift.scopes as scope (scope.owner_user_id ?? 'household')}
+			<section class="space-y-3">
+				<header class="flex items-center justify-between flex-wrap gap-2">
+					<h4 class="h4 font-semibold">{scopeLabel(scope.owner_user_id)}</h4>
+					<span class="text-xs text-surface-700-300">
+						Suma celów: {scope.target_sum_pct.toFixed(2)}% · Aktywa: {formatPLN(scope.total_value)}
+					</span>
+				</header>
+
+				{#if !scope.has_complete_target}
+					<div class="card preset-tonal-warning p-2 text-xs flex items-center gap-2">
+						<AlertTriangle size={14} />
+						Cele dla tego zakresu nie sumują się do 100%. Uzupełnij w
+						<a href="/settings/allocation" class="underline">ustawieniach</a>.
+					</div>
+				{/if}
+
+				<div class="space-y-2">
+					{#each scope.items as item (item.category)}
+						{@const overTarget = item.current_percentage > item.target_percentage}
+						<div class="space-y-1">
+							<div class="flex items-center justify-between gap-2 text-sm">
+								<span class="font-semibold">{categoryLabel(item.category)}</span>
+								<div class="flex items-center gap-2">
+									{#if item.severity === 'warning'}
+										<span class="badge preset-filled-warning-500 flex items-center gap-1">
+											<AlertTriangle size={12} /> Dryft {item.drift_pp >= 0
+												? '+'
+												: ''}{item.drift_pp.toFixed(1)} pp
+										</span>
+									{:else if item.severity === 'missing_target'}
+										<span class="badge preset-tonal-surface">Brak celu</span>
+									{:else}
+										<span class="badge preset-filled-success-500 flex items-center gap-1"
+											><CheckCircle2 size={12} /> OK</span
+										>
+									{/if}
+								</div>
+							</div>
+
+							<div
+								class="h-3 rounded-full bg-surface-200-800 overflow-hidden relative"
+								title="Aktualne: {item.current_percentage.toFixed(
+									1
+								)}% · Cel: {item.target_percentage.toFixed(1)}%"
+							>
+								<div
+									class="absolute inset-y-0 left-0 bg-surface-300-700"
+									style="width: {barWidth(item.target_percentage)}"
+								></div>
+								<div
+									class="absolute inset-y-0 left-0 {item.severity === 'warning'
+										? 'bg-warning-500'
+										: item.severity === 'missing_target'
+											? 'bg-error-400'
+											: 'bg-primary-500'} opacity-80"
+									style="width: {barWidth(item.current_percentage)}"
+								></div>
+							</div>
+
+							<div class="flex items-center justify-between text-xs text-surface-700-300">
+								<span>
+									{item.current_percentage.toFixed(1)}% ({formatPLN(item.current_value)}) · cel {item.target_percentage.toFixed(
+										1
+									)}%
+								</span>
+								{#if Math.abs(item.rebalance_amount) >= 1}
+									<span
+										class="font-semibold inline-flex items-center gap-1 {overTarget
+											? 'text-error-600-400'
+											: 'text-success-600-400'}"
+									>
+										{#if overTarget}
+											<ArrowDown size={12} /> SPRZEDAJ
+										{:else}
+											<ArrowUp size={12} /> DOKUP
+										{/if}
+										{formatSignedPLN(item.rebalance_amount)}
+									</span>
+								{/if}
+							</div>
+						</div>
+					{/each}
+				</div>
+			</section>
+		{/each}
+	</div>
+{/if}

--- a/src/lib/components/AllocationDriftWidget.test.ts
+++ b/src/lib/components/AllocationDriftWidget.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import AllocationDriftWidget from './AllocationDriftWidget.svelte';
+
+const baseScope = {
+	owner_user_id: null as number | null,
+	total_value: 100000,
+	target_sum_pct: 100,
+	has_complete_target: true,
+	items: [
+		{
+			category: 'stock',
+			owner_user_id: null,
+			current_value: 60000,
+			current_percentage: 60,
+			target_percentage: 60,
+			drift_pp: 0,
+			severity: 'ok' as const,
+			rebalance_amount: 0
+		}
+	]
+};
+
+describe('AllocationDriftWidget', () => {
+	it('renders nothing when no scopes are present', () => {
+		const { container } = render(AllocationDriftWidget, {
+			props: { drift: { scopes: [] }, owners: [] }
+		});
+		expect(container.textContent ?? '').not.toContain('Dryft alokacji');
+	});
+
+	it('renders scope label and category for household scope', () => {
+		render(AllocationDriftWidget, {
+			props: { drift: { scopes: [baseScope] }, owners: [] }
+		});
+		expect(screen.getByText('Dryft alokacji')).toBeTruthy();
+		expect(screen.getByText('Wspólne')).toBeTruthy();
+		expect(screen.getByText('Akcje')).toBeTruthy();
+	});
+
+	it('renders ok badge when severity is ok', () => {
+		render(AllocationDriftWidget, {
+			props: { drift: { scopes: [baseScope] }, owners: [] }
+		});
+		expect(screen.getByText('OK')).toBeTruthy();
+	});
+
+	it('renders warning badge with drift pp when severity is warning', () => {
+		const scope = {
+			...baseScope,
+			items: [
+				{
+					...baseScope.items[0],
+					current_percentage: 80,
+					target_percentage: 60,
+					drift_pp: 20,
+					severity: 'warning' as const,
+					rebalance_amount: -20000
+				}
+			]
+		};
+		render(AllocationDriftWidget, {
+			props: { drift: { scopes: [scope] }, owners: [] }
+		});
+		expect(screen.getByText(/Dryft \+20\.0 pp/)).toBeTruthy();
+		expect(screen.getByText(/SPRZEDAJ/)).toBeTruthy();
+	});
+
+	it('shows rebalance hint with DOKUP when under target', () => {
+		const scope = {
+			...baseScope,
+			items: [
+				{
+					...baseScope.items[0],
+					current_percentage: 40,
+					target_percentage: 60,
+					drift_pp: -20,
+					severity: 'warning' as const,
+					rebalance_amount: 20000
+				}
+			]
+		};
+		render(AllocationDriftWidget, {
+			props: { drift: { scopes: [scope] }, owners: [] }
+		});
+		expect(screen.getByText(/DOKUP/)).toBeTruthy();
+	});
+
+	it('shows incomplete-target warning when sum != 100', () => {
+		const scope = { ...baseScope, target_sum_pct: 90, has_complete_target: false };
+		render(AllocationDriftWidget, {
+			props: { drift: { scopes: [scope] }, owners: [] }
+		});
+		expect(screen.getByText(/nie sumują się do 100/)).toBeTruthy();
+	});
+
+	it('renders missing_target badge for untargeted holdings', () => {
+		const scope = {
+			...baseScope,
+			items: [
+				{
+					...baseScope.items[0],
+					category: 'crypto',
+					current_percentage: 5,
+					target_percentage: 0,
+					drift_pp: 5,
+					severity: 'missing_target' as const,
+					rebalance_amount: -5000
+				}
+			]
+		};
+		render(AllocationDriftWidget, {
+			props: { drift: { scopes: [scope] }, owners: [] }
+		});
+		expect(screen.getByText('Brak celu')).toBeTruthy();
+	});
+
+	it('uses owner name when scope has owner_user_id', () => {
+		const scope = { ...baseScope, owner_user_id: 1 };
+		render(AllocationDriftWidget, {
+			props: {
+				drift: { scopes: [scope] },
+				owners: [{ id: 1, name: 'Marcin' }]
+			}
+		});
+		expect(screen.getByText('Marcin')).toBeTruthy();
+	});
+});

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -503,6 +503,279 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/allocation/drift": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Actual vs target allocation drift */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            scopes?: {
+                                has_complete_target?: boolean;
+                                items?: {
+                                    category?: string;
+                                    /** Format: double */
+                                    current_percentage?: number;
+                                    /** Format: double */
+                                    current_value?: number;
+                                    /** Format: double */
+                                    drift_pp?: number;
+                                    owner_user_id?: number | null;
+                                    /** Format: double */
+                                    rebalance_amount?: number;
+                                    severity?: string;
+                                    /** Format: double */
+                                    target_percentage?: number;
+                                }[];
+                                owner_user_id?: number | null;
+                                /** Format: double */
+                                target_sum_pct?: number;
+                                /** Format: double */
+                                total_value?: number;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/allocation/targets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List allocation targets */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            targets?: {
+                                category?: string;
+                                /** Format: date-time */
+                                created_at?: string;
+                                id?: number;
+                                owner_user_id?: number | null;
+                                /** Format: double */
+                                target_pct?: number;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create allocation target */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        category?: string;
+                        owner_user_id?: number | null;
+                        /** Format: double */
+                        target_pct?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            category?: string;
+                            /** Format: date-time */
+                            created_at?: string;
+                            id?: number;
+                            owner_user_id?: number | null;
+                            /** Format: double */
+                            target_pct?: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/allocation/targets/replace": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Replace all targets for one owner scope */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        owner_user_id?: number | null;
+                        targets?: {
+                            category?: string;
+                            /** Format: double */
+                            target_pct?: number;
+                        }[];
+                    };
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            targets?: {
+                                category?: string;
+                                /** Format: date-time */
+                                created_at?: string;
+                                id?: number;
+                                owner_user_id?: number | null;
+                                /** Format: double */
+                                target_pct?: number;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/allocation/targets/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update allocation target */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: double */
+                        target_pct?: number | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            category?: string;
+                            /** Format: date-time */
+                            created_at?: string;
+                            id?: number;
+                            owner_user_id?: number | null;
+                            /** Format: double */
+                            target_pct?: number;
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        /** Delete allocation target */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/assets": {
         parameters: {
             query?: never;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import Skeleton from '$lib/components/Skeleton.svelte';
 	import DashboardCharts from '$lib/components/DashboardCharts.svelte';
+	import AllocationDriftWidget from '$lib/components/AllocationDriftWidget.svelte';
 	import DateRangePicker from '$lib/components/DateRangePicker.svelte';
 	import DeltaBadge from '$lib/components/DeltaBadge.svelte';
 	import { formatPLN } from '$lib/utils/format';
@@ -342,6 +343,10 @@
 					{/each}
 				</div>
 			</div>
+		{/if}
+
+		{#if dashboard.allocationDrift?.scopes?.length > 0}
+			<AllocationDriftWidget drift={dashboard.allocationDrift} {owners} />
 		{/if}
 
 		<DashboardCharts

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -22,10 +22,11 @@ export async function load({ fetch, url }) {
 
 	const dashboardData = (async () => {
 		try {
-			const [dashboardRes, retirementRes, bondsRes] = await Promise.all([
+			const [dashboardRes, retirementRes, bondsRes, driftRes] = await Promise.all([
 				fetch(dashboardURL),
 				fetch(`${apiUrl}/api/retirement/stats?year=${currentYear}`),
-				fetch(`${apiUrl}/api/bonds`)
+				fetch(`${apiUrl}/api/bonds`),
+				fetch(`${apiUrl}/api/allocation/drift`)
 			]);
 
 			if (!dashboardRes.ok) {
@@ -35,12 +36,14 @@ export async function load({ fetch, url }) {
 			const dashboard = await dashboardRes.json();
 			const retirementStats = retirementRes.ok ? await retirementRes.json() : [];
 			const bondsBody = bondsRes.ok ? await bondsRes.json() : { total_value: 0, total_count: 0 };
+			const allocationDrift = driftRes.ok ? await driftRes.json() : { scopes: [] };
 
 			return {
 				...dashboard,
 				retirementStats,
 				treasuryBondsValue: bondsBody.total_value ?? 0,
-				treasuryBondsCount: bondsBody.total_count ?? 0
+				treasuryBondsCount: bondsBody.total_count ?? 0,
+				allocationDrift
 			};
 		} catch (err) {
 			if (isHttpError(err)) {

--- a/src/routes/settings/+layout.svelte
+++ b/src/routes/settings/+layout.svelte
@@ -6,6 +6,7 @@
 
 	const tabs = $derived([
 		{ href: '/settings/config', label: 'Konfiguracja' },
+		{ href: '/settings/allocation', label: 'Cele alokacji' },
 		{ href: '/settings', label: 'Ustawienia' },
 		...(data.user?.isAdmin ? [{ href: '/settings/users', label: 'Użytkownicy' }] : [])
 	]);

--- a/src/routes/settings/allocation/+page.svelte
+++ b/src/routes/settings/allocation/+page.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+	import { resolveApiUrl } from '$lib/api';
+	import { invalidateAll } from '$app/navigation';
+	import { toast } from '$lib/stores/toast.svelte';
+	import { ownerName, type OwnerOption } from '$lib/types/owners';
+	import type { PageData } from './$types';
+
+	interface Target {
+		id: number;
+		category: string;
+		owner_user_id: number | null;
+		target_pct: number;
+		created_at: string;
+	}
+
+	type Scope = number | null;
+
+	const CATEGORIES = [
+		{ value: 'bank', label: 'Bank' },
+		{ value: 'saving_account', label: 'Konto oszczędnościowe' },
+		{ value: 'stock', label: 'Akcje' },
+		{ value: 'bond', label: 'Obligacje' },
+		{ value: 'gold', label: 'Złoto' },
+		{ value: 'real_estate', label: 'Nieruchomości' },
+		{ value: 'ppk', label: 'PPK' },
+		{ value: 'fund', label: 'Fundusze' },
+		{ value: 'etf', label: 'ETF' },
+		{ value: 'vehicle', label: 'Pojazdy' }
+	];
+
+	let { data }: { data: PageData } = $props();
+
+	const targets = $derived(data.targets.targets as Target[]);
+	const owners = $derived((data.owners ?? []) as OwnerOption[]);
+	const apiUrl = resolveApiUrl();
+
+	let selectedScope: Scope = $state(null);
+
+	const scopeTargets = $derived(targets.filter((t) => t.owner_user_id === selectedScope));
+
+	let draft = $state<{ category: string; target_pct: number }[]>([]);
+	let dirty = $state(false);
+	let saving = $state(false);
+
+	$effect(() => {
+		const list = targets
+			.filter((t) => t.owner_user_id === selectedScope)
+			.map((t) => ({ category: t.category, target_pct: t.target_pct }));
+		draft = list;
+		dirty = false;
+	});
+
+	const draftSum = $derived(draft.reduce((acc, row) => acc + (Number(row.target_pct) || 0), 0));
+	const sumOk = $derived(Math.abs(draftSum - 100) < 0.01 || draft.length === 0);
+
+	function addRow(): void {
+		const used = new Set(draft.map((d) => d.category));
+		const next = CATEGORIES.find((c) => !used.has(c.value));
+		if (!next) {
+			toast.error('Wszystkie kategorie są już dodane');
+			return;
+		}
+		draft = [...draft, { category: next.value, target_pct: 0 }];
+		dirty = true;
+	}
+
+	function removeRow(index: number): void {
+		draft = draft.filter((_, i) => i !== index);
+		dirty = true;
+	}
+
+	function markDirty(): void {
+		dirty = true;
+	}
+
+	async function save(): Promise<void> {
+		if (!sumOk) {
+			toast.error(`Suma musi wynosić 100% (aktualnie: ${draftSum.toFixed(2)}%)`);
+			return;
+		}
+		const used = new Set<string>();
+		for (const row of draft) {
+			if (used.has(row.category)) {
+				toast.error(`Kategoria „${row.category}" powtarza się`);
+				return;
+			}
+			used.add(row.category);
+		}
+		saving = true;
+		try {
+			const res = await fetch(`${apiUrl}/api/allocation/targets/replace`, {
+				method: 'PUT',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({
+					owner_user_id: selectedScope,
+					targets: draft.map((d) => ({
+						category: d.category,
+						target_pct: Number(d.target_pct)
+					}))
+				})
+			});
+			if (!res.ok) {
+				const err = await res.json().catch(() => null);
+				const detail =
+					err && typeof err === 'object' && 'detail' in err && err.detail
+						? typeof err.detail === 'string'
+							? err.detail
+							: JSON.stringify(err.detail)
+						: 'Zapis nie powiódł się';
+				throw new Error(detail);
+			}
+			toast.success('Cele alokacji zapisane');
+			dirty = false;
+			await invalidateAll();
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Wystąpił błąd');
+		} finally {
+			saving = false;
+		}
+	}
+
+	function scopeLabel(scope: Scope): string {
+		if (scope === null) return 'Wspólne (gospodarstwo)';
+		return ownerName(owners, scope);
+	}
+
+	function categoryLabel(value: string): string {
+		return CATEGORIES.find((c) => c.value === value)?.label ?? value;
+	}
+</script>
+
+<div class="space-y-6">
+	<div class="space-y-1">
+		<h1 class="h2">Cele alokacji</h1>
+		<p class="text-surface-700-300 text-sm">
+			Ustaw docelowy procentowy podział aktywów. Suma musi wynosić 100% w obrębie wybranego zakresu.
+		</p>
+	</div>
+
+	<div class="card preset-filled-surface-50-950 p-5 space-y-4">
+		<label class="label max-w-md">
+			<span class="font-semibold text-sm">Zakres</span>
+			<select class="select" bind:value={selectedScope}>
+				<option value={null}>Wspólne (gospodarstwo)</option>
+				{#each owners as owner}
+					<option value={owner.id}>{owner.name}</option>
+				{/each}
+			</select>
+		</label>
+
+		<div class="space-y-2">
+			<h2 class="h4 font-semibold">{scopeLabel(selectedScope)}</h2>
+
+			<table class="table">
+				<thead>
+					<tr>
+						<th>Kategoria</th>
+						<th>Docelowy %</th>
+						<th class="w-20"></th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each draft as row, idx (idx)}
+						<tr>
+							<td>
+								<select class="select" bind:value={row.category} onchange={markDirty}>
+									{#each CATEGORIES as cat}
+										<option value={cat.value}>{cat.label}</option>
+									{/each}
+								</select>
+							</td>
+							<td>
+								<input
+									type="number"
+									class="input"
+									step="0.01"
+									min="0"
+									max="100"
+									bind:value={row.target_pct}
+									oninput={markDirty}
+								/>
+							</td>
+							<td>
+								<button
+									type="button"
+									class="btn btn-sm preset-tonal-error"
+									onclick={() => removeRow(idx)}
+								>
+									Usuń
+								</button>
+							</td>
+						</tr>
+					{/each}
+					{#if draft.length === 0}
+						<tr>
+							<td colspan="3" class="text-surface-700-300 italic">
+								Brak celów — dodaj pierwszą kategorię.
+							</td>
+						</tr>
+					{/if}
+				</tbody>
+				<tfoot>
+					<tr>
+						<th class="text-right">Suma</th>
+						<th class={sumOk ? 'text-success-600-400 font-bold' : 'text-error-600-400 font-bold'}>
+							{draftSum.toFixed(2)}%
+						</th>
+						<th></th>
+					</tr>
+				</tfoot>
+			</table>
+
+			<div class="flex flex-wrap gap-2">
+				<button
+					type="button"
+					class="btn preset-tonal-surface"
+					onclick={addRow}
+					disabled={draft.length >= CATEGORIES.length}
+				>
+					Dodaj kategorię
+				</button>
+				<button
+					type="button"
+					class="btn preset-filled-primary-500"
+					onclick={save}
+					disabled={saving || !dirty || !sumOk}
+				>
+					{saving ? 'Zapisywanie...' : 'Zapisz'}
+				</button>
+				{#if !sumOk && draft.length > 0}
+					<span class="text-error-600-400 text-sm self-center"
+						>Suma musi wynosić dokładnie 100%.</span
+					>
+				{/if}
+			</div>
+		</div>
+
+		{#if scopeTargets.length > 0}
+			<p class="text-xs text-surface-700-300">
+				Aktualnie zapisanych celów dla tego zakresu: {scopeTargets.length}.
+			</p>
+		{/if}
+	</div>
+
+	<div class="card preset-filled-surface-100-900 p-4 space-y-2">
+		<h2 class="h4">Jak to działa?</h2>
+		<ul class="text-sm text-surface-700-300 list-disc pl-6 space-y-1">
+			<li>
+				Cele można definiować osobno dla całego gospodarstwa (Wspólne) i dla każdego użytkownika.
+			</li>
+			<li>
+				Suma celów musi wynosić dokładnie 100% (z tolerancją 0.01). Zapis bez tej sumy jest
+				zablokowany.
+			</li>
+			<li>
+				Widget „Dryft alokacji" na dashboardzie pokazuje porównanie celu z aktualnym stanem oraz
+				sugerowane kwoty rebalansu, gdy odchylenie przekracza ±5 punktów procentowych.
+			</li>
+			<li>
+				Nieoznaczone celami kategorie aktywów (np. spadek lub nowa inwestycja) pojawią się w
+				widgecie jako „brak celu" — dopisz je tutaj, aby były uwzględnione w rebalansie.
+			</li>
+		</ul>
+	</div>
+</div>

--- a/src/routes/settings/allocation/+page.ts
+++ b/src/routes/settings/allocation/+page.ts
@@ -1,0 +1,18 @@
+import { error } from '@sveltejs/kit';
+import { resolveApiUrl } from '$lib/api';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ fetch }) => {
+	const apiUrl = resolveApiUrl();
+
+	const [targetsRes, ownersRes] = await Promise.all([
+		fetch(`${apiUrl}/api/allocation/targets`),
+		fetch(`${apiUrl}/api/users`)
+	]);
+	if (!targetsRes.ok) {
+		throw error(targetsRes.status, 'Nie udało się pobrać celów alokacji');
+	}
+	const targets = await targetsRes.json();
+	const owners = ownersRes.ok ? await ownersRes.json() : [];
+	return { targets, owners };
+};

--- a/src/routes/settings/allocation/page.test.ts
+++ b/src/routes/settings/allocation/page.test.ts
@@ -23,6 +23,7 @@ vi.mock('$lib/stores/toast.svelte', () => ({
 function pageData(targets: unknown[] = [], owners: unknown[] = []) {
 	return {
 		data: {
+			user: null,
 			targets: { targets },
 			owners
 		}

--- a/src/routes/settings/allocation/page.test.ts
+++ b/src/routes/settings/allocation/page.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import Page from './+page.svelte';
+
+vi.mock('$env/dynamic/public', () => ({
+	env: {
+		PUBLIC_API_URL_BROWSER: 'http://localhost:8000',
+		PUBLIC_API_URL: 'http://localhost:8000'
+	}
+}));
+
+vi.mock('$app/environment', () => ({ browser: false }));
+
+vi.mock('$app/navigation', () => ({
+	invalidateAll: vi.fn(),
+	goto: vi.fn()
+}));
+
+vi.mock('$lib/stores/toast.svelte', () => ({
+	toast: { success: vi.fn(), error: vi.fn() }
+}));
+
+function pageData(targets: unknown[] = [], owners: unknown[] = []) {
+	return {
+		data: {
+			targets: { targets },
+			owners
+		}
+	};
+}
+
+describe('settings/allocation page', () => {
+	it('renders the headline and scope picker', () => {
+		render(Page, pageData());
+		expect(screen.getByText('Cele alokacji')).toBeTruthy();
+		expect(screen.getAllByText('Wspólne (gospodarstwo)').length).toBeGreaterThan(0);
+	});
+
+	it('shows empty-state row when no targets configured', () => {
+		render(Page, pageData());
+		expect(screen.getByText(/Brak celów/)).toBeTruthy();
+	});
+
+	it('seeds draft with existing household targets', () => {
+		render(
+			Page,
+			pageData([
+				{
+					id: 1,
+					category: 'stock',
+					owner_user_id: null,
+					target_pct: 60,
+					created_at: '2026-01-01T00:00:00'
+				},
+				{
+					id: 2,
+					category: 'bond',
+					owner_user_id: null,
+					target_pct: 40,
+					created_at: '2026-01-01T00:00:00'
+				}
+			])
+		);
+		expect(screen.getByText('100.00%')).toBeTruthy();
+	});
+
+	it('blocks save when sum != 100', async () => {
+		render(
+			Page,
+			pageData([
+				{
+					id: 1,
+					category: 'stock',
+					owner_user_id: null,
+					target_pct: 50,
+					created_at: '2026-01-01T00:00:00'
+				}
+			])
+		);
+		const saveButton = screen.getByRole('button', { name: /Zapisz/ });
+		expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+	});
+
+	it('disables add button when all categories used', () => {
+		const allCats = [
+			'bank',
+			'saving_account',
+			'stock',
+			'bond',
+			'gold',
+			'real_estate',
+			'ppk',
+			'fund',
+			'etf',
+			'vehicle'
+		];
+		const targets = allCats.map((cat, i) => ({
+			id: i + 1,
+			category: cat,
+			owner_user_id: null,
+			target_pct: 10,
+			created_at: '2026-01-01T00:00:00'
+		}));
+		render(Page, pageData(targets));
+		const addButton = screen.getByRole('button', { name: /Dodaj kategorię/ });
+		expect((addButton as HTMLButtonElement).disabled).toBe(true);
+	});
+
+	it('lists owner names in scope picker', () => {
+		render(
+			Page,
+			pageData(
+				[],
+				[
+					{ id: 1, name: 'Marcin' },
+					{ id: 2, name: 'Ewa' }
+				]
+			)
+		);
+		expect(screen.getByRole('option', { name: 'Marcin' })).toBeTruthy();
+		expect(screen.getByRole('option', { name: 'Ewa' })).toBeTruthy();
+	});
+
+	it('adds a new row when add button is clicked', async () => {
+		render(Page, pageData());
+		const addButton = screen.getByRole('button', { name: /Dodaj kategorię/ });
+		await fireEvent.click(addButton);
+		expect(screen.queryByText(/Brak celów/)).toBeNull();
+	});
+});


### PR DESCRIPTION
## Motivation

Closes #381. Users want to set target asset-class percentages (e.g. 60/30/10 stocks/bonds/cash) per owner or for the whole household, then see at a glance how far their portfolio has drifted from those targets and what to buy/sell to rebalance.

## Implementation information

**Backend (`backend-go/internal/allocation/`)**
- New `allocation_targets` table: `(id, category, owner_user_id NULL, target_pct, created_at)` with a `COALESCE(owner_user_id, -1), category` unique index so each scope can have at most one row per category. Bootstrapped via `schema.sql` for fresh DBs + `EnsureSchema` for existing prod installs (matches the `bonds` pattern). FK to `users(id) ON DELETE CASCADE`.
- CRUD endpoints under `/api/allocation/targets`:
  - `GET` / `POST` / `PUT {id}` / `DELETE {id}` — individual CRUD
  - `PUT /replace` — atomic bulk replace per owner scope, validated to sum to exactly 100. Wrapped in a `pg_advisory_xact_lock` per scope so two concurrent saves can't tear state.
- `GET /api/allocation/drift` — joins the latest snapshot's holdings (asset accounts, `is_active=true` only) against the configured targets and returns per-scope items with `current_pct`, `target_pct`, `drift_pp`, `severity` (`ok` / `warning` if `|drift|>5pp` / `missing_target`), and `rebalance_amount` in PLN.
- Validation rejects liability categories (mortgage, installment) — targeting a debt % doesn't make sense.

**Frontend**
- `src/routes/settings/allocation/+page.svelte` — scope-picker (household + each user) + editable table of category/percent rows. Save button is disabled until the sum equals 100. Posts to `PUT /replace`.
- `src/lib/components/AllocationDriftWidget.svelte` — side-by-side bars (target = grey, actual = colored overlay), per-category drift badge, and "DOKUP / SPRZEDAJ X PLN" rebalance hints.
- Mounted on the main dashboard, only renders when at least one scope has targets configured.

**Self-review fixes applied**
- `LatestHoldings` now propagates DB errors (was swallowing all errors as "no snapshots")
- Excluded soft-deleted accounts from the drift query (forward-looking, unlike the dashboard's historical net worth)
- Added FK-violation handling in `Create` for the validate→insert race when a user is deleted mid-flight
- Added `Request` schema to PUT openapi spec

**Alternatives considered**
- Extending the existing `app_config.allocation_stocks/bonds/gold` global percentages — rejected, can't express per-owner targets the issue requires.
- Allowing sum != 100 with a warning — rejected, the issue explicitly mandates the hard constraint.
- Reusing the existing `allocation_analysis` block in `dashboard.go` — separate domain, drift is per-owner and uses a different data source (targets table vs. global config), kept it isolated.

## Supporting documentation

Subissue of #355 (Finance-Buddy improvements umbrella).

> Changelog: feat(allocation): target allocation + drift alerts