### PR TITLE
feat(transactions): recurring transactions

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -5106,10 +5106,14 @@
               "application/json": {
                 "schema": {
                   "properties": {
+                    "already_minted": {
+                      "type": "boolean"
+                    },
                     "date": {
                       "type": "string"
                     },
                     "transaction_id": {
+                      "nullable": true,
                       "type": "integer"
                     }
                   },

--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -4711,6 +4711,607 @@
         ]
       }
     },
+    "/api/recurring": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "recurring": {
+                      "items": {
+                        "properties": {
+                          "account_id": {
+                            "type": "integer"
+                          },
+                          "active": {
+                            "type": "boolean"
+                          },
+                          "amount": {
+                            "type": "string"
+                          },
+                          "category": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "day_of_month": {
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "end_date": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "frequency": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "last_run_date": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "next_occurrence": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "owner_user_id": {
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "skipped_dates": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "start_date": {
+                            "type": "string"
+                          },
+                          "transaction_type": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List recurring templates",
+        "tags": [
+          "recurring"
+        ]
+      },
+      "post": {
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account_id": {
+                      "type": "integer"
+                    },
+                    "active": {
+                      "type": "boolean"
+                    },
+                    "amount": {
+                      "type": "string"
+                    },
+                    "category": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "day_of_month": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "end_date": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "frequency": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "last_run_date": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "next_occurrence": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "skipped_dates": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "start_date": {
+                      "type": "string"
+                    },
+                    "transaction_type": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create a recurring template",
+        "tags": [
+          "recurring"
+        ]
+      }
+    },
+    "/api/recurring/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete a recurring template",
+        "tags": [
+          "recurring"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account_id": {
+                      "type": "integer"
+                    },
+                    "active": {
+                      "type": "boolean"
+                    },
+                    "amount": {
+                      "type": "string"
+                    },
+                    "category": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "day_of_month": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "end_date": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "frequency": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "last_run_date": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "next_occurrence": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "skipped_dates": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "start_date": {
+                      "type": "string"
+                    },
+                    "transaction_type": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get a recurring template",
+        "tags": [
+          "recurring"
+        ]
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account_id": {
+                      "type": "integer"
+                    },
+                    "active": {
+                      "type": "boolean"
+                    },
+                    "amount": {
+                      "type": "string"
+                    },
+                    "category": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "day_of_month": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "end_date": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "frequency": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "last_run_date": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "next_occurrence": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "skipped_dates": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "start_date": {
+                      "type": "string"
+                    },
+                    "transaction_type": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Update a recurring template",
+        "tags": [
+          "recurring"
+        ]
+      }
+    },
+    "/api/recurring/{id}/run-now": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "date": {
+                      "type": "string"
+                    },
+                    "transaction_id": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Mint an ad-hoc transaction now",
+        "tags": [
+          "recurring"
+        ]
+      }
+    },
+    "/api/recurring/{id}/skip": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account_id": {
+                      "type": "integer"
+                    },
+                    "active": {
+                      "type": "boolean"
+                    },
+                    "amount": {
+                      "type": "string"
+                    },
+                    "category": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "day_of_month": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "end_date": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "frequency": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "last_run_date": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "next_occurrence": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "skipped_dates": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "start_date": {
+                      "type": "string"
+                    },
+                    "transaction_type": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Skip an occurrence",
+        "tags": [
+          "recurring"
+        ]
+      }
+    },
+    "/api/recurring/{id}/unskip": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account_id": {
+                      "type": "integer"
+                    },
+                    "active": {
+                      "type": "boolean"
+                    },
+                    "amount": {
+                      "type": "string"
+                    },
+                    "category": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "day_of_month": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "end_date": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "frequency": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "last_run_date": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "next_occurrence": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "owner_user_id": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "skipped_dates": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "start_date": {
+                      "type": "string"
+                    },
+                    "transaction_type": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Resume a previously skipped occurrence",
+        "tags": [
+          "recurring"
+        ]
+      }
+    },
     "/api/retirement/limits/{year}": {
       "get": {
         "parameters": [

--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/bonds"
 	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 	"github.com/Automaat/finance-buddy/backend-go/internal/db"
+	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/scheduler"
 	"github.com/Automaat/finance-buddy/backend-go/internal/server"
 )
@@ -110,6 +111,10 @@ func run() int {
 		// CPI monthly-refresh scheduler — replaces the Python APScheduler job.
 		sched := scheduler.NewCPIScheduler(cpi.NewStore(pool), cpi.NewGUSFetcher(), logger)
 		go sched.Run(ctx)
+
+		// Daily recurring-transaction generator (issue #384).
+		recSched := recurring.NewScheduler(recurring.NewStore(pool), logger)
+		go recSched.Run(ctx)
 	} else {
 		logger.Warn("no DB config (DATABASE_URL or PGHOST) — DB-backed endpoints will 404")
 	}

--- a/backend-go/cmd/gen-openapi/routes.go
+++ b/backend-go/cmd/gen-openapi/routes.go
@@ -16,6 +16,7 @@ import (
 	equitygrants "github.com/Automaat/finance-buddy/backend-go/internal/equity_grants"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/investment"
+	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
 	"github.com/Automaat/finance-buddy/backend-go/internal/salaries"
 	"github.com/Automaat/finance-buddy/backend-go/internal/simulations"
@@ -58,6 +59,7 @@ func allRoutes() []apispec.Route {
 		investment.APISpec,
 		simulations.APISpec,
 		transactions.APISpec,
+		recurring.APISpec,
 		debtpayments.APISpec,
 		debts.APISpec,
 		allocation.APISpec,

--- a/backend-go/internal/db/migrate.go
+++ b/backend-go/internal/db/migrate.go
@@ -61,6 +61,44 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
 	if err := addAppConfigWithdrawalRate(ctx, pool); err != nil {
 		return err
 	}
+	if err := createRecurringTransactionsTable(ctx, pool); err != nil {
+		return err
+	}
+	return nil
+}
+
+// createRecurringTransactionsTable creates the recurring_transactions table
+// for issue #384 on existing databases. New installs get it from schema.sql.
+// Idempotent via IF NOT EXISTS.
+func createRecurringTransactionsTable(ctx context.Context, pool *pgxpool.Pool) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS recurring_transactions (
+			id serial PRIMARY KEY,
+			account_id integer NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+			amount numeric(15,2) NOT NULL,
+			owner_user_id integer REFERENCES users(id) ON DELETE RESTRICT,
+			transaction_type varchar(20),
+			category varchar(50),
+			description varchar(200) NOT NULL DEFAULT '',
+			frequency varchar(16) NOT NULL,
+			day_of_month integer,
+			start_date date NOT NULL,
+			end_date date,
+			active boolean NOT NULL DEFAULT true,
+			skipped_dates date[] NOT NULL DEFAULT ARRAY[]::date[],
+			last_run_date date,
+			created_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc'),
+			updated_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc')
+		)`,
+		`ALTER TABLE recurring_transactions ADD COLUMN IF NOT EXISTS category varchar(50)`,
+		`CREATE INDEX IF NOT EXISTS ix_recurring_transactions_active_account
+		   ON recurring_transactions (active, account_id)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := pool.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("create recurring_transactions: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/backend-go/internal/db/schema.sql
+++ b/backend-go/internal/db/schema.sql
@@ -667,6 +667,11 @@ CREATE TABLE public.recurring_transactions (
     updated_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc')
 );
 
+
+--
+-- Name: recurring_transactions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
 CREATE SEQUENCE public.recurring_transactions_id_seq
     AS integer
     START WITH 1
@@ -676,13 +681,6 @@ CREATE SEQUENCE public.recurring_transactions_id_seq
     CACHE 1;
 
 ALTER SEQUENCE public.recurring_transactions_id_seq OWNED BY public.recurring_transactions.id;
-ALTER TABLE ONLY public.recurring_transactions ALTER COLUMN id SET DEFAULT nextval('public.recurring_transactions_id_seq'::regclass);
-ALTER TABLE ONLY public.recurring_transactions ADD CONSTRAINT recurring_transactions_pkey PRIMARY KEY (id);
-ALTER TABLE ONLY public.recurring_transactions
-    ADD CONSTRAINT recurring_transactions_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(id) ON DELETE CASCADE;
-ALTER TABLE ONLY public.recurring_transactions
-    ADD CONSTRAINT recurring_transactions_owner_user_id_fkey FOREIGN KEY (owner_user_id) REFERENCES public.users(id) ON DELETE RESTRICT;
-CREATE INDEX ix_recurring_transactions_active_account ON public.recurring_transactions USING btree (active, account_id);
 
 
 --
@@ -822,6 +820,13 @@ ALTER TABLE ONLY public.snapshots ALTER COLUMN id SET DEFAULT nextval('public.sn
 --
 
 ALTER TABLE ONLY public.transactions ALTER COLUMN id SET DEFAULT nextval('public.transactions_id_seq'::regclass);
+
+
+--
+-- Name: recurring_transactions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recurring_transactions ALTER COLUMN id SET DEFAULT nextval('public.recurring_transactions_id_seq'::regclass);
 
 
 --
@@ -977,6 +982,21 @@ ALTER TABLE ONLY public.transactions
 
 
 --
+-- Name: recurring_transactions recurring_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recurring_transactions
+    ADD CONSTRAINT recurring_transactions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ix_recurring_transactions_active_account; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recurring_transactions_active_account ON public.recurring_transactions USING btree (active, account_id);
+
+
+--
 -- Name: snapshot_values uix_snapshot_account; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1110,6 +1130,14 @@ ALTER TABLE ONLY public.transactions
 
 
 --
+-- Name: recurring_transactions recurring_transactions_account_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recurring_transactions
+    ADD CONSTRAINT recurring_transactions_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(id) ON DELETE CASCADE;
+
+
+--
 -- Name: owner_user_id foreign keys; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1118,6 +1146,9 @@ ALTER TABLE ONLY public.accounts
 
 ALTER TABLE ONLY public.transactions
     ADD CONSTRAINT transactions_owner_user_id_fkey FOREIGN KEY (owner_user_id) REFERENCES public.users(id) ON DELETE RESTRICT;
+
+ALTER TABLE ONLY public.recurring_transactions
+    ADD CONSTRAINT recurring_transactions_owner_user_id_fkey FOREIGN KEY (owner_user_id) REFERENCES public.users(id) ON DELETE RESTRICT;
 
 ALTER TABLE ONLY public.salary_records
     ADD CONSTRAINT salary_records_owner_user_id_fkey FOREIGN KEY (owner_user_id) REFERENCES public.users(id) ON DELETE RESTRICT;

--- a/backend-go/internal/db/schema.sql
+++ b/backend-go/internal/db/schema.sql
@@ -645,6 +645,47 @@ CREATE TABLE public.transactions (
 
 
 --
+-- Name: recurring_transactions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.recurring_transactions (
+    id integer NOT NULL,
+    account_id integer NOT NULL,
+    amount numeric(15,2) NOT NULL,
+    owner_user_id integer,
+    transaction_type character varying(20),
+    category character varying(50),
+    description character varying(200) NOT NULL DEFAULT '',
+    frequency character varying(16) NOT NULL,
+    day_of_month integer,
+    start_date date NOT NULL,
+    end_date date,
+    active boolean NOT NULL DEFAULT true,
+    skipped_dates date[] NOT NULL DEFAULT ARRAY[]::date[],
+    last_run_date date,
+    created_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc'),
+    updated_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc')
+);
+
+CREATE SEQUENCE public.recurring_transactions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.recurring_transactions_id_seq OWNED BY public.recurring_transactions.id;
+ALTER TABLE ONLY public.recurring_transactions ALTER COLUMN id SET DEFAULT nextval('public.recurring_transactions_id_seq'::regclass);
+ALTER TABLE ONLY public.recurring_transactions ADD CONSTRAINT recurring_transactions_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.recurring_transactions
+    ADD CONSTRAINT recurring_transactions_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.recurring_transactions
+    ADD CONSTRAINT recurring_transactions_owner_user_id_fkey FOREIGN KEY (owner_user_id) REFERENCES public.users(id) ON DELETE RESTRICT;
+CREATE INDEX ix_recurring_transactions_active_account ON public.recurring_transactions USING btree (active, account_id);
+
+
+--
 -- Name: transactions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 

--- a/backend-go/internal/recurring/handler.go
+++ b/backend-go/internal/recurring/handler.go
@@ -54,8 +54,9 @@ type listResponse struct {
 }
 
 type runNowResponse struct {
-	TransactionID int    `json:"transaction_id"`
+	TransactionID *int   `json:"transaction_id"`
 	Date          string `json:"date"`
+	AlreadyMinted bool   `json:"already_minted"`
 }
 
 func formatDate(t time.Time) string { return t.UTC().Format("2006-01-02") }
@@ -66,7 +67,10 @@ func formatDatePtr(t *time.Time) *string {
 	s := formatDate(*t)
 	return &s
 }
-func formatTimestamp(t time.Time) string { return t.UTC().Format("2006-01-02T15:04:05") }
+
+// formatTimestamp matches the isoNaive layout used across the rest of the Go
+// API (microsecond precision, naive UTC). Cf. internal/transactions/handler.go.
+func formatTimestamp(t time.Time) string { return t.UTC().Format("2006-01-02T15:04:05.999999") }
 
 func (h *Handler) toResponse(r Recurring) response {
 	skips := make([]string, 0, len(r.SkippedDates))
@@ -81,7 +85,7 @@ func (h *Handler) toResponse(r Recurring) response {
 	return response{
 		ID:              r.ID,
 		AccountID:       r.AccountID,
-		Amount:          r.Amount.String(),
+		Amount:          r.Amount.StringFixed(2),
 		OwnerUserID:     r.OwnerUserID,
 		TransactionType: r.TransactionType,
 		Category:        r.Category,
@@ -220,19 +224,20 @@ func (h *Handler) RunNow(w http.ResponseWriter, r *http.Request) {
 	}
 	today := h.now().UTC().Truncate(24 * time.Hour)
 	txID, err := h.store.MintOccurrence(r.Context(), row, today)
-	if err != nil {
-		if IsAlreadyMinted(err) {
-			writeError(w, http.StatusConflict, "Occurrence already minted for today")
-			return
-		}
+	if err != nil && !IsAlreadyMinted(err) {
 		h.logger.Error("run-now mint", "err", err)
 		writeError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	writeJSON(w, http.StatusCreated, map[string]any{
-		"transaction_id": txID,
-		"date":           formatDate(today),
-	})
+	resp := runNowResponse{Date: formatDate(today), AlreadyMinted: IsAlreadyMinted(err)}
+	if !resp.AlreadyMinted {
+		resp.TransactionID = &txID
+	}
+	status := http.StatusCreated
+	if resp.AlreadyMinted {
+		status = http.StatusOK
+	}
+	writeJSON(w, status, resp)
 }
 
 // Skip serves POST /api/recurring/{id}/skip — adds the supplied date (or

--- a/backend-go/internal/recurring/handler.go
+++ b/backend-go/internal/recurring/handler.go
@@ -1,0 +1,533 @@
+package recurring
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+)
+
+// Handler is the HTTP boundary for /api/recurring.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+	now    func() time.Time
+}
+
+// NewHandler wires the store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger, now: time.Now}
+}
+
+type response struct {
+	ID              int      `json:"id"`
+	AccountID       int      `json:"account_id"`
+	Amount          string   `json:"amount"`
+	OwnerUserID     *int     `json:"owner_user_id"`
+	TransactionType *string  `json:"transaction_type"`
+	Category        *string  `json:"category"`
+	Description     string   `json:"description"`
+	Frequency       string   `json:"frequency"`
+	DayOfMonth      *int     `json:"day_of_month"`
+	StartDate       string   `json:"start_date"`
+	EndDate         *string  `json:"end_date"`
+	Active          bool     `json:"active"`
+	SkippedDates    []string `json:"skipped_dates"`
+	LastRunDate     *string  `json:"last_run_date"`
+	NextOccurrence  *string  `json:"next_occurrence"`
+	CreatedAt       string   `json:"created_at"`
+	UpdatedAt       string   `json:"updated_at"`
+}
+
+type listResponse struct {
+	Recurring []response `json:"recurring"`
+}
+
+type runNowResponse struct {
+	TransactionID int    `json:"transaction_id"`
+	Date          string `json:"date"`
+}
+
+func formatDate(t time.Time) string { return t.UTC().Format("2006-01-02") }
+func formatDatePtr(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := formatDate(*t)
+	return &s
+}
+func formatTimestamp(t time.Time) string { return t.UTC().Format("2006-01-02T15:04:05") }
+
+func (h *Handler) toResponse(r Recurring) response {
+	skips := make([]string, 0, len(r.SkippedDates))
+	for _, s := range r.SkippedDates {
+		skips = append(skips, formatDate(s))
+	}
+	var next *string
+	if n, ok := NextOccurrence(r, h.now().UTC()); ok {
+		s := formatDate(n)
+		next = &s
+	}
+	return response{
+		ID:              r.ID,
+		AccountID:       r.AccountID,
+		Amount:          r.Amount.String(),
+		OwnerUserID:     r.OwnerUserID,
+		TransactionType: r.TransactionType,
+		Category:        r.Category,
+		Description:     r.Description,
+		Frequency:       string(r.Frequency),
+		DayOfMonth:      r.DayOfMonth,
+		StartDate:       formatDate(r.StartDate),
+		EndDate:         formatDatePtr(r.EndDate),
+		Active:          r.Active,
+		SkippedDates:    skips,
+		LastRunDate:     formatDatePtr(r.LastRunDate),
+		NextOccurrence:  next,
+		CreatedAt:       formatTimestamp(r.CreatedAt),
+		UpdatedAt:       formatTimestamp(r.UpdatedAt),
+	}
+}
+
+// List serves GET /api/recurring.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.store.List(r.Context())
+	if err != nil {
+		h.logger.Error("list recurring", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := make([]response, 0, len(rows))
+	for i := range rows {
+		out = append(out, h.toResponse(rows[i]))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"recurring": out})
+}
+
+// Create serves POST /api/recurring.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	raw, err := readBody(r)
+	if err != nil {
+		writeValidation(w, "body", "Invalid JSON body")
+		return
+	}
+	in, vErr := buildInput(raw)
+	if vErr != nil {
+		writeValidation(w, vErr.Field, vErr.Msg)
+		return
+	}
+	exists, err := h.store.AccountExists(r.Context(), in.AccountID)
+	if err != nil {
+		h.logger.Error("account check", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	if !exists {
+		writeError(w, http.StatusBadRequest, "Account not found or inactive")
+		return
+	}
+	created, err := h.store.Create(r.Context(), in)
+	if err != nil {
+		h.logger.Error("create recurring", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, h.toResponse(created))
+}
+
+// Get serves GET /api/recurring/{id}.
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	row, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, h.toResponse(row))
+}
+
+// Update serves PUT /api/recurring/{id}.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	raw, err := readBody(r)
+	if err != nil {
+		writeValidation(w, "body", "Invalid JSON body")
+		return
+	}
+	in, vErr := buildInput(raw)
+	if vErr != nil {
+		writeValidation(w, vErr.Field, vErr.Msg)
+		return
+	}
+	exists, err := h.store.AccountExists(r.Context(), in.AccountID)
+	if err != nil {
+		h.logger.Error("account check", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	if !exists {
+		writeError(w, http.StatusBadRequest, "Account not found or inactive")
+		return
+	}
+	updated, err := h.store.Update(r.Context(), id, in)
+	if err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, h.toResponse(updated))
+}
+
+// Delete serves DELETE /api/recurring/{id}.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.Delete(r.Context(), id); err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// RunNow serves POST /api/recurring/{id}/run-now — mints an ad-hoc
+// transaction from the template, dated today.
+func (h *Handler) RunNow(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	row, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	today := h.now().UTC().Truncate(24 * time.Hour)
+	txID, err := h.store.MintOccurrence(r.Context(), row, today)
+	if err != nil {
+		if IsAlreadyMinted(err) {
+			writeError(w, http.StatusConflict, "Occurrence already minted for today")
+			return
+		}
+		h.logger.Error("run-now mint", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"transaction_id": txID,
+		"date":           formatDate(today),
+	})
+}
+
+// Skip serves POST /api/recurring/{id}/skip — adds the supplied date (or
+// today's next occurrence by default) to skipped_dates.
+func (h *Handler) Skip(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	row, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	date := r.URL.Query().Get("date")
+	var target time.Time
+	if date == "" {
+		next, found := NextOccurrence(row, h.now().UTC())
+		if !found {
+			writeError(w, http.StatusBadRequest, "No upcoming occurrence to skip")
+			return
+		}
+		target = next
+	} else {
+		t, err := time.Parse("2006-01-02", date)
+		if err != nil {
+			writeValidation(w, "date", "must be YYYY-MM-DD")
+			return
+		}
+		target = t
+	}
+	if err := h.store.AppendSkip(r.Context(), id, target); err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	updated, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, h.toResponse(updated))
+}
+
+// Unskip serves POST /api/recurring/{id}/unskip?date=YYYY-MM-DD — removes
+// the date from skipped_dates so the cadence resumes generating it.
+func (h *Handler) Unskip(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	date := r.URL.Query().Get("date")
+	if date == "" {
+		writeValidation(w, "date", "required")
+		return
+	}
+	target, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		writeValidation(w, "date", "must be YYYY-MM-DD")
+		return
+	}
+	if err := h.store.RemoveSkip(r.Context(), id, target); err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	updated, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, h.toResponse(updated))
+}
+
+func (h *Handler) writeStoreError(w http.ResponseWriter, err error) {
+	if errors.Is(err, ErrNotFound) {
+		writeError(w, http.StatusNotFound, "Recurring transaction not found")
+		return
+	}
+	h.logger.Error("recurring store", "err", err)
+	writeError(w, http.StatusInternalServerError, "Internal Server Error")
+}
+
+func parseID(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(raw)
+	if err != nil || id <= 0 {
+		writeValidation(w, "id", "must be a positive integer")
+		return 0, false
+	}
+	return id, true
+}
+
+func readBody(r *http.Request) (map[string]json.RawMessage, error) {
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func buildInput(raw map[string]json.RawMessage) (CreateInput, *validationError) {
+	var in CreateInput
+	if vErr := readAccountAndAmount(raw, &in); vErr != nil {
+		return in, vErr
+	}
+	if vErr := readOptionalStrings(raw, &in); vErr != nil {
+		return in, vErr
+	}
+	if vErr := readCadence(raw, &in); vErr != nil {
+		return in, vErr
+	}
+	return in, readDatesAndActive(raw, &in)
+}
+
+func readAccountAndAmount(raw map[string]json.RawMessage, in *CreateInput) *validationError {
+	if err := requireInt(raw, "account_id", &in.AccountID); err != nil {
+		return err
+	}
+	if in.AccountID <= 0 {
+		return &validationError{Field: "account_id", Msg: "must be positive"}
+	}
+	amount, err := requireDecimal(raw, "amount")
+	if err != nil {
+		return err
+	}
+	in.Amount = amount
+	if v, ok := raw["owner_user_id"]; ok && string(v) != "null" {
+		var n int
+		if jerr := json.Unmarshal(v, &n); jerr != nil {
+			return &validationError{Field: "owner_user_id", Msg: "must be integer or null"}
+		}
+		in.OwnerUserID = &n
+	}
+	return nil
+}
+
+func readOptionalStrings(raw map[string]json.RawMessage, in *CreateInput) *validationError {
+	if v, ok := raw["transaction_type"]; ok && string(v) != "null" {
+		var s string
+		if jerr := json.Unmarshal(v, &s); jerr != nil {
+			return &validationError{Field: "transaction_type", Msg: "must be a string"}
+		}
+		if s = strings.TrimSpace(s); s != "" {
+			in.TransactionType = &s
+		}
+	}
+	if v, ok := raw["category"]; ok && string(v) != "null" {
+		var s string
+		if jerr := json.Unmarshal(v, &s); jerr != nil {
+			return &validationError{Field: "category", Msg: "must be a string"}
+		}
+		if s = strings.TrimSpace(s); s != "" {
+			if len(s) > 50 {
+				return &validationError{Field: "category", Msg: "max 50 chars"}
+			}
+			in.Category = &s
+		}
+	}
+	if v, ok := raw["description"]; ok && string(v) != "null" {
+		if jerr := json.Unmarshal(v, &in.Description); jerr != nil {
+			return &validationError{Field: "description", Msg: "must be a string"}
+		}
+	}
+	if len(in.Description) > 200 {
+		return &validationError{Field: "description", Msg: "max 200 chars"}
+	}
+	return nil
+}
+
+func readCadence(raw map[string]json.RawMessage, in *CreateInput) *validationError {
+	var freq string
+	if err := requireString(raw, "frequency", &freq); err != nil {
+		return err
+	}
+	if !IsValidFrequency(freq) {
+		return &validationError{Field: "frequency", Msg: "invalid cadence"}
+	}
+	in.Frequency = Frequency(freq)
+	if v, ok := raw["day_of_month"]; ok && string(v) != "null" {
+		var d int
+		if jerr := json.Unmarshal(v, &d); jerr != nil {
+			return &validationError{Field: "day_of_month", Msg: "must be integer or null"}
+		}
+		if d < 1 || d > 31 {
+			return &validationError{Field: "day_of_month", Msg: "must be 1-31"}
+		}
+		in.DayOfMonth = &d
+	}
+	return nil
+}
+
+func readDatesAndActive(raw map[string]json.RawMessage, in *CreateInput) *validationError {
+	startStr, err := requireDate(raw, "start_date")
+	if err != nil {
+		return err
+	}
+	in.StartDate = startStr
+	if v, ok := raw["end_date"]; ok && string(v) != "null" {
+		var s string
+		if jerr := json.Unmarshal(v, &s); jerr != nil {
+			return &validationError{Field: "end_date", Msg: "must be YYYY-MM-DD or null"}
+		}
+		t, derr := time.Parse("2006-01-02", s)
+		if derr != nil {
+			return &validationError{Field: "end_date", Msg: "must be YYYY-MM-DD"}
+		}
+		if t.Before(in.StartDate) {
+			return &validationError{Field: "end_date", Msg: "must be on or after start_date"}
+		}
+		in.EndDate = &t
+	}
+	in.Active = true
+	if v, ok := raw["active"]; ok && string(v) != "null" {
+		if jerr := json.Unmarshal(v, &in.Active); jerr != nil {
+			return &validationError{Field: "active", Msg: "must be a boolean"}
+		}
+	}
+	return nil
+}
+
+func requireInt(raw map[string]json.RawMessage, key string, dest *int) *validationError {
+	v, ok := raw[key]
+	if !ok || string(v) == "null" {
+		return &validationError{Field: key, Msg: "required"}
+	}
+	if err := json.Unmarshal(v, dest); err != nil {
+		return &validationError{Field: key, Msg: "must be integer"}
+	}
+	return nil
+}
+
+func requireString(raw map[string]json.RawMessage, key string, dest *string) *validationError {
+	v, ok := raw[key]
+	if !ok || string(v) == "null" {
+		return &validationError{Field: key, Msg: "required"}
+	}
+	if err := json.Unmarshal(v, dest); err != nil {
+		return &validationError{Field: key, Msg: "must be a string"}
+	}
+	if *dest == "" {
+		return &validationError{Field: key, Msg: "cannot be empty"}
+	}
+	return nil
+}
+
+func requireDecimal(raw map[string]json.RawMessage, key string) (decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || string(v) == "null" {
+		return decimal.Zero, &validationError{Field: key, Msg: "required"}
+	}
+	// Parse from JSON bytes to preserve precision per CLAUDE.md guidance.
+	s := strings.Trim(string(v), `"`)
+	d, err := decimal.NewFromString(s)
+	if err != nil {
+		return decimal.Zero, &validationError{Field: key, Msg: "must be a number"}
+	}
+	return d, nil
+}
+
+func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *validationError) {
+	v, ok := raw[key]
+	if !ok || string(v) == "null" {
+		return time.Time{}, &validationError{Field: key, Msg: "required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be a string"}
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, &validationError{Field: key, Msg: "must be YYYY-MM-DD"}
+	}
+	return t, nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidation(w http.ResponseWriter, field, msg string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{"type": "value_error", "loc": []string{"body", field}, "msg": msg},
+		},
+	})
+}

--- a/backend-go/internal/recurring/occurrence.go
+++ b/backend-go/internal/recurring/occurrence.go
@@ -1,0 +1,138 @@
+package recurring
+
+import "time"
+
+// NextOccurrence returns the next date at or after `from` (inclusive) on which
+// the recurring template should fire, taking into account StartDate, EndDate,
+// SkippedDates, and the cadence. Returns (zero, false) when the template is
+// terminated (past EndDate, inactive, or no further occurrence in 10 years).
+func NextOccurrence(r Recurring, from time.Time) (time.Time, bool) {
+	if !r.Active {
+		return time.Time{}, false
+	}
+	skipped := skipSet(r.SkippedDates)
+	candidate := r.StartDate
+	if from.After(candidate) {
+		candidate = from
+	}
+	candidate = candidate.UTC().Truncate(24 * time.Hour)
+	limit := candidate.AddDate(10, 0, 0)
+
+	candidate = alignToCadence(r, candidate)
+
+	for candidate.Before(limit) {
+		if r.EndDate != nil && candidate.After(*r.EndDate) {
+			return time.Time{}, false
+		}
+		if !skipped[candidate.UTC().Format("2006-01-02")] {
+			return candidate, true
+		}
+		candidate = advance(r, candidate)
+	}
+	return time.Time{}, false
+}
+
+// DueOccurrences enumerates dates at which a recurring template should fire
+// strictly after LastRunDate (or its StartDate when never run) and on or
+// before `asOf`. Skipped + post-end dates are filtered out. Used by the
+// scheduler to mint concrete transactions on demand.
+func DueOccurrences(r Recurring, asOf time.Time) []time.Time {
+	if !r.Active {
+		return nil
+	}
+	asOf = asOf.UTC().Truncate(24 * time.Hour)
+	cursor := r.StartDate
+	if r.LastRunDate != nil {
+		cursor = advance(r, *r.LastRunDate)
+	}
+	cursor = alignToCadence(r, cursor)
+	skipped := skipSet(r.SkippedDates)
+	out := []time.Time{}
+	limit := asOf.AddDate(1, 0, 0) // safety net
+	for !cursor.After(asOf) && cursor.Before(limit) {
+		if r.EndDate != nil && cursor.After(*r.EndDate) {
+			break
+		}
+		if !skipped[cursor.Format("2006-01-02")] {
+			out = append(out, cursor)
+		}
+		cursor = advance(r, cursor)
+	}
+	return out
+}
+
+func skipSet(dates []time.Time) map[string]bool {
+	out := make(map[string]bool, len(dates))
+	for _, d := range dates {
+		out[d.UTC().Format("2006-01-02")] = true
+	}
+	return out
+}
+
+// alignToCadence pushes `t` forward to the next valid firing date for the
+// template's cadence — for monthly/quarterly/yearly that means the configured
+// day_of_month in the current period (or the next one if already past). For
+// weekly cadences it snaps to the next StartDate + 7n date >= t.
+func alignToCadence(r Recurring, t time.Time) time.Time {
+	switch r.Frequency {
+	case FrequencyDaily:
+		return t
+	case FrequencyWeekly:
+		if !t.After(r.StartDate) {
+			return r.StartDate
+		}
+		diffDays := int(t.Sub(r.StartDate).Hours() / 24)
+		weeks := diffDays / 7
+		candidate := r.StartDate.AddDate(0, 0, weeks*7)
+		if candidate.Before(t) {
+			candidate = candidate.AddDate(0, 0, 7)
+		}
+		return candidate
+	case FrequencyMonthly, FrequencyQuarterly, FrequencyYearly:
+		day := dayOfMonth(r)
+		candidate := monthlyAligned(t, day)
+		if candidate.Before(t) {
+			candidate = advance(r, candidate)
+		}
+		return candidate
+	}
+	return t
+}
+
+func monthlyAligned(t time.Time, day int) time.Time {
+	year, month, _ := t.Date()
+	last := lastDayOfMonth(year, month)
+	if day > last {
+		day = last
+	}
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}
+
+func lastDayOfMonth(year int, month time.Month) int {
+	first := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+	return first.AddDate(0, 1, -1).Day()
+}
+
+func dayOfMonth(r Recurring) int {
+	if r.DayOfMonth != nil && *r.DayOfMonth > 0 {
+		return *r.DayOfMonth
+	}
+	return r.StartDate.Day()
+}
+
+// advance returns the next firing date after t for the template's cadence.
+func advance(r Recurring, t time.Time) time.Time {
+	switch r.Frequency {
+	case FrequencyDaily:
+		return t.AddDate(0, 0, 1)
+	case FrequencyWeekly:
+		return t.AddDate(0, 0, 7)
+	case FrequencyMonthly:
+		return monthlyAligned(t.AddDate(0, 1, 0), dayOfMonth(r))
+	case FrequencyQuarterly:
+		return monthlyAligned(t.AddDate(0, 3, 0), dayOfMonth(r))
+	case FrequencyYearly:
+		return monthlyAligned(t.AddDate(1, 0, 0), dayOfMonth(r))
+	}
+	return t.AddDate(0, 0, 1)
+}

--- a/backend-go/internal/recurring/occurrence_test.go
+++ b/backend-go/internal/recurring/occurrence_test.go
@@ -1,0 +1,179 @@
+package recurring
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func mustParse(t *testing.T, s string) time.Time {
+	t.Helper()
+	out, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return out
+}
+
+func intPtr(v int) *int {
+	out := new(int)
+	*out = v
+	return out
+}
+
+func TestNextOccurrence_MonthlyAlignsToDay(t *testing.T) {
+	r := Recurring{
+		Active:     true,
+		Frequency:  FrequencyMonthly,
+		StartDate:  mustParse(t, "2026-01-01"),
+		DayOfMonth: intPtr(15),
+		Amount:     decimal.NewFromInt(1000),
+	}
+	got, ok := NextOccurrence(r, mustParse(t, "2026-01-20"))
+	if !ok {
+		t.Fatalf("expected occurrence, got none")
+	}
+	if got.Format("2006-01-02") != "2026-02-15" {
+		t.Errorf("expected 2026-02-15, got %s", got.Format("2006-01-02"))
+	}
+}
+
+func TestNextOccurrence_MonthlyClampsToShortMonth(t *testing.T) {
+	r := Recurring{
+		Active:     true,
+		Frequency:  FrequencyMonthly,
+		StartDate:  mustParse(t, "2026-01-31"),
+		DayOfMonth: intPtr(31),
+	}
+	got, ok := NextOccurrence(r, mustParse(t, "2026-02-01"))
+	if !ok {
+		t.Fatalf("expected occurrence")
+	}
+	if got.Format("2006-01-02") != "2026-02-28" {
+		t.Errorf("February clamp failed: got %s", got.Format("2006-01-02"))
+	}
+}
+
+func TestNextOccurrence_WeeklyAdvancesBy7(t *testing.T) {
+	r := Recurring{
+		Active:    true,
+		Frequency: FrequencyWeekly,
+		StartDate: mustParse(t, "2026-01-05"),
+	}
+	got, ok := NextOccurrence(r, mustParse(t, "2026-01-06"))
+	if !ok {
+		t.Fatalf("expected occurrence")
+	}
+	if got.Format("2006-01-02") != "2026-01-12" {
+		t.Errorf("expected 2026-01-12, got %s", got.Format("2006-01-02"))
+	}
+}
+
+func TestNextOccurrence_RespectsEndDate(t *testing.T) {
+	end := mustParse(t, "2026-02-28")
+	r := Recurring{
+		Active:     true,
+		Frequency:  FrequencyMonthly,
+		StartDate:  mustParse(t, "2026-01-15"),
+		DayOfMonth: intPtr(15),
+		EndDate:    &end,
+	}
+	_, ok := NextOccurrence(r, mustParse(t, "2026-03-01"))
+	if ok {
+		t.Errorf("should have no occurrence past EndDate")
+	}
+}
+
+func TestNextOccurrence_SkipsListedDates(t *testing.T) {
+	r := Recurring{
+		Active:       true,
+		Frequency:    FrequencyMonthly,
+		StartDate:    mustParse(t, "2026-01-15"),
+		DayOfMonth:   intPtr(15),
+		SkippedDates: []time.Time{mustParse(t, "2026-02-15")},
+	}
+	got, ok := NextOccurrence(r, mustParse(t, "2026-02-01"))
+	if !ok {
+		t.Fatalf("expected occurrence")
+	}
+	if got.Format("2006-01-02") != "2026-03-15" {
+		t.Errorf("expected March 15 (Feb skipped), got %s", got.Format("2006-01-02"))
+	}
+}
+
+func TestNextOccurrence_InactiveReturnsNone(t *testing.T) {
+	r := Recurring{Active: false, Frequency: FrequencyMonthly, StartDate: mustParse(t, "2026-01-01")}
+	if _, ok := NextOccurrence(r, mustParse(t, "2026-01-01")); ok {
+		t.Errorf("inactive template should yield no occurrence")
+	}
+}
+
+func TestDueOccurrences_FromStartUpToNow(t *testing.T) {
+	r := Recurring{
+		Active:     true,
+		Frequency:  FrequencyMonthly,
+		StartDate:  mustParse(t, "2026-01-15"),
+		DayOfMonth: intPtr(15),
+	}
+	got := DueOccurrences(r, mustParse(t, "2026-04-20"))
+	if len(got) != 4 {
+		t.Fatalf("expected 4 occurrences Jan/Feb/Mar/Apr, got %d", len(got))
+	}
+}
+
+func TestDueOccurrences_StartsAfterLastRun(t *testing.T) {
+	last := mustParse(t, "2026-02-15")
+	r := Recurring{
+		Active:      true,
+		Frequency:   FrequencyMonthly,
+		StartDate:   mustParse(t, "2026-01-15"),
+		DayOfMonth:  intPtr(15),
+		LastRunDate: &last,
+	}
+	got := DueOccurrences(r, mustParse(t, "2026-04-20"))
+	if len(got) != 2 {
+		t.Fatalf("expected Mar+Apr, got %d", len(got))
+	}
+	if got[0].Format("2006-01-02") != "2026-03-15" {
+		t.Errorf("first should be Mar 15, got %s", got[0])
+	}
+}
+
+func TestDueOccurrences_SkipsListedDates(t *testing.T) {
+	r := Recurring{
+		Active:       true,
+		Frequency:    FrequencyMonthly,
+		StartDate:    mustParse(t, "2026-01-15"),
+		DayOfMonth:   intPtr(15),
+		SkippedDates: []time.Time{mustParse(t, "2026-02-15")},
+	}
+	got := DueOccurrences(r, mustParse(t, "2026-03-20"))
+	if len(got) != 2 {
+		t.Fatalf("expected Jan + Mar (Feb skipped), got %d", len(got))
+	}
+}
+
+func TestDueOccurrences_RespectsEndDate(t *testing.T) {
+	end := mustParse(t, "2026-02-28")
+	r := Recurring{
+		Active:     true,
+		Frequency:  FrequencyMonthly,
+		StartDate:  mustParse(t, "2026-01-15"),
+		DayOfMonth: intPtr(15),
+		EndDate:    &end,
+	}
+	got := DueOccurrences(r, mustParse(t, "2026-05-01"))
+	if len(got) != 2 {
+		t.Fatalf("expected Jan + Feb only, got %d", len(got))
+	}
+}
+
+func TestIsValidFrequency(t *testing.T) {
+	if !IsValidFrequency("monthly") {
+		t.Errorf("monthly should be valid")
+	}
+	if IsValidFrequency("biweekly") {
+		t.Errorf("biweekly should be invalid")
+	}
+}

--- a/backend-go/internal/recurring/openapi.go
+++ b/backend-go/internal/recurring/openapi.go
@@ -1,0 +1,19 @@
+package recurring
+
+import (
+	"net/http"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+)
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "GET", Path: "/api/recurring", Tag: "recurring", Summary: "List recurring templates", Response: listResponse{}},
+	{Method: "POST", Path: "/api/recurring", Tag: "recurring", Summary: "Create a recurring template", Status: http.StatusCreated, Response: response{}},
+	{Method: "GET", Path: "/api/recurring/{id}", Tag: "recurring", Summary: "Get a recurring template", Response: response{}},
+	{Method: "PUT", Path: "/api/recurring/{id}", Tag: "recurring", Summary: "Update a recurring template", Response: response{}},
+	{Method: "DELETE", Path: "/api/recurring/{id}", Tag: "recurring", Summary: "Delete a recurring template", Status: http.StatusNoContent},
+	{Method: "POST", Path: "/api/recurring/{id}/run-now", Tag: "recurring", Summary: "Mint an ad-hoc transaction now", Status: http.StatusCreated, Response: runNowResponse{}},
+	{Method: "POST", Path: "/api/recurring/{id}/skip", Tag: "recurring", Summary: "Skip an occurrence", Response: response{}},
+	{Method: "POST", Path: "/api/recurring/{id}/unskip", Tag: "recurring", Summary: "Resume a previously skipped occurrence", Response: response{}},
+}

