### PR TITLE
test(coverage): lift frontend above 80%

### DIFF
--- a/backend-go/internal/equity_grants/vesting_test.go
+++ b/backend-go/internal/equity_grants/vesting_test.go
@@ -1,0 +1,207 @@
+package equitygrants
+
+import (
+	"testing"
+	"time"
+)
+
+func date(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
+func TestMonthsBetween(t *testing.T) {
+	tests := []struct {
+		name       string
+		start, end string
+		want       int
+	}{
+		{"same day", "2025-01-15", "2025-01-15", 0},
+		{"one full month", "2025-01-15", "2025-02-15", 1},
+		{"one day short of full month", "2025-01-15", "2025-02-14", 0},
+		{"twelve months", "2024-01-15", "2025-01-15", 12},
+		{"thirteen months minus a day", "2024-01-15", "2025-02-14", 12},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MonthsBetween(date(tt.start), date(tt.end))
+			if got != tt.want {
+				t.Fatalf("MonthsBetween(%s, %s) = %d, want %d", tt.start, tt.end, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVestedSharesAt_standardFourYearOneYearCliff(t *testing.T) {
+	s := Schedule{
+		TotalShares:         4800,
+		VestStartDate:       date("2025-01-01"),
+		VestCliffMonths:     12,
+		VestTotalMonths:     48,
+		VestFrequencyMonths: 1,
+	}
+
+	if got := VestedSharesAt(s, date("2025-06-01")); got != 0 {
+		t.Errorf("pre-cliff vested = %d, want 0", got)
+	}
+	// On cliff: 12 months elapsed → exactly 1 year vested (1200 shares).
+	if got := VestedSharesAt(s, date("2026-01-01")); got != 1200 {
+		t.Errorf("at-cliff vested = %d, want 1200", got)
+	}
+	// At full vest.
+	if got := VestedSharesAt(s, date("2029-01-01")); got != 4800 {
+		t.Errorf("full-vest vested = %d, want 4800", got)
+	}
+	// After full vest, still capped.
+	if got := VestedSharesAt(s, date("2030-01-01")); got != 4800 {
+		t.Errorf("post-vest vested = %d, want 4800 (capped)", got)
+	}
+}
+
+func TestVestedSharesAt_beforeStartReturnsZero(t *testing.T) {
+	s := Schedule{
+		TotalShares:         1000,
+		VestStartDate:       date("2025-01-01"),
+		VestCliffMonths:     0,
+		VestTotalMonths:     12,
+		VestFrequencyMonths: 1,
+	}
+	if got := VestedSharesAt(s, date("2024-12-31")); got != 0 {
+		t.Errorf("pre-start vested = %d, want 0", got)
+	}
+}
+
+func TestVestedSharesAt_liquidityEventBlocksVesting(t *testing.T) {
+	liq := date("2027-06-01")
+	s := Schedule{
+		TotalShares:            1000,
+		VestStartDate:          date("2025-01-01"),
+		VestCliffMonths:        12,
+		VestTotalMonths:        48,
+		VestFrequencyMonths:    1,
+		RequiresLiquidityEvent: true,
+		LiquidityEventDate:     &liq,
+	}
+	// Past the cliff, but liquidity event still in the future → 0.
+	if got := VestedSharesAt(s, date("2026-06-01")); got != 0 {
+		t.Errorf("pre-liquidity vested = %d, want 0", got)
+	}
+	// Past liquidity event → normal time-based math kicks in.
+	if got := VestedSharesAt(s, date("2027-06-01")); got == 0 {
+		t.Errorf("post-liquidity vested = 0, want >0")
+	}
+}
+
+func TestVestedSharesAt_liquidityEventMissingDateReturnsZero(t *testing.T) {
+	s := Schedule{
+		TotalShares:            1000,
+		VestStartDate:          date("2025-01-01"),
+		VestCliffMonths:        0,
+		VestTotalMonths:        12,
+		VestFrequencyMonths:    1,
+		RequiresLiquidityEvent: true,
+		LiquidityEventDate:     nil,
+	}
+	if got := VestedSharesAt(s, date("2026-01-01")); got != 0 {
+		t.Errorf("vested without liquidity date = %d, want 0", got)
+	}
+}
+
+func TestVestedSharesAt_customScheduleSumsAtOrBeforeElapsed(t *testing.T) {
+	s := Schedule{
+		TotalShares:   2000,
+		VestStartDate: date("2025-01-01"),
+		CustomSchedule: []CustomScheduleEntry{
+			{Month: 12, Pct: 25},
+			{Month: 24, Pct: 25},
+			{Month: 36, Pct: 25},
+			{Month: 48, Pct: 25},
+		},
+		VestTotalMonths: 48,
+	}
+	// At 6 months: nothing.
+	if got := VestedSharesAt(s, date("2025-07-01")); got != 0 {
+		t.Errorf("6-month custom vested = %d, want 0", got)
+	}
+	// At 12 months exactly: 25% → 500.
+	if got := VestedSharesAt(s, date("2026-01-01")); got != 500 {
+		t.Errorf("12-month custom vested = %d, want 500", got)
+	}
+	// At 48 months: 100% → 2000.
+	if got := VestedSharesAt(s, date("2029-01-01")); got != 2000 {
+		t.Errorf("48-month custom vested = %d, want 2000", got)
+	}
+}
+
+func TestVestedSharesAt_customScheduleCapsAtTotal(t *testing.T) {
+	// A schedule that over-promises (sums to 200%) should still cap at total.
+	s := Schedule{
+		TotalShares:   1000,
+		VestStartDate: date("2025-01-01"),
+		CustomSchedule: []CustomScheduleEntry{
+			{Month: 12, Pct: 200},
+		},
+		VestTotalMonths: 48,
+	}
+	if got := VestedSharesAt(s, date("2026-01-01")); got != 1000 {
+		t.Errorf("over-vest custom = %d, want 1000 (capped)", got)
+	}
+}
+
+func TestVestedSharesAt_zeroTotalMonthsReturnsAll(t *testing.T) {
+	s := Schedule{
+		TotalShares:         1000,
+		VestStartDate:       date("2025-01-01"),
+		VestCliffMonths:     0,
+		VestTotalMonths:     0,
+		VestFrequencyMonths: 1,
+	}
+	if got := VestedSharesAt(s, date("2025-01-01")); got != 1000 {
+		t.Errorf("zero-total-months vested = %d, want 1000", got)
+	}
+}
+
+func TestVestingProgressPct(t *testing.T) {
+	s := Schedule{
+		TotalShares:         1000,
+		VestStartDate:       date("2025-01-01"),
+		VestCliffMonths:     12,
+		VestTotalMonths:     48,
+		VestFrequencyMonths: 1,
+	}
+	// At cliff: 25%.
+	if got := VestingProgressPct(s, date("2026-01-01")); got != 25 {
+		t.Errorf("cliff progress = %v, want 25", got)
+	}
+	// Pre-cliff: 0%.
+	if got := VestingProgressPct(s, date("2025-06-01")); got != 0 {
+		t.Errorf("pre-cliff progress = %v, want 0", got)
+	}
+}
+
+func TestVestingProgressPct_zeroTotalSharesReturnsZero(t *testing.T) {
+	s := Schedule{TotalShares: 0, VestStartDate: date("2025-01-01")}
+	if got := VestingProgressPct(s, date("2026-01-01")); got != 0 {
+		t.Errorf("zero-shares progress = %v, want 0", got)
+	}
+}
+
+func TestFreqMonthsFromString(t *testing.T) {
+	cases := map[string]int{
+		"monthly":   1,
+		"quarterly": 3,
+		"yearly":    12,
+		"":          1,
+		"weekly":    1, // default fallback
+	}
+	for input, want := range cases {
+		if got := FreqMonthsFromString(input); got != want {
+			t.Errorf("FreqMonthsFromString(%q) = %d, want %d", input, got, want)
+		}
+	}
+}

--- a/backend-go/internal/equity_grants/vesting_test.go
+++ b/backend-go/internal/equity_grants/vesting_test.go
@@ -13,8 +13,6 @@ func date(s string) time.Time {
 	return t
 }
 
-func ptrTime(t time.Time) *time.Time { return &t }
-
 func TestMonthsBetween(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/src/lib/components/DateRangePicker.test.ts
+++ b/src/lib/components/DateRangePicker.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { goto } from '$app/navigation';
+import DateRangePicker from './DateRangePicker.svelte';
+
+const mocks = vi.hoisted(async () => {
+	const { writable } = await import('svelte/store');
+	return { pageStore: writable({ url: new URL('http://localhost/') }) };
+});
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn()
+}));
+
+vi.mock('$app/stores', async () => ({
+	page: (await mocks).pageStore
+}));
+
+async function setUrl(url: string) {
+	(await mocks).pageStore.set({ url: new URL(url) });
+}
+
+describe('DateRangePicker', () => {
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		await setUrl('http://localhost/metryki');
+	});
+
+	it('renders all preset chips plus custom', () => {
+		render(DateRangePicker, { props: {} });
+		expect(screen.getByRole('button', { name: '1M' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: '3M' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: '6M' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: '1R' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: '3L' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: '5L' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Wszystko' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Własny' })).toBeTruthy();
+	});
+
+	it('marks "Wszystko" as active when no range param is present', () => {
+		render(DateRangePicker, { props: {} });
+		expect(screen.getByRole('button', { name: 'Wszystko' }).getAttribute('aria-pressed')).toBe(
+			'true'
+		);
+	});
+
+	it('marks the URL preset as active', async () => {
+		await setUrl('http://localhost/metryki?range=3m');
+		render(DateRangePicker, { props: {} });
+		expect(screen.getByRole('button', { name: '3M' }).getAttribute('aria-pressed')).toBe('true');
+	});
+
+	it('navigates with range= when a preset chip is clicked', async () => {
+		render(DateRangePicker, { props: {} });
+		await fireEvent.click(screen.getByRole('button', { name: '1M' }));
+		expect(goto).toHaveBeenCalledWith('/metryki?range=1m', { keepFocus: true });
+	});
+
+	it('navigates without range= when "Wszystko" is clicked from another preset', async () => {
+		await setUrl('http://localhost/metryki?range=1m');
+		render(DateRangePicker, { props: {} });
+		await fireEvent.click(screen.getByRole('button', { name: 'Wszystko' }));
+		expect(goto).toHaveBeenCalledWith('/metryki', { keepFocus: true });
+	});
+
+	it('does nothing when clicking the already-active preset', async () => {
+		await setUrl('http://localhost/metryki?range=1m');
+		render(DateRangePicker, { props: {} });
+		await fireEvent.click(screen.getByRole('button', { name: '1M' }));
+		expect(goto).not.toHaveBeenCalled();
+	});
+
+	it('clicking "Własny" with no bounds sets range=custom', async () => {
+		render(DateRangePicker, { props: {} });
+		await fireEvent.click(screen.getByRole('button', { name: 'Własny' }));
+		expect(goto).toHaveBeenCalledWith('/metryki?range=custom', { keepFocus: true });
+	});
+
+	it('shows the custom date form when active range is custom', async () => {
+		await setUrl('http://localhost/metryki?range=custom&date_from=2024-01-01&date_to=2024-12-31');
+		render(DateRangePicker, { props: {} });
+		expect(screen.getByLabelText('Data od')).toBeTruthy();
+		expect(screen.getByLabelText('Data do')).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Zastosuj' })).toBeTruthy();
+	});
+
+	it('infers custom mode when only date_from/date_to are present', async () => {
+		await setUrl('http://localhost/metryki?date_from=2024-01-01');
+		render(DateRangePicker, { props: {} });
+		expect(screen.getByRole('button', { name: 'Własny' }).getAttribute('aria-pressed')).toBe(
+			'true'
+		);
+	});
+
+	it('Apply submits range=custom plus the entered bounds', async () => {
+		await setUrl('http://localhost/metryki?range=custom');
+		render(DateRangePicker, { props: {} });
+		const from = screen.getByLabelText('Data od') as HTMLInputElement;
+		const to = screen.getByLabelText('Data do') as HTMLInputElement;
+		await fireEvent.input(from, { target: { value: '2024-01-01' } });
+		await fireEvent.input(to, { target: { value: '2024-12-31' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Zastosuj' }));
+		expect(goto).toHaveBeenCalled();
+		const lastCall = (goto as ReturnType<typeof vi.fn>).mock.calls.at(-1);
+		const target = String(lastCall?.[0] ?? '');
+		expect(target).toContain('range=custom');
+		expect(target).toContain('date_from=2024-01-01');
+		expect(target).toContain('date_to=2024-12-31');
+	});
+
+	it('Apply with empty bounds drops the date params from the URL', async () => {
+		await setUrl('http://localhost/metryki?range=custom&date_from=2024-01-01&date_to=2024-12-31');
+		render(DateRangePicker, { props: {} });
+		const from = screen.getByLabelText('Data od') as HTMLInputElement;
+		const to = screen.getByLabelText('Data do') as HTMLInputElement;
+		await fireEvent.input(from, { target: { value: '' } });
+		await fireEvent.input(to, { target: { value: '' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Zastosuj' }));
+		const lastCall = (goto as ReturnType<typeof vi.fn>).mock.calls.at(-1);
+		const target = String(lastCall?.[0] ?? '');
+		expect(target).toContain('range=custom');
+		expect(target).not.toContain('date_from=');
+		expect(target).not.toContain('date_to=');
+	});
+
+	it('uses the explicit path prop instead of $page.url.pathname', async () => {
+		await setUrl('http://localhost/something-else');
+		render(DateRangePicker, { props: { path: '/metryki' } });
+		await fireEvent.click(screen.getByRole('button', { name: '1M' }));
+		expect(goto).toHaveBeenCalledWith('/metryki?range=1m', { keepFocus: true });
+	});
+});

--- a/src/lib/components/SnapshotForm.test.ts
+++ b/src/lib/components/SnapshotForm.test.ts
@@ -308,3 +308,222 @@ describe('SnapshotForm submit', () => {
 		);
 	});
 });
+
+describe('SnapshotForm — sections, hide/show, modals', () => {
+	const bankAccount = makeAccount({
+		id: 1,
+		name: 'Konto Główne',
+		category: 'bank',
+		current_value: 5000
+	});
+	const hiddenBank = makeAccount({
+		id: 2,
+		name: 'Konto Pomocnicze',
+		category: 'bank',
+		current_value: 0
+	});
+	const ikeAccount = makeAccount({
+		id: 3,
+		name: 'IKE Marcin',
+		category: 'stock',
+		account_wrapper: 'IKE',
+		current_value: 12000
+	});
+	const stockAccount = makeAccount({
+		id: 4,
+		name: 'Maklerski',
+		category: 'stock',
+		current_value: 8000
+	});
+	const apartment = makeAsset({ id: 5, name: 'Mieszkanie', current_value: 500000 });
+	const hiddenAsset = makeAsset({ id: 6, name: 'Działka', current_value: 0 });
+	const carAccount = makeAccount({
+		id: 7,
+		name: 'Auto',
+		category: 'vehicle',
+		current_value: 30000
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('renders the Emerytura section when retirement accounts exist', () => {
+		render(SnapshotForm, {
+			props: { assets: [ikeAccount], liabilities: [], physicalAssets: [] }
+		});
+		expect(screen.getByRole('heading', { name: /Emerytura/ })).toBeTruthy();
+		expect(screen.getByText('IKE')).toBeTruthy();
+	});
+
+	it('renders Inwestycje and Majątek headers', () => {
+		render(SnapshotForm, {
+			props: {
+				assets: [bankAccount, stockAccount, carAccount],
+				liabilities: [],
+				physicalAssets: [apartment]
+			}
+		});
+		expect(screen.getByRole('heading', { name: /Inwestycje/ })).toBeTruthy();
+		expect(screen.getByRole('heading', { name: /Majątek/ })).toBeTruthy();
+		expect(screen.getByLabelText(/Auto/)).toBeTruthy();
+		expect(screen.getByLabelText(/Mieszkanie/)).toBeTruthy();
+	});
+
+	it('hidden accounts (current_value 0) appear under "Pokaż ukryte konta" and can be re-added', async () => {
+		render(SnapshotForm, {
+			props: { assets: [bankAccount, hiddenBank], liabilities: [], physicalAssets: [] }
+		});
+		// Hidden one isn't in the visible value list initially.
+		expect(screen.queryByLabelText(/Konto Pomocnicze/)).toBeNull();
+		await fireEvent.click(screen.getByRole('button', { name: /Konto Pomocnicze/ }));
+		expect(screen.getByLabelText(/Konto Pomocnicze/)).toBeTruthy();
+	});
+
+	it('hidden physical assets can be re-added from Majątek section', async () => {
+		render(SnapshotForm, {
+			props: { assets: [], liabilities: [], physicalAssets: [apartment, hiddenAsset] }
+		});
+		expect(screen.queryByLabelText(/Działka/)).toBeNull();
+		await fireEvent.click(screen.getByRole('button', { name: /Działka/ }));
+		expect(screen.getByLabelText(/Działka/)).toBeTruthy();
+	});
+
+	it('opens the new-account modal when the "+ Dodaj nowe konto" button under financial is clicked', async () => {
+		render(SnapshotForm, {
+			props: { assets: [bankAccount], liabilities: [], physicalAssets: [] }
+		});
+		const addBtns = screen.getAllByRole('button', { name: /Dodaj nowe konto/ });
+		await fireEvent.click(addBtns[0]);
+		// Modal asks for "Nazwa konta" — its label is sufficient evidence.
+		await waitFor(() => expect(screen.getByLabelText(/Nazwa konta/)).toBeTruthy());
+	});
+
+	it('blocks new-account create when name is empty', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+		render(SnapshotForm, {
+			props: { assets: [bankAccount], liabilities: [], physicalAssets: [] }
+		});
+		const addBtns = screen.getAllByRole('button', { name: /Dodaj nowe konto/ });
+		await fireEvent.click(addBtns[0]);
+		// Click the modal's confirm button — name is empty.
+		const createBtn = screen.getByRole('button', { name: 'Utwórz konto' });
+		await fireEvent.click(createBtn);
+		await waitFor(() => expect(screen.getByText('Nazwa konta jest wymagana')).toBeTruthy());
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('POSTs a new account when the form is submitted', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				id: 99,
+				name: 'New Bank',
+				type: 'asset',
+				category: 'bank',
+				owner_user_id: null,
+				currency: 'PLN',
+				account_wrapper: null,
+				purpose: 'general',
+				square_meters: null,
+				is_active: true,
+				receives_contributions: false,
+				created_at: '2026-05-20',
+				current_value: 0
+			})
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		render(SnapshotForm, {
+			props: { assets: [bankAccount], liabilities: [], physicalAssets: [] }
+		});
+		const addBtns = screen.getAllByRole('button', { name: /Dodaj nowe konto/ });
+		await fireEvent.click(addBtns[0]);
+		const nameInput = screen.getByLabelText(/^Nazwa konta/) as HTMLInputElement;
+		await fireEvent.input(nameInput, { target: { value: 'New Bank' } });
+		const createBtn = screen.getByRole('button', { name: 'Utwórz konto' });
+		await fireEvent.click(createBtn);
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe('http://localhost:8000/api/accounts');
+		expect((init as RequestInit).method).toBe('POST');
+		const body = JSON.parse((init as RequestInit).body as string);
+		expect(body).toMatchObject({
+			name: 'New Bank',
+			type: 'asset',
+			category: 'bank',
+			currency: 'PLN'
+		});
+	});
+
+	it('shows detail error when create-account API fails', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: false,
+			json: async () => ({ detail: 'Already exists' })
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		render(SnapshotForm, {
+			props: { assets: [bankAccount], liabilities: [], physicalAssets: [] }
+		});
+		const addBtns = screen.getAllByRole('button', { name: /Dodaj nowe konto/ });
+		await fireEvent.click(addBtns[0]);
+		const nameInput = screen.getByLabelText(/^Nazwa konta/) as HTMLInputElement;
+		await fireEvent.input(nameInput, { target: { value: 'Dup' } });
+		const createBtn = screen.getByRole('button', { name: 'Utwórz konto' });
+		await fireEvent.click(createBtn);
+		await waitFor(() => expect(screen.getByText('Already exists')).toBeTruthy());
+	});
+
+	it('opens the new-asset modal and POSTs a new asset on submit', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				id: 42,
+				name: 'Nowy Majątek',
+				is_active: true,
+				created_at: '2026-05-20',
+				current_value: 0
+			})
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		render(SnapshotForm, {
+			props: { assets: [], liabilities: [], physicalAssets: [apartment] }
+		});
+		await fireEvent.click(screen.getByRole('button', { name: /Dodaj nowy majątek/ }));
+		const nameInput = screen.getByLabelText(/Nazwa/) as HTMLInputElement;
+		await fireEvent.input(nameInput, { target: { value: 'Nowy Majątek' } });
+		const createBtn = screen.getByRole('button', { name: 'Utwórz majątek' });
+		await fireEvent.click(createBtn);
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe('http://localhost:8000/api/assets');
+		expect((init as RequestInit).method).toBe('POST');
+		const body = JSON.parse((init as RequestInit).body as string);
+		expect(body).toEqual({ name: 'Nowy Majątek' });
+	});
+
+	it('blocks new-asset create when name is empty', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+		render(SnapshotForm, {
+			props: { assets: [], liabilities: [], physicalAssets: [apartment] }
+		});
+		await fireEvent.click(screen.getByRole('button', { name: /Dodaj nowy majątek/ }));
+		const createBtn = screen.getByRole('button', { name: 'Utwórz majątek' });
+		await fireEvent.click(createBtn);
+		await waitFor(() => expect(screen.getByText('Nazwa majątku jest wymagana')).toBeTruthy());
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('Anuluj button navigates to "/"', async () => {
+		render(SnapshotForm, {
+			props: { assets: [], liabilities: [], physicalAssets: [] }
+		});
+		await fireEvent.click(screen.getByRole('button', { name: 'Anuluj' }));
+		expect(goto).toHaveBeenCalledWith('/');
+	});
+});

--- a/src/lib/components/salaries/EquityFormModal.test.ts
+++ b/src/lib/components/salaries/EquityFormModal.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import EquityFormModal, { type VestingPreset } from './EquityFormModal.svelte';
+import type { EquityFormData } from './EquityFormModal.svelte';
+import type { EquityTaxTreatment } from '$lib/types/salaries';
+
+beforeAll(() => {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn()
+		}))
+	});
+});
+
+function makeData(overrides: Partial<EquityFormData> = {}): EquityFormData {
+	return {
+		grant_date: '2026-01-01',
+		type: 'rsu',
+		company: 'Acme',
+		owner_user_id: 1,
+		total_shares: 1000,
+		strike_price: null,
+		currency: 'USD',
+		vest_start_date: '2026-01-01',
+		vest_cliff_months: 12,
+		vest_total_months: 48,
+		vest_frequency: 'monthly',
+		preset: '4yr_1yrcliff',
+		vest_custom_schedule: null,
+		requires_liquidity_event: false,
+		liquidity_event_date: null,
+		tax_treatment: 'capital_gains_19',
+		notes: '',
+		...overrides
+	};
+}
+
+const presets: Record<string, VestingPreset> = {
+	'4yr_1yrcliff': {
+		label: '4-letni z 1-letnim cliffem',
+		cliff: 12,
+		total: 48,
+		frequency: 'monthly',
+		custom: null
+	},
+	custom: {
+		label: 'Niestandardowy',
+		cliff: 0,
+		total: 0,
+		frequency: 'monthly',
+		custom: []
+	}
+};
+
+const taxTreatmentLabels: Record<EquityTaxTreatment, string> = {
+	capital_gains_19: 'Kapitałowy (19%)',
+	employment_income: 'Wynagrodzenie'
+};
+
+const baseProps = {
+	open: true,
+	editing: false,
+	error: '',
+	saving: false,
+	today: '2026-05-20',
+	owners: [
+		{ id: 1, name: 'Marcin' },
+		{ id: 2, name: 'Ewa' }
+	],
+	vestingPresets: presets,
+	taxTreatmentLabels,
+	onApplyPreset: vi.fn(),
+	onSave: vi.fn(),
+	onCancel: vi.fn()
+};
+
+describe('EquityFormModal', () => {
+	it('renders the New title when not editing', () => {
+		render(EquityFormModal, { props: { ...baseProps, data: makeData() } });
+		expect(screen.getByText('Nowy grant')).toBeTruthy();
+	});
+
+	it('renders the Edit title when editing', () => {
+		render(EquityFormModal, {
+			props: { ...baseProps, editing: true, data: makeData() }
+		});
+		expect(screen.getByText('Edytuj grant')).toBeTruthy();
+	});
+
+	it('renders error block when error prop is set', () => {
+		render(EquityFormModal, {
+			props: { ...baseProps, error: 'Coś poszło nie tak', data: makeData() }
+		});
+		expect(screen.getByText('Coś poszło nie tak')).toBeTruthy();
+	});
+
+	it('shows saving label and disables confirm while saving', () => {
+		render(EquityFormModal, {
+			props: { ...baseProps, saving: true, data: makeData() }
+		});
+		const confirmBtn = screen.getByRole('button', { name: 'Zapisywanie...' }) as HTMLButtonElement;
+		expect(confirmBtn.disabled).toBe(true);
+	});
+
+	it('hides strike price input for rsu and shows it for options', async () => {
+		const { rerender } = render(EquityFormModal, {
+			props: { ...baseProps, data: makeData({ type: 'rsu' }) }
+		});
+		expect(screen.queryByText(/Strike price/i)).toBeNull();
+		await rerender({ ...baseProps, data: makeData({ type: 'option', strike_price: 1.5 }) });
+		expect(screen.getByText(/Strike price/i)).toBeTruthy();
+	});
+
+	it('calls onApplyPreset when preset select changes', async () => {
+		const onApplyPreset = vi.fn();
+		render(EquityFormModal, {
+			props: { ...baseProps, onApplyPreset, data: makeData() }
+		});
+		const schemat = screen.getByText('Schemat').parentElement!.querySelector('select')!;
+		await fireEvent.change(schemat, { target: { value: 'custom' } });
+		expect(onApplyPreset).toHaveBeenCalledWith('custom');
+	});
+
+	it('renders custom schedule editor when preset is custom', () => {
+		render(EquityFormModal, {
+			props: {
+				...baseProps,
+				data: makeData({
+					preset: 'custom',
+					vest_custom_schedule: [{ month: 12, pct: 25 }]
+				})
+			}
+		});
+		expect(screen.getByText(/Niestandardowy harmonogram/)).toBeTruthy();
+		expect(screen.getByRole('button', { name: /Dodaj zdarzenie/i })).toBeTruthy();
+		expect(screen.getByRole('button', { name: /Usuń wiersz/i })).toBeTruthy();
+	});
+
+	it('adds a custom schedule row when "Dodaj zdarzenie" is clicked', async () => {
+		const data = makeData({ preset: 'custom', vest_custom_schedule: [] });
+		render(EquityFormModal, { props: { ...baseProps, data } });
+		await fireEvent.click(screen.getByRole('button', { name: /Dodaj zdarzenie/i }));
+		expect(data.vest_custom_schedule).toEqual([{ month: 0, pct: 0 }]);
+	});
+
+	it('removes a custom schedule row when trash icon is clicked', async () => {
+		const data = makeData({
+			preset: 'custom',
+			vest_custom_schedule: [
+				{ month: 6, pct: 10 },
+				{ month: 12, pct: 20 }
+			]
+		});
+		render(EquityFormModal, { props: { ...baseProps, data } });
+		const removeBtns = screen.getAllByRole('button', { name: /Usuń wiersz/i });
+		await fireEvent.click(removeBtns[0]);
+		expect(data.vest_custom_schedule).toEqual([{ month: 12, pct: 20 }]);
+	});
+
+	it('shows liquidity event date input only when the checkbox is checked', async () => {
+		const { rerender } = render(EquityFormModal, {
+			props: { ...baseProps, data: makeData({ requires_liquidity_event: false }) }
+		});
+		expect(screen.queryByText(/Data liquidity event/i)).toBeNull();
+		await rerender({ ...baseProps, data: makeData({ requires_liquidity_event: true }) });
+		expect(screen.getByText(/Data liquidity event/i)).toBeTruthy();
+	});
+
+	it('lists every owner in the owner select', () => {
+		render(EquityFormModal, { props: { ...baseProps, data: makeData() } });
+		expect(screen.getByText('Marcin')).toBeTruthy();
+		expect(screen.getByText('Ewa')).toBeTruthy();
+	});
+
+	it('lists every tax treatment label', () => {
+		render(EquityFormModal, { props: { ...baseProps, data: makeData() } });
+		expect(screen.getByText('Kapitałowy (19%)')).toBeTruthy();
+		expect(screen.getByText('Wynagrodzenie')).toBeTruthy();
+	});
+
+	it('invokes onSave when submitting via the form (preventDefault)', async () => {
+		const onSave = vi.fn();
+		const { container } = render(EquityFormModal, {
+			props: { ...baseProps, onSave, data: makeData() }
+		});
+		const form = container.querySelector('form')!;
+		await fireEvent.submit(form);
+		expect(onSave).toHaveBeenCalled();
+	});
+
+	it('invokes onSave when the modal confirm button is clicked', async () => {
+		const onSave = vi.fn();
+		render(EquityFormModal, {
+			props: { ...baseProps, onSave, data: makeData() }
+		});
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+		expect(onSave).toHaveBeenCalled();
+	});
+
+	it('invokes onCancel when the modal cancel button is clicked', async () => {
+		const onCancel = vi.fn();
+		render(EquityFormModal, {
+			props: { ...baseProps, onCancel, data: makeData() }
+		});
+		await fireEvent.click(screen.getByRole('button', { name: /Anuluj|Cancel/ }));
+		expect(onCancel).toHaveBeenCalled();
+	});
+});

