### PR TITLE
feat(simulations): WIBOR rate-shock scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ e2e/.auth/
 # Misc
 .vercel
 .netlify
+.claude/

--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -5597,6 +5597,85 @@
         ]
       }
     },
+    "/api/simulations/wibor": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "inputs": {
+                      "properties": {
+                        "base_annual_rate": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "base_payment": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "remaining_months": {
+                          "type": "integer"
+                        },
+                        "remaining_principal": {
+                          "format": "double",
+                          "type": "number"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "scenarios": {
+                      "items": {
+                        "properties": {
+                          "annual_rate": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "delta_pp": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "monthly_payment": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "rate_floored": {
+                            "type": "boolean"
+                          },
+                          "term_months": {
+                            "type": "integer"
+                          },
+                          "total_interest": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "yearly_balances": {
+                            "items": {
+                              "format": "double",
+                              "type": "number"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "WIBOR rate-shock scenarios",
+        "tags": [
+          "simulations"
+        ]
+      }
+    },
     "/api/snapshots": {
       "get": {
         "responses": {

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -164,6 +164,7 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 
 	simHandler := simulations.NewHandler(simulations.NewStore(pool), logger)
 	r.Post("/api/simulations/mortgage-vs-invest", simHandler.MortgageVsInvest)
+	r.Post("/api/simulations/wibor", simHandler.WiborScenarios)
 	r.Post("/api/simulations/retirement", simHandler.Retirement)
 	r.Get("/api/simulations/prefill", simHandler.Prefill)
 	r.Post("/api/simulations/monte-carlo", simHandler.MonteCarlo)

--- a/backend-go/internal/simulations/handler.go
+++ b/backend-go/internal/simulations/handler.go
@@ -179,9 +179,8 @@ type wiborScenarioWire struct {
 }
 
 type wiborResponse struct {
-	Inputs      wiborInputsWire     `json:"inputs"`
-	BasePayment pyFloat             `json:"base_payment"`
-	Scenarios   []wiborScenarioWire `json:"scenarios"`
+	Inputs    wiborInputsWire     `json:"inputs"`
+	Scenarios []wiborScenarioWire `json:"scenarios"`
 }
 
 // WiborScenarios serves POST /api/simulations/wibor.
@@ -202,9 +201,8 @@ func (h *Handler) WiborScenarios(w http.ResponseWriter, r *http.Request) {
 			RemainingPrincipal: pyFloat(in.RemainingPrincipal),
 			BaseAnnualRate:     pyFloat(in.BaseAnnualRate),
 			RemainingMonths:    in.RemainingMonths,
-			BasePayment:        pyFloat(in.BasePayment),
+			BasePayment:        pyFloat(result.BasePayment),
 		},
-		BasePayment: pyFloat(result.BasePayment),
 	}
 	resp.Scenarios = make([]wiborScenarioWire, 0, len(result.Scenarios))
 	for _, s := range result.Scenarios {

--- a/backend-go/internal/simulations/handler.go
+++ b/backend-go/internal/simulations/handler.go
@@ -159,6 +159,72 @@ func (h *Handler) MortgageVsInvest(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// --- WIBOR scenarios wire types ---
+
+type wiborInputsWire struct {
+	RemainingPrincipal pyFloat `json:"remaining_principal"`
+	BaseAnnualRate     pyFloat `json:"base_annual_rate"`
+	RemainingMonths    int     `json:"remaining_months"`
+	BasePayment        pyFloat `json:"base_payment"`
+}
+
+type wiborScenarioWire struct {
+	DeltaPP        pyFloat   `json:"delta_pp"`
+	AnnualRate     pyFloat   `json:"annual_rate"`
+	MonthlyPayment pyFloat   `json:"monthly_payment"`
+	TotalInterest  pyFloat   `json:"total_interest"`
+	TermMonths     int       `json:"term_months"`
+	RateFloored    bool      `json:"rate_floored"`
+	YearlyBalances []pyFloat `json:"yearly_balances"`
+}
+
+type wiborResponse struct {
+	Inputs      wiborInputsWire     `json:"inputs"`
+	BasePayment pyFloat             `json:"base_payment"`
+	Scenarios   []wiborScenarioWire `json:"scenarios"`
+}
+
+// WiborScenarios serves POST /api/simulations/wibor.
+func (h *Handler) WiborScenarios(w http.ResponseWriter, r *http.Request) {
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	in, vErr := buildWiborInputs(raw)
+	if vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	result := SimulateWiborScenarios(in, DefaultWiborDeltas)
+	resp := wiborResponse{
+		Inputs: wiborInputsWire{
+			RemainingPrincipal: pyFloat(in.RemainingPrincipal),
+			BaseAnnualRate:     pyFloat(in.BaseAnnualRate),
+			RemainingMonths:    in.RemainingMonths,
+			BasePayment:        pyFloat(in.BasePayment),
+		},
+		BasePayment: pyFloat(result.BasePayment),
+	}
+	resp.Scenarios = make([]wiborScenarioWire, 0, len(result.Scenarios))
+	for _, s := range result.Scenarios {
+		balances := make([]pyFloat, 0, len(s.YearlyBalances))
+		for _, b := range s.YearlyBalances {
+			balances = append(balances, pyFloat(b))
+		}
+		resp.Scenarios = append(resp.Scenarios, wiborScenarioWire{
+			DeltaPP:        pyFloat(s.DeltaPP),
+			AnnualRate:     pyFloat(s.AnnualRate),
+			MonthlyPayment: pyFloat(s.MonthlyPayment),
+			TotalInterest:  pyFloat(s.TotalInterest),
+			TermMonths:     s.TermMonths,
+			RateFloored:    s.RateFloored,
+			YearlyBalances: balances,
+		})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // Prefill serves GET /api/simulations/prefill.
 func (h *Handler) Prefill(w http.ResponseWriter, r *http.Request) {
 	data, err := h.store.LoadPrefill(r.Context())

--- a/backend-go/internal/simulations/openapi.go
+++ b/backend-go/internal/simulations/openapi.go
@@ -11,4 +11,5 @@ var APISpec = []apispec.Route{
 	{Method: "POST", Path: "/api/simulations/retirement", Tag: "simulations", Summary: "Retirement account projection"},
 	{Method: "GET", Path: "/api/simulations/prefill", Tag: "simulations", Summary: "Prefill simulation inputs"},
 	{Method: "POST", Path: "/api/simulations/monte-carlo", Tag: "simulations", Summary: "Monte Carlo retirement projection", Response: MonteCarloResult{}},
+	{Method: "POST", Path: "/api/simulations/wibor", Tag: "simulations", Summary: "WIBOR rate-shock scenarios", Response: wiborResponse{}},
 }

--- a/backend-go/internal/simulations/validation.go
+++ b/backend-go/internal/simulations/validation.go
@@ -69,6 +69,46 @@ func buildMortgageInputs(raw map[string]json.RawMessage) (MortgageInputs, *valid
 	return in, nil
 }
 
+// --- WIBOR scenarios ---
+
+func buildWiborInputs(raw map[string]json.RawMessage) (WiborScenarioInputs, *validationError) {
+	var in WiborScenarioInputs
+	var vErr *validationError
+
+	in.RemainingPrincipal, vErr = requireFloat(raw, "remaining_principal")
+	if vErr != nil {
+		return in, vErr
+	}
+	if in.RemainingPrincipal <= 0 {
+		return in, &validationError{Field: "remaining_principal", Msg: "Remaining principal must be positive"}
+	}
+	in.BaseAnnualRate, vErr = requireFloat(raw, "base_annual_rate")
+	if vErr != nil {
+		return in, vErr
+	}
+	if in.BaseAnnualRate <= 0 || in.BaseAnnualRate > 30 {
+		return in, &validationError{Field: "base_annual_rate", Msg: "Base annual rate must be between 0 and 30%"}
+	}
+	in.RemainingMonths, vErr = requireInt(raw, "remaining_months")
+	if vErr != nil {
+		return in, vErr
+	}
+	if in.RemainingMonths < 1 || in.RemainingMonths > 600 {
+		return in, &validationError{Field: "remaining_months", Msg: "Remaining months must be between 1 and 600"}
+	}
+	if v, ok := raw["base_payment"]; ok && !isNullRaw(v) {
+		f, err := floatFromRaw(v)
+		if err != nil {
+			return in, &validationError{Field: "base_payment", Msg: "must be a number"}
+		}
+		if f < 0 {
+			return in, &validationError{Field: "base_payment", Msg: "Base payment cannot be negative"}
+		}
+		in.BasePayment = f
+	}
+	return in, nil
+}
+
 // --- retirement ---
 
 type ikeIkzeInput struct {

--- a/backend-go/internal/simulations/validation.go
+++ b/backend-go/internal/simulations/validation.go
@@ -87,7 +87,7 @@ func buildWiborInputs(raw map[string]json.RawMessage) (WiborScenarioInputs, *val
 		return in, vErr
 	}
 	if in.BaseAnnualRate <= 0 || in.BaseAnnualRate > 30 {
-		return in, &validationError{Field: "base_annual_rate", Msg: "Base annual rate must be between 0 and 30%"}
+		return in, &validationError{Field: "base_annual_rate", Msg: "Base annual rate must be > 0 and <= 30%"}
 	}
 	in.RemainingMonths, vErr = requireInt(raw, "remaining_months")
 	if vErr != nil {

--- a/backend-go/internal/simulations/wibor.go
+++ b/backend-go/internal/simulations/wibor.go
@@ -27,7 +27,7 @@ type WiborScenarioRow struct {
 	RateFloored bool
 	// YearlyBalances are end-of-year mortgage balances under the
 	// rescheduled-payment scenario (bank recalcs payment to keep the
-	// original term). Length == ceil(TermMonths/12) at most.
+	// original term). Length == ceil(RemainingMonths/12).
 	YearlyBalances []float64
 }
 

--- a/backend-go/internal/simulations/wibor.go
+++ b/backend-go/internal/simulations/wibor.go
@@ -1,0 +1,138 @@
+package simulations
+
+import "math"
+
+// WiborScenarioInputs is the validated payload for /api/simulations/wibor.
+//
+// BaseAnnualRate is the current effective rate (WIBOR + bank margin) on the
+// loan. Scenarios are applied as additive percentage-point shocks to this
+// base; e.g. +2 pp means a 200-bps rise in the effective rate.
+type WiborScenarioInputs struct {
+	RemainingPrincipal float64
+	BaseAnnualRate     float64
+	RemainingMonths    int
+	BasePayment        float64
+}
+
+// WiborScenarioRow is one rate shock's projection.
+type WiborScenarioRow struct {
+	DeltaPP        float64
+	AnnualRate     float64
+	MonthlyPayment float64
+	TotalInterest  float64
+	TermMonths     int
+	// RateFloored is true when the requested shock would push the effective
+	// rate at or below zero, and the simulator clamped it to a positive
+	// floor (0.01%) so the math remains valid.
+	RateFloored bool
+	// YearlyBalances are end-of-year mortgage balances under the
+	// rescheduled-payment scenario (bank recalcs payment to keep the
+	// original term). Length == ceil(TermMonths/12) at most.
+	YearlyBalances []float64
+}
+
+// WiborScenarioResult bundles the base payment with each scenario.
+type WiborScenarioResult struct {
+	BasePayment float64
+	Scenarios   []WiborScenarioRow
+}
+
+// DefaultWiborDeltas are the standard shocks per #371.
+var DefaultWiborDeltas = []float64{-1, 0, 1, 2, 3}
+
+// SimulateWiborScenarios computes, for each rate shock:
+//   - the new monthly payment that fully amortizes the remaining principal over
+//     the original term at the shocked rate;
+//   - the cumulative interest paid over that term;
+//   - the term required if the borrower keeps paying BasePayment at the new
+//     rate (clamped to 1200 months to bound runaway scenarios where the
+//     base payment can't cover monthly interest).
+//
+// Pure function — same inputs always produce same outputs.
+func SimulateWiborScenarios(in WiborScenarioInputs, deltas []float64) WiborScenarioResult {
+	rows := make([]WiborScenarioRow, 0, len(deltas))
+	for _, d := range deltas {
+		requested := in.BaseAnnualRate + d
+		rate := requested
+		floored := false
+		if rate <= 0 {
+			rate = 0.01
+			floored = true
+		}
+		monthlyRate := rate / 100 / 12
+		n := float64(in.RemainingMonths)
+		var payment float64
+		if monthlyRate == 0 {
+			payment = in.RemainingPrincipal / n
+		} else {
+			factor := math.Pow(1+monthlyRate, n)
+			payment = in.RemainingPrincipal * (monthlyRate * factor) / (factor - 1)
+		}
+		totalInterest := payment*n - in.RemainingPrincipal
+
+		termMonths := in.RemainingMonths
+		if in.BasePayment > 0 {
+			termMonths = termAtFixedPayment(in.RemainingPrincipal, monthlyRate, in.BasePayment)
+		}
+
+		rows = append(rows, WiborScenarioRow{
+			DeltaPP:        d,
+			AnnualRate:     round(rate, 4),
+			MonthlyPayment: round(payment, 2),
+			TotalInterest:  round(totalInterest, 2),
+			TermMonths:     termMonths,
+			RateFloored:    floored,
+			YearlyBalances: yearlyAmortization(in.RemainingPrincipal, monthlyRate, payment, in.RemainingMonths),
+		})
+	}
+	return WiborScenarioResult{BasePayment: round(in.BasePayment, 2), Scenarios: rows}
+}
+
+// yearlyAmortization returns the end-of-year mortgage balance for each year
+// of the loan under the rescheduled-payment scenario. Element [0] is the
+// balance at the end of year 1.
+func yearlyAmortization(principal, monthlyRate, payment float64, months int) []float64 {
+	years := (months + 11) / 12
+	out := make([]float64, 0, years)
+	balance := principal
+	for m := 1; m <= months; m++ {
+		interest := balance * monthlyRate
+		principalPaid := payment - interest
+		balance -= principalPaid
+		if balance < 0 {
+			balance = 0
+		}
+		if m%12 == 0 || m == months {
+			out = append(out, round(balance, 2))
+		}
+	}
+	return out
+}
+
+// termAtFixedPayment returns the number of months needed to amortize
+// `principal` at monthly rate `r` while paying `payment` each month. Returns
+// the loan's original term cap (1200 months / 100 years) when payment doesn't
+// cover monthly interest — the loan would never amortize.
+func termAtFixedPayment(principal, monthlyRate, payment float64) int {
+	const maxTermMonths = 1200
+	if monthlyRate <= 0 {
+		months := math.Ceil(principal / payment)
+		if months > maxTermMonths {
+			return maxTermMonths
+		}
+		return int(months)
+	}
+	monthlyInterestAtStart := principal * monthlyRate
+	if payment <= monthlyInterestAtStart {
+		return maxTermMonths
+	}
+	denom := 1 - monthlyRate*principal/payment
+	if denom <= 0 {
+		return maxTermMonths
+	}
+	months := -math.Log(denom) / math.Log(1+monthlyRate)
+	if months > maxTermMonths {
+		return maxTermMonths
+	}
+	return int(math.Ceil(months))
+}

--- a/backend-go/internal/simulations/wibor_test.go
+++ b/backend-go/internal/simulations/wibor_test.go
@@ -1,0 +1,132 @@
+package simulations
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSimulateWiborScenarios_BaselineMatchesAnnuityFormula(t *testing.T) {
+	in := WiborScenarioInputs{
+		RemainingPrincipal: 300000,
+		BaseAnnualRate:     6.5,
+		RemainingMonths:    240,
+		BasePayment:        2237.40,
+	}
+	out := SimulateWiborScenarios(in, []float64{0})
+	if len(out.Scenarios) != 1 {
+		t.Fatalf("expected 1 scenario, got %d", len(out.Scenarios))
+	}
+	s := out.Scenarios[0]
+	// 300000 @ 6.5% / 240 months -> ~2236.72
+	if math.Abs(s.MonthlyPayment-2236.72) > 1.0 {
+		t.Errorf("baseline payment = %f, expected ~2236.72", s.MonthlyPayment)
+	}
+	expectedInterest := s.MonthlyPayment*float64(in.RemainingMonths) - in.RemainingPrincipal
+	if math.Abs(s.TotalInterest-round(expectedInterest, 2)) > 1.0 {
+		t.Errorf("total interest = %f, expected %f", s.TotalInterest, expectedInterest)
+	}
+	if s.TermMonths != in.RemainingMonths {
+		t.Errorf("term at base payment = %d, expected %d", s.TermMonths, in.RemainingMonths)
+	}
+}
+
+func TestSimulateWiborScenarios_PaymentRisesWithRate(t *testing.T) {
+	in := WiborScenarioInputs{
+		RemainingPrincipal: 300000,
+		BaseAnnualRate:     6.5,
+		RemainingMonths:    240,
+		BasePayment:        2237.40,
+	}
+	out := SimulateWiborScenarios(in, []float64{-1, 0, 1, 2, 3})
+	if len(out.Scenarios) != 5 {
+		t.Fatalf("expected 5 scenarios, got %d", len(out.Scenarios))
+	}
+	for i := 1; i < len(out.Scenarios); i++ {
+		if out.Scenarios[i].MonthlyPayment <= out.Scenarios[i-1].MonthlyPayment {
+			t.Errorf("payment should rise with rate, got %f then %f",
+				out.Scenarios[i-1].MonthlyPayment, out.Scenarios[i].MonthlyPayment)
+		}
+	}
+}
+
+func TestSimulateWiborScenarios_FixedPaymentExtendsTerm(t *testing.T) {
+	in := WiborScenarioInputs{
+		RemainingPrincipal: 300000,
+		BaseAnnualRate:     6.5,
+		RemainingMonths:    240,
+		BasePayment:        2237.40,
+	}
+	out := SimulateWiborScenarios(in, []float64{2})
+	if len(out.Scenarios) != 1 {
+		t.Fatalf("expected 1 scenario, got %d", len(out.Scenarios))
+	}
+	if out.Scenarios[0].TermMonths <= in.RemainingMonths {
+		t.Errorf("term should extend at higher rate when payment fixed, got %d (orig %d)",
+			out.Scenarios[0].TermMonths, in.RemainingMonths)
+	}
+}
+
+func TestSimulateWiborScenarios_CapsTermWhenPaymentBelowInterest(t *testing.T) {
+	in := WiborScenarioInputs{
+		RemainingPrincipal: 1000000,
+		BaseAnnualRate:     5,
+		RemainingMonths:    240,
+		BasePayment:        100, // way below monthly interest
+	}
+	out := SimulateWiborScenarios(in, []float64{5})
+	if out.Scenarios[0].TermMonths != 1200 {
+		t.Errorf("expected term capped to 1200, got %d", out.Scenarios[0].TermMonths)
+	}
+}
+
+func TestSimulateWiborScenarios_ZeroBasePaymentKeepsOriginalTerm(t *testing.T) {
+	in := WiborScenarioInputs{
+		RemainingPrincipal: 300000,
+		BaseAnnualRate:     6.5,
+		RemainingMonths:    240,
+	}
+	out := SimulateWiborScenarios(in, []float64{0, 2})
+	for _, s := range out.Scenarios {
+		if s.TermMonths != in.RemainingMonths {
+			t.Errorf("with no BasePayment, term should equal RemainingMonths, got %d", s.TermMonths)
+		}
+	}
+}
+
+func TestSimulateWiborScenarios_FloorsRateAtPositive(t *testing.T) {
+	in := WiborScenarioInputs{
+		RemainingPrincipal: 100000,
+		BaseAnnualRate:     0.5,
+		RemainingMonths:    120,
+	}
+	out := SimulateWiborScenarios(in, []float64{-5})
+	if out.Scenarios[0].AnnualRate <= 0 {
+		t.Errorf("rate should be floored above 0, got %f", out.Scenarios[0].AnnualRate)
+	}
+	if !out.Scenarios[0].RateFloored {
+		t.Errorf("RateFloored should flag the clamp, got false")
+	}
+}
+
+func TestSimulateWiborScenarios_BalanceConvergesToZero(t *testing.T) {
+	in := WiborScenarioInputs{
+		RemainingPrincipal: 100000,
+		BaseAnnualRate:     5,
+		RemainingMonths:    120,
+	}
+	out := SimulateWiborScenarios(in, []float64{0})
+	balances := out.Scenarios[0].YearlyBalances
+	if len(balances) == 0 {
+		t.Fatalf("expected non-empty yearly balances")
+	}
+	final := balances[len(balances)-1]
+	if final > 1.0 {
+		t.Errorf("end-of-term balance should be ~0, got %f", final)
+	}
+	for i := 1; i < len(balances); i++ {
+		if balances[i] > balances[i-1] {
+			t.Errorf("balance should decrease, year %d > year %d (%f > %f)",
+				i, i-1, balances[i], balances[i-1])
+		}
+	}
+}

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -3808,6 +3808,65 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/simulations/wibor": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** WIBOR rate-shock scenarios */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            inputs?: {
+                                /** Format: double */
+                                base_annual_rate?: number;
+                                /** Format: double */
+                                base_payment?: number;
+                                remaining_months?: number;
+                                /** Format: double */
+                                remaining_principal?: number;
+                            };
+                            scenarios?: {
+                                /** Format: double */
+                                annual_rate?: number;
+                                /** Format: double */
+                                delta_pp?: number;
+                                /** Format: double */
+                                monthly_payment?: number;
+                                rate_floored?: boolean;
+                                term_months?: number;
+                                /** Format: double */
+                                total_interest?: number;
+                                yearly_balances?: number[];
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/snapshots": {
         parameters: {
             query?: never;

--- a/src/routes/simulations/+layout.svelte
+++ b/src/routes/simulations/+layout.svelte
@@ -4,6 +4,7 @@
 	const tabs = [
 		{ href: '/simulations', label: 'Emerytalne' },
 		{ href: '/simulations/mortgage', label: 'Hipoteka' },
+		{ href: '/simulations/wibor', label: 'WIBOR' },
 		{ href: '/simulations/zus', label: 'Emerytura ZUS' },
 		{ href: '/simulations/kalkulator', label: 'Kalkulator' }
 	];

--- a/src/routes/simulations/wibor/+page.svelte
+++ b/src/routes/simulations/wibor/+page.svelte
@@ -16,8 +16,15 @@
 		yearly_balances: number[];
 	}
 
-	interface WiborResponse {
+	interface WiborInputs {
+		remaining_principal: number;
+		base_annual_rate: number;
+		remaining_months: number;
 		base_payment: number;
+	}
+
+	interface WiborResponse {
+		inputs: WiborInputs;
 		scenarios: ScenarioRow[];
 	}
 
@@ -26,7 +33,10 @@
 	let remainingMonths = $state(240);
 	let basePayment = $state(0);
 
-	let results: WiborResponse | null = $state(null);
+	let results = $state<WiborResponse | null>(null);
+	const baselinePayment = $derived(
+		results?.scenarios.find((s) => s.delta_pp === 0)?.monthly_payment ?? 0
+	);
 	let loading = $state(false);
 	let error = $state('');
 	let chartContainer: HTMLDivElement | undefined = $state();
@@ -36,6 +46,11 @@
 	async function runSimulation(): Promise<void> {
 		loading = true;
 		error = '';
+		if (chartHandle) {
+			chartHandle.dispose();
+			chartHandle = null;
+			chart = null;
+		}
 		results = null;
 		try {
 			const apiUrl = resolveApiUrl();
@@ -254,15 +269,15 @@
 									<td class="text-right">{row.annual_rate.toFixed(2)}%</td>
 									<td class="text-right">{formatCurrency(row.monthly_payment)} PLN</td>
 									<td
-										class="text-right {row.monthly_payment > results.base_payment
+										class="text-right {row.monthly_payment > baselinePayment
 											? 'text-error-500'
-											: row.monthly_payment < results.base_payment
+											: row.monthly_payment < baselinePayment
 												? 'text-success-500'
 												: ''}"
 									>
-										{#if results.base_payment > 0 && row.delta_pp !== 0}
-											{row.monthly_payment > results.base_payment ? '+' : ''}{formatCurrency(
-												row.monthly_payment - results.base_payment
+										{#if row.delta_pp !== 0}
+											{row.monthly_payment > baselinePayment ? '+' : ''}{formatCurrency(
+												row.monthly_payment - baselinePayment
 											)} PLN
 										{:else}
 											—

--- a/src/routes/simulations/wibor/+page.svelte
+++ b/src/routes/simulations/wibor/+page.svelte
@@ -1,0 +1,293 @@
+<script lang="ts">
+	import { onMount, tick } from 'svelte';
+	import { resolveApiUrl } from '$lib/api';
+	import * as echarts from 'echarts';
+	import type { EChartsOption } from 'echarts';
+	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
+	import { Info } from 'lucide-svelte';
+
+	interface ScenarioRow {
+		delta_pp: number;
+		annual_rate: number;
+		monthly_payment: number;
+		total_interest: number;
+		term_months: number;
+		rate_floored: boolean;
+		yearly_balances: number[];
+	}
+
+	interface WiborResponse {
+		base_payment: number;
+		scenarios: ScenarioRow[];
+	}
+
+	let remainingPrincipal = $state(300000);
+	let baseAnnualRate = $state(7.5);
+	let remainingMonths = $state(240);
+	let basePayment = $state(0);
+
+	let results: WiborResponse | null = $state(null);
+	let loading = $state(false);
+	let error = $state('');
+	let chartContainer: HTMLDivElement | undefined = $state();
+	let chartHandle: ChartHandle | null = null;
+	let chart: echarts.ECharts | null = null;
+
+	async function runSimulation(): Promise<void> {
+		loading = true;
+		error = '';
+		results = null;
+		try {
+			const apiUrl = resolveApiUrl();
+			const response = await fetch(`${apiUrl}/api/simulations/wibor`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					remaining_principal: remainingPrincipal,
+					base_annual_rate: baseAnnualRate,
+					remaining_months: remainingMonths,
+					base_payment: basePayment > 0 ? basePayment : null
+				})
+			});
+			if (!response.ok) {
+				const detail = await response.json().catch(() => ({ detail: response.statusText }));
+				throw new Error(detail.detail ?? response.statusText);
+			}
+			results = (await response.json()) as WiborResponse;
+			await tick();
+			renderChart();
+		} catch (err) {
+			console.error('WIBOR scenarios failed:', err);
+			if (err instanceof Error) error = err.message;
+		} finally {
+			loading = false;
+		}
+	}
+
+	const SCENARIO_COLORS = ['#A3BE8C', '#5E81AC', '#EBCB8B', '#D08770', '#BF616A'];
+
+	function renderChart(): void {
+		if (!results || !chartContainer) return;
+		if (!chartHandle) {
+			chartHandle = createChart(chartContainer);
+			chart = chartHandle.chart;
+		}
+		const maxYears = Math.max(...results.scenarios.map((s) => s.yearly_balances.length));
+		const xAxis = Array.from({ length: maxYears }, (_, i) => `Rok ${i + 1}`);
+		const series = results.scenarios.map((s, idx) => ({
+			name: formatDelta(s.delta_pp),
+			type: 'line' as const,
+			data: s.yearly_balances,
+			smooth: true,
+			showSymbol: false,
+			emphasis: { focus: 'series' as const },
+			itemStyle: { color: SCENARIO_COLORS[idx % SCENARIO_COLORS.length] },
+			lineStyle: { width: s.delta_pp === 0 ? 3 : 2 }
+		}));
+		const option: EChartsOption = {
+			title: { text: 'Saldo kredytu w czasie (amortyzacja)' },
+			tooltip: {
+				trigger: 'axis',
+				formatter: (params: unknown) => {
+					const list = params as Array<{ name: string; seriesName: string; value: number }>;
+					let out = `<strong>${list[0]?.name ?? ''}</strong><br/>`;
+					for (const p of list) {
+						const v = p.value ?? 0;
+						out += `${p.seriesName}: ${v.toLocaleString('pl-PL', { maximumFractionDigits: 0 })} PLN<br/>`;
+					}
+					return out;
+				}
+			},
+			legend: { data: series.map((s) => s.name), bottom: 0 },
+			grid: { left: '3%', right: '4%', bottom: '20%', containLabel: true },
+			xAxis: { type: 'category', data: xAxis },
+			yAxis: {
+				type: 'value',
+				name: 'Saldo (PLN)',
+				axisLabel: { formatter: (v: number) => `${(v / 1000).toFixed(0)}k` }
+			},
+			series
+		};
+		chart?.setOption(option);
+	}
+
+	function formatCurrency(value: number): string {
+		return value.toLocaleString('pl-PL', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+	}
+
+	function formatDelta(delta: number): string {
+		if (delta === 0) return 'obecna';
+		const sign = delta > 0 ? '+' : '';
+		return `${sign}${delta} pp`;
+	}
+
+	function formatMonths(m: number): string {
+		const years = Math.floor(m / 12);
+		const months = m % 12;
+		if (years === 0) return `${months} mies.`;
+		if (months === 0) return `${years} lat`;
+		return `${years} lat ${months} mies.`;
+	}
+
+	onMount(() => {
+		return () => {
+			chartHandle?.dispose();
+			chartHandle = null;
+			chart = null;
+		};
+	});
+</script>
+
+<svelte:head>
+	<title>WIBOR — Symulacje | Finansowa Forteca</title>
+</svelte:head>
+
+<div class="space-y-4">
+	<div class="flex items-center gap-2">
+		<h1 class="h1">Szoki WIBOR</h1>
+		<details class="relative inline-block">
+			<summary class="cursor-pointer text-surface-600-400" aria-label="Co to jest WIBOR">
+				<Info size={20} />
+			</summary>
+			<div
+				class="absolute left-0 z-20 mt-2 w-80 sm:w-96 card preset-filled-surface-100-900 p-3 text-sm shadow-xl"
+			>
+				<p>
+					<strong>WIBOR</strong> (Warsaw Interbank Offered Rate) to średnia stawka, po jakiej banki pożyczają
+					sobie pieniądze. Większość polskich hipotek ma oprocentowanie zmienne: rata = WIBOR (3M lub
+					6M) + marża banku. Gdy WIBOR rośnie, rata kredytu rośnie wraz z nim.
+				</p>
+				<p class="mt-2">
+					W 2022 WIBOR 3M wzrósł z ~0.2% do ~7.6% w ciągu roku — rata wzrosła o około 70%. Ta
+					symulacja pokazuje, jak rata i koszt odsetek zmieniają się przy szokach +/-1pp, +2pp,
+					+3pp.
+				</p>
+			</div>
+		</details>
+	</div>
+
+	<div class="grid grid-cols-1 lg:grid-cols-[400px_1fr] gap-6 items-start">
+		<div class="card preset-filled-surface-100-900 p-5 space-y-4">
+			<h2 class="h3">Parametry kredytu</h2>
+			<div class="flex flex-col gap-3">
+				<label class="label">
+					<span class="text-sm font-semibold">Pozostały kapitał (PLN)</span>
+					<input type="number" bind:value={remainingPrincipal} min="1" step="10000" class="input" />
+				</label>
+				<label class="label">
+					<span class="text-sm font-semibold">Obecne oprocentowanie (% rocznie)</span>
+					<input
+						type="number"
+						bind:value={baseAnnualRate}
+						min="0.1"
+						max="30"
+						step="0.1"
+						class="input"
+					/>
+					<span class="text-xs text-surface-600-400">WIBOR + marża banku</span>
+				</label>
+				<label class="label">
+					<span class="text-sm font-semibold">Pozostałe miesiące</span>
+					<input
+						type="number"
+						bind:value={remainingMonths}
+						min="1"
+						max="600"
+						step="1"
+						class="input"
+					/>
+					<span class="text-xs text-surface-600-400">
+						{Math.floor(remainingMonths / 12)} lat {remainingMonths % 12} mies.
+					</span>
+				</label>
+				<label class="label">
+					<span class="text-sm font-semibold">Obecna rata (PLN, opcjonalnie)</span>
+					<input type="number" bind:value={basePayment} min="0" step="50" class="input" />
+					<span class="text-xs text-surface-600-400">
+						Zostaw 0 aby pominąć. Jeśli podasz, policzymy też, ile lat zajmie spłata przy tej racie
+						po szoku.
+					</span>
+				</label>
+			</div>
+
+			<button
+				class="btn preset-filled-primary-500 w-full"
+				onclick={runSimulation}
+				disabled={loading}
+			>
+				{loading ? 'Obliczanie...' : 'Policz scenariusze'}
+			</button>
+
+			{#if error}
+				<div class="card preset-filled-error-500 p-3 text-sm">{error}</div>
+			{/if}
+		</div>
+
+		{#if results}
+			<div class="card preset-filled-surface-100-900 p-5 space-y-4">
+				<h2 class="h3">Wyniki</h2>
+
+				<div class="table-wrap">
+					<table class="table table-hover text-sm">
+						<thead>
+							<tr>
+								<th>Scenariusz</th>
+								<th class="text-right">Oprocentowanie</th>
+								<th class="text-right">Rata miesięczna</th>
+								<th class="text-right">Δ rata</th>
+								<th class="text-right">Łączne odsetki</th>
+								{#if basePayment > 0}
+									<th class="text-right">Spłata przy obecnej racie</th>
+								{/if}
+							</tr>
+						</thead>
+						<tbody>
+							{#each results.scenarios as row (row.delta_pp)}
+								<tr class:font-semibold={row.delta_pp === 0}>
+									<td>
+										{formatDelta(row.delta_pp)}
+										{#if row.rate_floored}<span
+												class="ml-1 text-xs text-warning-500"
+												title="Szok obniżyłby stopę poniżej zera — przycięto do 0.01%">⚠</span
+											>{/if}
+									</td>
+									<td class="text-right">{row.annual_rate.toFixed(2)}%</td>
+									<td class="text-right">{formatCurrency(row.monthly_payment)} PLN</td>
+									<td
+										class="text-right {row.monthly_payment > results.base_payment
+											? 'text-error-500'
+											: row.monthly_payment < results.base_payment
+												? 'text-success-500'
+												: ''}"
+									>
+										{#if results.base_payment > 0 && row.delta_pp !== 0}
+											{row.monthly_payment > results.base_payment ? '+' : ''}{formatCurrency(
+												row.monthly_payment - results.base_payment
+											)} PLN
+										{:else}
+											—
+										{/if}
+									</td>
+									<td class="text-right">{formatCurrency(row.total_interest)} PLN</td>
+									{#if basePayment > 0}
+										<td class="text-right">
+											{row.term_months >= 1200 ? '> 100 lat' : formatMonths(row.term_months)}
+										</td>
+									{/if}
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+
+				<div bind:this={chartContainer} class="w-full h-[280px] sm:h-[380px]"></div>
+
+				<p class="text-xs text-surface-600-400">
+					Symulacja zakłada amortyzację w pozostałym okresie po szoku. Bank zwykle aktualizuje ratę
+					po zmianie WIBOR — kolumna <em>Spłata przy obecnej racie</em> pokazuje, ile lat zajmie spłata,
+					gdybyś zachował obecną wysokość raty.
+				</p>
+			</div>
+		{/if}
+	</div>
+</div>


### PR DESCRIPTION
## Motivation

Polish mortgages are mostly variable-rate (WIBOR-linked). Real risk during the 2022 rate spike (WIBOR 3M from ~0.2% to ~7.6% in a year). The existing mortgage simulator only does mortgage-vs-invest comparison — no rate-shock analysis.

## Implementation information

- Backend: pure `SimulateWiborScenarios` for the standard ±1/0/+1/+2/+3 pp shocks. For each scenario: new monthly payment (annuity formula), total interest over the original term, year-by-year balance trajectory for amortization curves, and — when the user supplies their current payment — the term required to amortize at that fixed payment (capped at 100 years).
- A `RateFloored` flag is returned when a downward shock would push the rate at or below zero; the simulator clamps to 0.01% and surfaces a ⚠ in the UI rather than silently producing a misleading row.
- New POST /api/simulations/wibor endpoint.
- New /simulations/wibor route with form + results table + multi-line amortization chart per scenario + educational WIBOR tooltip. Linked from the simulations layout tabs.

Closes #371

> Changelog: feat(simulations): WIBOR rate-shock scenarios