--- a/backend-go/internal/recurring/scheduler.go
+++ b/backend-go/internal/recurring/scheduler.go
@@ -1,0 +1,84 @@
+package recurring
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// Scheduler walks all active recurring templates and mints concrete
+// transactions for every occurrence that fell on or before `asOf` and hasn't
+// already been generated. ProcessDue is idempotent thanks to the
+// last_run_date watermark and per-template skip list.
+type Scheduler struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewScheduler wires the store + logger.
+func NewScheduler(store *Store, logger *slog.Logger) *Scheduler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Scheduler{store: store, logger: logger}
+}
+
+// ProcessDue iterates active templates and inserts any due transactions.
+// Returns the number of transactions created.
+func (s *Scheduler) ProcessDue(ctx context.Context, asOf time.Time) (int, error) {
+	rows, err := s.store.ListActive(ctx)
+	if err != nil {
+		return 0, err
+	}
+	created := 0
+	for i := range rows {
+		r := &rows[i]
+		due := DueOccurrences(*r, asOf)
+		for _, d := range due {
+			_, err := s.store.MintOccurrence(ctx, *r, d)
+			if IsAlreadyMinted(err) {
+				continue
+			}
+			if err != nil {
+				s.logger.Error("recurring: mint",
+					"recurring_id", r.ID, "date", d.Format("2006-01-02"), "err", err)
+				continue
+			}
+			created++
+		}
+	}
+	return created, nil
+}
+
+// Run loops fire ProcessDue daily at the configured hour (Europe/Warsaw if
+// available, else UTC). Intended to run in its own goroutine.
+func (s *Scheduler) Run(ctx context.Context) {
+	loc, err := time.LoadLocation("Europe/Warsaw")
+	if err != nil {
+		s.logger.Warn("recurring: tz unavailable, using UTC", "err", err)
+		loc = time.UTC
+	}
+	// Process immediately on boot so a fresh start mints any missed runs.
+	if n, err := s.ProcessDue(ctx, time.Now().UTC()); err != nil {
+		s.logger.Warn("recurring: startup pass failed", "err", err)
+	} else if n > 0 {
+		s.logger.Info("recurring: startup pass minted transactions", "count", n)
+	}
+	for {
+		now := time.Now().In(loc)
+		next := time.Date(now.Year(), now.Month(), now.Day()+1, 4, 0, 0, 0, loc)
+		wait := next.Sub(now)
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+			if n, err := s.ProcessDue(ctx, time.Now().UTC()); err != nil {
+				s.logger.Warn("recurring: nightly pass failed", "err", err)
+			} else if n > 0 {
+				s.logger.Info("recurring: nightly pass minted transactions", "count", n)
+			}
+		}
+	}
+}

