### PR TITLE
feat(ui): frontend error boundary + capture

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -2,7 +2,10 @@
 // for information about these interfaces
 declare global {
 	namespace App {
-		// interface Error {}
+		interface Error {
+			message: string;
+			stack?: string;
+		}
 		interface Locals {
 			user: { username: string; name: string; isAdmin: boolean } | null;
 		}

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,0 +1,22 @@
+import type { HandleClientError } from '@sveltejs/kit';
+import { dev } from '$app/environment';
+import { toast } from '$lib/stores/toast.svelte';
+
+// SvelteKit error hook — fires on uncaught errors during load() and component
+// rendering. The default reaches `+error.svelte`; we also surface a toast so
+// the user gets a signal even when the broken view is not the active route.
+export const handleError: HandleClientError = ({ error, status }) => {
+	const message = error instanceof Error ? error.message : String(error);
+	if (dev) {
+		console.error('[handleError]', error);
+	} else {
+		console.error('[handleError]', message);
+	}
+	if (status !== 404) {
+		toast.error(`Coś poszło nie tak: ${message}`);
+	}
+	return {
+		message,
+		stack: dev && error instanceof Error ? error.stack : undefined
+	};
+};

--- a/src/lib/components/GlobalErrorCapture.svelte
+++ b/src/lib/components/GlobalErrorCapture.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { dev } from '$app/environment';
+	import { toast } from '$lib/stores/toast.svelte';
+
+	// Errors we have already toasted in the last few seconds — dedupes runaway
+	// loops where the same error fires repeatedly (React-style infinite render
+	// or fetch-storm), instead of spamming the screen.
+	const recent = new Map<string, number>();
+	const DEDUP_WINDOW_MS = 5000;
+
+	function show(message: string): void {
+		const now = Date.now();
+		for (const [key, ts] of recent) {
+			if (now - ts > DEDUP_WINDOW_MS) recent.delete(key);
+		}
+		if (recent.has(message)) return;
+		recent.set(message, now);
+		toast.error(message);
+	}
+
+	function describe(reason: unknown): string {
+		if (reason instanceof Error) return reason.message || reason.name;
+		if (typeof reason === 'string') return reason;
+		try {
+			return JSON.stringify(reason);
+		} catch {
+			return String(reason);
+		}
+	}
+
+	onMount(() => {
+		const onError = (event: ErrorEvent) => {
+			const msg = event.error instanceof Error ? event.error.message : event.message;
+			console.error('[window.onerror]', event.error ?? event.message);
+			show(`Niespodziewany błąd: ${msg || 'unknown'}`);
+		};
+		const onRejection = (event: PromiseRejectionEvent) => {
+			console.error('[unhandledrejection]', event.reason);
+			show(`Niespodziewany błąd: ${describe(event.reason)}`);
+		};
+		window.addEventListener('error', onError);
+		window.addEventListener('unhandledrejection', onRejection);
+		if (dev) {
+			console.info('[GlobalErrorCapture] window-level handlers attached');
+		}
+		return () => {
+			window.removeEventListener('error', onError);
+			window.removeEventListener('unhandledrejection', onRejection);
+		};
+	});
+</script>

--- a/src/lib/components/GlobalErrorCapture.test.ts
+++ b/src/lib/components/GlobalErrorCapture.test.ts
@@ -28,12 +28,22 @@ describe('GlobalErrorCapture', () => {
 		render(GlobalErrorCapture);
 		const promise = Promise.reject(new Error('rejected'));
 		promise.catch(() => {}); // suppress vitest unhandled-rejection warning
-		window.dispatchEvent(
-			new PromiseRejectionEvent('unhandledrejection', {
+		// PromiseRejectionEvent may not be implemented in every jsdom build —
+		// fall back to a plain Event with the same shape.
+		type RejectionLike = Event & { promise: Promise<unknown>; reason: unknown };
+		let event: RejectionLike;
+		if (typeof PromiseRejectionEvent === 'function') {
+			event = new PromiseRejectionEvent('unhandledrejection', {
 				promise,
 				reason: new Error('rejected')
-			})
-		);
+			}) as RejectionLike;
+		} else {
+			const ev = new Event('unhandledrejection') as RejectionLike;
+			ev.promise = promise;
+			ev.reason = new Error('rejected');
+			event = ev;
+		}
+		window.dispatchEvent(event);
 		expect(toastSpy).toHaveBeenCalledOnce();
 		expect(toastSpy.mock.calls[0][0]).toContain('rejected');
 	});

--- a/src/lib/components/GlobalErrorCapture.test.ts
+++ b/src/lib/components/GlobalErrorCapture.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+import GlobalErrorCapture from './GlobalErrorCapture.svelte';
+import { toast } from '$lib/stores/toast.svelte';
+
+describe('GlobalErrorCapture', () => {
+	let toastSpy: ReturnType<typeof vi.spyOn>;
+	let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		toastSpy = vi.spyOn(toast, 'error').mockImplementation(() => 0);
+		consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		toastSpy.mockRestore();
+		consoleSpy.mockRestore();
+	});
+
+	it('toasts on window error events', () => {
+		render(GlobalErrorCapture);
+		window.dispatchEvent(new ErrorEvent('error', { message: 'oops', error: new Error('boom') }));
+		expect(toastSpy).toHaveBeenCalledOnce();
+		expect(toastSpy.mock.calls[0][0]).toContain('boom');
+	});
+
+	it('toasts on unhandled promise rejections', () => {
+		render(GlobalErrorCapture);
+		const promise = Promise.reject(new Error('rejected'));
+		promise.catch(() => {}); // suppress vitest unhandled-rejection warning
+		window.dispatchEvent(
+			new PromiseRejectionEvent('unhandledrejection', {
+				promise,
+				reason: new Error('rejected')
+			})
+		);
+		expect(toastSpy).toHaveBeenCalledOnce();
+		expect(toastSpy.mock.calls[0][0]).toContain('rejected');
+	});
+
+	it('dedupes repeated identical errors within 5s', () => {
+		render(GlobalErrorCapture);
+		const err = new Error('same');
+		window.dispatchEvent(new ErrorEvent('error', { message: 'same', error: err }));
+		window.dispatchEvent(new ErrorEvent('error', { message: 'same', error: err }));
+		window.dispatchEvent(new ErrorEvent('error', { message: 'same', error: err }));
+		expect(toastSpy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { invalidateAll } from '$app/navigation';
-	import { TriangleAlert, RefreshCw } from 'lucide-svelte';
+	import { dev } from '$app/environment';
+	import { toast } from '$lib/stores/toast.svelte';
+	import { TriangleAlert, RefreshCw, Bug } from 'lucide-svelte';
 
 	let retrying = $state(false);
 
@@ -13,6 +15,24 @@
 			retrying = false;
 		}
 	}
+
+	async function report() {
+		const payload = [
+			`status: ${$page.status}`,
+			`url: ${$page.url.toString()}`,
+			`message: ${$page.error?.message ?? '—'}`,
+			$page.error?.stack ? `stack:\n${$page.error.stack}` : ''
+		]
+			.filter(Boolean)
+			.join('\n');
+		try {
+			await navigator.clipboard.writeText(payload);
+			toast.success('Skopiowano szczegóły błędu do schowka.');
+		} catch {
+			toast.error('Nie udało się skopiować szczegółów — skopiuj ręcznie z konsoli.');
+			console.error('[error-report]\n' + payload);
+		}
+	}
 </script>
 
 <div class="error-boundary">
@@ -22,10 +42,20 @@
 		{$page.error?.message || 'Nie udało się załadować danych.'}
 	</p>
 	<p class="error-status">Kod błędu: {$page.status}</p>
+	{#if dev && $page.error?.stack}
+		<details class="error-stack">
+			<summary>Szczegóły dla deweloperów</summary>
+			<pre>{$page.error.stack}</pre>
+		</details>
+	{/if}
 	<div class="error-actions">
 		<button type="button" onclick={retry} disabled={retrying}>
 			<RefreshCw size={18} />
 			{retrying ? 'Ponawianie…' : 'Spróbuj ponownie'}
+		</button>
+		<button type="button" class="report" onclick={report}>
+			<Bug size={18} />
+			Zgłoś
 		</button>
 		<a href="/" class="home-link">Wróć do pulpitu</a>
 	</div>
@@ -66,6 +96,28 @@
 		margin: 0;
 	}
 
+	.error-stack {
+		max-width: 100%;
+		text-align: left;
+		font-size: var(--font-size-0);
+		color: var(--color-text-2);
+		background: var(--surface-2);
+		border-radius: var(--radius-2);
+		padding: var(--size-2) var(--size-3);
+	}
+
+	.error-stack summary {
+		cursor: pointer;
+		font-weight: var(--font-weight-6);
+	}
+
+	.error-stack pre {
+		margin: var(--size-2) 0 0;
+		overflow-x: auto;
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+
 	.error-actions {
 		display: flex;
 		flex-wrap: wrap;
@@ -87,6 +139,11 @@
 		border: none;
 		border-radius: var(--radius-2);
 		cursor: pointer;
+	}
+
+	button.report {
+		color: var(--color-text-1);
+		background: var(--surface-3);
 	}
 
 	button:disabled {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
 	import Toast from '$lib/components/Toast.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import KeyboardShortcuts from '$lib/components/KeyboardShortcuts.svelte';
+	import GlobalErrorCapture from '$lib/components/GlobalErrorCapture.svelte';
 	import BottomSheet from '$lib/components/BottomSheet.svelte';
 	import { navPrefs } from '$lib/stores/navPrefs.svelte';
 	import { NAV_ROUTES, type NavRoute } from '$lib/nav/routes';
@@ -45,6 +46,7 @@
 
 <Toast />
 <Confirm />
+<GlobalErrorCapture />
 
 {#if !isLoginPage}
 	<KeyboardShortcuts />


### PR DESCRIPTION
## Motivation

Toast store covers expected errors. Unexpected exceptions today crash the route silently or show a stack trace. We need a catch-all. Subissue of #355.

## Implementation information

- New `hooks.client.ts` with SvelteKit `handleError` — logs, toasts (skipping 404), and forwards the message (+ stack in dev) to the error page via a typed `App.Error`.
- New `GlobalErrorCapture.svelte` component mounted in the root layout. Listens for `window.error` and `unhandledrejection`, toasts the message (deduped in a 5-second window so a runaway loop doesn't spam the user), and logs to the console.
- `+error.svelte` upgraded with a Report button (copies status / url / message / stack to clipboard) and a dev-only collapsible stack trace.
- `App.Error` typed with `{ message, stack? }`.
- Sentry SDK is left out — flagged optional in the issue and not enabled in this codebase; adding it later behind `PUBLIC_SENTRY_DSN` is a one-file change in `hooks.client.ts`.

Closes #391

> Changelog: feat(ui): frontend error boundary + capture