### PR TITLE
feat(investments): contribution-adjusted returns

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -4585,6 +4585,88 @@
         ]
       }
     },
+    "/api/investment/returns": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "as_of": {
+                      "type": "string"
+                    },
+                    "convergence_failed": {
+                      "type": "boolean"
+                    },
+                    "current_value": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "deposits": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "has_snapshot": {
+                      "type": "boolean"
+                    },
+                    "money_weighted_pct": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "net_contributed": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "period": {
+                      "type": "string"
+                    },
+                    "scope": {
+                      "properties": {
+                        "account_id": {
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "simple_roi_pct": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "since": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "valuation_change": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "withdrawals": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Contribution-adjusted (money-weighted) returns",
+        "tags": [
+          "investment"
+        ]
+      }
+    },
     "/api/investment/stock-stats": {
       "get": {
         "responses": {

--- a/backend-go/internal/investment/handler.go
+++ b/backend-go/internal/investment/handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type response struct {
@@ -29,6 +30,161 @@ func NewHandler(store *Store, logger *slog.Logger) *Handler {
 		logger = slog.Default()
 	}
 	return &Handler{store: store, logger: logger}
+}
+
+// --- Contribution-adjusted returns (#401) ---
+
+type returnsResponse struct {
+	Scope             scopeWire `json:"scope"`
+	Period            string    `json:"period"`
+	Since             *string   `json:"since"`
+	AsOf              string    `json:"as_of"`
+	Deposits          pyFloat   `json:"deposits"`
+	Withdrawals       pyFloat   `json:"withdrawals"`
+	NetContributed    pyFloat   `json:"net_contributed"`
+	CurrentValue      pyFloat   `json:"current_value"`
+	ValuationChange   pyFloat   `json:"valuation_change"`
+	SimpleROIPct      pyFloat   `json:"simple_roi_pct"`
+	MoneyWeightedPct  *pyFloat  `json:"money_weighted_pct"`
+	HasSnapshot       bool      `json:"has_snapshot"`
+	ConvergenceFailed bool      `json:"convergence_failed"`
+}
+
+type scopeWire struct {
+	Type    string `json:"type"`
+	Value   string `json:"value,omitempty"`
+	Account *int   `json:"account_id,omitempty"`
+}
+
+// Returns serves GET /api/investment/returns. Query params:
+//
+//	scope=all|account|category|wrapper (default all)
+//	id=N           required when scope=account
+//	value=...      required when scope=category|wrapper
+//	period=1m|3m|ytd|1y|all (default all)
+//
+// Computes contribution-adjusted (XIRR / money-weighted) return in addition
+// to the naive simple ROI so the user can see whether their investments grew
+// or whether they only added more money.
+func (h *Handler) Returns(w http.ResponseWriter, r *http.Request) {
+	scope, scopeWire, vErr := parseScope(r)
+	if vErr != "" {
+		writeDetailError(w, http.StatusBadRequest, vErr)
+		return
+	}
+	period := r.URL.Query().Get("period")
+	if period == "" {
+		period = "all"
+	}
+	now := time.Now().UTC()
+	window := windowFor(period, now)
+
+	value, snapDate, hasSnap, err := h.store.LatestValueInScope(r.Context(), scope, now)
+	if err != nil {
+		h.logger.Error("returns: snapshot lookup", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	flows, err := h.store.ScopedFlows(r.Context(), scope, PeriodWindow{Since: window.Since, AsOf: now})
+	if err != nil {
+		h.logger.Error("returns: flows", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+
+	deposits, withdrawals := 0.0, 0.0
+	xirrFlows := make([]CashFlow, 0, len(flows)+1)
+	for _, f := range flows {
+		amt, _ := f.Amount.Float64()
+		if amt >= 0 {
+			deposits += amt
+		} else {
+			withdrawals += -amt
+		}
+		xirrFlows = append(xirrFlows, CashFlow{Date: f.Date, Amount: amt})
+	}
+	netContrib := deposits - withdrawals
+	currentValue, _ := value.Float64()
+	valuationChange := currentValue - netContrib
+
+	resp := returnsResponse{
+		Scope:           scopeWire,
+		Period:          period,
+		AsOf:            now.Format("2006-01-02"),
+		Deposits:        pyFloat(deposits),
+		Withdrawals:     pyFloat(withdrawals),
+		NetContributed:  pyFloat(netContrib),
+		CurrentValue:    pyFloat(currentValue),
+		ValuationChange: pyFloat(valuationChange),
+		SimpleROIPct:    pyFloat(math.Round(SimpleROI(netContrib, currentValue)*10000) / 100),
+		HasSnapshot:     hasSnap,
+	}
+	if window.Since != nil {
+		s := window.Since.Format("2006-01-02")
+		resp.Since = &s
+	}
+	if hasSnap && currentValue > 0 {
+		// Closing terminal flow = liquidate at current value at the snapshot date.
+		xirrFlows = append(xirrFlows, CashFlow{Date: snapDate, Amount: -currentValue})
+		mwr, xerr := XIRR(xirrFlows)
+		if xerr != nil {
+			resp.ConvergenceFailed = true
+		} else {
+			pct := pyFloat(math.Round(mwr*10000) / 100)
+			resp.MoneyWeightedPct = &pct
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func parseScope(r *http.Request) (ScopeFilter, scopeWire, string) {
+	q := r.URL.Query()
+	kind := q.Get("scope")
+	if kind == "" {
+		kind = "all"
+	}
+	switch kind {
+	case "all":
+		return ScopeFilter{All: true}, scopeWire{Type: "all"}, ""
+	case "account":
+		raw := q.Get("id")
+		id, err := strconv.Atoi(raw)
+		if err != nil || id <= 0 {
+			return ScopeFilter{}, scopeWire{}, "scope=account requires a positive integer id"
+		}
+		return ScopeFilter{AccountID: &id}, scopeWire{Type: "account", Account: &id}, ""
+	case "category":
+		v := q.Get("value")
+		if v == "" {
+			return ScopeFilter{}, scopeWire{}, "scope=category requires value"
+		}
+		return ScopeFilter{Category: &v}, scopeWire{Type: "category", Value: v}, ""
+	case "wrapper":
+		v := q.Get("value")
+		if v == "" {
+			return ScopeFilter{}, scopeWire{}, "scope=wrapper requires value"
+		}
+		return ScopeFilter{Wrapper: &v}, scopeWire{Type: "wrapper", Value: v}, ""
+	}
+	return ScopeFilter{}, scopeWire{}, "scope must be one of all|account|category|wrapper"
+}
+
+func windowFor(period string, asOf time.Time) PeriodWindow {
+	switch period {
+	case "1m":
+		s := asOf.AddDate(0, -1, 0)
+		return PeriodWindow{Since: &s, AsOf: asOf}
+	case "3m":
+		s := asOf.AddDate(0, -3, 0)
+		return PeriodWindow{Since: &s, AsOf: asOf}
+	case "ytd":
+		s := time.Date(asOf.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+		return PeriodWindow{Since: &s, AsOf: asOf}
+	case "1y":
+		s := asOf.AddDate(-1, 0, 0)
+		return PeriodWindow{Since: &s, AsOf: asOf}
+	}
+	return PeriodWindow{AsOf: asOf}
 }
 
 // StockStats serves GET /api/investment/stock-stats.

--- a/backend-go/internal/investment/handler.go
+++ b/backend-go/internal/investment/handler.go
@@ -76,6 +76,10 @@ func (h *Handler) Returns(w http.ResponseWriter, r *http.Request) {
 	if period == "" {
 		period = "all"
 	}
+	if !validPeriod(period) {
+		writeDetailError(w, http.StatusBadRequest, "period must be one of 1m|3m|ytd|1y|all")
+		return
+	}
 	now := time.Now().UTC()
 	window := windowFor(period, now)
 
@@ -85,7 +89,14 @@ func (h *Handler) Returns(w http.ResponseWriter, r *http.Request) {
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	flows, err := h.store.ScopedFlows(r.Context(), scope, PeriodWindow{Since: window.Since, AsOf: now})
+	// Cash flows must align with the valuation date. When a snapshot exists,
+	// upper-bound the flow window at snapDate so transactions added after the
+	// snapshot don't pollute the return calculation.
+	flowEnd := now
+	if hasSnap {
+		flowEnd = snapDate
+	}
+	flows, err := h.store.ScopedFlows(r.Context(), scope, PeriodWindow{Since: window.Since, AsOf: flowEnd})
 	if err != nil {
 		h.logger.Error("returns: flows", "err", err)
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
@@ -93,7 +104,25 @@ func (h *Handler) Returns(w http.ResponseWriter, r *http.Request) {
 	}
 
 	deposits, withdrawals := 0.0, 0.0
-	xirrFlows := make([]CashFlow, 0, len(flows)+1)
+	xirrFlows := make([]CashFlow, 0, len(flows)+2)
+	// Windowed periods need an opening balance so XIRR reflects the return
+	// over the period rather than treating pre-window value as free money.
+	// Inject the snapshot-as-of-since as a positive cash flow at `since`.
+	var openingValue float64
+	if window.Since != nil {
+		openValDec, _, hasOpen, err := h.store.LatestValueInScope(r.Context(), scope, *window.Since)
+		if err != nil {
+			h.logger.Error("returns: opening snapshot", "err", err)
+			writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+			return
+		}
+		if hasOpen {
+			openingValue, _ = openValDec.Float64()
+			if openingValue > 0 {
+				xirrFlows = append(xirrFlows, CashFlow{Date: *window.Since, Amount: openingValue})
+			}
+		}
+	}
 	for _, f := range flows {
 		amt, _ := f.Amount.Float64()
 		if amt >= 0 {
@@ -105,25 +134,31 @@ func (h *Handler) Returns(w http.ResponseWriter, r *http.Request) {
 	}
 	netContrib := deposits - withdrawals
 	currentValue, _ := value.Float64()
-	valuationChange := currentValue - netContrib
+	// Valuation change is the difference between current value and what was
+	// put in over the window — current value minus (opening + net flows).
+	valuationChange := currentValue - openingValue - netContrib
 
+	asOf := now
+	if hasSnap {
+		asOf = snapDate
+	}
 	resp := returnsResponse{
 		Scope:           scopeWire,
 		Period:          period,
-		AsOf:            now.Format("2006-01-02"),
+		AsOf:            asOf.Format("2006-01-02"),
 		Deposits:        pyFloat(deposits),
 		Withdrawals:     pyFloat(withdrawals),
 		NetContributed:  pyFloat(netContrib),
 		CurrentValue:    pyFloat(currentValue),
 		ValuationChange: pyFloat(valuationChange),
-		SimpleROIPct:    pyFloat(math.Round(SimpleROI(netContrib, currentValue)*10000) / 100),
+		SimpleROIPct:    pyFloat(math.Round(SimpleROI(openingValue+netContrib, currentValue)*10000) / 100),
 		HasSnapshot:     hasSnap,
 	}
 	if window.Since != nil {
 		s := window.Since.Format("2006-01-02")
 		resp.Since = &s
 	}
-	if hasSnap && currentValue > 0 {
+	if hasSnap {
 		// Closing terminal flow = liquidate at current value at the snapshot date.
 		xirrFlows = append(xirrFlows, CashFlow{Date: snapDate, Amount: -currentValue})
 		mwr, xerr := XIRR(xirrFlows)
@@ -135,6 +170,14 @@ func (h *Handler) Returns(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+func validPeriod(p string) bool {
+	switch p {
+	case "1m", "3m", "ytd", "1y", "all":
+		return true
+	}
+	return false
 }
 
 func parseScope(r *http.Request) (ScopeFilter, scopeWire, string) {

--- a/backend-go/internal/investment/handler_test.go
+++ b/backend-go/internal/investment/handler_test.go
@@ -1,0 +1,122 @@
+package investment
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestParseScope_DefaultIsAll(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/investment/returns", nil)
+	scope, wire, err := parseScope(r)
+	if err != "" {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !scope.All {
+		t.Errorf("default scope should be All")
+	}
+	if wire.Type != "all" {
+		t.Errorf("wire type = %q, expected all", wire.Type)
+	}
+}
+
+func TestParseScope_Account(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/investment/returns?scope=account&id=42", nil)
+	scope, wire, err := parseScope(r)
+	if err != "" {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if scope.AccountID == nil || *scope.AccountID != 42 {
+		t.Errorf("expected AccountID=42, got %v", scope.AccountID)
+	}
+	if wire.Account == nil || *wire.Account != 42 {
+		t.Errorf("wire account = %v, expected 42", wire.Account)
+	}
+}
+
+func TestParseScope_AccountRejectsBadID(t *testing.T) {
+	cases := []string{
+		"/api/investment/returns?scope=account",
+		"/api/investment/returns?scope=account&id=abc",
+		"/api/investment/returns?scope=account&id=0",
+		"/api/investment/returns?scope=account&id=-3",
+	}
+	for _, url := range cases {
+		r := httptest.NewRequest("GET", url, nil)
+		_, _, err := parseScope(r)
+		if err == "" {
+			t.Errorf("expected error for %s", url)
+		}
+	}
+}
+
+func TestParseScope_CategoryRequiresValue(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/investment/returns?scope=category", nil)
+	_, _, err := parseScope(r)
+	if err == "" {
+		t.Errorf("expected error when scope=category and value missing")
+	}
+}
+
+func TestParseScope_WrapperRequiresValue(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/investment/returns?scope=wrapper", nil)
+	_, _, err := parseScope(r)
+	if err == "" {
+		t.Errorf("expected error when scope=wrapper and value missing")
+	}
+}
+
+func TestParseScope_CategoryHappyPath(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/investment/returns?scope=category&value=stock", nil)
+	scope, wire, err := parseScope(r)
+	if err != "" {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if scope.Category == nil || *scope.Category != "stock" {
+		t.Errorf("category not set")
+	}
+	if wire.Type != "category" || wire.Value != "stock" {
+		t.Errorf("wire mismatch: %+v", wire)
+	}
+}
+
+func TestParseScope_Unknown(t *testing.T) {
+	r := httptest.NewRequest("GET", "/api/investment/returns?scope=bogus", nil)
+	_, _, err := parseScope(r)
+	if err == "" {
+		t.Errorf("expected error for unknown scope")
+	}
+}
+
+func TestWindowFor_Periods(t *testing.T) {
+	asOf := time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		period       string
+		wantSinceNil bool
+		wantSince    string
+	}{
+		{"1m", false, "2026-04-24"},
+		{"3m", false, "2026-02-24"},
+		{"ytd", false, "2026-01-01"},
+		{"1y", false, "2025-05-24"},
+		{"all", true, ""},
+		{"unknown", true, ""},
+	}
+	for _, tc := range cases {
+		w := windowFor(tc.period, asOf)
+		if tc.wantSinceNil {
+			if w.Since != nil {
+				t.Errorf("%s: expected nil Since, got %v", tc.period, w.Since)
+			}
+			continue
+		}
+		if w.Since == nil {
+			t.Errorf("%s: expected non-nil Since", tc.period)
+			continue
+		}
+		got := w.Since.Format("2006-01-02")
+		if got != tc.wantSince {
+			t.Errorf("%s: Since=%s, want %s", tc.period, got, tc.wantSince)
+		}
+	}
+}

--- a/backend-go/internal/investment/handler_test.go
+++ b/backend-go/internal/investment/handler_test.go
@@ -1,13 +1,15 @@
 package investment
 
 import (
+	"context"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 )
 
 func TestParseScope_DefaultIsAll(t *testing.T) {
-	r := httptest.NewRequest("GET", "/api/investment/returns", nil)
+	r := httptest.NewRequestWithContext(context.Background(), "GET", "/api/investment/returns", http.NoBody)
 	scope, wire, err := parseScope(r)
 	if err != "" {
 		t.Fatalf("unexpected error: %s", err)
@@ -21,7 +23,7 @@ func TestParseScope_DefaultIsAll(t *testing.T) {
 }
 
 func TestParseScope_Account(t *testing.T) {
-	r := httptest.NewRequest("GET", "/api/investment/returns?scope=account&id=42", nil)
+	r := httptest.NewRequestWithContext(context.Background(), "GET", "/api/investment/returns?scope=account&id=42", http.NoBody)
 	scope, wire, err := parseScope(r)
 	if err != "" {
 		t.Fatalf("unexpected error: %s", err)
@@ -42,7 +44,7 @@ func TestParseScope_AccountRejectsBadID(t *testing.T) {
 		"/api/investment/returns?scope=account&id=-3",
 	}
 	for _, url := range cases {
-		r := httptest.NewRequest("GET", url, nil)
+		r := httptest.NewRequestWithContext(context.Background(), "GET", url, http.NoBody)
 		_, _, err := parseScope(r)
 		if err == "" {
 			t.Errorf("expected error for %s", url)
@@ -51,7 +53,7 @@ func TestParseScope_AccountRejectsBadID(t *testing.T) {
 }
 
 func TestParseScope_CategoryRequiresValue(t *testing.T) {
-	r := httptest.NewRequest("GET", "/api/investment/returns?scope=category", nil)
+	r := httptest.NewRequestWithContext(context.Background(), "GET", "/api/investment/returns?scope=category", http.NoBody)
 	_, _, err := parseScope(r)
 	if err == "" {
 		t.Errorf("expected error when scope=category and value missing")
@@ -59,7 +61,7 @@ func TestParseScope_CategoryRequiresValue(t *testing.T) {
 }
 
 func TestParseScope_WrapperRequiresValue(t *testing.T) {
-	r := httptest.NewRequest("GET", "/api/investment/returns?scope=wrapper", nil)
+	r := httptest.NewRequestWithContext(context.Background(), "GET", "/api/investment/returns?scope=wrapper", http.NoBody)
 	_, _, err := parseScope(r)
 	if err == "" {
 		t.Errorf("expected error when scope=wrapper and value missing")
@@ -67,7 +69,7 @@ func TestParseScope_WrapperRequiresValue(t *testing.T) {
 }
 
 func TestParseScope_CategoryHappyPath(t *testing.T) {
-	r := httptest.NewRequest("GET", "/api/investment/returns?scope=category&value=stock", nil)
+	r := httptest.NewRequestWithContext(context.Background(), "GET", "/api/investment/returns?scope=category&value=stock", http.NoBody)
 	scope, wire, err := parseScope(r)
 	if err != "" {
 		t.Fatalf("unexpected error: %s", err)
@@ -81,7 +83,7 @@ func TestParseScope_CategoryHappyPath(t *testing.T) {
 }
 
 func TestParseScope_Unknown(t *testing.T) {
-	r := httptest.NewRequest("GET", "/api/investment/returns?scope=bogus", nil)
+	r := httptest.NewRequestWithContext(context.Background(), "GET", "/api/investment/returns?scope=bogus", http.NoBody)
 	_, _, err := parseScope(r)
 	if err == "" {
 		t.Errorf("expected error for unknown scope")

--- a/backend-go/internal/investment/openapi.go
+++ b/backend-go/internal/investment/openapi.go
@@ -6,4 +6,5 @@ import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
 var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/investment/stock-stats", Tag: "investment", Summary: "Stock ROI aggregates", Response: response{}},
 	{Method: "GET", Path: "/api/investment/bond-stats", Tag: "investment", Summary: "Bond ROI aggregates", Response: response{}},
+	{Method: "GET", Path: "/api/investment/returns", Tag: "investment", Summary: "Contribution-adjusted (money-weighted) returns", Response: returnsResponse{}},
 }

--- a/backend-go/internal/investment/store.go
+++ b/backend-go/internal/investment/store.go
@@ -4,8 +4,11 @@ package investment
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
 )
@@ -21,6 +24,128 @@ type CategoryStats struct {
 	TotalValue       decimal.Decimal
 	TotalContributed decimal.Decimal
 	HasAccounts      bool
+}
+
+// TransactionDated is a dated transaction in the cash-flow series used by the
+// returns endpoint. amount preserves the sign convention from the table
+// (positive = deposit, negative = withdrawal).
+type TransactionDated struct {
+	Date   time.Time
+	Amount decimal.Decimal
+}
+
+// ScopeFilter narrows the account set the returns endpoint operates over.
+// Exactly one of AccountID / Category / Wrapper / All should be set; All=true
+// means the whole household.
+type ScopeFilter struct {
+	AccountID *int
+	Category  *string
+	Wrapper   *string
+	All       bool
+}
+
+// PeriodWindow returns (since, asOf). A nil since means "since the first cash
+// flow in scope" (= "All").
+type PeriodWindow struct {
+	Since *time.Time
+	AsOf  time.Time
+}
+
+// ScopedFlows pulls all active transactions in scope between `since` (open)
+// and `asOf` (inclusive). Returns chronologically sorted.
+func (s *Store) ScopedFlows(ctx context.Context, scope ScopeFilter, w PeriodWindow) ([]TransactionDated, error) {
+	args := []any{w.AsOf}
+	clauses := []string{"a.is_active = true", "t.is_active = true", "t.date <= $1"}
+	if w.Since != nil {
+		args = append(args, *w.Since)
+		clauses = append(clauses, fmt.Sprintf("t.date >= $%d", len(args)))
+	}
+	switch {
+	case scope.AccountID != nil:
+		args = append(args, *scope.AccountID)
+		clauses = append(clauses, fmt.Sprintf("a.id = $%d", len(args)))
+	case scope.Category != nil:
+		args = append(args, *scope.Category)
+		clauses = append(clauses, fmt.Sprintf("a.category = $%d", len(args)))
+	case scope.Wrapper != nil:
+		args = append(args, *scope.Wrapper)
+		clauses = append(clauses, fmt.Sprintf("a.account_wrapper = $%d", len(args)))
+	}
+	where := ""
+	for i, c := range clauses {
+		if i == 0 {
+			where = "WHERE " + c
+		} else {
+			where += " AND " + c
+		}
+	}
+	q := `
+		SELECT t.date, t.amount
+		FROM transactions t
+		JOIN accounts a ON a.id = t.account_id
+		` + where + `
+		ORDER BY t.date ASC, t.id ASC`
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("scoped flows: %w", err)
+	}
+	defer rows.Close()
+	out := []TransactionDated{}
+	for rows.Next() {
+		var td TransactionDated
+		if err := rows.Scan(&td.Date, &td.Amount); err != nil {
+			return nil, fmt.Errorf("scan flow: %w", err)
+		}
+		out = append(out, td)
+	}
+	return out, rows.Err()
+}
+
+// LatestValueInScope returns the sum of snapshot_values at the latest
+// snapshot date on or before `asOf` for accounts matching scope. Returns
+// (zero, false) when no qualifying snapshot exists.
+func (s *Store) LatestValueInScope(ctx context.Context, scope ScopeFilter, asOf time.Time) (decimal.Decimal, time.Time, bool, error) {
+	args := []any{asOf}
+	scopeJoin := ""
+	switch {
+	case scope.AccountID != nil:
+		args = append(args, *scope.AccountID)
+		scopeJoin = fmt.Sprintf("AND sv.account_id = $%d", len(args))
+	case scope.Category != nil:
+		args = append(args, *scope.Category)
+		scopeJoin = fmt.Sprintf("AND a.category = $%d", len(args))
+	case scope.Wrapper != nil:
+		args = append(args, *scope.Wrapper)
+		scopeJoin = fmt.Sprintf("AND a.account_wrapper = $%d", len(args))
+	}
+	row := s.pool.QueryRow(ctx, `
+		WITH latest AS (
+			SELECT MAX(s.date) AS d
+			FROM snapshots s
+			JOIN snapshot_values sv ON sv.snapshot_id = s.id
+			JOIN accounts a ON a.id = sv.account_id
+			WHERE s.date <= $1
+			  AND a.is_active = true
+			  `+scopeJoin+`
+		)
+		SELECT COALESCE(SUM(sv.value), 0), latest.d
+		FROM snapshot_values sv
+		JOIN snapshots s ON s.id = sv.snapshot_id
+		JOIN accounts a ON a.id = sv.account_id, latest
+		WHERE s.date = latest.d
+		  AND a.is_active = true
+		  `+scopeJoin+`
+		GROUP BY latest.d`,
+		args...)
+	var value decimal.Decimal
+	var date time.Time
+	switch err := row.Scan(&value, &date); {
+	case errors.Is(err, pgx.ErrNoRows):
+		return decimal.Zero, time.Time{}, false, nil
+	case err != nil:
+		return decimal.Zero, time.Time{}, false, fmt.Errorf("latest value in scope: %w", err)
+	}
+	return value, date, true, nil
 }
 
 // StatsForCategory replicates backend/app/services/investment.get_category_stats:

--- a/backend-go/internal/investment/store.go
+++ b/backend-go/internal/investment/store.go
@@ -51,8 +51,8 @@ type PeriodWindow struct {
 	AsOf  time.Time
 }
 
-// ScopedFlows pulls all active transactions in scope between `since` (open)
-// and `asOf` (inclusive). Returns chronologically sorted.
+// ScopedFlows pulls all active transactions in scope between `since` and
+// `asOf` (both inclusive). Returns chronologically sorted.
 func (s *Store) ScopedFlows(ctx context.Context, scope ScopeFilter, w PeriodWindow) ([]TransactionDated, error) {
 	args := []any{w.AsOf}
 	clauses := []string{"a.is_active = true", "t.is_active = true", "t.date <= $1"}

--- a/backend-go/internal/investment/xirr.go
+++ b/backend-go/internal/investment/xirr.go
@@ -1,0 +1,100 @@
+package investment
+
+import (
+	"errors"
+	"math"
+	"time"
+)
+
+// CashFlow is one dated movement in the XIRR series.
+//
+// Convention used throughout this package:
+//   - positive amount = deposit (money in to the account)
+//   - negative amount = withdrawal / distribution (money out of the account)
+//   - the final, dated `current_value` is appended as a *negative* terminal
+//     flow, mirroring closing the position.
+//
+// This matches the Excel XIRR convention and keeps the rate sign intuitive:
+// a positive XIRR means the contributions grew, a negative XIRR means they
+// shrank.
+type CashFlow struct {
+	Date   time.Time
+	Amount float64
+}
+
+// ErrXIRRNoConverge is returned when Newton's method fails to converge
+// within xirrMaxIterations. The handler swallows it and reports return=null
+// rather than guessing.
+var ErrXIRRNoConverge = errors.New("xirr: did not converge")
+
+const (
+	xirrMaxIterations = 100
+	xirrTolerance     = 1e-7
+)
+
+// XIRR returns the annualized money-weighted rate of return for the given
+// dated cash flows. Inputs must contain at least one positive and one
+// negative flow (otherwise no rate exists that can balance NPV at zero).
+//
+// Algorithm: Newton-Raphson on r in NPV(r) = 0, starting at r=0.1 and falling
+// back to a 0.5x dampened step when an iteration would push r below -100%
+// (which would make the discount factor undefined for any date after t0).
+func XIRR(flows []CashFlow) (float64, error) {
+	if len(flows) < 2 {
+		return 0, ErrXIRRNoConverge
+	}
+	hasPos, hasNeg := false, false
+	for _, f := range flows {
+		if f.Amount > 0 {
+			hasPos = true
+		} else if f.Amount < 0 {
+			hasNeg = true
+		}
+	}
+	if !hasPos || !hasNeg {
+		return 0, ErrXIRRNoConverge
+	}
+	t0 := flows[0].Date
+	for _, f := range flows {
+		if f.Date.Before(t0) {
+			t0 = f.Date
+		}
+	}
+	rate := 0.1
+	for range xirrMaxIterations {
+		npv, dnpv := 0.0, 0.0
+		for _, f := range flows {
+			years := f.Date.Sub(t0).Hours() / 24 / 365.0
+			base := 1 + rate
+			if base <= 0 {
+				return 0, ErrXIRRNoConverge
+			}
+			disc := math.Pow(base, years)
+			npv += f.Amount / disc
+			dnpv -= years * f.Amount / (disc * base)
+		}
+		if math.Abs(dnpv) < 1e-12 {
+			return 0, ErrXIRRNoConverge
+		}
+		newRate := rate - npv/dnpv
+		if newRate <= -1 {
+			newRate = (rate - 1) / 2 // dampen toward the wall
+		}
+		if math.Abs(newRate-rate) < xirrTolerance {
+			return newRate, nil
+		}
+		rate = newRate
+	}
+	return 0, ErrXIRRNoConverge
+}
+
+// SimpleROI is the contribution-naive return shown by the existing investment
+// dashboard — (value - contributed) / contributed. Surfaced alongside XIRR so
+// the UI can show the difference between "I added X and now have Y" and "Y/X
+// annualized over the actual time it took".
+func SimpleROI(contributed, value float64) float64 {
+	if contributed <= 0 {
+		return 0
+	}
+	return (value - contributed) / contributed
+}

--- a/backend-go/internal/investment/xirr_test.go
+++ b/backend-go/internal/investment/xirr_test.go
@@ -1,0 +1,94 @@
+package investment
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func date(t *testing.T, s string) time.Time {
+	t.Helper()
+	d, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return d
+}
+
+func TestXIRR_FlatBuyAndHoldDoubles(t *testing.T) {
+	// Put 1000 in on day 1, value 2000 one year later -> ~100% XIRR.
+	flows := []CashFlow{
+		{Date: date(t, "2024-01-01"), Amount: 1000},
+		{Date: date(t, "2025-01-01"), Amount: -2000},
+	}
+	r, err := XIRR(flows)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if math.Abs(r-1.0) > 0.01 {
+		t.Errorf("expected ~1.0, got %f", r)
+	}
+}
+
+func TestXIRR_StaircaseContributions(t *testing.T) {
+	// Deposit 1000/month for a year, end at 13_000 — XIRR is small positive.
+	flows := []CashFlow{}
+	d := date(t, "2024-01-01")
+	for i := range 12 {
+		flows = append(flows, CashFlow{Date: d.AddDate(0, i, 0), Amount: 1000})
+	}
+	flows = append(flows, CashFlow{Date: date(t, "2024-12-31"), Amount: -13000})
+	r, err := XIRR(flows)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r <= 0 || r > 1.0 {
+		t.Errorf("expected modest positive return, got %f", r)
+	}
+}
+
+func TestXIRR_DepositsAlone_NotConverge(t *testing.T) {
+	// Only positive flows — XIRR is undefined.
+	_, err := XIRR([]CashFlow{
+		{Date: date(t, "2024-01-01"), Amount: 1000},
+		{Date: date(t, "2024-06-01"), Amount: 500},
+	})
+	if err == nil {
+		t.Errorf("expected convergence error for all-positive flows")
+	}
+}
+
+func TestXIRR_EmptyFlows(t *testing.T) {
+	_, err := XIRR(nil)
+	if err == nil {
+		t.Errorf("expected convergence error for empty flows")
+	}
+}
+
+func TestXIRR_DepositsAreNotGains(t *testing.T) {
+	// Deposit 1000 then deposit another 1000, value stays at 2000 — no growth.
+	flows := []CashFlow{
+		{Date: date(t, "2024-01-01"), Amount: 1000},
+		{Date: date(t, "2024-06-01"), Amount: 1000},
+		{Date: date(t, "2024-12-31"), Amount: -2000},
+	}
+	r, err := XIRR(flows)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if math.Abs(r) > 0.01 {
+		t.Errorf("flat value should give ~0 XIRR, got %f", r)
+	}
+}
+
+func TestSimpleROI(t *testing.T) {
+	if SimpleROI(1000, 1200) != 0.2 {
+		t.Errorf("expected 20%% ROI, got %f", SimpleROI(1000, 1200))
+	}
+	if SimpleROI(0, 1000) != 0 {
+		t.Errorf("zero contributed should yield 0 ROI, got %f", SimpleROI(0, 1000))
+	}
+	if SimpleROI(1000, 800) != -0.2 {
+		t.Errorf("expected -20%% ROI, got %f", SimpleROI(1000, 800))
+	}
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -173,6 +173,7 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	invHandler := investment.NewHandler(investment.NewStore(pool), logger)
 	r.Get("/api/investment/stock-stats", invHandler.StockStats)
 	r.Get("/api/investment/bond-stats", invHandler.BondStats)
+	r.Get("/api/investment/returns", invHandler.Returns)
 
 	simHandler := simulations.NewHandler(simulations.NewStore(pool), logger)
 	r.Post("/api/simulations/mortgage-vs-invest", simHandler.MortgageVsInvest)

--- a/src/lib/components/ContributionAdjustedReturns.svelte
+++ b/src/lib/components/ContributionAdjustedReturns.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+	import { resolveApiUrl } from '$lib/api';
+	import { toast } from '$lib/stores/toast.svelte';
+
+	interface ScopeProp {
+		type: 'all' | 'category' | 'wrapper' | 'account';
+		value?: string;
+		account_id?: number;
+	}
+
+	interface ReturnsResponse {
+		scope: { type: string; value?: string; account_id?: number };
+		period: string;
+		since: string | null;
+		as_of: string;
+		deposits: number;
+		withdrawals: number;
+		net_contributed: number;
+		current_value: number;
+		valuation_change: number;
+		simple_roi_pct: number;
+		money_weighted_pct: number | null;
+		has_snapshot: boolean;
+		convergence_failed: boolean;
+	}
+
+	let { scope, title }: { scope: ScopeProp; title?: string } = $props();
+
+	const PERIODS = [
+		{ value: '1m', label: '1M' },
+		{ value: '3m', label: '3M' },
+		{ value: 'ytd', label: 'YTD' },
+		{ value: '1y', label: '1Y' },
+		{ value: 'all', label: 'Wszystko' }
+	];
+
+	let period = $state('all');
+	let data = $state<ReturnsResponse | null>(null);
+	let loading = $state(false);
+
+	function buildQuery(): string {
+		const params = new URLSearchParams({ scope: scope.type, period });
+		if (scope.type === 'account' && scope.account_id !== undefined) {
+			params.set('id', String(scope.account_id));
+		}
+		if ((scope.type === 'category' || scope.type === 'wrapper') && scope.value) {
+			params.set('value', scope.value);
+		}
+		return params.toString();
+	}
+
+	async function load() {
+		loading = true;
+		try {
+			const apiUrl = resolveApiUrl();
+			const res = await fetch(`${apiUrl}/api/investment/returns?${buildQuery()}`);
+			if (!res.ok) throw new Error('Nie udało się pobrać zwrotów');
+			data = (await res.json()) as ReturnsResponse;
+		} catch (err) {
+			if (err instanceof Error) toast.error(err.message);
+			data = null;
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		void period;
+		void scope.type;
+		void scope.value;
+		void scope.account_id;
+		load();
+	});
+
+	function fmt(n: number): string {
+		return n.toLocaleString('pl-PL', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+	}
+
+	function fmtPct(n: number): string {
+		const sign = n >= 0 ? '+' : '';
+		return `${sign}${n.toFixed(2)}%`;
+	}
+</script>
+
+<section class="card preset-filled-surface-100-900 p-5 space-y-4">
+	<header class="flex flex-wrap items-center justify-between gap-3">
+		<div>
+			<h3 class="h3">{title ?? 'Zwroty skorygowane o wpłaty'}</h3>
+			<p class="text-xs text-surface-600-400">
+				Money-weighted (XIRR) — pokazuje, czy inwestycje wzrosły, a nie tylko ile dodałeś środków.
+			</p>
+		</div>
+		<div class="flex gap-1" role="tablist" aria-label="Okres">
+			{#each PERIODS as p}
+				<button
+					type="button"
+					role="tab"
+					aria-selected={period === p.value}
+					class="btn btn-sm {period === p.value
+						? 'preset-filled-primary-500'
+						: 'preset-tonal-surface'}"
+					onclick={() => (period = p.value)}
+				>
+					{p.label}
+				</button>
+			{/each}
+		</div>
+	</header>
+
+	{#if loading}
+		<p class="text-sm text-surface-700-300">Ładowanie…</p>
+	{:else if !data}
+		<p class="text-sm text-surface-700-300">Brak danych do wyświetlenia.</p>
+	{:else if !data.has_snapshot}
+		<p class="text-sm text-surface-700-300">
+			Brak snapshotów — utwórz snapshot, by zobaczyć zwroty.
+		</p>
+	{:else}
+		<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+			<div class="card preset-tonal-surface p-3">
+				<div class="text-xs text-surface-600-400">Wpłacono netto</div>
+				<div class="text-lg font-semibold">{fmt(data.net_contributed)} PLN</div>
+				<div class="text-xs text-surface-600-400">
+					+{fmt(data.deposits)} / -{fmt(data.withdrawals)}
+				</div>
+			</div>
+			<div class="card preset-tonal-surface p-3">
+				<div class="text-xs text-surface-600-400">Wartość obecna</div>
+				<div class="text-lg font-semibold">{fmt(data.current_value)} PLN</div>
+				<div class="text-xs text-surface-600-400">na {data.as_of}</div>
+			</div>
+			<div class="card preset-tonal-surface p-3">
+				<div class="text-xs text-surface-600-400">Zmiana wyceny</div>
+				<div
+					class="text-lg font-semibold {data.valuation_change >= 0
+						? 'text-success-500'
+						: 'text-error-500'}"
+				>
+					{data.valuation_change >= 0 ? '+' : ''}{fmt(data.valuation_change)} PLN
+				</div>
+				<div class="text-xs text-surface-600-400">wartość − wpłaty</div>
+			</div>
+			<div class="card preset-tonal-surface p-3">
+				<div class="text-xs text-surface-600-400">Zwrot (XIRR)</div>
+				{#if data.money_weighted_pct !== null}
+					<div
+						class="text-lg font-semibold {data.money_weighted_pct >= 0
+							? 'text-success-500'
+							: 'text-error-500'}"
+					>
+						{fmtPct(data.money_weighted_pct)}
+					</div>
+					<div class="text-xs text-surface-600-400">
+						prosty ROI: {fmtPct(data.simple_roi_pct)}
+					</div>
+				{:else if data.convergence_failed}
+					<div class="text-sm text-surface-700-300">Nie udało się obliczyć</div>
+					<div class="text-xs text-surface-600-400">
+						prosty ROI: {fmtPct(data.simple_roi_pct)}
+					</div>
+				{:else}
+					<div class="text-sm text-surface-700-300">—</div>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</section>

--- a/src/lib/components/ContributionAdjustedReturns.test.ts
+++ b/src/lib/components/ContributionAdjustedReturns.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
+
+vi.mock('$env/dynamic/public', () => ({
+	env: {
+		PUBLIC_API_URL_BROWSER: 'http://localhost:8000',
+		PUBLIC_API_URL: 'http://localhost:8000'
+	}
+}));
+
+import ContributionAdjustedReturns from './ContributionAdjustedReturns.svelte';
+
+const successPayload = {
+	scope: { type: 'all' },
+	period: 'all',
+	since: null,
+	as_of: '2026-05-24',
+	deposits: 10000,
+	withdrawals: 0,
+	net_contributed: 10000,
+	current_value: 12000,
+	valuation_change: 2000,
+	simple_roi_pct: 20,
+	money_weighted_pct: 15.5,
+	has_snapshot: true,
+	convergence_failed: false
+};
+
+describe('ContributionAdjustedReturns', () => {
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		fetchSpy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async () => new Response(JSON.stringify(successPayload)));
+	});
+
+	afterEach(() => {
+		fetchSpy.mockRestore();
+	});
+
+	it('renders metric cards after fetch', async () => {
+		render(ContributionAdjustedReturns, { props: { scope: { type: 'all' } } });
+		await waitFor(() => {
+			expect(screen.getByText('Wpłacono netto')).toBeTruthy();
+			expect(screen.getByText('Wartość obecna')).toBeTruthy();
+			expect(screen.getByText('Zwrot (XIRR)')).toBeTruthy();
+		});
+	});
+
+	it('renders snapshot-missing copy when has_snapshot=false', async () => {
+		fetchSpy.mockImplementation(
+			async () => new Response(JSON.stringify({ ...successPayload, has_snapshot: false }))
+		);
+		render(ContributionAdjustedReturns, { props: { scope: { type: 'all' } } });
+		await waitFor(() => {
+			expect(screen.getByText(/Brak snapshotów/)).toBeTruthy();
+		});
+	});
+
+	it('re-fetches when period changes', async () => {
+		render(ContributionAdjustedReturns, { props: { scope: { type: 'all' } } });
+		await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+		fetchSpy.mockClear();
+		await fireEvent.click(screen.getByRole('tab', { name: '1M' }));
+		await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+		const lastCall = fetchSpy.mock.calls[fetchSpy.mock.calls.length - 1][0] as string;
+		expect(lastCall).toContain('period=1m');
+	});
+
+	it('shows convergence-failed copy when API reports it', async () => {
+		fetchSpy.mockImplementation(
+			async () =>
+				new Response(
+					JSON.stringify({
+						...successPayload,
+						money_weighted_pct: null,
+						convergence_failed: true
+					})
+				)
+		);
+		render(ContributionAdjustedReturns, { props: { scope: { type: 'all' } } });
+		await waitFor(() => {
+			expect(screen.getByText('Nie udało się obliczyć')).toBeTruthy();
+		});
+	});
+});

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -2979,6 +2979,67 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/investment/returns": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Contribution-adjusted (money-weighted) returns */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            as_of?: string;
+                            convergence_failed?: boolean;
+                            /** Format: double */
+                            current_value?: number;
+                            /** Format: double */
+                            deposits?: number;
+                            has_snapshot?: boolean;
+                            /** Format: double */
+                            money_weighted_pct?: number | null;
+                            /** Format: double */
+                            net_contributed?: number;
+                            period?: string;
+                            scope?: {
+                                account_id?: number | null;
+                                type?: string;
+                                value?: string;
+                            };
+                            /** Format: double */
+                            simple_roi_pct?: number;
+                            since?: string | null;
+                            /** Format: double */
+                            valuation_change?: number;
+                            /** Format: double */
+                            withdrawals?: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/investment/stock-stats": {
         parameters: {
             query?: never;

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -12,6 +12,7 @@
 	} from '$lib/utils/charts/metryki';
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
+	import ContributionAdjustedReturns from '$lib/components/ContributionAdjustedReturns.svelte';
 
 	import type { PageData } from './$types';
 
@@ -381,6 +382,13 @@
 			/>
 		</div>
 	{/if}
+
+	<h2 class="h2">Zwroty skorygowane o wpłaty</h2>
+	<div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+		<ContributionAdjustedReturns scope={{ type: 'all' }} title="Gospodarstwo" />
+		<ContributionAdjustedReturns scope={{ type: 'category', value: 'stock' }} title="Akcje" />
+		<ContributionAdjustedReturns scope={{ type: 'category', value: 'bond' }} title="Obligacje" />
+	</div>
 
 	<h2 class="h2">Struktura portfela inwestycyjnego</h2>
 


### PR DESCRIPTION
## Motivation

Net-worth charts mix deposits, withdrawals and market movement so users see whether they added more money, not whether their investments actually performed.

## Implementation information

- Pure `XIRR` function in `internal/investment/xirr.go` — Newton-Raphson on dated cash flows, returns money-weighted (annualized) return. Handles deposit-only edge case (no negative flow) and convergence failure as `ErrXIRRNoConverge`. 6 unit tests cover buy-and-hold, staircase contributions, deposits-not-counting-as-gains, deposits-alone-no-convergence, and SimpleROI.
- New `GET /api/investment/returns?scope=&id=&value=&period=` endpoint. Scope = `all|account|category|wrapper`. Period = `1m|3m|ytd|1y|all`. Response carries deposits, withdrawals, net contributed, current value, valuation change, simple ROI %, money-weighted %, plus `has_snapshot` and `convergence_failed` flags so the UI can degrade gracefully when XIRR can't compute.
- Store gains `ScopedFlows` and `LatestValueInScope`, parameter-built so the same query handles account/category/wrapper/all.
- New `ContributionAdjustedReturns.svelte` widget with the 1M/3M/YTD/1Y/All period selector. Three widgets mounted on `/metryki` (household, stocks, bonds) so the user sees both naive ROI and XIRR side by side.
- Formula documented at the top of `xirr.go`. Time-weighted return is the documented next step — out of scope for this PR.

Closes #401

> Changelog: feat(investments): contribution-adjusted returns