--- a/src/lib/components/salaries/ValuationFormModal.test.ts
+++ b/src/lib/components/salaries/ValuationFormModal.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import ValuationFormModal, { type ValuationFormData } from './ValuationFormModal.svelte';
+
+beforeAll(() => {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn()
+		}))
+	});
+});
+
+function makeData(overrides: Partial<ValuationFormData> = {}): ValuationFormData {
+	return {
+		company: 'Acme',
+		date: '2026-05-01',
+		currency: 'USD',
+		fmv_per_share: 12.5,
+		fmv_low: null,
+		fmv_high: null,
+		source: '409a',
+		common_stock_discount_pct: null,
+		notes: '',
+		...overrides
+	};
+}
+
+const baseProps = {
+	open: true,
+	editing: false,
+	error: '',
+	saving: false,
+	onSave: vi.fn(),
+	onCancel: vi.fn()
+};
+
+describe('ValuationFormModal', () => {
+	it('renders the New title when not editing', () => {
+		render(ValuationFormModal, { props: { ...baseProps, data: makeData() } });
+		expect(screen.getByText('Nowa wycena')).toBeTruthy();
+	});
+
+	it('renders the Edit title when editing', () => {
+		render(ValuationFormModal, {
+			props: { ...baseProps, editing: true, data: makeData() }
+		});
+		expect(screen.getByText('Edytuj wycenę')).toBeTruthy();
+	});
+
+	it('renders error block when error prop is set', () => {
+		render(ValuationFormModal, {
+			props: { ...baseProps, error: 'Bzdura', data: makeData() }
+		});
+		expect(screen.getByText('Bzdura')).toBeTruthy();
+	});
+
+	it('shows saving label and disables confirm while saving', () => {
+		render(ValuationFormModal, {
+			props: { ...baseProps, saving: true, data: makeData() }
+		});
+		const confirmBtn = screen.getByRole('button', { name: 'Zapisywanie...' }) as HTMLButtonElement;
+		expect(confirmBtn.disabled).toBe(true);
+	});
+
+	it('renders the four valuation sources', () => {
+		render(ValuationFormModal, { props: { ...baseProps, data: makeData() } });
+		expect(screen.getByText('409A')).toBeTruthy();
+		expect(screen.getByText(/Runda preferred/i)).toBeTruthy();
+		expect(screen.getByText(/Tender/i)).toBeTruthy();
+		expect(screen.getByText(/Estymacja/i)).toBeTruthy();
+	});
+
+	it('invokes onSave when submitting via the form (preventDefault)', async () => {
+		const onSave = vi.fn();
+		const { container } = render(ValuationFormModal, {
+			props: { ...baseProps, onSave, data: makeData() }
+		});
+		const form = container.querySelector('form')!;
+		await fireEvent.submit(form);
+		expect(onSave).toHaveBeenCalled();
+	});
+
+	it('invokes onSave when the modal confirm button is clicked', async () => {
+		const onSave = vi.fn();
+		render(ValuationFormModal, {
+			props: { ...baseProps, onSave, data: makeData() }
+		});
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+		expect(onSave).toHaveBeenCalled();
+	});
+
+	it('invokes onCancel when the cancel button is clicked', async () => {
+		const onCancel = vi.fn();
+		render(ValuationFormModal, {
+			props: { ...baseProps, onCancel, data: makeData() }
+		});
+		await fireEvent.click(screen.getByRole('button', { name: /Anuluj|Cancel/ }));
+		expect(onCancel).toHaveBeenCalled();
+	});
+
+	it('renders the common stock discount input with placeholder', () => {
+		render(ValuationFormModal, { props: { ...baseProps, data: makeData() } });
+		const placeholder = screen.getByPlaceholderText('np. 30');
+		expect(placeholder).toBeTruthy();
+	});
+});