--- a/backend-go/internal/recurring/store.go
+++ b/backend-go/internal/recurring/store.go
@@ -1,0 +1,269 @@
+package recurring
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Store is the persistence boundary for recurring transactions.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const recurringCols = `
+	id, account_id, amount, owner_user_id, transaction_type, category, description,
+	frequency, day_of_month, start_date, end_date, active, skipped_dates,
+	last_run_date, created_at, updated_at
+`
+
+func scanRow(row pgx.Row) (Recurring, error) {
+	var r Recurring
+	var freq string
+	if err := row.Scan(
+		&r.ID, &r.AccountID, &r.Amount, &r.OwnerUserID, &r.TransactionType, &r.Category,
+		&r.Description, &freq, &r.DayOfMonth, &r.StartDate, &r.EndDate, &r.Active,
+		&r.SkippedDates, &r.LastRunDate, &r.CreatedAt, &r.UpdatedAt,
+	); err != nil {
+		return Recurring{}, err
+	}
+	r.Frequency = Frequency(freq)
+	return r, nil
+}
+
+// List returns all recurring templates, ordered by creation.
+func (s *Store) List(ctx context.Context) ([]Recurring, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT `+recurringCols+`
+		FROM recurring_transactions
+		ORDER BY created_at DESC, id DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("list recurring: %w", err)
+	}
+	defer rows.Close()
+	out := []Recurring{}
+	for rows.Next() {
+		r, err := scanRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan recurring: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ListActive returns active templates only — used by the scheduler.
+func (s *Store) ListActive(ctx context.Context) ([]Recurring, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT `+recurringCols+`
+		FROM recurring_transactions
+		WHERE active = true
+		ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list active recurring: %w", err)
+	}
+	defer rows.Close()
+	out := []Recurring{}
+	for rows.Next() {
+		r, err := scanRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan active recurring: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// Get returns one template by ID, ErrNotFound when missing.
+func (s *Store) Get(ctx context.Context, id int) (Recurring, error) {
+	row := s.pool.QueryRow(ctx, `SELECT `+recurringCols+` FROM recurring_transactions WHERE id = $1`, id)
+	r, err := scanRow(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Recurring{}, ErrNotFound
+	}
+	if err != nil {
+		return Recurring{}, fmt.Errorf("get recurring %d: %w", id, err)
+	}
+	return r, nil
+}
+
+// CreateInput is the validated payload for Create.
+type CreateInput struct {
+	AccountID       int
+	Amount          decimal.Decimal
+	OwnerUserID     *int
+	TransactionType *string
+	Category        *string
+	Description     string
+	Frequency       Frequency
+	DayOfMonth      *int
+	StartDate       time.Time
+	EndDate         *time.Time
+	Active          bool
+}
+
+// Create inserts a new template, returning the persisted row.
+func (s *Store) Create(ctx context.Context, in CreateInput) (Recurring, error) {
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO recurring_transactions
+			(account_id, amount, owner_user_id, transaction_type, category, description,
+			 frequency, day_of_month, start_date, end_date, active)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		RETURNING `+recurringCols,
+		in.AccountID, in.Amount, in.OwnerUserID, in.TransactionType, in.Category, in.Description,
+		string(in.Frequency), in.DayOfMonth, in.StartDate, in.EndDate, in.Active,
+	)
+	return scanRow(row)
+}
+
+// UpdateInput is the validated payload for Update; same shape as CreateInput.
+type UpdateInput = CreateInput
+
+// Update overwrites a template. ErrNotFound when id is unknown.
+func (s *Store) Update(ctx context.Context, id int, in UpdateInput) (Recurring, error) {
+	row := s.pool.QueryRow(ctx, `
+		UPDATE recurring_transactions
+		SET account_id = $1, amount = $2, owner_user_id = $3, transaction_type = $4,
+		    category = $5, description = $6, frequency = $7, day_of_month = $8,
+		    start_date = $9, end_date = $10, active = $11,
+		    updated_at = (now() at time zone 'utc')
+		WHERE id = $12
+		RETURNING `+recurringCols,
+		in.AccountID, in.Amount, in.OwnerUserID, in.TransactionType, in.Category,
+		in.Description, string(in.Frequency), in.DayOfMonth, in.StartDate, in.EndDate,
+		in.Active, id,
+	)
+	r, err := scanRow(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Recurring{}, ErrNotFound
+	}
+	if err != nil {
+		return Recurring{}, fmt.Errorf("update recurring %d: %w", id, err)
+	}
+	return r, nil
+}
+
+// Delete removes the template. ErrNotFound when id is unknown.
+func (s *Store) Delete(ctx context.Context, id int) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM recurring_transactions WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete recurring %d: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// AppendSkip adds a date to skipped_dates (dedup at the SQL level).
+func (s *Store) AppendSkip(ctx context.Context, id int, date time.Time) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE recurring_transactions
+		SET skipped_dates = (
+		    SELECT array_agg(DISTINCT d ORDER BY d)
+		    FROM unnest(skipped_dates || $2::date) AS d
+		),
+		updated_at = (now() at time zone 'utc')
+		WHERE id = $1`, id, date)
+	if err != nil {
+		return fmt.Errorf("append skip on %d: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// RemoveSkip drops `date` from skipped_dates if present.
+func (s *Store) RemoveSkip(ctx context.Context, id int, date time.Time) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE recurring_transactions
+		SET skipped_dates = array_remove(skipped_dates, $2::date),
+		    updated_at = (now() at time zone 'utc')
+		WHERE id = $1`, id, date)
+	if err != nil {
+		return fmt.Errorf("remove skip on %d: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// AccountExists reports whether the given account id refers to an active
+// account; used to reject creates pointing at deleted accounts.
+func (s *Store) AccountExists(ctx context.Context, id int) (bool, error) {
+	var exists bool
+	if err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM accounts WHERE id = $1 AND is_active = true)`,
+		id,
+	).Scan(&exists); err != nil {
+		return false, fmt.Errorf("account presence check: %w", err)
+	}
+	return exists, nil
+}
+
+// MintOccurrence inserts a concrete transaction for `r` on `date` and records
+// the run, atomically and under a per-template advisory lock. The lock
+// serializes a concurrent scheduler tick and a user clicking "Run now" so the
+// same (recurring_id, date) cannot mint two transactions. Returns the new
+// transaction id.
+func (s *Store) MintOccurrence(ctx context.Context, r Recurring, date time.Time) (int, error) {
+	var id int
+	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+		if _, lockErr := tx.Exec(ctx,
+			`SELECT pg_advisory_xact_lock(hashtext($1))`,
+			fmt.Sprintf("recurring_%d", r.ID),
+		); lockErr != nil {
+			return fmt.Errorf("advisory lock: %w", lockErr)
+		}
+		var freshLast *time.Time
+		if err := tx.QueryRow(ctx,
+			`SELECT last_run_date FROM recurring_transactions WHERE id = $1`, r.ID,
+		).Scan(&freshLast); err != nil {
+			return fmt.Errorf("reload last_run_date: %w", err)
+		}
+		if freshLast != nil && !freshLast.Before(date) {
+			return errAlreadyMinted
+		}
+		if err := tx.QueryRow(ctx, `
+			INSERT INTO transactions (account_id, amount, date, owner_user_id, transaction_type, is_active, created_at)
+			VALUES ($1, $2, $3, $4, $5, true, (now() at time zone 'utc'))
+			RETURNING id`,
+			r.AccountID, r.Amount, date, r.OwnerUserID, r.TransactionType,
+		).Scan(&id); err != nil {
+			return fmt.Errorf("insert recurring-generated transaction: %w", err)
+		}
+		if _, err := tx.Exec(ctx, `
+			UPDATE recurring_transactions
+			SET last_run_date = $2, updated_at = (now() at time zone 'utc')
+			WHERE id = $1`, r.ID, date); err != nil {
+			return fmt.Errorf("update last_run_date: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+// errAlreadyMinted signals that a concurrent caller already minted this or a
+// later occurrence; mapped to nothing at the handler — Run Now silently
+// no-ops to keep the UI idempotent.
+var errAlreadyMinted = errors.New("recurring: occurrence already minted")
+
+// IsAlreadyMinted reports whether err is the already-minted sentinel.
+func IsAlreadyMinted(err error) bool {
+	return errors.Is(err, errAlreadyMinted)
+}

--- a/backend-go/internal/recurring/store.go
+++ b/backend-go/internal/recurring/store.go
@@ -259,8 +259,9 @@ func (s *Store) MintOccurrence(ctx context.Context, r Recurring, date time.Time)
 }
 
 // errAlreadyMinted signals that a concurrent caller already minted this or a
-// later occurrence; mapped to nothing at the handler — Run Now silently
-// no-ops to keep the UI idempotent.
+// later occurrence. The HTTP layer turns it into a 200 OK with
+// {already_minted: true} so Run Now is idempotent for the client; the
+// scheduler swallows it silently.
 var errAlreadyMinted = errors.New("recurring: occurrence already minted")
 
 // IsAlreadyMinted reports whether err is the already-minted sentinel.

--- a/backend-go/internal/recurring/types.go
+++ b/backend-go/internal/recurring/types.go
@@ -1,0 +1,72 @@
+// Package recurring implements scheduled / recurring transactions —
+// templates that generate concrete `transactions` rows on a cadence
+// (monthly salary, mortgage payment, subscriptions). Subissue of #355.
+//
+// The scheduler in internal/scheduler runs ProcessDue daily; the API in
+// handler.go exposes CRUD, manual "run now", and per-occurrence skip.
+package recurring
+
+import (
+	"errors"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Frequency is the recurrence cadence.
+type Frequency string
+
+const (
+	FrequencyDaily     Frequency = "daily"
+	FrequencyWeekly    Frequency = "weekly"
+	FrequencyMonthly   Frequency = "monthly"
+	FrequencyQuarterly Frequency = "quarterly"
+	FrequencyYearly    Frequency = "yearly"
+)
+
+var validFrequencies = []Frequency{
+	FrequencyDaily, FrequencyWeekly, FrequencyMonthly, FrequencyQuarterly, FrequencyYearly,
+}
+
+// IsValidFrequency reports whether s is a known cadence.
+func IsValidFrequency(s string) bool {
+	for _, f := range validFrequencies {
+		if string(f) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidFrequencies returns a fresh copy of the canonical cadence list.
+func ValidFrequencies() []Frequency {
+	out := make([]Frequency, len(validFrequencies))
+	copy(out, validFrequencies)
+	return out
+}
+
+// Recurring is a recurring-transaction template row.
+type Recurring struct {
+	ID              int
+	AccountID       int
+	Amount          decimal.Decimal
+	OwnerUserID     *int
+	TransactionType *string
+	Category        *string
+	Description     string
+	Frequency       Frequency
+	DayOfMonth      *int
+	StartDate       time.Time
+	EndDate         *time.Time
+	Active          bool
+	SkippedDates    []time.Time
+	LastRunDate     *time.Time
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+// Sentinel errors mapped to HTTP statuses by the handler.
+var (
+	ErrNotFound        = errors.New("recurring transaction not found")
+	ErrAccountNotFound = errors.New("account not found")
+)

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/investment"
+	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
 	"github.com/Automaat/finance-buddy/backend-go/internal/salaries"
 	"github.com/Automaat/finance-buddy/backend-go/internal/simulations"
@@ -133,6 +134,17 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	r.Get("/api/transactions", txHandler.ListAll)
 	r.Get("/api/transactions/counts", txHandler.Counts)
 	r.Get("/api/transactions/types", txHandler.Types)
+
+	recStore := recurring.NewStore(pool)
+	recHandler := recurring.NewHandler(recStore, logger)
+	r.Get("/api/recurring", recHandler.List)
+	r.Post("/api/recurring", recHandler.Create)
+	r.Get("/api/recurring/{id}", recHandler.Get)
+	r.Put("/api/recurring/{id}", recHandler.Update)
+	r.Delete("/api/recurring/{id}", recHandler.Delete)
+	r.Post("/api/recurring/{id}/run-now", recHandler.RunNow)
+	r.Post("/api/recurring/{id}/skip", recHandler.Skip)
+	r.Post("/api/recurring/{id}/unskip", recHandler.Unskip)
 
 	dpStore := debtpayments.NewStore(pool)
 	dpHandler := debtpayments.NewHandler(dpStore, logger)

--- a/src/lib/nav/routes.ts
+++ b/src/lib/nav/routes.ts
@@ -11,7 +11,8 @@ import {
 	Coins,
 	Dices,
 	Settings,
-	Target
+	Target,
+	Repeat
 } from 'lucide-svelte';
 
 export const NAV_ROUTES = [
@@ -21,6 +22,7 @@ export const NAV_ROUTES = [
 	{ href: '/retirement', label: 'Emerytura', icon: Dices },
 	{ href: '/accounts', label: 'Konta', icon: Wallet },
 	{ href: '/transactions', label: 'Transakcje', icon: ArrowRightLeft },
+	{ href: '/recurring', label: 'Cykliczne', icon: Repeat },
 	{ href: '/assets', label: 'Majątek', icon: Home },
 	{ href: '/bonds', label: 'Obligacje', icon: Coins },
 	{ href: '/debts', label: 'Zobowiązania', icon: ClipboardList },

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -3115,6 +3115,369 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/recurring": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List recurring templates */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            recurring?: {
+                                account_id?: number;
+                                active?: boolean;
+                                amount?: string;
+                                category?: string | null;
+                                created_at?: string;
+                                day_of_month?: number | null;
+                                description?: string;
+                                end_date?: string | null;
+                                frequency?: string;
+                                id?: number;
+                                last_run_date?: string | null;
+                                next_occurrence?: string | null;
+                                owner_user_id?: number | null;
+                                skipped_dates?: string[];
+                                start_date?: string;
+                                transaction_type?: string | null;
+                                updated_at?: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create a recurring template */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            account_id?: number;
+                            active?: boolean;
+                            amount?: string;
+                            category?: string | null;
+                            created_at?: string;
+                            day_of_month?: number | null;
+                            description?: string;
+                            end_date?: string | null;
+                            frequency?: string;
+                            id?: number;
+                            last_run_date?: string | null;
+                            next_occurrence?: string | null;
+                            owner_user_id?: number | null;
+                            skipped_dates?: string[];
+                            start_date?: string;
+                            transaction_type?: string | null;
+                            updated_at?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/recurring/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a recurring template */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            account_id?: number;
+                            active?: boolean;
+                            amount?: string;
+                            category?: string | null;
+                            created_at?: string;
+                            day_of_month?: number | null;
+                            description?: string;
+                            end_date?: string | null;
+                            frequency?: string;
+                            id?: number;
+                            last_run_date?: string | null;
+                            next_occurrence?: string | null;
+                            owner_user_id?: number | null;
+                            skipped_dates?: string[];
+                            start_date?: string;
+                            transaction_type?: string | null;
+                            updated_at?: string;
+                        };
+                    };
+                };
+            };
+        };
+        /** Update a recurring template */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            account_id?: number;
+                            active?: boolean;
+                            amount?: string;
+                            category?: string | null;
+                            created_at?: string;
+                            day_of_month?: number | null;
+                            description?: string;
+                            end_date?: string | null;
+                            frequency?: string;
+                            id?: number;
+                            last_run_date?: string | null;
+                            next_occurrence?: string | null;
+                            owner_user_id?: number | null;
+                            skipped_dates?: string[];
+                            start_date?: string;
+                            transaction_type?: string | null;
+                            updated_at?: string;
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        /** Delete a recurring template */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/recurring/{id}/run-now": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Mint an ad-hoc transaction now */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            date?: string;
+                            transaction_id?: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/recurring/{id}/skip": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Skip an occurrence */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            account_id?: number;
+                            active?: boolean;
+                            amount?: string;
+                            category?: string | null;
+                            created_at?: string;
+                            day_of_month?: number | null;
+                            description?: string;
+                            end_date?: string | null;
+                            frequency?: string;
+                            id?: number;
+                            last_run_date?: string | null;
+                            next_occurrence?: string | null;
+                            owner_user_id?: number | null;
+                            skipped_dates?: string[];
+                            start_date?: string;
+                            transaction_type?: string | null;
+                            updated_at?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/recurring/{id}/unskip": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Resume a previously skipped occurrence */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            account_id?: number;
+                            active?: boolean;
+                            amount?: string;
+                            category?: string | null;
+                            created_at?: string;
+                            day_of_month?: number | null;
+                            description?: string;
+                            end_date?: string | null;
+                            frequency?: string;
+                            id?: number;
+                            last_run_date?: string | null;
+                            next_occurrence?: string | null;
+                            owner_user_id?: number | null;
+                            skipped_dates?: string[];
+                            start_date?: string;
+                            transaction_type?: string | null;
+                            updated_at?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/retirement/limits/{year}": {
         parameters: {
             query?: never;

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -3353,8 +3353,9 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            already_minted?: boolean;
                             date?: string;
-                            transaction_id?: number;
+                            transaction_id?: number | null;
                         };
                     };
                 };

--- a/src/routes/recurring/+page.svelte
+++ b/src/routes/recurring/+page.svelte
@@ -1,0 +1,346 @@
+<script lang="ts">
+	import { invalidateAll } from '$app/navigation';
+	import { resolveApiUrl } from '$lib/api';
+	import { toast } from '$lib/stores/toast.svelte';
+	import Modal from '$lib/components/Modal.svelte';
+	import { Plus, Play, SkipForward, Trash2, Pencil } from 'lucide-svelte';
+	import type { PageData } from './$types';
+	import type { RecurringRow, AccountOption } from './+page';
+
+	let { data }: { data: PageData } = $props();
+
+	const FREQUENCIES = [
+		{ value: 'daily', label: 'Codziennie' },
+		{ value: 'weekly', label: 'Co tydzień' },
+		{ value: 'monthly', label: 'Co miesiąc' },
+		{ value: 'quarterly', label: 'Co kwartał' },
+		{ value: 'yearly', label: 'Co rok' }
+	];
+
+	const accountsById = $derived(
+		new Map<number, AccountOption>(data.accounts.map((a) => [a.id, a]))
+	);
+
+	let modalOpen = $state(false);
+	let editingId = $state<number | null>(null);
+	let form = $state(emptyForm());
+	let saving = $state(false);
+
+	function emptyForm() {
+		const today = new Date().toISOString().slice(0, 10);
+		return {
+			account_id: data.accounts[0]?.id ?? 0,
+			amount: '0.00',
+			category: '',
+			description: '',
+			frequency: 'monthly',
+			day_of_month: 1,
+			start_date: today,
+			end_date: '',
+			active: true
+		};
+	}
+
+	function openCreate() {
+		editingId = null;
+		form = emptyForm();
+		modalOpen = true;
+	}
+
+	function openEdit(row: RecurringRow) {
+		editingId = row.id;
+		form = {
+			account_id: row.account_id,
+			amount: row.amount,
+			category: row.category ?? '',
+			description: row.description,
+			frequency: row.frequency,
+			day_of_month: row.day_of_month ?? 1,
+			start_date: row.start_date,
+			end_date: row.end_date ?? '',
+			active: row.active
+		};
+		modalOpen = true;
+	}
+
+	async function save() {
+		saving = true;
+		try {
+			const apiUrl = resolveApiUrl();
+			const body = {
+				account_id: form.account_id,
+				amount: form.amount,
+				category: form.category || null,
+				description: form.description,
+				frequency: form.frequency,
+				day_of_month: form.day_of_month,
+				start_date: form.start_date,
+				end_date: form.end_date || null,
+				active: form.active
+			};
+			const url =
+				editingId === null ? `${apiUrl}/api/recurring` : `${apiUrl}/api/recurring/${editingId}`;
+			const method = editingId === null ? 'POST' : 'PUT';
+			const res = await fetch(url, {
+				method,
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body)
+			});
+			if (!res.ok) {
+				const detail = await res.json().catch(() => ({ detail: res.statusText }));
+				throw new Error(detail.detail ?? res.statusText);
+			}
+			modalOpen = false;
+			toast.success(editingId === null ? 'Utworzono' : 'Zapisano');
+			await invalidateAll();
+		} catch (err) {
+			if (err instanceof Error) toast.error(err.message);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function runNow(row: RecurringRow) {
+		try {
+			const apiUrl = resolveApiUrl();
+			const res = await fetch(`${apiUrl}/api/recurring/${row.id}/run-now`, { method: 'POST' });
+			if (!res.ok) throw new Error('Nie udało się utworzyć transakcji');
+			toast.success(
+				`Utworzono transakcję na dziś dla "${row.description || 'recurring #' + row.id}"`
+			);
+			await invalidateAll();
+		} catch (err) {
+			if (err instanceof Error) toast.error(err.message);
+		}
+	}
+
+	async function skipNext(row: RecurringRow) {
+		try {
+			const apiUrl = resolveApiUrl();
+			const res = await fetch(`${apiUrl}/api/recurring/${row.id}/skip`, { method: 'POST' });
+			if (!res.ok) throw new Error('Nie udało się pominąć następnego wystąpienia');
+			toast.success('Pominięto następne wystąpienie');
+			await invalidateAll();
+		} catch (err) {
+			if (err instanceof Error) toast.error(err.message);
+		}
+	}
+
+	async function unskip(row: RecurringRow, date: string) {
+		try {
+			const apiUrl = resolveApiUrl();
+			const res = await fetch(
+				`${apiUrl}/api/recurring/${row.id}/unskip?date=${encodeURIComponent(date)}`,
+				{ method: 'POST' }
+			);
+			if (!res.ok) throw new Error('Nie udało się przywrócić wystąpienia');
+			toast.success('Przywrócono wystąpienie');
+			await invalidateAll();
+		} catch (err) {
+			if (err instanceof Error) toast.error(err.message);
+		}
+	}
+
+	async function remove(row: RecurringRow) {
+		if (!confirm(`Usunąć "${row.description || 'recurring #' + row.id}"?`)) return;
+		try {
+			const apiUrl = resolveApiUrl();
+			const res = await fetch(`${apiUrl}/api/recurring/${row.id}`, { method: 'DELETE' });
+			if (!res.ok) throw new Error('Nie udało się usunąć');
+			toast.success('Usunięto');
+			await invalidateAll();
+		} catch (err) {
+			if (err instanceof Error) toast.error(err.message);
+		}
+	}
+
+	function frequencyLabel(freq: string): string {
+		return FREQUENCIES.find((f) => f.value === freq)?.label ?? freq;
+	}
+</script>
+
+<svelte:head>
+	<title>Transakcje cykliczne | Finansowa Forteca</title>
+</svelte:head>
+
+<div class="space-y-4">
+	<div class="flex items-center justify-between">
+		<div>
+			<h1 class="h1">Transakcje cykliczne</h1>
+			<p class="text-sm text-surface-700-300">
+				Szablony, z których planowo generowane są transakcje (wypłata, rata, subskrypcje).
+			</p>
+		</div>
+		<button type="button" class="btn preset-filled-primary-500" onclick={openCreate}>
+			<Plus size={16} />
+			<span>Dodaj</span>
+		</button>
+	</div>
+
+	{#if data.recurring.length === 0}
+		<div class="card preset-tonal-surface p-6 text-center text-sm text-surface-700-300">
+			Brak transakcji cyklicznych. Kliknij „Dodaj" aby zacząć.
+		</div>
+	{:else}
+		<div class="table-wrap">
+			<table class="table table-hover text-sm">
+				<thead>
+					<tr>
+						<th>Opis</th>
+						<th>Konto</th>
+						<th class="text-right">Kwota</th>
+						<th>Częstotliwość</th>
+						<th>Następne</th>
+						<th>Status</th>
+						<th class="text-right">Akcje</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each data.recurring as row (row.id)}
+						<tr>
+							<td>
+								<div>{row.description || '—'}</div>
+								{#if row.category}
+									<div class="text-xs text-surface-600-400">{row.category}</div>
+								{/if}
+							</td>
+							<td>{accountsById.get(row.account_id)?.name ?? '—'}</td>
+							<td class="text-right">{row.amount} PLN</td>
+							<td>{frequencyLabel(row.frequency)}</td>
+							<td>{row.next_occurrence ?? '—'}</td>
+							<td>
+								{#if row.active}
+									<span class="badge preset-tonal-success">Aktywna</span>
+								{:else}
+									<span class="badge preset-tonal-surface">Wstrzymana</span>
+								{/if}
+							</td>
+							<td class="text-right">
+								<div class="flex justify-end gap-1">
+									<button
+										type="button"
+										class="btn-icon btn-icon-sm"
+										aria-label="Uruchom teraz"
+										title="Uruchom teraz"
+										onclick={() => runNow(row)}
+									>
+										<Play size={16} />
+									</button>
+									<button
+										type="button"
+										class="btn-icon btn-icon-sm"
+										aria-label="Pomiń następne"
+										title="Pomiń następne"
+										disabled={!row.next_occurrence}
+										onclick={() => skipNext(row)}
+									>
+										<SkipForward size={16} />
+									</button>
+									<button
+										type="button"
+										class="btn-icon btn-icon-sm"
+										aria-label="Edytuj"
+										title="Edytuj"
+										onclick={() => openEdit(row)}
+									>
+										<Pencil size={16} />
+									</button>
+									<button
+										type="button"
+										class="btn-icon btn-icon-sm"
+										aria-label="Usuń"
+										title="Usuń"
+										onclick={() => remove(row)}
+									>
+										<Trash2 size={16} />
+									</button>
+								</div>
+							</td>
+						</tr>
+						{#if row.skipped_dates.length > 0}
+							<tr>
+								<td colspan="7" class="text-xs">
+									<div class="flex flex-wrap items-center gap-2 px-2 py-1">
+										<span class="text-surface-600-400">Pominięte:</span>
+										{#each row.skipped_dates as d}
+											<button
+												type="button"
+												class="badge preset-tonal-warning cursor-pointer"
+												title="Przywróć {d}"
+												onclick={() => unskip(row, d)}
+											>
+												{d} ×
+											</button>
+										{/each}
+									</div>
+								</td>
+							</tr>
+						{/if}
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
+</div>
+
+<Modal
+	open={modalOpen}
+	title={editingId === null ? 'Nowa transakcja cykliczna' : 'Edytuj transakcję cykliczną'}
+	onCancel={() => (modalOpen = false)}
+	onConfirm={save}
+	confirmDisabled={saving}
+	confirmText={saving ? 'Zapisywanie...' : 'Zapisz'}
+>
+	<div class="flex flex-col gap-3">
+		<label class="label">
+			<span class="text-sm font-semibold">Konto</span>
+			<select bind:value={form.account_id} class="select">
+				{#each data.accounts as acc}
+					<option value={acc.id}>{acc.name}</option>
+				{/each}
+			</select>
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Opis</span>
+			<input type="text" bind:value={form.description} maxlength="200" class="input" />
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Kategoria (opcjonalnie)</span>
+			<input type="text" bind:value={form.category} maxlength="50" class="input" />
+			<span class="text-xs text-surface-600-400"> np. wynagrodzenie, hipoteka, subskrypcja </span>
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Kwota (PLN)</span>
+			<input type="text" bind:value={form.amount} class="input" />
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Częstotliwość</span>
+			<select bind:value={form.frequency} class="select">
+				{#each FREQUENCIES as freq}
+					<option value={freq.value}>{freq.label}</option>
+				{/each}
+			</select>
+		</label>
+		{#if form.frequency === 'monthly' || form.frequency === 'quarterly' || form.frequency === 'yearly'}
+			<label class="label">
+				<span class="text-sm font-semibold">Dzień miesiąca</span>
+				<input type="number" bind:value={form.day_of_month} min="1" max="31" class="input" />
+				<span class="text-xs text-surface-600-400">
+					Jeśli miesiąc krótszy, użyje ostatniego dnia.
+				</span>
+			</label>
+		{/if}
+		<label class="label">
+			<span class="text-sm font-semibold">Data początkowa</span>
+			<input type="date" bind:value={form.start_date} class="input" />
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Data końcowa (opcjonalnie)</span>
+			<input type="date" bind:value={form.end_date} class="input" />
+		</label>
+		<label class="flex items-center gap-2 cursor-pointer">
+			<input type="checkbox" bind:checked={form.active} class="checkbox" />
+			<span class="text-sm">Aktywna</span>
+		</label>
+	</div>
+</Modal>

--- a/src/routes/recurring/+page.svelte
+++ b/src/routes/recurring/+page.svelte
@@ -2,6 +2,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import { resolveApiUrl } from '$lib/api';
 	import { toast } from '$lib/stores/toast.svelte';
+	import { confirm } from '$lib/stores/confirm.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import { Plus, Play, SkipForward, Trash2, Pencil } from 'lucide-svelte';
 	import type { PageData } from './$types';
@@ -42,6 +43,10 @@
 	}
 
 	function openCreate() {
+		if (data.accounts.length === 0) {
+			toast.error('Najpierw utwórz konto, do którego będą trafiać transakcje.');
+			return;
+		}
 		editingId = null;
 		form = emptyForm();
 		modalOpen = true;
@@ -105,9 +110,13 @@
 			const apiUrl = resolveApiUrl();
 			const res = await fetch(`${apiUrl}/api/recurring/${row.id}/run-now`, { method: 'POST' });
 			if (!res.ok) throw new Error('Nie udało się utworzyć transakcji');
-			toast.success(
-				`Utworzono transakcję na dziś dla "${row.description || 'recurring #' + row.id}"`
-			);
+			const payload = (await res.json().catch(() => null)) as { already_minted?: boolean } | null;
+			const label = row.description || `recurring #${row.id}`;
+			if (payload?.already_minted) {
+				toast.info(`„${label}" już utworzono dziś — pominięto.`);
+			} else {
+				toast.success(`Utworzono transakcję na dziś dla „${label}".`);
+			}
 			await invalidateAll();
 		} catch (err) {
 			if (err instanceof Error) toast.error(err.message);
@@ -142,7 +151,14 @@
 	}
 
 	async function remove(row: RecurringRow) {
-		if (!confirm(`Usunąć "${row.description || 'recurring #' + row.id}"?`)) return;
+		const label = row.description || `recurring #${row.id}`;
+		const ok = await confirm({
+			title: 'Usunąć transakcję cykliczną?',
+			message: `„${label}" zostanie trwale usunięta.`,
+			danger: true,
+			confirmText: 'Usuń'
+		});
+		if (!ok) return;
 		try {
 			const apiUrl = resolveApiUrl();
 			const res = await fetch(`${apiUrl}/api/recurring/${row.id}`, { method: 'DELETE' });
@@ -179,7 +195,7 @@
 
 	{#if data.recurring.length === 0}
 		<div class="card preset-tonal-surface p-6 text-center text-sm text-surface-700-300">
-			Brak transakcji cyklicznych. Kliknij „Dodaj" aby zacząć.
+			Brak transakcji cyklicznych. Kliknij „Dodaj” aby zacząć.
 		</div>
 	{:else}
 		<div class="table-wrap">

--- a/src/routes/recurring/+page.ts
+++ b/src/routes/recurring/+page.ts
@@ -1,0 +1,48 @@
+import { error } from '@sveltejs/kit';
+import { resolveApiUrl } from '$lib/api';
+import type { PageLoad } from './$types';
+
+export interface RecurringRow {
+	id: number;
+	account_id: number;
+	amount: string;
+	owner_user_id: number | null;
+	transaction_type: string | null;
+	category: string | null;
+	description: string;
+	frequency: string;
+	day_of_month: number | null;
+	start_date: string;
+	end_date: string | null;
+	active: boolean;
+	skipped_dates: string[];
+	last_run_date: string | null;
+	next_occurrence: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface AccountOption {
+	id: number;
+	name: string;
+}
+
+export const load: PageLoad = async ({ fetch }) => {
+	const apiUrl = resolveApiUrl();
+	const [recurringRes, accountsRes] = await Promise.all([
+		fetch(`${apiUrl}/api/recurring`),
+		fetch(`${apiUrl}/api/accounts`)
+	]);
+	if (!recurringRes.ok) {
+		throw error(recurringRes.status, 'Failed to load recurring transactions');
+	}
+	if (!accountsRes.ok) {
+		throw error(accountsRes.status, 'Failed to load accounts');
+	}
+	const recurringData = (await recurringRes.json()) as { recurring: RecurringRow[] };
+	const accountsData = (await accountsRes.json()) as { accounts: AccountOption[] };
+	return {
+		recurring: recurringData.recurring,
+		accounts: accountsData.accounts.map((a) => ({ id: a.id, name: a.name }))
+	};
+};


### PR DESCRIPTION
## Motivation

Salary, mortgage payments and subscriptions are monthly — currently re-entered by hand each cycle. Subissue of #355.

## Implementation information

- New `recurring_transactions` table (account_id, amount, owner_user_id, transaction_type, category, description, frequency, day_of_month, start_date, end_date, active, skipped_dates, last_run_date, timestamps). Schema baseline + additive migration covering existing databases.
- Pure occurrence engine in `internal/recurring/occurrence.go` with `NextOccurrence` and `DueOccurrences` (handles daily/weekly/monthly/quarterly/yearly, short-month clamping, end-date, skip list, last-run watermark). 12 unit tests.
- Store + handler for full CRUD plus `/run-now`, `/skip`, `/unskip`. `MintOccurrence` runs in a transaction under a per-template Postgres advisory lock so a concurrent scheduler tick and a user-clicked "Run now" can't double-insert the same occurrence (returns `IsAlreadyMinted` on conflict).
- In-process scheduler fires once on boot (to catch up missed runs) then daily at 04:00 Europe/Warsaw.
- New `/recurring` SvelteKit page: create/edit modal, list with next-occurrence preview, status badge, action buttons (run now / skip / edit / delete), and inline skipped-dates pills that can be un-skipped with a click.
- `Cykliczne` added to nav routes (auto-available in the More sheet from #366).

Closes #384

> Changelog: feat(transactions): recurring transactions