### PR TITLE
feat(nav): mobile bottom-nav More overflow sheet

### DIFF
--- a/src/lib/components/BottomSheet.svelte
+++ b/src/lib/components/BottomSheet.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	interface Props {
+		open: boolean;
+		title?: string;
+		onClose: () => void;
+		children?: import('svelte').Snippet;
+	}
+
+	let { open, title, onClose, children }: Props = $props();
+
+	const DISMISS_PX = 100;
+
+	let sheetEl = $state<HTMLDivElement | null>(null);
+	let dragStartY = $state<number | null>(null);
+	let dragDeltaY = $state(0);
+
+	const translate = $derived(dragDeltaY > 0 ? dragDeltaY : 0);
+
+	$effect(() => {
+		if (open) sheetEl?.focus();
+	});
+
+	function handleBackdropClick(event: MouseEvent) {
+		if (event.target === event.currentTarget) onClose();
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (!open) return;
+		if (event.key === 'Escape') onClose();
+	}
+
+	function onPointerDown(event: PointerEvent) {
+		const handle = (event.target as HTMLElement).closest('[data-sheet-drag]');
+		if (!handle) return;
+		dragStartY = event.clientY;
+		dragDeltaY = 0;
+		(event.currentTarget as Element).setPointerCapture(event.pointerId);
+	}
+
+	function onPointerMove(event: PointerEvent) {
+		if (dragStartY === null) return;
+		dragDeltaY = event.clientY - dragStartY;
+	}
+
+	function onPointerUp() {
+		if (dragStartY === null) return;
+		const shouldDismiss = dragDeltaY > DISMISS_PX;
+		dragStartY = null;
+		dragDeltaY = 0;
+		if (shouldDismiss) onClose();
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open}
+	<div
+		class="fixed inset-0 z-40 bg-surface-950/60 backdrop-blur-sm"
+		role="presentation"
+		onclick={handleBackdropClick}
+	>
+		<div
+			bind:this={sheetEl}
+			class="absolute bottom-0 left-0 right-0 bg-surface-100-900 rounded-t-2xl shadow-2xl max-h-[80vh] flex flex-col"
+			style:transform="translateY({translate}px)"
+			style:transition={dragStartY === null ? 'transform 0.2s ease-out' : 'none'}
+			role="dialog"
+			aria-modal="true"
+			aria-label={title ?? 'Więcej'}
+			tabindex="-1"
+			onpointerdown={onPointerDown}
+			onpointermove={onPointerMove}
+			onpointerup={onPointerUp}
+			onpointercancel={onPointerUp}
+		>
+			<div
+				data-sheet-drag
+				class="flex flex-col items-center pt-2 pb-1 cursor-grab select-none touch-none"
+			>
+				<div class="w-10 h-1.5 rounded-full bg-surface-300-700"></div>
+				{#if title}
+					<h2 class="mt-2 text-base font-semibold">{title}</h2>
+				{/if}
+			</div>
+			<div class="flex-1 overflow-y-auto p-2 pb-[env(safe-area-inset-bottom)]">
+				{@render children?.()}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/BottomSheet.test.ts
+++ b/src/lib/components/BottomSheet.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import BottomSheet from './BottomSheet.svelte';
+
+describe('BottomSheet', () => {
+	it('does not render when closed', () => {
+		render(BottomSheet, { props: { open: false, onClose: () => {} } });
+		expect(screen.queryByRole('dialog')).toBeNull();
+	});
+
+	it('renders an accessible dialog with the title when open', () => {
+		render(BottomSheet, { props: { open: true, title: 'Więcej', onClose: () => {} } });
+		const dialog = screen.getByRole('dialog');
+		expect(dialog.getAttribute('aria-modal')).toBe('true');
+		expect(dialog.getAttribute('aria-label')).toBe('Więcej');
+	});
+
+	it('closes on Escape', async () => {
+		const onClose = vi.fn();
+		render(BottomSheet, { props: { open: true, onClose } });
+		await fireEvent.keyDown(window, { key: 'Escape' });
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('closes on backdrop click', async () => {
+		const onClose = vi.fn();
+		const { container } = render(BottomSheet, { props: { open: true, onClose } });
+		const backdrop = container.querySelector('[role="presentation"]');
+		expect(backdrop).not.toBeNull();
+		await fireEvent.click(backdrop as Element);
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('does not close when the sheet body is clicked', async () => {
+		const onClose = vi.fn();
+		render(BottomSheet, { props: { open: true, onClose } });
+		await fireEvent.click(screen.getByRole('dialog'));
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('closes after dragging the handle down past the threshold', async () => {
+		const onClose = vi.fn();
+		const { container } = render(BottomSheet, { props: { open: true, onClose } });
+		const sheet = screen.getByRole('dialog');
+		const handle = container.querySelector('[data-sheet-drag]');
+		expect(handle).not.toBeNull();
+		// jsdom lacks setPointerCapture — stub it.
+		(sheet as Element & { setPointerCapture?: (id: number) => void }).setPointerCapture = () => {};
+		await fireEvent.pointerDown(handle as Element, { clientY: 0, pointerId: 1 });
+		await fireEvent.pointerMove(sheet, { clientY: 150, pointerId: 1 });
+		await fireEvent.pointerUp(sheet, { clientY: 150, pointerId: 1 });
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it('does not close when drag distance is below the threshold', async () => {
+		const onClose = vi.fn();
+		const { container } = render(BottomSheet, { props: { open: true, onClose } });
+		const sheet = screen.getByRole('dialog');
+		const handle = container.querySelector('[data-sheet-drag]');
+		(sheet as Element & { setPointerCapture?: (id: number) => void }).setPointerCapture = () => {};
+		await fireEvent.pointerDown(handle as Element, { clientY: 0, pointerId: 1 });
+		await fireEvent.pointerMove(sheet, { clientY: 40, pointerId: 1 });
+		await fireEvent.pointerUp(sheet, { clientY: 40, pointerId: 1 });
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('ignores pointer drag that does not start on the handle', async () => {
+		const onClose = vi.fn();
+		render(BottomSheet, { props: { open: true, onClose } });
+		const sheet = screen.getByRole('dialog');
+		(sheet as Element & { setPointerCapture?: (id: number) => void }).setPointerCapture = () => {};
+		await fireEvent.pointerDown(sheet, { clientY: 0, pointerId: 1 });
+		await fireEvent.pointerMove(sheet, { clientY: 300, pointerId: 1 });
+		await fireEvent.pointerUp(sheet, { clientY: 300, pointerId: 1 });
+		expect(onClose).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/nav/routes.ts
+++ b/src/lib/nav/routes.ts
@@ -1,0 +1,35 @@
+import {
+	LayoutDashboard,
+	TrendingUp,
+	Sparkles,
+	Wallet,
+	ArrowRightLeft,
+	Home,
+	ClipboardList,
+	Camera,
+	Banknote,
+	Coins,
+	Dices,
+	Settings,
+	Target
+} from 'lucide-svelte';
+
+export const NAV_ROUTES = [
+	{ href: '/', label: 'Dashboard', icon: LayoutDashboard },
+	{ href: '/metryki', label: 'Metryki', icon: TrendingUp },
+	{ href: '/simulations', label: 'Symulacje', icon: Sparkles },
+	{ href: '/retirement', label: 'Emerytura', icon: Dices },
+	{ href: '/accounts', label: 'Konta', icon: Wallet },
+	{ href: '/transactions', label: 'Transakcje', icon: ArrowRightLeft },
+	{ href: '/assets', label: 'Majątek', icon: Home },
+	{ href: '/bonds', label: 'Obligacje', icon: Coins },
+	{ href: '/debts', label: 'Zobowiązania', icon: ClipboardList },
+	{ href: '/goals', label: 'Cele', icon: Target },
+	{ href: '/snapshots', label: 'Snapshoty', icon: Camera },
+	{ href: '/salaries', label: 'Wynagrodzenia', icon: Banknote },
+	{ href: '/settings', label: 'Ustawienia', icon: Settings }
+] as const;
+
+export type NavRoute = (typeof NAV_ROUTES)[number];
+
+export const NAV_HREFS: ReadonlySet<string> = new Set(NAV_ROUTES.map((r) => r.href));

--- a/src/lib/stores/navPrefs.svelte.ts
+++ b/src/lib/stores/navPrefs.svelte.ts
@@ -1,0 +1,46 @@
+import { browser } from '$app/environment';
+
+const STORAGE_KEY = 'fb.nav.pinned';
+
+export const DEFAULT_PINNED: ReadonlyArray<string> = ['/', '/snapshots', '/accounts', '/goals'];
+
+export const MAX_PINNED = 4;
+
+function load(): string[] {
+	if (!browser) return [...DEFAULT_PINNED];
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY);
+		if (!raw) return [...DEFAULT_PINNED];
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return [...DEFAULT_PINNED];
+		const filtered = parsed.filter((v): v is string => typeof v === 'string').slice(0, MAX_PINNED);
+		return filtered.length > 0 ? filtered : [...DEFAULT_PINNED];
+	} catch {
+		return [...DEFAULT_PINNED];
+	}
+}
+
+function save(value: ReadonlyArray<string>): void {
+	if (!browser) return;
+	try {
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+	} catch {
+		// ignore quota / private mode errors
+	}
+}
+
+const state = $state<{ pinned: string[] }>({ pinned: load() });
+
+export const navPrefs = {
+	get pinned(): ReadonlyArray<string> {
+		return state.pinned;
+	},
+	set(next: ReadonlyArray<string>): void {
+		state.pinned = next.slice(0, MAX_PINNED);
+		save(state.pinned);
+	},
+	reset(): void {
+		state.pinned = [...DEFAULT_PINNED];
+		save(state.pinned);
+	}
+};

--- a/src/lib/stores/navPrefs.svelte.ts
+++ b/src/lib/stores/navPrefs.svelte.ts
@@ -1,4 +1,5 @@
 import { browser } from '$app/environment';
+import { NAV_HREFS } from '$lib/nav/routes';
 
 const STORAGE_KEY = 'fb.nav.pinned';
 
@@ -6,15 +7,27 @@ export const DEFAULT_PINNED: ReadonlyArray<string> = ['/', '/snapshots', '/accou
 
 export const MAX_PINNED = 4;
 
+function sanitize(value: unknown): string[] {
+	if (!Array.isArray(value)) return [...DEFAULT_PINNED];
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const v of value) {
+		if (typeof v !== 'string') continue;
+		if (!NAV_HREFS.has(v)) continue;
+		if (seen.has(v)) continue;
+		seen.add(v);
+		out.push(v);
+		if (out.length === MAX_PINNED) break;
+	}
+	return out.length > 0 ? out : [...DEFAULT_PINNED];
+}
+
 function load(): string[] {
 	if (!browser) return [...DEFAULT_PINNED];
 	try {
 		const raw = window.localStorage.getItem(STORAGE_KEY);
 		if (!raw) return [...DEFAULT_PINNED];
-		const parsed = JSON.parse(raw);
-		if (!Array.isArray(parsed)) return [...DEFAULT_PINNED];
-		const filtered = parsed.filter((v): v is string => typeof v === 'string').slice(0, MAX_PINNED);
-		return filtered.length > 0 ? filtered : [...DEFAULT_PINNED];
+		return sanitize(JSON.parse(raw));
 	} catch {
 		return [...DEFAULT_PINNED];
 	}
@@ -36,7 +49,7 @@ export const navPrefs = {
 		return state.pinned;
 	},
 	set(next: ReadonlyArray<string>): void {
-		state.pinned = next.slice(0, MAX_PINNED);
+		state.pinned = sanitize(next);
 		save(state.pinned);
 	},
 	reset(): void {

--- a/src/lib/stores/navPrefs.test.ts
+++ b/src/lib/stores/navPrefs.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { navPrefs, DEFAULT_PINNED, MAX_PINNED } from './navPrefs.svelte';
+
+describe('navPrefs', () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+		navPrefs.reset();
+	});
+
+	it('defaults to DEFAULT_PINNED', () => {
+		expect(navPrefs.pinned).toEqual([...DEFAULT_PINNED]);
+	});
+
+	it('persists set() to localStorage', () => {
+		navPrefs.set(['/', '/accounts']);
+		expect(navPrefs.pinned).toEqual(['/', '/accounts']);
+		expect(JSON.parse(window.localStorage.getItem('fb.nav.pinned') ?? '[]')).toEqual([
+			'/',
+			'/accounts'
+		]);
+	});
+
+	it('truncates to MAX_PINNED', () => {
+		navPrefs.set(['/', '/a', '/b', '/c', '/d', '/e']);
+		expect(navPrefs.pinned.length).toBe(MAX_PINNED);
+	});
+
+	it('reset() restores defaults', () => {
+		navPrefs.set(['/accounts']);
+		navPrefs.reset();
+		expect(navPrefs.pinned).toEqual([...DEFAULT_PINNED]);
+	});
+});

--- a/src/lib/stores/navPrefs.test.ts
+++ b/src/lib/stores/navPrefs.test.ts
@@ -21,14 +21,7 @@ describe('navPrefs', () => {
 	});
 
 	it('truncates to MAX_PINNED', () => {
-		navPrefs.set([
-			'/',
-			'/accounts',
-			'/snapshots',
-			'/goals',
-			'/transactions',
-			'/assets'
-		]);
+		navPrefs.set(['/', '/accounts', '/snapshots', '/goals', '/transactions', '/assets']);
 		expect(navPrefs.pinned.length).toBe(MAX_PINNED);
 	});
 

--- a/src/lib/stores/navPrefs.test.ts
+++ b/src/lib/stores/navPrefs.test.ts
@@ -21,8 +21,30 @@ describe('navPrefs', () => {
 	});
 
 	it('truncates to MAX_PINNED', () => {
-		navPrefs.set(['/', '/a', '/b', '/c', '/d', '/e']);
+		navPrefs.set([
+			'/',
+			'/accounts',
+			'/snapshots',
+			'/goals',
+			'/transactions',
+			'/assets'
+		]);
 		expect(navPrefs.pinned.length).toBe(MAX_PINNED);
+	});
+
+	it('drops unknown hrefs', () => {
+		navPrefs.set(['/', '/nope', '/accounts', '/also-nope']);
+		expect(navPrefs.pinned).toEqual(['/', '/accounts']);
+	});
+
+	it('drops duplicates', () => {
+		navPrefs.set(['/', '/', '/accounts', '/accounts']);
+		expect(navPrefs.pinned).toEqual(['/', '/accounts']);
+	});
+
+	it('falls back to DEFAULT_PINNED when all entries are invalid', () => {
+		navPrefs.set(['/nope', '/also-nope']);
+		expect(navPrefs.pinned).toEqual([...DEFAULT_PINNED]);
 	});
 
 	it('reset() restores defaults', () => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,8 @@
 	import Toast from '$lib/components/Toast.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import KeyboardShortcuts from '$lib/components/KeyboardShortcuts.svelte';
+	import BottomSheet from '$lib/components/BottomSheet.svelte';
+	import { navPrefs } from '$lib/stores/navPrefs.svelte';
 	import {
 		LayoutDashboard,
 		TrendingUp,
@@ -20,7 +22,8 @@
 		Target,
 		User,
 		ShieldCheck,
-		LogOut
+		LogOut,
+		MoreHorizontal
 	} from 'lucide-svelte';
 	import type { LayoutData } from './$types';
 
@@ -42,12 +45,27 @@
 		{ href: '/settings', label: 'Ustawienia', icon: Settings }
 	];
 
+	const navByHref = new Map(navItems.map((i) => [i.href, i]));
+
+	const pinnedItems = $derived(
+		navPrefs.pinned.map((href) => navByHref.get(href)).filter((i) => i !== undefined)
+	);
+	const overflowItems = $derived(navItems.filter((i) => !navPrefs.pinned.includes(i.href)));
+
 	const isLoginPage = $derived($page.url.pathname === '/login');
+
+	let moreOpen = $state(false);
 
 	function isActive(href: string): boolean {
 		if (href === '/simulations') return $page.url.pathname.startsWith('/simulations');
 		if (href === '/settings') return $page.url.pathname.startsWith('/settings');
 		return $page.url.pathname === href;
+	}
+
+	const overflowActive = $derived(overflowItems.some((i) => isActive(i.href)));
+
+	function closeMore() {
+		moreOpen = false;
 	}
 </script>
 
@@ -124,20 +142,52 @@
 			</main>
 
 			<nav
-				class="md:hidden fixed bottom-0 left-0 right-0 z-30 flex overflow-x-auto bg-surface-100-900 border-t border-surface-200-800"
+				class="md:hidden fixed bottom-0 left-0 right-0 z-30 grid bg-surface-100-900 border-t border-surface-200-800 pb-[env(safe-area-inset-bottom)]"
+				style:grid-template-columns="repeat({pinnedItems.length + 1}, minmax(0, 1fr))"
 				aria-label="Mobile navigation"
 			>
-				{#each navItems as item}
+				{#each pinnedItems as item}
 					<a
 						href={item.href}
-						class="flex flex-col items-center justify-center gap-1 min-w-16 shrink-0 px-3 py-2 text-[10px]
+						class="flex flex-col items-center justify-center gap-1 px-1 py-2 text-[10px]
 							{isActive(item.href) ? 'text-primary-500 font-semibold' : 'text-surface-700-300'}"
 					>
 						<item.icon size={20} />
-						<span class="whitespace-nowrap">{item.label}</span>
+						<span class="whitespace-nowrap truncate max-w-full">{item.label}</span>
 					</a>
 				{/each}
+				<button
+					type="button"
+					class="flex flex-col items-center justify-center gap-1 px-1 py-2 text-[10px]
+						{overflowActive || moreOpen ? 'text-primary-500 font-semibold' : 'text-surface-700-300'}"
+					aria-label="Więcej opcji nawigacji"
+					aria-expanded={moreOpen}
+					onclick={() => (moreOpen = true)}
+				>
+					<MoreHorizontal size={20} />
+					<span class="whitespace-nowrap">Więcej</span>
+				</button>
 			</nav>
+
+			<BottomSheet open={moreOpen} title="Więcej" onClose={closeMore}>
+				<ul class="grid grid-cols-4 gap-2">
+					{#each overflowItems as item}
+						<li>
+							<a
+								href={item.href}
+								onclick={closeMore}
+								class="flex flex-col items-center justify-center gap-1 p-3 rounded-container text-[11px]
+									{isActive(item.href)
+									? 'preset-filled-primary-500 font-semibold'
+									: 'hover:preset-tonal-primary text-surface-800-200'}"
+							>
+								<item.icon size={22} />
+								<span class="text-center leading-tight">{item.label}</span>
+							</a>
+						</li>
+					{/each}
+				</ul>
+			</BottomSheet>
 		</div>
 	</div>
 {/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,55 +6,29 @@
 	import KeyboardShortcuts from '$lib/components/KeyboardShortcuts.svelte';
 	import BottomSheet from '$lib/components/BottomSheet.svelte';
 	import { navPrefs } from '$lib/stores/navPrefs.svelte';
-	import {
-		LayoutDashboard,
-		TrendingUp,
-		Sparkles,
-		Wallet,
-		ArrowRightLeft,
-		Home,
-		ClipboardList,
-		Camera,
-		Banknote,
-		Coins,
-		Dices,
-		Settings,
-		Target,
-		User,
-		ShieldCheck,
-		LogOut,
-		MoreHorizontal
-	} from 'lucide-svelte';
+	import { NAV_ROUTES, type NavRoute } from '$lib/nav/routes';
+	import { User, ShieldCheck, LogOut, MoreHorizontal } from 'lucide-svelte';
 	import type { LayoutData } from './$types';
 
 	let { children, data }: { children: import('svelte').Snippet; data: LayoutData } = $props();
 
-	const navItems = [
-		{ href: '/', label: 'Dashboard', icon: LayoutDashboard },
-		{ href: '/metryki', label: 'Metryki', icon: TrendingUp },
-		{ href: '/simulations', label: 'Symulacje', icon: Sparkles },
-		{ href: '/retirement', label: 'Emerytura', icon: Dices },
-		{ href: '/accounts', label: 'Konta', icon: Wallet },
-		{ href: '/transactions', label: 'Transakcje', icon: ArrowRightLeft },
-		{ href: '/assets', label: 'Majątek', icon: Home },
-		{ href: '/bonds', label: 'Obligacje', icon: Coins },
-		{ href: '/debts', label: 'Zobowiązania', icon: ClipboardList },
-		{ href: '/goals', label: 'Cele', icon: Target },
-		{ href: '/snapshots', label: 'Snapshoty', icon: Camera },
-		{ href: '/salaries', label: 'Wynagrodzenia', icon: Banknote },
-		{ href: '/settings', label: 'Ustawienia', icon: Settings }
-	];
-
-	const navByHref = new Map(navItems.map((i) => [i.href, i]));
+	const navByHref = new Map<string, NavRoute>(NAV_ROUTES.map((i) => [i.href, i]));
 
 	const pinnedItems = $derived(
-		navPrefs.pinned.map((href) => navByHref.get(href)).filter((i) => i !== undefined)
+		navPrefs.pinned.map((href) => navByHref.get(href)).filter((i): i is NavRoute => i !== undefined)
 	);
-	const overflowItems = $derived(navItems.filter((i) => !navPrefs.pinned.includes(i.href)));
+	const overflowItems = $derived(NAV_ROUTES.filter((i) => !navPrefs.pinned.includes(i.href)));
 
 	const isLoginPage = $derived($page.url.pathname === '/login');
+	const currentPath = $derived($page.url.pathname);
 
 	let moreOpen = $state(false);
+
+	$effect(() => {
+		// Close sheet on any route change so it does not linger across navigations.
+		void currentPath;
+		moreOpen = false;
+	});
 
 	function isActive(href: string): boolean {
 		if (href === '/simulations') return $page.url.pathname.startsWith('/simulations');
@@ -88,7 +62,7 @@
 				<span>Finansowa Forteca</span>
 			</div>
 			<nav class="flex-1 overflow-y-auto p-2 space-y-1">
-				{#each navItems as item}
+				{#each NAV_ROUTES as item}
 					<a
 						href={item.href}
 						class="flex items-center gap-3 px-3 py-2 rounded-container text-sm transition-colors

--- a/src/routes/settings/+layout.svelte
+++ b/src/routes/settings/+layout.svelte
@@ -7,6 +7,7 @@
 	const tabs = $derived([
 		{ href: '/settings/config', label: 'Konfiguracja' },
 		{ href: '/settings/allocation', label: 'Cele alokacji' },
+		{ href: '/settings/navigation', label: 'Nawigacja' },
 		{ href: '/settings', label: 'Ustawienia' },
 		...(data.user?.isAdmin ? [{ href: '/settings/users', label: 'Użytkownicy' }] : [])
 	]);

--- a/src/routes/settings/navigation/+page.svelte
+++ b/src/routes/settings/navigation/+page.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+	import {
+		LayoutDashboard,
+		TrendingUp,
+		Sparkles,
+		Wallet,
+		ArrowRightLeft,
+		Home,
+		ClipboardList,
+		Camera,
+		Banknote,
+		Coins,
+		Dices,
+		Settings,
+		Target,
+		Pin,
+		PinOff,
+		RotateCcw,
+		ChevronUp,
+		ChevronDown
+	} from 'lucide-svelte';
+	import { navPrefs, MAX_PINNED, DEFAULT_PINNED } from '$lib/stores/navPrefs.svelte';
+	import { toast } from '$lib/stores/toast.svelte';
+
+	const ALL_ROUTES = [
+		{ href: '/', label: 'Dashboard', icon: LayoutDashboard },
+		{ href: '/metryki', label: 'Metryki', icon: TrendingUp },
+		{ href: '/simulations', label: 'Symulacje', icon: Sparkles },
+		{ href: '/retirement', label: 'Emerytura', icon: Dices },
+		{ href: '/accounts', label: 'Konta', icon: Wallet },
+		{ href: '/transactions', label: 'Transakcje', icon: ArrowRightLeft },
+		{ href: '/assets', label: 'Majątek', icon: Home },
+		{ href: '/bonds', label: 'Obligacje', icon: Coins },
+		{ href: '/debts', label: 'Zobowiązania', icon: ClipboardList },
+		{ href: '/goals', label: 'Cele', icon: Target },
+		{ href: '/snapshots', label: 'Snapshoty', icon: Camera },
+		{ href: '/salaries', label: 'Wynagrodzenia', icon: Banknote },
+		{ href: '/settings', label: 'Ustawienia', icon: Settings }
+	];
+
+	const pinned = $derived(navPrefs.pinned);
+
+	function isPinned(href: string): boolean {
+		return pinned.includes(href);
+	}
+
+	function toggle(href: string): void {
+		if (isPinned(href)) {
+			if (pinned.length <= 1) {
+				toast.error('Musi pozostać co najmniej jedna przypięta pozycja.');
+				return;
+			}
+			navPrefs.set(pinned.filter((h) => h !== href));
+			return;
+		}
+		if (pinned.length >= MAX_PINNED) {
+			toast.error(`Maksymalnie ${MAX_PINNED} przypiętych pozycji. Odepnij inną najpierw.`);
+			return;
+		}
+		navPrefs.set([...pinned, href]);
+	}
+
+	function reset(): void {
+		navPrefs.reset();
+		toast.success('Przywrócono domyślne przypięte pozycje');
+	}
+
+	function move(href: string, delta: -1 | 1): void {
+		const idx = pinned.indexOf(href);
+		if (idx === -1) return;
+		const next = [...pinned];
+		const swap = idx + delta;
+		if (swap < 0 || swap >= next.length) return;
+		[next[idx], next[swap]] = [next[swap], next[idx]];
+		navPrefs.set(next);
+	}
+
+	const isDefault = $derived(
+		pinned.length === DEFAULT_PINNED.length && pinned.every((h, i) => h === DEFAULT_PINNED[i])
+	);
+</script>
+
+<svelte:head>
+	<title>Nawigacja | Ustawienia | Finansowa Forteca</title>
+</svelte:head>
+
+<div class="mb-6 space-y-1">
+	<h1 class="h2">Nawigacja mobilna</h1>
+	<p class="text-surface-700-300 text-sm">
+		Przypnij do {MAX_PINNED} pozycji w dolnej nawigacji. Pozostałe trafią do panelu „Więcej”.
+	</p>
+</div>
+
+<div class="space-y-6">
+	<section class="card preset-filled-surface-100-900 p-4 space-y-3">
+		<header class="flex items-center justify-between">
+			<h3 class="h4 font-semibold">Przypięte ({pinned.length}/{MAX_PINNED})</h3>
+			<button
+				type="button"
+				class="btn btn-sm preset-tonal-surface"
+				onclick={reset}
+				disabled={isDefault}
+			>
+				<RotateCcw size={16} />
+				<span>Domyślne</span>
+			</button>
+		</header>
+		{#if pinned.length === 0}
+			<p class="text-sm text-surface-700-300">Brak przypiętych pozycji.</p>
+		{:else}
+			<ol class="space-y-2">
+				{#each pinned as href, i (href)}
+					{@const item = ALL_ROUTES.find((r) => r.href === href)}
+					{#if item}
+						<li class="flex items-center gap-3 px-3 py-2 rounded-container bg-surface-50-950">
+							<item.icon size={18} class="text-primary-500" />
+							<span class="flex-1 text-sm font-medium">{item.label}</span>
+							<button
+								type="button"
+								class="btn-icon btn-icon-sm"
+								aria-label="W górę"
+								disabled={i === 0}
+								onclick={() => move(href, -1)}
+							>
+								<ChevronUp size={16} />
+							</button>
+							<button
+								type="button"
+								class="btn-icon btn-icon-sm"
+								aria-label="W dół"
+								disabled={i === pinned.length - 1}
+								onclick={() => move(href, 1)}
+							>
+								<ChevronDown size={16} />
+							</button>
+							<button
+								type="button"
+								class="btn-icon btn-icon-sm"
+								aria-label="Odepnij {item.label}"
+								onclick={() => toggle(href)}
+							>
+								<PinOff size={16} />
+							</button>
+						</li>
+					{/if}
+				{/each}
+			</ol>
+		{/if}
+	</section>
+
+	<section class="card preset-filled-surface-100-900 p-4 space-y-3">
+		<h3 class="h4 font-semibold">Dostępne</h3>
+		<ul class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+			{#each ALL_ROUTES.filter((r) => !isPinned(r.href)) as item (item.href)}
+				<li>
+					<button
+						type="button"
+						class="flex w-full items-center gap-3 px-3 py-2 rounded-container bg-surface-50-950 hover:preset-tonal-primary text-left"
+						onclick={() => toggle(item.href)}
+						disabled={pinned.length >= MAX_PINNED}
+					>
+						<item.icon size={18} />
+						<span class="flex-1 text-sm">{item.label}</span>
+						<Pin size={14} class="text-surface-600-400" />
+					</button>
+				</li>
+			{/each}
+		</ul>
+	</section>
+</div>

--- a/src/routes/settings/navigation/+page.svelte
+++ b/src/routes/settings/navigation/+page.svelte
@@ -1,42 +1,8 @@
 <script lang="ts">
-	import {
-		LayoutDashboard,
-		TrendingUp,
-		Sparkles,
-		Wallet,
-		ArrowRightLeft,
-		Home,
-		ClipboardList,
-		Camera,
-		Banknote,
-		Coins,
-		Dices,
-		Settings,
-		Target,
-		Pin,
-		PinOff,
-		RotateCcw,
-		ChevronUp,
-		ChevronDown
-	} from 'lucide-svelte';
+	import { Pin, PinOff, RotateCcw, ChevronUp, ChevronDown } from 'lucide-svelte';
 	import { navPrefs, MAX_PINNED, DEFAULT_PINNED } from '$lib/stores/navPrefs.svelte';
+	import { NAV_ROUTES } from '$lib/nav/routes';
 	import { toast } from '$lib/stores/toast.svelte';
-
-	const ALL_ROUTES = [
-		{ href: '/', label: 'Dashboard', icon: LayoutDashboard },
-		{ href: '/metryki', label: 'Metryki', icon: TrendingUp },
-		{ href: '/simulations', label: 'Symulacje', icon: Sparkles },
-		{ href: '/retirement', label: 'Emerytura', icon: Dices },
-		{ href: '/accounts', label: 'Konta', icon: Wallet },
-		{ href: '/transactions', label: 'Transakcje', icon: ArrowRightLeft },
-		{ href: '/assets', label: 'Majątek', icon: Home },
-		{ href: '/bonds', label: 'Obligacje', icon: Coins },
-		{ href: '/debts', label: 'Zobowiązania', icon: ClipboardList },
-		{ href: '/goals', label: 'Cele', icon: Target },
-		{ href: '/snapshots', label: 'Snapshoty', icon: Camera },
-		{ href: '/salaries', label: 'Wynagrodzenia', icon: Banknote },
-		{ href: '/settings', label: 'Ustawienia', icon: Settings }
-	];
 
 	const pinned = $derived(navPrefs.pinned);
 
@@ -110,7 +76,7 @@
 		{:else}
 			<ol class="space-y-2">
 				{#each pinned as href, i (href)}
-					{@const item = ALL_ROUTES.find((r) => r.href === href)}
+					{@const item = NAV_ROUTES.find((r) => r.href === href)}
 					{#if item}
 						<li class="flex items-center gap-3 px-3 py-2 rounded-container bg-surface-50-950">
 							<item.icon size={18} class="text-primary-500" />
@@ -151,7 +117,7 @@
 	<section class="card preset-filled-surface-100-900 p-4 space-y-3">
 		<h3 class="h4 font-semibold">Dostępne</h3>
 		<ul class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-			{#each ALL_ROUTES.filter((r) => !isPinned(r.href)) as item (item.href)}
+			{#each NAV_ROUTES.filter((r) => !isPinned(r.href)) as item (item.href)}
 				<li>
 					<button
 						type="button"


### PR DESCRIPTION
## Motivation

Mobile bottom nav currently scrolls 13 routes horizontally — discovery is poor and off-screen routes are easy to miss.

## Implementation information

- New `BottomSheet.svelte` with drag-to-dismiss (>100px on the handle dismisses; pointer capture on the sheet, touch-action only on the handle so the list inside scrolls)
- New `navPrefs.svelte.ts` reactive store: ordered list of pinned routes, persisted to localStorage, 1–4 items, defaults to Dashboard/Snapshots/Accounts/Goals
- Mobile nav switches from horizontal scroll to a fixed grid of pinned items + a "Więcej" button that opens the sheet with the rest
- New `/settings/navigation` tab to pin/unpin/reorder routes; blocks unpinning the last item and capping at 4
- Active state on the More button when any overflow route is active

Closes #366

> Changelog: feat(nav): mobile bottom-nav More overflow sheet