--- a/src/lib/utils/charts/metryki.test.ts
+++ b/src/lib/utils/charts/metryki.test.ts
@@ -242,9 +242,7 @@ describe('chart formatter callbacks', () => {
 	it('wrapper pie tooltip handles array params (axis trigger fallback)', () => {
 		const option = buildWrapperChartOption(wrappers);
 		const tooltip = option.tooltip as unknown as {
-			formatter: (
-				p: Array<{ name: string; value: number; percent?: number }>
-			) => string;
+			formatter: (p: Array<{ name: string; value: number; percent?: number }>) => string;
 		};
 		const html = tooltip.formatter([{ name: 'IKZE', value: 8000, percent: 40 }]);
 		expect(html).toContain('IKZE');
@@ -253,9 +251,7 @@ describe('chart formatter callbacks', () => {
 	it('investment trend tooltip computes returns and formats PLN', () => {
 		const option = buildInvestmentTrendChartOption(trendSeries);
 		const tooltip = option.tooltip as unknown as {
-			formatter: (
-				p: Array<{ axisValue: string; value: number; seriesName: string }>
-			) => string;
+			formatter: (p: Array<{ axisValue: string; value: number; seriesName: string }>) => string;
 		};
 		const html = tooltip.formatter([
 			{ axisValue: '2023-12-31', value: 2000, seriesName: 'Wpłaty' },
@@ -277,9 +273,7 @@ describe('chart formatter callbacks', () => {
 	it('wrapper trend tooltip and yAxis formatter cover the named-chart variant', () => {
 		const option = buildWrapperTrendChartOption('IKE w czasie', trendSeries);
 		const tooltip = option.tooltip as unknown as {
-			formatter: (
-				p: Array<{ axisValue: string; value: number; seriesName: string }>
-			) => string;
+			formatter: (p: Array<{ axisValue: string; value: number; seriesName: string }>) => string;
 		};
 		const html = tooltip.formatter([
 			{ axisValue: '2023-12-31', value: 2000, seriesName: 'Wpłaty' },

--- a/src/lib/utils/charts/metryki.test.ts
+++ b/src/lib/utils/charts/metryki.test.ts
@@ -183,4 +183,113 @@ describe('buildYearlyRoiChartOption', () => {
 		expect(xAxis.data).toEqual([]);
 		expect(series[0].data).toEqual([]);
 	});
+
+	it('label position callback flips below the axis for negative ROI', () => {
+		const option = buildYearlyRoiChartOption([], [], []);
+		const series = option.series as Array<{
+			label: { position: (p: { value: unknown }) => string };
+		}>;
+		expect(series[0].label.position({ value: 5 })).toBe('top');
+		expect(series[0].label.position({ value: -3 })).toBe('bottom');
+		expect(series[0].label.position({ value: 0 })).toBe('top');
+	});
+
+	it('tooltip formatter shows ROI per series and "brak danych" for nulls', () => {
+		const option = buildYearlyRoiChartOption([], [], []);
+		const tooltip = option.tooltip as unknown as {
+			formatter: (p: Array<{ seriesName: string; value: number | null }>) => string;
+		};
+		const html = tooltip.formatter([
+			{ seriesName: 'Akcje', value: 12 },
+			{ seriesName: 'Obligacje', value: null },
+			{ seriesName: 'PPK', value: 4 }
+		]);
+		expect(html).toContain('Akcje: 12%');
+		expect(html).toContain('Obligacje: brak danych');
+		expect(html).toContain('PPK: 4%');
+	});
+});
+
+describe('chart formatter callbacks', () => {
+	it('allocation xAxis formatter title-cases the category name', () => {
+		const option = buildAllocationChartOption(allocationCategories);
+		const xAxis = option.xAxis as { axisLabel: { formatter: (v: string) => string } };
+		expect(xAxis.axisLabel.formatter('akcje')).toBe('Akcje');
+		expect(xAxis.axisLabel.formatter('')).toBe('');
+	});
+
+	it('wrapper pie tooltip formats a single param', () => {
+		const option = buildWrapperChartOption(wrappers);
+		const tooltip = option.tooltip as unknown as {
+			formatter: (p: { name: string; value: number; percent?: number }) => string;
+		};
+		const html = tooltip.formatter({ name: 'IKE', value: 12000, percent: 60 });
+		expect(html).toContain('IKE');
+		expect(html).toContain('12');
+		expect(html).toContain('60.0%');
+	});
+
+	it('wrapper pie label formatter renders name and percent', () => {
+		const option = buildWrapperChartOption(wrappers);
+		const series = option.series as Array<{
+			label: { formatter: (p: { name: string; percent?: number }) => string };
+		}>;
+		expect(series[0].label.formatter({ name: 'IKE', percent: 33.33 })).toContain('IKE');
+		expect(series[0].label.formatter({ name: 'IKE', percent: 33.33 })).toContain('33.3%');
+		expect(series[0].label.formatter({ name: 'IKE' })).toContain('0.0%');
+	});
+
+	it('wrapper pie tooltip handles array params (axis trigger fallback)', () => {
+		const option = buildWrapperChartOption(wrappers);
+		const tooltip = option.tooltip as unknown as {
+			formatter: (
+				p: Array<{ name: string; value: number; percent?: number }>
+			) => string;
+		};
+		const html = tooltip.formatter([{ name: 'IKZE', value: 8000, percent: 40 }]);
+		expect(html).toContain('IKZE');
+	});
+
+	it('investment trend tooltip computes returns and formats PLN', () => {
+		const option = buildInvestmentTrendChartOption(trendSeries);
+		const tooltip = option.tooltip as unknown as {
+			formatter: (
+				p: Array<{ axisValue: string; value: number; seriesName: string }>
+			) => string;
+		};
+		const html = tooltip.formatter([
+			{ axisValue: '2023-12-31', value: 2000, seriesName: 'Wpłaty' },
+			{ axisValue: '2023-12-31', value: 2200, seriesName: 'Wartość portfela' }
+		]);
+		expect(html).toContain('2023-12-31');
+		expect(html).toContain('Wartość portfela');
+		expect(html).toContain('Wpłaty');
+		expect(html).toContain('Zyski');
+	});
+
+	it('investment trend yAxis formatter renders k-shorthand', () => {
+		const option = buildInvestmentTrendChartOption(trendSeries);
+		const yAxis = option.yAxis as { axisLabel: { formatter: (v: number) => string } };
+		expect(yAxis.axisLabel.formatter(15000)).toBe('15k');
+		expect(yAxis.axisLabel.formatter(0)).toBe('0k');
+	});
+
+	it('wrapper trend tooltip and yAxis formatter cover the named-chart variant', () => {
+		const option = buildWrapperTrendChartOption('IKE w czasie', trendSeries);
+		const tooltip = option.tooltip as unknown as {
+			formatter: (
+				p: Array<{ axisValue: string; value: number; seriesName: string }>
+			) => string;
+		};
+		const html = tooltip.formatter([
+			{ axisValue: '2023-12-31', value: 2000, seriesName: 'Wpłaty' },
+			{ axisValue: '2023-12-31', value: 2200, seriesName: 'Wartość portfela' }
+		]);
+		expect(html).toContain('Wartość');
+		expect(html).toContain('Wpłaty');
+		expect(html).toContain('Zyski');
+
+		const yAxis = option.yAxis as { axisLabel: { formatter: (v: number) => string } };
+		expect(yAxis.axisLabel.formatter(2500)).toBe('3k');
+	});
 });

--- a/src/lib/utils/charts/simulations.test.ts
+++ b/src/lib/utils/charts/simulations.test.ts
@@ -275,4 +275,59 @@ describe('buildRetirementByWrapperOption', () => {
 		expect(xAxis.data).toEqual(['60', '61']);
 		expect(xAxis.name).toBe('Wiek');
 	});
+
+	it('tooltip formatter sums series values and renders rows per wrapper', () => {
+		const sims = [
+			makeSimulation('IKE (Marcin)', [100, 200], 60),
+			makeSimulation('IKZE (Marcin)', [50, 75], 60),
+			makeSimulation('PPK (Marcin)', [10, 20], 60)
+		];
+		const option = buildRetirementByWrapperOption(sims, []);
+		const tooltip = option.tooltip as unknown as {
+			formatter: (
+				p: Array<{ name: string; seriesName: string; value: number }>
+			) => string;
+		};
+		const html = tooltip.formatter([
+			{ name: '60', seriesName: 'IKE', value: 100 },
+			{ name: '60', seriesName: 'IKZE', value: 50 },
+			{ name: '60', seriesName: 'PPK', value: 10 }
+		]);
+		expect(html).toContain('Wiek 60');
+		expect(html).toContain('IKE');
+		expect(html).toContain('IKZE');
+		expect(html).toContain('PPK');
+		expect(html).toContain('Razem');
+	});
+
+	it('tooltip formatter accepts a single non-array param', () => {
+		const sims = [makeSimulation('IKE (Marcin)', [100], 60)];
+		const option = buildRetirementByWrapperOption(sims, []);
+		const tooltip = option.tooltip as unknown as {
+			formatter: (p: { name: string; seriesName: string; value: number }) => string;
+		};
+		const html = tooltip.formatter({ name: '60', seriesName: 'IKE', value: 100 });
+		expect(html).toContain('Wiek 60');
+		expect(html).toContain('IKE');
+	});
+
+	it('tooltip formatter coerces null/undefined values to 0', () => {
+		const sims = [makeSimulation('IKE (Marcin)', [0], 60)];
+		const option = buildRetirementByWrapperOption(sims, []);
+		const tooltip = option.tooltip as unknown as {
+			formatter: (
+				p: Array<{ name: string; seriesName: string; value: unknown }>
+			) => string;
+		};
+		const html = tooltip.formatter([{ name: '60', seriesName: 'IKE', value: null }]);
+		expect(html).toContain('0 PLN');
+	});
+
+	it('yAxis formatter renders k-shorthand for retirement-by-wrapper chart', () => {
+		const sims = [makeSimulation('IKE (Marcin)', [100], 60)];
+		const option = buildRetirementByWrapperOption(sims, []);
+		const yAxis = option.yAxis as { axisLabel: { formatter: (v: number) => string } };
+		expect(yAxis.axisLabel.formatter(125000)).toBe('125k');
+		expect(yAxis.axisLabel.formatter(0)).toBe('0k');
+	});
 });

--- a/src/lib/utils/charts/simulations.test.ts
+++ b/src/lib/utils/charts/simulations.test.ts
@@ -284,9 +284,7 @@ describe('buildRetirementByWrapperOption', () => {
 		];
 		const option = buildRetirementByWrapperOption(sims, []);
 		const tooltip = option.tooltip as unknown as {
-			formatter: (
-				p: Array<{ name: string; seriesName: string; value: number }>
-			) => string;
+			formatter: (p: Array<{ name: string; seriesName: string; value: number }>) => string;
 		};
 		const html = tooltip.formatter([
 			{ name: '60', seriesName: 'IKE', value: 100 },
@@ -315,9 +313,7 @@ describe('buildRetirementByWrapperOption', () => {
 		const sims = [makeSimulation('IKE (Marcin)', [0], 60)];
 		const option = buildRetirementByWrapperOption(sims, []);
 		const tooltip = option.tooltip as unknown as {
-			formatter: (
-				p: Array<{ name: string; seriesName: string; value: unknown }>
-			) => string;
+			formatter: (p: Array<{ name: string; seriesName: string; value: unknown }>) => string;
 		};
 		const html = tooltip.formatter([{ name: '60', seriesName: 'IKE', value: null }]);
 		expect(html).toContain('0 PLN');

--- a/src/lib/utils/charts/waterfall.test.ts
+++ b/src/lib/utils/charts/waterfall.test.ts
@@ -105,4 +105,50 @@ describe('buildWaterfallOption', () => {
 		expect(html).toContain('Δ Zobowiązania');
 		expect(html).toContain('Saldo końcowe');
 	});
+
+	it('tooltip returns empty string when dataIndex is out of range', () => {
+		const opt = buildWaterfallOption(steps);
+		const tooltip = opt.tooltip as unknown as {
+			formatter: (params: Array<{ dataIndex: number }>) => string;
+		};
+		expect(tooltip.formatter([{ dataIndex: 999 }])).toBe('');
+	});
+
+	it('tooltip accepts a single (non-array) param', () => {
+		const opt = buildWaterfallOption(steps);
+		const tooltip = opt.tooltip as unknown as {
+			formatter: (params: { dataIndex: number }) => string;
+		};
+		expect(tooltip.formatter({ dataIndex: 0 })).toContain('Saldo początkowe');
+	});
+
+	it('xAxis falls back to the raw date when it is not parsable', () => {
+		const opt = buildWaterfallOption([
+			{
+				date: 'not-a-date',
+				snapshotId: 1,
+				startingNetWorth: 0,
+				endingNetWorth: 100,
+				assetDelta: 100,
+				liabilityDelta: 0
+			},
+			{
+				date: 'still-not-a-date',
+				snapshotId: 2,
+				startingNetWorth: 100,
+				endingNetWorth: 200,
+				assetDelta: 100,
+				liabilityDelta: 0
+			}
+		]);
+		const xAxis = opt.xAxis as { data: string[] };
+		expect(xAxis.data).toEqual(['not-a-date', 'still-not-a-date']);
+	});
+
+	it('both yAxis formatters render k-shorthand', () => {
+		const opt = buildWaterfallOption(steps);
+		const yAxes = opt.yAxis as Array<{ axisLabel: { formatter: (v: number) => string } }>;
+		expect(yAxes[0].axisLabel.formatter(12000)).toBe('12k');
+		expect(yAxes[1].axisLabel.formatter(45000)).toBe('45k');
+	});
 });

--- a/src/lib/utils/dateRange.test.ts
+++ b/src/lib/utils/dateRange.test.ts
@@ -42,6 +42,14 @@ describe('computePresetBounds', () => {
 	it('returns now-5y for "5y"', () => {
 		expect(computePresetBounds('5y', NOW)).toEqual({ from: '2021-05-23', to: '2026-05-23' });
 	});
+
+	it('returns now-6m for "6m"', () => {
+		expect(computePresetBounds('6m', NOW)).toEqual({ from: '2025-11-23', to: '2026-05-23' });
+	});
+
+	it('returns now-3y for "3y"', () => {
+		expect(computePresetBounds('3y', NOW)).toEqual({ from: '2023-05-23', to: '2026-05-23' });
+	});
 });
 
 describe('resolveRangeParams', () => {

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -277,3 +277,81 @@ describe('Dashboard retirement limits save flow', () => {
 		errorSpy.mockRestore();
 	});
 });
+
+describe('Dashboard — FIRE / runway / bonds cards', () => {
+	it('renders FIRE+runway card when metric_cards has values', async () => {
+		render(Page, {
+			props: {
+				data: buildData({
+					dashboardData: {
+						net_worth_history: [{ date: '2024-01-01', value: 5000 }],
+						current_net_worth: 6000,
+						change_vs_last_month: 1000,
+						total_assets: 10000,
+						total_liabilities: 4000,
+						allocation: [],
+						retirementStats: [],
+						tile_deltas: baseTileDeltas,
+						metric_cards: {
+							fire_number: 1000000,
+							runway_months: 18.5,
+							fi_progress: 25,
+							annual_expenses: 40000,
+							withdrawal_rate: 0.04
+						}
+					}
+				})
+			}
+		});
+		await waitFor(() => expect(screen.getByText(/FIRE i runway/)).toBeTruthy());
+		expect(screen.getByText('FI progress')).toBeTruthy();
+		expect(screen.getByText('25.0%')).toBeTruthy();
+		expect(screen.getByText('18.5 mies.')).toBeTruthy();
+		expect(screen.getByText(/SWR 4\.0%/)).toBeTruthy();
+	});
+
+	it('renders the treasury bonds card when count > 0', async () => {
+		render(Page, {
+			props: {
+				data: buildData({
+					dashboardData: {
+						net_worth_history: [{ date: '2024-01-01', value: 5000 }],
+						current_net_worth: 6000,
+						change_vs_last_month: 1000,
+						total_assets: 10000,
+						total_liabilities: 4000,
+						allocation: [],
+						retirementStats: [],
+						tile_deltas: baseTileDeltas,
+						treasuryBondsCount: 3,
+						treasuryBondsValue: 30000
+					}
+				})
+			}
+		});
+		await waitFor(() => expect(screen.getByText('Obligacje skarbowe')).toBeTruthy());
+		expect(screen.getByText('3 obligacji (auto-wycena wg CPI)')).toBeTruthy();
+	});
+
+	it('singularises bonds count to "obligacja" when count is 1', async () => {
+		render(Page, {
+			props: {
+				data: buildData({
+					dashboardData: {
+						net_worth_history: [{ date: '2024-01-01', value: 5000 }],
+						current_net_worth: 6000,
+						change_vs_last_month: 1000,
+						total_assets: 10000,
+						total_liabilities: 4000,
+						allocation: [],
+						retirementStats: [],
+						tile_deltas: baseTileDeltas,
+						treasuryBondsCount: 1,
+						treasuryBondsValue: 10000
+					}
+				})
+			}
+		});
+		await waitFor(() => expect(screen.getByText('1 obligacja (auto-wycena wg CPI)')).toBeTruthy());
+	});
+});

--- a/src/routes/salaries/page.test.ts
+++ b/src/routes/salaries/page.test.ts
@@ -326,7 +326,9 @@ describe('Salaries page — equity grant flows', () => {
 		await fireEvent.input(sharesInput, { target: { value: '0' } });
 		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
 
-		await waitFor(() => expect(screen.getByText('Liczba akcji musi być większa niż 0')).toBeTruthy());
+		await waitFor(() =>
+			expect(screen.getByText('Liczba akcji musi być większa niż 0')).toBeTruthy()
+		);
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 

--- a/src/routes/salaries/page.test.ts
+++ b/src/routes/salaries/page.test.ts
@@ -286,3 +286,242 @@ describe('Salaries page — saveSalary validation & error display', () => {
 		await waitFor(() => expect(invalidateAll).toHaveBeenCalled());
 	});
 });
+
+describe('Salaries page — equity grant flows', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-05-20T12:00:00Z'));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	it('blocks save when company is empty', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: baseData } });
+		await fireEvent.click(screen.getByRole('button', { name: /Nowy grant/i }));
+		// Modal renders with defaults (RSU, 1000 shares etc.), but company is empty.
+		const sharesInput = screen.getByLabelText(/Liczba akcji/) as HTMLInputElement;
+		await fireEvent.input(sharesInput, { target: { value: '1000' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() => expect(screen.getByText('Firma nie może być pusta')).toBeTruthy());
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('blocks save when total_shares is zero', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: baseData } });
+		await fireEvent.click(screen.getByRole('button', { name: /Nowy grant/i }));
+		const companyInput = screen.getByLabelText(/Firma\*/) as HTMLInputElement;
+		await fireEvent.input(companyInput, { target: { value: 'Acme' } });
+		const sharesInput = screen.getByLabelText(/Liczba akcji/) as HTMLInputElement;
+		await fireEvent.input(sharesInput, { target: { value: '0' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() => expect(screen.getByText('Liczba akcji musi być większa niż 0')).toBeTruthy());
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('blocks save when option type missing strike price', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: baseData } });
+		await fireEvent.click(screen.getByRole('button', { name: /Nowy grant/i }));
+		const companyInput = screen.getByLabelText(/Firma\*/) as HTMLInputElement;
+		await fireEvent.input(companyInput, { target: { value: 'Acme' } });
+		const sharesInput = screen.getByLabelText(/Liczba akcji/) as HTMLInputElement;
+		await fireEvent.input(sharesInput, { target: { value: '1000' } });
+		const typeSelect = screen.getByLabelText(/Typ\*/) as HTMLSelectElement;
+		await fireEvent.change(typeSelect, { target: { value: 'option' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() =>
+			expect(screen.getByText('Opcje wymagają ceny wykonania (strike price)')).toBeTruthy()
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('POSTs a grant and closes the modal on success', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: baseData } });
+		await fireEvent.click(screen.getByRole('button', { name: /Nowy grant/i }));
+		const companyInput = screen.getByLabelText(/Firma\*/) as HTMLInputElement;
+		await fireEvent.input(companyInput, { target: { value: 'Acme' } });
+		const sharesInput = screen.getByLabelText(/Liczba akcji/) as HTMLInputElement;
+		await fireEvent.input(sharesInput, { target: { value: '1000' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe('http://localhost:8000/api/equity-grants');
+		expect((init as RequestInit).method).toBe('POST');
+		const body = JSON.parse((init as RequestInit).body as string);
+		expect(body).toMatchObject({
+			type: 'rsu',
+			company: 'Acme',
+			owner_user_id: 1,
+			total_shares: 1000
+		});
+		await waitFor(() => expect(invalidateAll).toHaveBeenCalled());
+	});
+
+	it('renders 422-detail array errors joined with semicolons', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: false,
+			json: async () => ({
+				detail: [{ msg: 'shares too low' }, { msg: 'bad date' }]
+			})
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: baseData } });
+		await fireEvent.click(screen.getByRole('button', { name: /Nowy grant/i }));
+		const companyInput = screen.getByLabelText(/Firma\*/) as HTMLInputElement;
+		await fireEvent.input(companyInput, { target: { value: 'Acme' } });
+		const sharesInput = screen.getByLabelText(/Liczba akcji/) as HTMLInputElement;
+		await fireEvent.input(sharesInput, { target: { value: '1000' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() => expect(screen.getByText('shares too low; bad date')).toBeTruthy());
+	});
+
+	it('renders string detail unchanged on 409 conflict', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: false,
+			json: async () => ({ detail: 'Grant already exists' })
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: baseData } });
+		await fireEvent.click(screen.getByRole('button', { name: /Nowy grant/i }));
+		const companyInput = screen.getByLabelText(/Firma\*/) as HTMLInputElement;
+		await fireEvent.input(companyInput, { target: { value: 'Acme' } });
+		const sharesInput = screen.getByLabelText(/Liczba akcji/) as HTMLInputElement;
+		await fireEvent.input(sharesInput, { target: { value: '1000' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() => expect(screen.getByText('Grant already exists')).toBeTruthy());
+	});
+});
+
+describe('Salaries page — valuation flows', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-05-20T12:00:00Z'));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	it('blocks save when company is empty', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: baseData } });
+		await fireEvent.click(screen.getByRole('button', { name: /Nowa wycena/i }));
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() => expect(screen.getByText('Firma nie może być pusta')).toBeTruthy());
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('blocks save when fmv_low > fmv_per_share', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: baseData } });
+		await fireEvent.click(screen.getByRole('button', { name: /Nowa wycena/i }));
+		const companyInput = screen.getByLabelText(/Firma\*/) as HTMLInputElement;
+		await fireEvent.input(companyInput, { target: { value: 'Acme' } });
+		const fmv = screen.getByLabelText(/FMV per share/) as HTMLInputElement;
+		await fireEvent.input(fmv, { target: { value: '5' } });
+		const low = screen.getByLabelText(/FMV low/) as HTMLInputElement;
+		await fireEvent.input(low, { target: { value: '10' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() =>
+			expect(screen.getByText('fmv_low nie może być większe niż fmv_per_share')).toBeTruthy()
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('blocks save when fmv_high < fmv_per_share', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: baseData } });
+		await fireEvent.click(screen.getByRole('button', { name: /Nowa wycena/i }));
+		const companyInput = screen.getByLabelText(/Firma\*/) as HTMLInputElement;
+		await fireEvent.input(companyInput, { target: { value: 'Acme' } });
+		const fmv = screen.getByLabelText(/FMV per share/) as HTMLInputElement;
+		await fireEvent.input(fmv, { target: { value: '10' } });
+		const high = screen.getByLabelText(/FMV high/) as HTMLInputElement;
+		await fireEvent.input(high, { target: { value: '5' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() =>
+			expect(screen.getByText('fmv_high nie może być mniejsze niż fmv_per_share')).toBeTruthy()
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('POSTs a valuation and closes the modal on success', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: baseData } });
+		await fireEvent.click(screen.getByRole('button', { name: /Nowa wycena/i }));
+		const companyInput = screen.getByLabelText(/Firma\*/) as HTMLInputElement;
+		await fireEvent.input(companyInput, { target: { value: 'Acme' } });
+		const fmv = screen.getByLabelText(/FMV per share/) as HTMLInputElement;
+		await fireEvent.input(fmv, { target: { value: '12.5' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe('http://localhost:8000/api/company-valuations');
+		expect((init as RequestInit).method).toBe('POST');
+		const body = JSON.parse((init as RequestInit).body as string);
+		expect(body).toMatchObject({
+			company: 'Acme',
+			currency: 'USD',
+			fmv_per_share: 12.5,
+			source: '409a'
+		});
+		await waitFor(() => expect(invalidateAll).toHaveBeenCalled());
+	});
+
+	it('renders 422-detail array errors joined with semicolons', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: false,
+			json: async () => ({
+				detail: [{ msg: 'fmv missing' }, { msg: 'bad source' }]
+			})
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: baseData } });
+		await fireEvent.click(screen.getByRole('button', { name: /Nowa wycena/i }));
+		const companyInput = screen.getByLabelText(/Firma\*/) as HTMLInputElement;
+		await fireEvent.input(companyInput, { target: { value: 'Acme' } });
+		const fmv = screen.getByLabelText(/FMV per share/) as HTMLInputElement;
+		await fireEvent.input(fmv, { target: { value: '12.5' } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
+
+		await waitFor(() => expect(screen.getByText('fmv missing; bad source')).toBeTruthy());
+	});
+});

--- a/src/routes/simulations/page.test.ts
+++ b/src/routes/simulations/page.test.ts
@@ -155,4 +155,107 @@ describe('Simulations Page — run simulation', () => {
 		await waitFor(() => expect(screen.getByText(/Simulation failed/)).toBeTruthy());
 		expect(screen.queryByRole('heading', { name: 'Wyniki symulacji' })).toBeNull();
 	});
+
+	it('renders PPK and brokerage controls per owner', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.getByText('PPK (Marcin)')).toBeTruthy();
+		expect(screen.getByText('PPK (Ewa)')).toBeTruthy();
+		expect(screen.getByText('Rachunek maklerski (Marcin)')).toBeTruthy();
+		expect(screen.getByText('Rachunek maklerski (Ewa)')).toBeTruthy();
+	});
+
+	it('renders the Założenia parameters block', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.getByText(/Roczna stopa zwrotu/)).toBeTruthy();
+		expect(screen.getByText(/Wzrost limitów wpłat/)).toBeTruthy();
+		expect(screen.getByText(/Przewidywany wzrost wynagrodzeń/)).toBeTruthy();
+	});
+
+	it('blocks simulation when PPK employee rate is out of range', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: mockData } });
+		// Enable PPK for Marcin via its checkbox.
+		const ppkLabel = screen.getByText('PPK (Marcin)');
+		const ppkCheckbox = ppkLabel.parentElement!.querySelector(
+			'input[type="checkbox"]'
+		) as HTMLInputElement;
+		await fireEvent.click(ppkCheckbox);
+
+		// Find employee-rate input within the same PPK card.
+		const card = ppkLabel.closest('.card') as HTMLElement;
+		const employeeInput = Array.from(card.querySelectorAll('input[type="number"]')).find(
+			(el) => (el as HTMLInputElement).min === '0.5'
+		) as HTMLInputElement;
+		await fireEvent.input(employeeInput, { target: { value: '10' } });
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Uruchom symulację' }));
+
+		await waitFor(() =>
+			expect(
+				screen.getByText(/PPK Marcin: Składka pracownika musi być w zakresie 0\.5-4%/)
+			).toBeTruthy()
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('blocks simulation when PPK employer rate is out of range', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: mockData } });
+		const ppkLabel = screen.getByText('PPK (Marcin)');
+		const ppkCheckbox = ppkLabel.parentElement!.querySelector(
+			'input[type="checkbox"]'
+		) as HTMLInputElement;
+		await fireEvent.click(ppkCheckbox);
+
+		const card = ppkLabel.closest('.card') as HTMLElement;
+		const employerInput = Array.from(card.querySelectorAll('input[type="number"]')).find(
+			(el) => (el as HTMLInputElement).min === '1.5'
+		) as HTMLInputElement;
+		await fireEvent.input(employerInput, { target: { value: '10' } });
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Uruchom symulację' }));
+
+		await waitFor(() =>
+			expect(
+				screen.getByText(/PPK Marcin: Składka pracodawcy musi być w zakresie 1\.5-4%/)
+			).toBeTruthy()
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('blocks simulation when salary above threshold but belowThreshold checked', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		render(Page, { props: { data: mockData } });
+		const ppkLabel = screen.getByText('PPK (Marcin)');
+		const ppkCheckbox = ppkLabel.parentElement!.querySelector(
+			'input[type="checkbox"]'
+		) as HTMLInputElement;
+		await fireEvent.click(ppkCheckbox);
+
+		const card = ppkLabel.closest('.card') as HTMLElement;
+		// Salary input has step="500".
+		const salaryInput = Array.from(card.querySelectorAll('input[type="number"]')).find(
+			(el) => (el as HTMLInputElement).step === '500'
+		) as HTMLInputElement;
+		await fireEvent.input(salaryInput, { target: { value: '999999' } });
+		// Check the "below threshold" box — contradicts the very large salary.
+		const belowThresholdLabel = card.querySelector('label.flex.items-start') as HTMLElement;
+		const belowThresholdCheckbox = belowThresholdLabel.querySelector(
+			'input[type="checkbox"]'
+		) as HTMLInputElement;
+		await fireEvent.click(belowThresholdCheckbox);
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Uruchom symulację' }));
+
+		await waitFor(() =>
+			expect(screen.getByText(/PPK Marcin: Wynagrodzenie przekracza próg/)).toBeTruthy()
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Motivation

Codecov target is 80% project/patch coverage but frontend dropped to ~66.5% statements / ~68% lines. Bring frontend coverage above the 80% threshold so future PRs aren't blocked by the project gate.

## Implementation information

New unit / component tests:

- **Chart formatters** — exercise ECharts tooltip/axisLabel/label callbacks in `metryki.ts`, `simulations.ts`, `waterfall.ts` (these previously rendered options without invoking the embedded functions)
- **DateRangePicker** — `\`$page.url\`` mock + goto spy; covers preset selection, custom range, path override
- **EquityFormModal** / **ValuationFormModal** — new test files for the two form modals that were at <6% coverage
- **SnapshotForm** — extended to cover sections (Emerytura/Inwestycje/Majątek), hidden-then-restored accounts/assets, in-form new-account/new-asset POST flows, Anuluj navigation
- **salaries page** — equity grant + valuation flows (validation, POST, 422-detail joining, string-detail conflict)
- **simulations page** — PPK employee/employer rate range validation, salary-above-threshold guard, extra render assertions
- **dashboard page** — FIRE/runway card with metric_cards, treasury-bonds card singular/plural
- **dateRange** — fill in 6m/3y preset branches
- **Go** — \`equity_grants\` vesting math unit tests (MonthsBetween, VestedSharesAt with cliff/custom/liquidity, VestingProgressPct, FreqMonthsFromString)

Results: frontend statements 66.55% → 80.71%; lines 68.07% → 81.66%; all 430 frontend tests pass; new Go tests pass.

## Supporting documentation

n/a