### PR TITLE
feat(investments): holdings, lots, manual quotes

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -4544,6 +4544,439 @@
         ]
       }
     },
+    "/api/holdings": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "holdings": {
+                      "items": {
+                        "properties": {
+                          "average_cost": {
+                            "type": "string"
+                          },
+                          "cost_basis": {
+                            "type": "string"
+                          },
+                          "latest_quote": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "latest_quote_date": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "market_value": {
+                            "type": "string"
+                          },
+                          "quantity": {
+                            "type": "string"
+                          },
+                          "realized_gain": {
+                            "type": "string"
+                          },
+                          "security": {
+                            "properties": {
+                              "asset_type": {
+                                "type": "string"
+                              },
+                              "created_at": {
+                                "type": "string"
+                              },
+                              "currency": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "integer"
+                              },
+                              "isin": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "symbol": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "unrealized_gain": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Aggregated holdings across accounts",
+        "tags": [
+          "holdings"
+        ]
+      }
+    },
+    "/api/holdings/lots": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "lots": {
+                      "items": {
+                        "properties": {
+                          "account_id": {
+                            "type": "integer"
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "date": {
+                            "type": "string"
+                          },
+                          "fee": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "price": {
+                            "type": "string"
+                          },
+                          "quantity": {
+                            "type": "string"
+                          },
+                          "security_id": {
+                            "type": "integer"
+                          },
+                          "side": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List lots (filterable by account_id/security_id)",
+        "tags": [
+          "holdings"
+        ]
+      },
+      "post": {
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account_id": {
+                      "type": "integer"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "date": {
+                      "type": "string"
+                    },
+                    "fee": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "price": {
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "type": "string"
+                    },
+                    "security_id": {
+                      "type": "integer"
+                    },
+                    "side": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create a lot",
+        "tags": [
+          "holdings"
+        ]
+      }
+    },
+    "/api/holdings/lots/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete a lot",
+        "tags": [
+          "holdings"
+        ]
+      }
+    },
+    "/api/holdings/securities": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "securities": {
+                      "items": {
+                        "properties": {
+                          "asset_type": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "isin": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "symbol": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List securities",
+        "tags": [
+          "holdings"
+        ]
+      },
+      "post": {
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "asset_type": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "isin": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "symbol": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create a security",
+        "tags": [
+          "holdings"
+        ]
+      }
+    },
+    "/api/holdings/securities/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete a security",
+        "tags": [
+          "holdings"
+        ]
+      }
+    },
+    "/api/holdings/securities/{id}/quotes": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "quotes": {
+                      "items": {
+                        "properties": {
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "date": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "price": {
+                            "type": "string"
+                          },
+                          "security_id": {
+                            "type": "integer"
+                          },
+                          "source": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List manual price quotes",
+        "tags": [
+          "holdings"
+        ]
+      },
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "date": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "price": {
+                      "type": "string"
+                    },
+                    "security_id": {
+                      "type": "integer"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Upsert a manual price quote",
+        "tags": [
+          "holdings"
+        ]
+      }
+    },
     "/api/investment/bond-stats": {
       "get": {
         "responses": {

--- a/backend-go/cmd/gen-openapi/routes.go
+++ b/backend-go/cmd/gen-openapi/routes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/debts"
 	equitygrants "github.com/Automaat/finance-buddy/backend-go/internal/equity_grants"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
+	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
 	"github.com/Automaat/finance-buddy/backend-go/internal/investment"
 	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
@@ -57,6 +58,7 @@ func allRoutes() []apispec.Route {
 		zus.APISpec,
 		retirement.APISpec,
 		investment.APISpec,
+		holdings.APISpec,
 		simulations.APISpec,
 		transactions.APISpec,
 		recurring.APISpec,

--- a/backend-go/internal/db/migrate.go
+++ b/backend-go/internal/db/migrate.go
@@ -64,6 +64,56 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
 	if err := createRecurringTransactionsTable(ctx, pool); err != nil {
 		return err
 	}
+	if err := createHoldingsTables(ctx, pool); err != nil {
+		return err
+	}
+	return nil
+}
+
+// createHoldingsTables creates the securities / lots / price_quotes tables
+// (issue #400) on existing databases. Fresh installs get them from schema.sql.
+// All statements are idempotent.
+func createHoldingsTables(ctx context.Context, pool *pgxpool.Pool) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS securities (
+			id serial PRIMARY KEY,
+			symbol varchar(32) NOT NULL,
+			isin varchar(12),
+			name varchar(200) NOT NULL,
+			asset_type varchar(16) NOT NULL,
+			currency varchar(3) NOT NULL DEFAULT 'PLN',
+			created_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc')
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS uq_securities_symbol ON securities (symbol)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS uq_securities_isin ON securities (isin) WHERE isin IS NOT NULL`,
+		`CREATE TABLE IF NOT EXISTS lots (
+			id serial PRIMARY KEY,
+			account_id integer NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+			security_id integer NOT NULL REFERENCES securities(id) ON DELETE RESTRICT,
+			side varchar(8) NOT NULL,
+			quantity numeric(20,8) NOT NULL,
+			price numeric(20,6) NOT NULL,
+			fee numeric(15,2) NOT NULL DEFAULT 0,
+			date ` + "DATE" + ` NOT NULL,
+			created_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc')
+		)`,
+		`CREATE INDEX IF NOT EXISTS ix_lots_security_date ON lots (security_id, date)`,
+		`CREATE INDEX IF NOT EXISTS ix_lots_account ON lots (account_id)`,
+		`CREATE TABLE IF NOT EXISTS price_quotes (
+			id serial PRIMARY KEY,
+			security_id integer NOT NULL REFERENCES securities(id) ON DELETE CASCADE,
+			date ` + "DATE" + ` NOT NULL,
+			price numeric(20,6) NOT NULL,
+			source varchar(40) NOT NULL DEFAULT 'manual',
+			created_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc')
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS uq_price_quotes_security_date ON price_quotes (security_id, date)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := pool.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("create holdings tables: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/backend-go/internal/db/schema.sql
+++ b/backend-go/internal/db/schema.sql
@@ -648,6 +648,82 @@ CREATE TABLE public.transactions (
 -- Name: recurring_transactions; Type: TABLE; Schema: public; Owner: -
 --
 
+CREATE TABLE public.securities (
+    id integer NOT NULL,
+    symbol character varying(32) NOT NULL,
+    isin character varying(12),
+    name character varying(200) NOT NULL,
+    asset_type character varying(16) NOT NULL,
+    currency character varying(3) NOT NULL DEFAULT 'PLN',
+    created_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc')
+);
+
+CREATE SEQUENCE public.securities_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.securities_id_seq OWNED BY public.securities.id;
+
+
+--
+-- Name: lots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lots (
+    id integer NOT NULL,
+    account_id integer NOT NULL,
+    security_id integer NOT NULL,
+    side character varying(8) NOT NULL,
+    quantity numeric(20,8) NOT NULL,
+    price numeric(20,6) NOT NULL,
+    fee numeric(15,2) NOT NULL DEFAULT 0,
+    date date NOT NULL,
+    created_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc')
+);
+
+CREATE SEQUENCE public.lots_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.lots_id_seq OWNED BY public.lots.id;
+
+
+--
+-- Name: price_quotes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.price_quotes (
+    id integer NOT NULL,
+    security_id integer NOT NULL,
+    date date NOT NULL,
+    price numeric(20,6) NOT NULL,
+    source character varying(40) NOT NULL DEFAULT 'manual',
+    created_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc')
+);
+
+CREATE SEQUENCE public.price_quotes_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.price_quotes_id_seq OWNED BY public.price_quotes.id;
+
+
+--
+-- Name: recurring_transactions; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.recurring_transactions (
     id integer NOT NULL,
     account_id integer NOT NULL,
@@ -828,6 +904,10 @@ ALTER TABLE ONLY public.transactions ALTER COLUMN id SET DEFAULT nextval('public
 
 ALTER TABLE ONLY public.recurring_transactions ALTER COLUMN id SET DEFAULT nextval('public.recurring_transactions_id_seq'::regclass);
 
+ALTER TABLE ONLY public.securities ALTER COLUMN id SET DEFAULT nextval('public.securities_id_seq'::regclass);
+ALTER TABLE ONLY public.lots ALTER COLUMN id SET DEFAULT nextval('public.lots_id_seq'::regclass);
+ALTER TABLE ONLY public.price_quotes ALTER COLUMN id SET DEFAULT nextval('public.price_quotes_id_seq'::regclass);
+
 
 --
 -- Name: accounts accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -997,6 +1077,38 @@ CREATE INDEX ix_recurring_transactions_active_account ON public.recurring_transa
 
 
 --
+-- Name: securities securities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.securities
+    ADD CONSTRAINT securities_pkey PRIMARY KEY (id);
+
+CREATE UNIQUE INDEX uq_securities_symbol ON public.securities USING btree (symbol);
+CREATE UNIQUE INDEX uq_securities_isin ON public.securities USING btree (isin) WHERE isin IS NOT NULL;
+
+
+--
+-- Name: lots lots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.lots
+    ADD CONSTRAINT lots_pkey PRIMARY KEY (id);
+
+CREATE INDEX ix_lots_security_date ON public.lots USING btree (security_id, date);
+CREATE INDEX ix_lots_account ON public.lots USING btree (account_id);
+
+
+--
+-- Name: price_quotes price_quotes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.price_quotes
+    ADD CONSTRAINT price_quotes_pkey PRIMARY KEY (id);
+
+CREATE UNIQUE INDEX uq_price_quotes_security_date ON public.price_quotes USING btree (security_id, date);
+
+
+--
 -- Name: snapshot_values uix_snapshot_account; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1149,6 +1261,13 @@ ALTER TABLE ONLY public.transactions
 
 ALTER TABLE ONLY public.recurring_transactions
     ADD CONSTRAINT recurring_transactions_owner_user_id_fkey FOREIGN KEY (owner_user_id) REFERENCES public.users(id) ON DELETE RESTRICT;
+
+ALTER TABLE ONLY public.lots
+    ADD CONSTRAINT lots_account_id_fkey FOREIGN KEY (account_id) REFERENCES public.accounts(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public.lots
+    ADD CONSTRAINT lots_security_id_fkey FOREIGN KEY (security_id) REFERENCES public.securities(id) ON DELETE RESTRICT;
+ALTER TABLE ONLY public.price_quotes
+    ADD CONSTRAINT price_quotes_security_id_fkey FOREIGN KEY (security_id) REFERENCES public.securities(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY public.salary_records
     ADD CONSTRAINT salary_records_owner_user_id_fkey FOREIGN KEY (owner_user_id) REFERENCES public.users(id) ON DELETE RESTRICT;

--- a/backend-go/internal/db/schema.sql
+++ b/backend-go/internal/db/schema.sql
@@ -645,7 +645,7 @@ CREATE TABLE public.transactions (
 
 
 --
--- Name: recurring_transactions; Type: TABLE; Schema: public; Owner: -
+-- Name: securities; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.securities (

--- a/backend-go/internal/holdings/costbasis.go
+++ b/backend-go/internal/holdings/costbasis.go
@@ -1,0 +1,131 @@
+// Package holdings implements per-security holdings tracking — buy/sell lots,
+// weighted-average cost basis, realized/unrealized gain, and manual price
+// quotes. Issue #400.
+//
+// Cost-basis convention: weighted average. For every buy, the average cost
+// rolls forward including the fee; for every sell, realized P&L is taken
+// against the running average and the fee subtracts from realized gain. This
+// matches the most common Polish broker reporting model and the IRS
+// "average cost" basis for funds. FIFO/LIFO can be added later behind a
+// per-account flag without changing the storage model.
+package holdings
+
+import (
+	"errors"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Side discriminates a Lot row.
+type Side string
+
+const (
+	SideBuy  Side = "buy"
+	SideSell Side = "sell"
+)
+
+// IsValidSide reports whether s is "buy" or "sell".
+func IsValidSide(s string) bool {
+	return s == string(SideBuy) || s == string(SideSell)
+}
+
+// Lot is one buy or sell of a security inside an account. The store reads
+// rows in chronological order and walks them through ComputeRunning to
+// produce per-security holdings.
+type Lot struct {
+	ID         int
+	AccountID  int
+	SecurityID int
+	Side       Side
+	Quantity   decimal.Decimal // always positive on the lot row; Side carries the sign
+	Price      decimal.Decimal // per-unit
+	Fee        decimal.Decimal // total fee for the lot, in account currency
+	Date       time.Time
+	CreatedAt  time.Time
+}
+
+// Running is the running cost-basis state for one security after a sequence
+// of lots has been replayed.
+type Running struct {
+	Quantity     decimal.Decimal
+	AverageCost  decimal.Decimal // per unit, weighted average
+	CostBasis    decimal.Decimal // Quantity * AverageCost (cached so callers don't need decimal math)
+	RealizedGain decimal.Decimal
+	TotalBought  decimal.Decimal // gross deposits — for return-attribution
+	TotalSold    decimal.Decimal // gross proceeds — same
+	FeesPaid     decimal.Decimal
+}
+
+// ErrOversell is returned by ComputeRunning when a sell lot exceeds the
+// current quantity held.
+var ErrOversell = errors.New("holdings: sell exceeds quantity held")
+
+// ComputeRunning replays a chronologically sorted lot history and returns the
+// final cost-basis state. Pure function — same input gives same output.
+//
+// Buy:
+//
+//	new_qty       = qty + lot.qty
+//	new_avg_cost  = (qty*avg_cost + lot.qty*lot.price + lot.fee) / new_qty
+//	cost_basis    = new_qty * new_avg_cost
+//	total_bought += lot.qty*lot.price + lot.fee
+//
+// Sell:
+//
+//	realized_gain += (lot.price - avg_cost) * lot.qty - lot.fee
+//	qty           -= lot.qty                 ; avg_cost unchanged
+//	cost_basis     = qty * avg_cost
+//	total_sold    += lot.qty*lot.price - lot.fee
+func ComputeRunning(lots []Lot) (Running, error) {
+	var r Running
+	for i := range lots {
+		l := &lots[i]
+		switch l.Side {
+		case SideBuy:
+			lotCost := l.Quantity.Mul(l.Price).Add(l.Fee)
+			newQty := r.Quantity.Add(l.Quantity)
+			if newQty.IsZero() {
+				r.AverageCost = decimal.Zero
+			} else {
+				existing := r.Quantity.Mul(r.AverageCost)
+				r.AverageCost = existing.Add(lotCost).Div(newQty)
+			}
+			r.Quantity = newQty
+			r.TotalBought = r.TotalBought.Add(lotCost)
+			r.FeesPaid = r.FeesPaid.Add(l.Fee)
+		case SideSell:
+			if l.Quantity.GreaterThan(r.Quantity) {
+				return Running{}, ErrOversell
+			}
+			gain := l.Price.Sub(r.AverageCost).Mul(l.Quantity).Sub(l.Fee)
+			r.RealizedGain = r.RealizedGain.Add(gain)
+			proceeds := l.Quantity.Mul(l.Price).Sub(l.Fee)
+			r.TotalSold = r.TotalSold.Add(proceeds)
+			r.Quantity = r.Quantity.Sub(l.Quantity)
+			r.FeesPaid = r.FeesPaid.Add(l.Fee)
+			if r.Quantity.IsZero() {
+				r.AverageCost = decimal.Zero
+			}
+		}
+	}
+	r.CostBasis = r.Quantity.Mul(r.AverageCost)
+	return r, nil
+}
+
+// UnrealizedGain reports the open-position gain at price `quote`. Returns
+// zero when no quote is supplied (Decimal.IsZero()).
+func UnrealizedGain(r Running, quote decimal.Decimal) decimal.Decimal {
+	if quote.IsZero() {
+		return decimal.Zero
+	}
+	return quote.Sub(r.AverageCost).Mul(r.Quantity)
+}
+
+// MarketValue is Quantity * latest quote, or CostBasis when no quote.
+func MarketValue(r Running, quote decimal.Decimal) decimal.Decimal {
+	if quote.IsZero() {
+		return r.CostBasis
+	}
+	return r.Quantity.Mul(quote)
+}

--- a/backend-go/internal/holdings/costbasis_test.go
+++ b/backend-go/internal/holdings/costbasis_test.go
@@ -1,0 +1,164 @@
+package holdings
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func d(s string) decimal.Decimal {
+	v, _ := decimal.NewFromString(s)
+	return v
+}
+
+func date(t *testing.T, s string) time.Time {
+	t.Helper()
+	out, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return out
+}
+
+func TestComputeRunning_SingleBuy(t *testing.T) {
+	r, err := ComputeRunning([]Lot{
+		{Side: SideBuy, Quantity: d("10"), Price: d("100"), Fee: d("5"), Date: date(t, "2024-01-01")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !r.Quantity.Equal(d("10")) {
+		t.Errorf("qty = %s, want 10", r.Quantity)
+	}
+	// avg = (10*100 + 5) / 10 = 100.5
+	if !r.AverageCost.Equal(d("100.5")) {
+		t.Errorf("avg cost = %s, want 100.5", r.AverageCost)
+	}
+	if !r.CostBasis.Equal(d("1005")) {
+		t.Errorf("basis = %s, want 1005", r.CostBasis)
+	}
+	if !r.RealizedGain.IsZero() {
+		t.Errorf("realized gain should be zero, got %s", r.RealizedGain)
+	}
+}
+
+func TestComputeRunning_WeightedAverageOnRepeatBuys(t *testing.T) {
+	// Buy 10 @ 100, then 10 @ 120. No fees. Avg should be 110.
+	r, err := ComputeRunning([]Lot{
+		{Side: SideBuy, Quantity: d("10"), Price: d("100"), Date: date(t, "2024-01-01")},
+		{Side: SideBuy, Quantity: d("10"), Price: d("120"), Date: date(t, "2024-02-01")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !r.Quantity.Equal(d("20")) {
+		t.Errorf("qty = %s, want 20", r.Quantity)
+	}
+	if !r.AverageCost.Equal(d("110")) {
+		t.Errorf("avg cost = %s, want 110", r.AverageCost)
+	}
+}
+
+func TestComputeRunning_PartialSaleRealizesGain(t *testing.T) {
+	// Buy 10 @ 100, sell 4 @ 150. Realized gain = (150 - 100) * 4 = 200.
+	// Remaining qty = 6, avg cost stays 100.
+	r, err := ComputeRunning([]Lot{
+		{Side: SideBuy, Quantity: d("10"), Price: d("100"), Date: date(t, "2024-01-01")},
+		{Side: SideSell, Quantity: d("4"), Price: d("150"), Date: date(t, "2024-06-01")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !r.Quantity.Equal(d("6")) {
+		t.Errorf("qty = %s, want 6", r.Quantity)
+	}
+	if !r.AverageCost.Equal(d("100")) {
+		t.Errorf("avg cost should stay 100, got %s", r.AverageCost)
+	}
+	if !r.RealizedGain.Equal(d("200")) {
+		t.Errorf("realized gain = %s, want 200", r.RealizedGain)
+	}
+}
+
+func TestComputeRunning_FullSaleZerosAvgCost(t *testing.T) {
+	r, err := ComputeRunning([]Lot{
+		{Side: SideBuy, Quantity: d("10"), Price: d("100"), Date: date(t, "2024-01-01")},
+		{Side: SideSell, Quantity: d("10"), Price: d("120"), Date: date(t, "2024-06-01")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !r.Quantity.IsZero() {
+		t.Errorf("qty = %s, want 0", r.Quantity)
+	}
+	if !r.AverageCost.IsZero() {
+		t.Errorf("avg cost = %s, want 0", r.AverageCost)
+	}
+	if !r.RealizedGain.Equal(d("200")) {
+		t.Errorf("realized gain = %s, want 200", r.RealizedGain)
+	}
+}
+
+func TestComputeRunning_SellWithFeeReducesGain(t *testing.T) {
+	r, err := ComputeRunning([]Lot{
+		{Side: SideBuy, Quantity: d("10"), Price: d("100"), Date: date(t, "2024-01-01")},
+		{Side: SideSell, Quantity: d("10"), Price: d("120"), Fee: d("15"), Date: date(t, "2024-06-01")},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Gain = (120 - 100) * 10 - 15 = 185
+	if !r.RealizedGain.Equal(d("185")) {
+		t.Errorf("realized gain = %s, want 185", r.RealizedGain)
+	}
+}
+
+func TestComputeRunning_OversellErrors(t *testing.T) {
+	_, err := ComputeRunning([]Lot{
+		{Side: SideBuy, Quantity: d("5"), Price: d("100"), Date: date(t, "2024-01-01")},
+		{Side: SideSell, Quantity: d("10"), Price: d("100"), Date: date(t, "2024-06-01")},
+	})
+	if !errors.Is(err, ErrOversell) {
+		t.Errorf("expected ErrOversell, got %v", err)
+	}
+}
+
+func TestUnrealizedGain(t *testing.T) {
+	r := Running{Quantity: d("10"), AverageCost: d("100")}
+	got := UnrealizedGain(r, d("120"))
+	if !got.Equal(d("200")) {
+		t.Errorf("unrealized = %s, want 200", got)
+	}
+}
+
+func TestUnrealizedGain_NoQuote(t *testing.T) {
+	r := Running{Quantity: d("10"), AverageCost: d("100")}
+	if !UnrealizedGain(r, decimal.Zero).IsZero() {
+		t.Errorf("no quote should yield zero unrealized")
+	}
+}
+
+func TestMarketValue_NoQuoteUsesCostBasis(t *testing.T) {
+	r := Running{Quantity: d("10"), AverageCost: d("100"), CostBasis: d("1000")}
+	if !MarketValue(r, decimal.Zero).Equal(d("1000")) {
+		t.Errorf("no quote should fall back to cost basis")
+	}
+}
+
+func TestMarketValue_QuotedUsesQuote(t *testing.T) {
+	r := Running{Quantity: d("10"), AverageCost: d("100"), CostBasis: d("1000")}
+	if !MarketValue(r, d("150")).Equal(d("1500")) {
+		t.Errorf("quote should give 1500")
+	}
+}
+
+func TestIsValidSide(t *testing.T) {
+	if !IsValidSide("buy") || !IsValidSide("sell") {
+		t.Errorf("buy/sell should be valid")
+	}
+	if IsValidSide("short") {
+		t.Errorf("short should be invalid")
+	}
+}

--- a/backend-go/internal/holdings/handler.go
+++ b/backend-go/internal/holdings/handler.go
@@ -11,7 +11,23 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/shopspring/decimal"
+)
+
+// pgErrorCode returns the SQLSTATE for a Postgres-driven error, or "" when
+// the error didn't originate from pgx.
+func pgErrorCode(err error) string {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code
+	}
+	return ""
+}
+
+const (
+	pgUniqueViolation     = "23505"
+	pgForeignKeyViolation = "23503"
 )
 
 // Handler is the HTTP boundary for /api/holdings.
@@ -81,6 +97,10 @@ func (h *Handler) CreateSecurity(w http.ResponseWriter, r *http.Request) {
 	}
 	created, err := h.store.CreateSecurity(r.Context(), sec)
 	if err != nil {
+		if pgErrorCode(err) == pgUniqueViolation {
+			writeError(w, http.StatusConflict, "A security with the same symbol or ISIN already exists")
+			return
+		}
 		h.logger.Error("create security", "err", err)
 		writeError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
@@ -99,8 +119,12 @@ func (h *Handler) DeleteSecurity(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusNotFound, "Security not found")
 			return
 		}
-		// Foreign-key violation from referencing lots.
-		writeError(w, http.StatusConflict, "Cannot delete security with lots; delete the lots first")
+		if pgErrorCode(err) == pgForeignKeyViolation {
+			writeError(w, http.StatusConflict, "Cannot delete security with lots; delete the lots first")
+			return
+		}
+		h.logger.Error("delete security", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -182,6 +206,10 @@ func (h *Handler) CreateLot(w http.ResponseWriter, r *http.Request) {
 	}
 	created, err := h.store.CreateLot(r.Context(), lot)
 	if err != nil {
+		if pgErrorCode(err) == pgForeignKeyViolation {
+			writeError(w, http.StatusNotFound, "Referenced account or security not found")
+			return
+		}
 		h.logger.Error("create lot", "err", err)
 		writeError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
@@ -269,6 +297,10 @@ func (h *Handler) UpsertQuote(w http.ResponseWriter, r *http.Request) {
 	}
 	saved, err := h.store.UpsertQuote(r.Context(), q)
 	if err != nil {
+		if pgErrorCode(err) == pgForeignKeyViolation {
+			writeError(w, http.StatusNotFound, "Security not found")
+			return
+		}
 		h.logger.Error("upsert quote", "err", err)
 		writeError(w, http.StatusInternalServerError, "Internal Server Error")
 		return

--- a/backend-go/internal/holdings/handler.go
+++ b/backend-go/internal/holdings/handler.go
@@ -1,0 +1,582 @@
+package holdings
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+)
+
+// Handler is the HTTP boundary for /api/holdings.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewHandler wires store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger}
+}
+
+// --- security wire types ---
+
+type securityResponse struct {
+	ID        int     `json:"id"`
+	Symbol    string  `json:"symbol"`
+	ISIN      *string `json:"isin"`
+	Name      string  `json:"name"`
+	AssetType string  `json:"asset_type"`
+	Currency  string  `json:"currency"`
+	CreatedAt string  `json:"created_at"`
+}
+
+type listSecuritiesResponse struct {
+	Securities []securityResponse `json:"securities"`
+}
+
+func toSecurity(s Security) securityResponse {
+	return securityResponse{
+		ID: s.ID, Symbol: s.Symbol, ISIN: s.ISIN, Name: s.Name,
+		AssetType: s.AssetType, Currency: s.Currency,
+		CreatedAt: s.CreatedAt.UTC().Format("2006-01-02T15:04:05.999999"),
+	}
+}
+
+// ListSecurities serves GET /api/holdings/securities.
+func (h *Handler) ListSecurities(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.store.ListSecurities(r.Context())
+	if err != nil {
+		h.logger.Error("list securities", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := make([]securityResponse, 0, len(rows))
+	for _, s := range rows {
+		out = append(out, toSecurity(s))
+	}
+	writeJSON(w, http.StatusOK, listSecuritiesResponse{Securities: out})
+}
+
+// CreateSecurity serves POST /api/holdings/securities.
+func (h *Handler) CreateSecurity(w http.ResponseWriter, r *http.Request) {
+	raw, err := readBody(r)
+	if err != nil {
+		writeValidation(w, "body", "Invalid JSON body")
+		return
+	}
+	sec, vErr := buildSecurityInput(raw)
+	if vErr != nil {
+		writeValidation(w, vErr.Field, vErr.Msg)
+		return
+	}
+	created, err := h.store.CreateSecurity(r.Context(), sec)
+	if err != nil {
+		h.logger.Error("create security", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toSecurity(created))
+}
+
+// DeleteSecurity serves DELETE /api/holdings/securities/{id}.
+func (h *Handler) DeleteSecurity(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.DeleteSecurity(r.Context(), id); err != nil {
+		if errors.Is(err, ErrSecurityNotFound) {
+			writeError(w, http.StatusNotFound, "Security not found")
+			return
+		}
+		// Foreign-key violation from referencing lots.
+		writeError(w, http.StatusConflict, "Cannot delete security with lots; delete the lots first")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- lot wire types ---
+
+type lotResponse struct {
+	ID         int    `json:"id"`
+	AccountID  int    `json:"account_id"`
+	SecurityID int    `json:"security_id"`
+	Side       string `json:"side"`
+	Quantity   string `json:"quantity"`
+	Price      string `json:"price"`
+	Fee        string `json:"fee"`
+	Date       string `json:"date"`
+	CreatedAt  string `json:"created_at"`
+}
+
+type listLotsResponse struct {
+	Lots []lotResponse `json:"lots"`
+}
+
+func toLot(l Lot) lotResponse {
+	return lotResponse{
+		ID: l.ID, AccountID: l.AccountID, SecurityID: l.SecurityID,
+		Side:      string(l.Side),
+		Quantity:  l.Quantity.String(),
+		Price:     l.Price.String(),
+		Fee:       l.Fee.StringFixed(2),
+		Date:      l.Date.UTC().Format("2006-01-02"),
+		CreatedAt: l.CreatedAt.UTC().Format("2006-01-02T15:04:05.999999"),
+	}
+}
+
+// ListLots serves GET /api/holdings/lots?account_id=&security_id=.
+func (h *Handler) ListLots(w http.ResponseWriter, r *http.Request) {
+	var accountID, securityID *int
+	if v := r.URL.Query().Get("account_id"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			writeValidation(w, "account_id", "must be a positive integer")
+			return
+		}
+		accountID = &n
+	}
+	if v := r.URL.Query().Get("security_id"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			writeValidation(w, "security_id", "must be a positive integer")
+			return
+		}
+		securityID = &n
+	}
+	rows, err := h.store.ListLots(r.Context(), accountID, securityID)
+	if err != nil {
+		h.logger.Error("list lots", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := make([]lotResponse, 0, len(rows))
+	for i := range rows {
+		out = append(out, toLot(rows[i]))
+	}
+	writeJSON(w, http.StatusOK, listLotsResponse{Lots: out})
+}
+
+// CreateLot serves POST /api/holdings/lots.
+func (h *Handler) CreateLot(w http.ResponseWriter, r *http.Request) {
+	raw, err := readBody(r)
+	if err != nil {
+		writeValidation(w, "body", "Invalid JSON body")
+		return
+	}
+	lot, vErr := buildLotInput(raw)
+	if vErr != nil {
+		writeValidation(w, vErr.Field, vErr.Msg)
+		return
+	}
+	created, err := h.store.CreateLot(r.Context(), lot)
+	if err != nil {
+		h.logger.Error("create lot", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toLot(created))
+}
+
+// DeleteLot serves DELETE /api/holdings/lots/{id}.
+func (h *Handler) DeleteLot(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.DeleteLot(r.Context(), id); err != nil {
+		if errors.Is(err, ErrLotNotFound) {
+			writeError(w, http.StatusNotFound, "Lot not found")
+			return
+		}
+		h.logger.Error("delete lot", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- quote wire types ---
+
+type quoteResponse struct {
+	ID         int    `json:"id"`
+	SecurityID int    `json:"security_id"`
+	Date       string `json:"date"`
+	Price      string `json:"price"`
+	Source     string `json:"source"`
+	CreatedAt  string `json:"created_at"`
+}
+
+type listQuotesResponse struct {
+	Quotes []quoteResponse `json:"quotes"`
+}
+
+func toQuote(q PriceQuote) quoteResponse {
+	return quoteResponse{
+		ID: q.ID, SecurityID: q.SecurityID,
+		Date:      q.Date.UTC().Format("2006-01-02"),
+		Price:     q.Price.String(),
+		Source:    q.Source,
+		CreatedAt: q.CreatedAt.UTC().Format("2006-01-02T15:04:05.999999"),
+	}
+}
+
+// ListQuotes serves GET /api/holdings/securities/{id}/quotes.
+func (h *Handler) ListQuotes(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	rows, err := h.store.ListQuotes(r.Context(), id)
+	if err != nil {
+		h.logger.Error("list quotes", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := make([]quoteResponse, 0, len(rows))
+	for _, q := range rows {
+		out = append(out, toQuote(q))
+	}
+	writeJSON(w, http.StatusOK, listQuotesResponse{Quotes: out})
+}
+
+// UpsertQuote serves POST /api/holdings/securities/{id}/quotes.
+func (h *Handler) UpsertQuote(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	raw, err := readBody(r)
+	if err != nil {
+		writeValidation(w, "body", "Invalid JSON body")
+		return
+	}
+	q, vErr := buildQuoteInput(raw, id)
+	if vErr != nil {
+		writeValidation(w, vErr.Field, vErr.Msg)
+		return
+	}
+	saved, err := h.store.UpsertQuote(r.Context(), q)
+	if err != nil {
+		h.logger.Error("upsert quote", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusOK, toQuote(saved))
+}
+
+// --- holdings aggregate ---
+
+type holdingRowResponse struct {
+	Security        securityResponse `json:"security"`
+	Quantity        string           `json:"quantity"`
+	AverageCost     string           `json:"average_cost"`
+	CostBasis       string           `json:"cost_basis"`
+	LatestQuote     *string          `json:"latest_quote"`
+	LatestQuoteDate *string          `json:"latest_quote_date"`
+	MarketValue     string           `json:"market_value"`
+	UnrealizedGain  string           `json:"unrealized_gain"`
+	RealizedGain    string           `json:"realized_gain"`
+}
+
+type holdingsResponse struct {
+	Holdings []holdingRowResponse `json:"holdings"`
+}
+
+// Holdings serves GET /api/holdings.
+func (h *Handler) Holdings(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.store.Holdings(r.Context())
+	if err != nil {
+		h.logger.Error("holdings", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := make([]holdingRowResponse, 0, len(rows))
+	for i := range rows {
+		hr := &rows[i]
+		row := holdingRowResponse{
+			Security:       toSecurity(hr.Security),
+			Quantity:       hr.Running.Quantity.String(),
+			AverageCost:    hr.Running.AverageCost.String(),
+			CostBasis:      hr.Running.CostBasis.StringFixed(2),
+			MarketValue:    hr.MarketValue.StringFixed(2),
+			UnrealizedGain: hr.UnrealizedGain.StringFixed(2),
+			RealizedGain:   hr.Running.RealizedGain.StringFixed(2),
+		}
+		if !hr.LatestQuote.IsZero() {
+			q := hr.LatestQuote.String()
+			row.LatestQuote = &q
+		}
+		if hr.LatestQuoteDate != nil {
+			d := hr.LatestQuoteDate.UTC().Format("2006-01-02")
+			row.LatestQuoteDate = &d
+		}
+		out = append(out, row)
+	}
+	writeJSON(w, http.StatusOK, holdingsResponse{Holdings: out})
+}
+
+// --- validation ---
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func buildSecurityInput(raw map[string]json.RawMessage) (Security, *validationError) {
+	var s Security
+	s.Currency = "PLN"
+	if v, ok := raw["symbol"]; ok && string(v) != "null" {
+		if err := json.Unmarshal(v, &s.Symbol); err != nil {
+			return s, &validationError{Field: "symbol", Msg: "must be a string"}
+		}
+	}
+	if s.Symbol = strings.TrimSpace(s.Symbol); s.Symbol == "" {
+		return s, &validationError{Field: "symbol", Msg: "required"}
+	}
+	if len(s.Symbol) > 32 {
+		return s, &validationError{Field: "symbol", Msg: "max 32 chars"}
+	}
+	if v, ok := raw["isin"]; ok && string(v) != "null" {
+		var isin string
+		if err := json.Unmarshal(v, &isin); err != nil {
+			return s, &validationError{Field: "isin", Msg: "must be a string"}
+		}
+		if isin = strings.TrimSpace(isin); isin != "" {
+			if len(isin) != 12 {
+				return s, &validationError{Field: "isin", Msg: "must be 12 chars"}
+			}
+			s.ISIN = &isin
+		}
+	}
+	if v, ok := raw["name"]; ok && string(v) != "null" {
+		if err := json.Unmarshal(v, &s.Name); err != nil {
+			return s, &validationError{Field: "name", Msg: "must be a string"}
+		}
+	}
+	if s.Name = strings.TrimSpace(s.Name); s.Name == "" {
+		return s, &validationError{Field: "name", Msg: "required"}
+	}
+	if len(s.Name) > 200 {
+		return s, &validationError{Field: "name", Msg: "max 200 chars"}
+	}
+	if v, ok := raw["asset_type"]; ok && string(v) != "null" {
+		if err := json.Unmarshal(v, &s.AssetType); err != nil {
+			return s, &validationError{Field: "asset_type", Msg: "must be a string"}
+		}
+	}
+	if !validAssetType(s.AssetType) {
+		return s, &validationError{Field: "asset_type", Msg: "must be one of stock|etf|bond|fund"}
+	}
+	if v, ok := raw["currency"]; ok && string(v) != "null" {
+		var c string
+		if err := json.Unmarshal(v, &c); err != nil {
+			return s, &validationError{Field: "currency", Msg: "must be a string"}
+		}
+		if c = strings.TrimSpace(c); c != "" {
+			if len(c) != 3 {
+				return s, &validationError{Field: "currency", Msg: "must be 3 chars"}
+			}
+			s.Currency = strings.ToUpper(c)
+		}
+	}
+	return s, nil
+}
+
+func validAssetType(t string) bool {
+	switch t {
+	case "stock", "etf", "bond", "fund":
+		return true
+	}
+	return false
+}
+
+func buildLotInput(raw map[string]json.RawMessage) (Lot, *validationError) {
+	var l Lot
+	if vErr := requireInt(raw, "account_id", &l.AccountID); vErr != nil {
+		return l, vErr
+	}
+	if l.AccountID <= 0 {
+		return l, &validationError{Field: "account_id", Msg: "must be positive"}
+	}
+	if vErr := requireInt(raw, "security_id", &l.SecurityID); vErr != nil {
+		return l, vErr
+	}
+	if l.SecurityID <= 0 {
+		return l, &validationError{Field: "security_id", Msg: "must be positive"}
+	}
+	var sideStr string
+	if vErr := requireString(raw, "side", &sideStr); vErr != nil {
+		return l, vErr
+	}
+	if !IsValidSide(sideStr) {
+		return l, &validationError{Field: "side", Msg: "must be buy or sell"}
+	}
+	l.Side = Side(sideStr)
+	qty, vErr := requireDecimal(raw, "quantity")
+	if vErr != nil {
+		return l, vErr
+	}
+	if qty.Sign() <= 0 {
+		return l, &validationError{Field: "quantity", Msg: "must be positive"}
+	}
+	l.Quantity = qty
+	price, vErr := requireDecimal(raw, "price")
+	if vErr != nil {
+		return l, vErr
+	}
+	if price.Sign() < 0 {
+		return l, &validationError{Field: "price", Msg: "must not be negative"}
+	}
+	l.Price = price
+	if v, ok := raw["fee"]; ok && string(v) != "null" {
+		fee, ferr := decimal.NewFromString(strings.Trim(string(v), `"`))
+		if ferr != nil {
+			return l, &validationError{Field: "fee", Msg: "must be a number"}
+		}
+		if fee.Sign() < 0 {
+			return l, &validationError{Field: "fee", Msg: "must not be negative"}
+		}
+		l.Fee = fee
+	}
+	dateStr, vErr := requireString2(raw, "date")
+	if vErr != nil {
+		return l, vErr
+	}
+	parsed, derr := time.Parse("2006-01-02", dateStr)
+	if derr != nil {
+		return l, &validationError{Field: "date", Msg: "must be YYYY-MM-DD"}
+	}
+	l.Date = parsed
+	return l, nil
+}
+
+func buildQuoteInput(raw map[string]json.RawMessage, securityID int) (PriceQuote, *validationError) {
+	q := PriceQuote{SecurityID: securityID, Source: "manual"}
+	dateStr, vErr := requireString2(raw, "date")
+	if vErr != nil {
+		return q, vErr
+	}
+	parsed, derr := time.Parse("2006-01-02", dateStr)
+	if derr != nil {
+		return q, &validationError{Field: "date", Msg: "must be YYYY-MM-DD"}
+	}
+	q.Date = parsed
+	price, vErr := requireDecimal(raw, "price")
+	if vErr != nil {
+		return q, vErr
+	}
+	if price.Sign() < 0 {
+		return q, &validationError{Field: "price", Msg: "must not be negative"}
+	}
+	q.Price = price
+	if v, ok := raw["source"]; ok && string(v) != "null" {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return q, &validationError{Field: "source", Msg: "must be a string"}
+		}
+		if s = strings.TrimSpace(s); s != "" {
+			if len(s) > 40 {
+				return q, &validationError{Field: "source", Msg: "max 40 chars"}
+			}
+			q.Source = s
+		}
+	}
+	return q, nil
+}
+
+// --- shared helpers ---
+
+func parseID(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(raw)
+	if err != nil || id <= 0 {
+		writeValidation(w, "id", "must be a positive integer")
+		return 0, false
+	}
+	return id, true
+}
+
+func readBody(r *http.Request) (map[string]json.RawMessage, error) {
+	raw := map[string]json.RawMessage{}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func requireInt(raw map[string]json.RawMessage, key string, dest *int) *validationError {
+	v, ok := raw[key]
+	if !ok || string(v) == "null" {
+		return &validationError{Field: key, Msg: "required"}
+	}
+	if err := json.Unmarshal(v, dest); err != nil {
+		return &validationError{Field: key, Msg: "must be integer"}
+	}
+	return nil
+}
+
+func requireString(raw map[string]json.RawMessage, key string, dest *string) *validationError {
+	v, ok := raw[key]
+	if !ok || string(v) == "null" {
+		return &validationError{Field: key, Msg: "required"}
+	}
+	if err := json.Unmarshal(v, dest); err != nil {
+		return &validationError{Field: key, Msg: "must be a string"}
+	}
+	if *dest == "" {
+		return &validationError{Field: key, Msg: "cannot be empty"}
+	}
+	return nil
+}
+
+func requireString2(raw map[string]json.RawMessage, key string) (string, *validationError) {
+	var s string
+	if vErr := requireString(raw, key, &s); vErr != nil {
+		return "", vErr
+	}
+	return s, nil
+}
+
+func requireDecimal(raw map[string]json.RawMessage, key string) (decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || string(v) == "null" {
+		return decimal.Zero, &validationError{Field: key, Msg: "required"}
+	}
+	d, err := decimal.NewFromString(strings.Trim(string(v), `"`))
+	if err != nil {
+		return decimal.Zero, &validationError{Field: key, Msg: "must be a number"}
+	}
+	return d, nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidation(w http.ResponseWriter, field, msg string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{"type": "value_error", "loc": []string{"body", field}, "msg": msg},
+		},
+	})
+}

--- a/backend-go/internal/holdings/openapi.go
+++ b/backend-go/internal/holdings/openapi.go
@@ -1,0 +1,20 @@
+package holdings
+
+import (
+	"net/http"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+)
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{Method: "GET", Path: "/api/holdings", Tag: "holdings", Summary: "Aggregated holdings across accounts", Response: holdingsResponse{}},
+	{Method: "GET", Path: "/api/holdings/securities", Tag: "holdings", Summary: "List securities", Response: listSecuritiesResponse{}},
+	{Method: "POST", Path: "/api/holdings/securities", Tag: "holdings", Summary: "Create a security", Status: http.StatusCreated, Response: securityResponse{}},
+	{Method: "DELETE", Path: "/api/holdings/securities/{id}", Tag: "holdings", Summary: "Delete a security", Status: http.StatusNoContent},
+	{Method: "GET", Path: "/api/holdings/securities/{id}/quotes", Tag: "holdings", Summary: "List manual price quotes", Response: listQuotesResponse{}},
+	{Method: "POST", Path: "/api/holdings/securities/{id}/quotes", Tag: "holdings", Summary: "Upsert a manual price quote", Response: quoteResponse{}},
+	{Method: "GET", Path: "/api/holdings/lots", Tag: "holdings", Summary: "List lots (filterable by account_id/security_id)", Response: listLotsResponse{}},
+	{Method: "POST", Path: "/api/holdings/lots", Tag: "holdings", Summary: "Create a lot", Status: http.StatusCreated, Response: lotResponse{}},
+	{Method: "DELETE", Path: "/api/holdings/lots/{id}", Tag: "holdings", Summary: "Delete a lot", Status: http.StatusNoContent},
+}

--- a/backend-go/internal/holdings/store.go
+++ b/backend-go/internal/holdings/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -289,7 +290,9 @@ func (s *Store) Holdings(ctx context.Context) ([]HoldingRow, error) {
 		run, runErr := ComputeRunning(lots)
 		if runErr != nil {
 			// Skip securities with corrupted lot histories rather than failing
-			// the whole endpoint.
+			// the whole endpoint. Log so the corruption is visible in ops.
+			slog.Default().Warn("holdings: skipping security with bad lot history",
+				"security_id", sec.ID, "symbol", sec.Symbol, "err", runErr)
 			continue
 		}
 		if run.Quantity.IsZero() && run.RealizedGain.IsZero() {

--- a/backend-go/internal/holdings/store.go
+++ b/backend-go/internal/holdings/store.go
@@ -1,0 +1,309 @@
+package holdings
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Store is the persistence boundary for securities, lots and price quotes.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
+
+// Security mirrors the securities table.
+type Security struct {
+	ID        int
+	Symbol    string
+	ISIN      *string
+	Name      string
+	AssetType string
+	Currency  string
+	CreatedAt time.Time
+}
+
+// PriceQuote mirrors the price_quotes table.
+type PriceQuote struct {
+	ID         int
+	SecurityID int
+	Date       time.Time
+	Price      decimal.Decimal
+	Source     string
+	CreatedAt  time.Time
+}
+
+// HoldingRow is one aggregated security position across all accounts.
+type HoldingRow struct {
+	Security        Security
+	Running         Running
+	LatestQuote     decimal.Decimal
+	LatestQuoteDate *time.Time
+	MarketValue     decimal.Decimal
+	UnrealizedGain  decimal.Decimal
+}
+
+// Sentinel errors.
+var (
+	ErrSecurityNotFound = errors.New("security not found")
+	ErrLotNotFound      = errors.New("lot not found")
+	ErrQuoteNotFound    = errors.New("price quote not found")
+)
+
+const secCols = `id, symbol, isin, name, asset_type, currency, created_at`
+
+func scanSecurity(row pgx.Row) (Security, error) {
+	var s Security
+	if err := row.Scan(&s.ID, &s.Symbol, &s.ISIN, &s.Name, &s.AssetType, &s.Currency, &s.CreatedAt); err != nil {
+		return Security{}, err
+	}
+	return s, nil
+}
+
+// ListSecurities returns all securities, ordered by symbol.
+func (s *Store) ListSecurities(ctx context.Context) ([]Security, error) {
+	rows, err := s.pool.Query(ctx, `SELECT `+secCols+` FROM securities ORDER BY symbol`)
+	if err != nil {
+		return nil, fmt.Errorf("list securities: %w", err)
+	}
+	defer rows.Close()
+	out := []Security{}
+	for rows.Next() {
+		sec, err := scanSecurity(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan security: %w", err)
+		}
+		out = append(out, sec)
+	}
+	return out, rows.Err()
+}
+
+// CreateSecurity inserts a new security.
+func (s *Store) CreateSecurity(ctx context.Context, sec Security) (Security, error) {
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO securities (symbol, isin, name, asset_type, currency)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING `+secCols,
+		sec.Symbol, sec.ISIN, sec.Name, sec.AssetType, sec.Currency,
+	)
+	return scanSecurity(row)
+}
+
+// GetSecurity returns one security by ID.
+func (s *Store) GetSecurity(ctx context.Context, id int) (Security, error) {
+	row := s.pool.QueryRow(ctx, `SELECT `+secCols+` FROM securities WHERE id = $1`, id)
+	sec, err := scanSecurity(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Security{}, ErrSecurityNotFound
+	}
+	return sec, err
+}
+
+// DeleteSecurity removes a security. Referenced lots block via ON DELETE RESTRICT.
+func (s *Store) DeleteSecurity(ctx context.Context, id int) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM securities WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete security: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrSecurityNotFound
+	}
+	return nil
+}
+
+const lotCols = `id, account_id, security_id, side, quantity, price, fee, date, created_at`
+
+func scanLot(row pgx.Row) (Lot, error) {
+	var l Lot
+	var sideStr string
+	if err := row.Scan(&l.ID, &l.AccountID, &l.SecurityID, &sideStr, &l.Quantity, &l.Price, &l.Fee, &l.Date, &l.CreatedAt); err != nil {
+		return Lot{}, err
+	}
+	l.Side = Side(sideStr)
+	return l, nil
+}
+
+// ListLots returns lots for a specific account or security, both optional.
+func (s *Store) ListLots(ctx context.Context, accountID, securityID *int) ([]Lot, error) {
+	args := []any{}
+	clauses := []string{}
+	if accountID != nil {
+		args = append(args, *accountID)
+		clauses = append(clauses, fmt.Sprintf("account_id = $%d", len(args)))
+	}
+	if securityID != nil {
+		args = append(args, *securityID)
+		clauses = append(clauses, fmt.Sprintf("security_id = $%d", len(args)))
+	}
+	where := ""
+	for i, c := range clauses {
+		if i == 0 {
+			where = " WHERE " + c
+		} else {
+			where += " AND " + c
+		}
+	}
+	rows, err := s.pool.Query(ctx, `SELECT `+lotCols+` FROM lots`+where+` ORDER BY date ASC, id ASC`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list lots: %w", err)
+	}
+	defer rows.Close()
+	out := []Lot{}
+	for rows.Next() {
+		l, err := scanLot(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan lot: %w", err)
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
+// CreateLot inserts a new lot.
+func (s *Store) CreateLot(ctx context.Context, l Lot) (Lot, error) {
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO lots (account_id, security_id, side, quantity, price, fee, date)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING `+lotCols,
+		l.AccountID, l.SecurityID, string(l.Side), l.Quantity, l.Price, l.Fee, l.Date,
+	)
+	return scanLot(row)
+}
+
+// DeleteLot removes a lot by id.
+func (s *Store) DeleteLot(ctx context.Context, id int) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM lots WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete lot: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrLotNotFound
+	}
+	return nil
+}
+
+const quoteCols = `id, security_id, date, price, source, created_at`
+
+func scanQuote(row pgx.Row) (PriceQuote, error) {
+	var q PriceQuote
+	if err := row.Scan(&q.ID, &q.SecurityID, &q.Date, &q.Price, &q.Source, &q.CreatedAt); err != nil {
+		return PriceQuote{}, err
+	}
+	return q, nil
+}
+
+// UpsertQuote inserts or updates a quote on (security_id, date).
+func (s *Store) UpsertQuote(ctx context.Context, q PriceQuote) (PriceQuote, error) {
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO price_quotes (security_id, date, price, source)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (security_id, date) DO UPDATE
+		SET price = EXCLUDED.price, source = EXCLUDED.source
+		RETURNING `+quoteCols,
+		q.SecurityID, q.Date, q.Price, q.Source,
+	)
+	return scanQuote(row)
+}
+
+// ListQuotes returns all quotes for a security, ordered by date desc.
+func (s *Store) ListQuotes(ctx context.Context, securityID int) ([]PriceQuote, error) {
+	rows, err := s.pool.Query(ctx, `SELECT `+quoteCols+` FROM price_quotes WHERE security_id = $1 ORDER BY date DESC`, securityID)
+	if err != nil {
+		return nil, fmt.Errorf("list quotes: %w", err)
+	}
+	defer rows.Close()
+	out := []PriceQuote{}
+	for rows.Next() {
+		q, err := scanQuote(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan quote: %w", err)
+		}
+		out = append(out, q)
+	}
+	return out, rows.Err()
+}
+
+// DeleteQuote removes a quote by id.
+func (s *Store) DeleteQuote(ctx context.Context, id int) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM price_quotes WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete quote: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrQuoteNotFound
+	}
+	return nil
+}
+
+// latestQuotes returns latest price per security as of now.
+func (s *Store) latestQuotes(ctx context.Context) (map[int]PriceQuote, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT DISTINCT ON (security_id) `+quoteCols+`
+		FROM price_quotes
+		ORDER BY security_id, date DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("latest quotes: %w", err)
+	}
+	defer rows.Close()
+	out := map[int]PriceQuote{}
+	for rows.Next() {
+		q, err := scanQuote(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan latest quote: %w", err)
+		}
+		out[q.SecurityID] = q
+	}
+	return out, rows.Err()
+}
+
+// Holdings replays every lot, groups by security, attaches the latest quote,
+// and returns one HoldingRow per security with non-zero quantity.
+func (s *Store) Holdings(ctx context.Context) ([]HoldingRow, error) {
+	securities, err := s.ListSecurities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	allLots, err := s.ListLots(ctx, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	quotes, err := s.latestQuotes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	bySec := map[int][]Lot{}
+	for i := range allLots {
+		l := &allLots[i]
+		bySec[l.SecurityID] = append(bySec[l.SecurityID], *l)
+	}
+	out := []HoldingRow{}
+	for _, sec := range securities {
+		lots := bySec[sec.ID]
+		run, runErr := ComputeRunning(lots)
+		if runErr != nil {
+			// Skip securities with corrupted lot histories rather than failing
+			// the whole endpoint.
+			continue
+		}
+		if run.Quantity.IsZero() && run.RealizedGain.IsZero() {
+			continue
+		}
+		row := HoldingRow{Security: sec, Running: run}
+		if q, ok := quotes[sec.ID]; ok {
+			row.LatestQuote = q.Price
+			d := q.Date
+			row.LatestQuoteDate = &d
+		}
+		row.MarketValue = MarketValue(run, row.LatestQuote)
+		row.UnrealizedGain = UnrealizedGain(run, row.LatestQuote)
+		out = append(out, row)
+	}
+	return out, nil
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -32,6 +32,7 @@ import (
 	equitygrants "github.com/Automaat/finance-buddy/backend-go/internal/equity_grants"
 	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
+	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
 	"github.com/Automaat/finance-buddy/backend-go/internal/investment"
 	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
@@ -174,6 +175,18 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	r.Get("/api/investment/stock-stats", invHandler.StockStats)
 	r.Get("/api/investment/bond-stats", invHandler.BondStats)
 	r.Get("/api/investment/returns", invHandler.Returns)
+
+	hStore := holdings.NewStore(pool)
+	hHandler := holdings.NewHandler(hStore, logger)
+	r.Get("/api/holdings", hHandler.Holdings)
+	r.Get("/api/holdings/securities", hHandler.ListSecurities)
+	r.Post("/api/holdings/securities", hHandler.CreateSecurity)
+	r.Delete("/api/holdings/securities/{id}", hHandler.DeleteSecurity)
+	r.Get("/api/holdings/securities/{id}/quotes", hHandler.ListQuotes)
+	r.Post("/api/holdings/securities/{id}/quotes", hHandler.UpsertQuote)
+	r.Get("/api/holdings/lots", hHandler.ListLots)
+	r.Post("/api/holdings/lots", hHandler.CreateLot)
+	r.Delete("/api/holdings/lots/{id}", hHandler.DeleteLot)
 
 	simHandler := simulations.NewHandler(simulations.NewStore(pool), logger)
 	r.Post("/api/simulations/mortgage-vs-invest", simHandler.MortgageVsInvest)

--- a/src/lib/nav/routes.ts
+++ b/src/lib/nav/routes.ts
@@ -12,7 +12,8 @@ import {
 	Dices,
 	Settings,
 	Target,
-	Repeat
+	Repeat,
+	Briefcase
 } from 'lucide-svelte';
 
 export const NAV_ROUTES = [
@@ -25,6 +26,7 @@ export const NAV_ROUTES = [
 	{ href: '/recurring', label: 'Cykliczne', icon: Repeat },
 	{ href: '/assets', label: 'Majątek', icon: Home },
 	{ href: '/bonds', label: 'Obligacje', icon: Coins },
+	{ href: '/holdings', label: 'Holdings', icon: Briefcase },
 	{ href: '/debts', label: 'Zobowiązania', icon: ClipboardList },
 	{ href: '/goals', label: 'Cele', icon: Target },
 	{ href: '/snapshots', label: 'Snapshoty', icon: Camera },

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -2933,6 +2933,362 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/holdings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Aggregated holdings across accounts */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            holdings?: {
+                                average_cost?: string;
+                                cost_basis?: string;
+                                latest_quote?: string | null;
+                                latest_quote_date?: string | null;
+                                market_value?: string;
+                                quantity?: string;
+                                realized_gain?: string;
+                                security?: {
+                                    asset_type?: string;
+                                    created_at?: string;
+                                    currency?: string;
+                                    id?: number;
+                                    isin?: string | null;
+                                    name?: string;
+                                    symbol?: string;
+                                };
+                                unrealized_gain?: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/holdings/lots": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List lots (filterable by account_id/security_id) */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            lots?: {
+                                account_id?: number;
+                                created_at?: string;
+                                date?: string;
+                                fee?: string;
+                                id?: number;
+                                price?: string;
+                                quantity?: string;
+                                security_id?: number;
+                                side?: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create a lot */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            account_id?: number;
+                            created_at?: string;
+                            date?: string;
+                            fee?: string;
+                            id?: number;
+                            price?: string;
+                            quantity?: string;
+                            security_id?: number;
+                            side?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/holdings/lots/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a lot */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/holdings/securities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List securities */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            securities?: {
+                                asset_type?: string;
+                                created_at?: string;
+                                currency?: string;
+                                id?: number;
+                                isin?: string | null;
+                                name?: string;
+                                symbol?: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create a security */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            asset_type?: string;
+                            created_at?: string;
+                            currency?: string;
+                            id?: number;
+                            isin?: string | null;
+                            name?: string;
+                            symbol?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/holdings/securities/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a security */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/holdings/securities/{id}/quotes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List manual price quotes */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            quotes?: {
+                                created_at?: string;
+                                date?: string;
+                                id?: number;
+                                price?: string;
+                                security_id?: number;
+                                source?: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Upsert a manual price quote */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            created_at?: string;
+                            date?: string;
+                            id?: number;
+                            price?: string;
+                            security_id?: number;
+                            source?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/investment/bond-stats": {
         parameters: {
             query?: never;

--- a/src/routes/holdings/+page.svelte
+++ b/src/routes/holdings/+page.svelte
@@ -167,7 +167,7 @@
 	async function deleteSecurity(s: { id: number; symbol: string }) {
 		const ok = await confirm({
 			title: 'Usunąć papier wartościowy?',
-			message: `„${s.symbol}" zostanie trwale usunięty.`,
+			message: `„${s.symbol}” zostanie trwale usunięty.`,
 			danger: true,
 			confirmText: 'Usuń'
 		});

--- a/src/routes/holdings/+page.svelte
+++ b/src/routes/holdings/+page.svelte
@@ -1,0 +1,438 @@
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import { invalidateAll } from '$app/navigation';
+	import { resolveApiUrl } from '$lib/api';
+	import { toast } from '$lib/stores/toast.svelte';
+	import { confirm } from '$lib/stores/confirm.svelte';
+	import Modal from '$lib/components/Modal.svelte';
+	import { Plus, Trash2, BarChart } from 'lucide-svelte';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	const ASSET_TYPES = [
+		{ value: 'stock', label: 'Akcja' },
+		{ value: 'etf', label: 'ETF' },
+		{ value: 'bond', label: 'Obligacja' },
+		{ value: 'fund', label: 'Fundusz' }
+	];
+
+	let securityModalOpen = $state(false);
+	let lotModalOpen = $state(false);
+	let quoteModalOpen = $state(false);
+	let saving = $state(false);
+
+	let securityForm = $state({
+		symbol: '',
+		isin: '',
+		name: '',
+		asset_type: 'stock',
+		currency: 'PLN'
+	});
+
+	let lotForm = $state(
+		untrack(() => ({
+			account_id: data.accounts[0]?.id ?? 0,
+			security_id: data.securities[0]?.id ?? 0,
+			side: 'buy',
+			quantity: '0',
+			price: '0',
+			fee: '0',
+			date: new Date().toISOString().slice(0, 10)
+		}))
+	);
+
+	let quoteForm = $state(
+		untrack(() => ({
+			security_id: data.securities[0]?.id ?? 0,
+			date: new Date().toISOString().slice(0, 10),
+			price: '0'
+		}))
+	);
+
+	function openSecurityModal() {
+		securityForm = { symbol: '', isin: '', name: '', asset_type: 'stock', currency: 'PLN' };
+		securityModalOpen = true;
+	}
+
+	function openLotModal() {
+		if (data.accounts.length === 0) {
+			toast.error('Najpierw dodaj konto.');
+			return;
+		}
+		if (data.securities.length === 0) {
+			toast.error('Najpierw dodaj papier wartościowy.');
+			return;
+		}
+		lotForm = {
+			account_id: data.accounts[0].id,
+			security_id: data.securities[0].id,
+			side: 'buy',
+			quantity: '0',
+			price: '0',
+			fee: '0',
+			date: new Date().toISOString().slice(0, 10)
+		};
+		lotModalOpen = true;
+	}
+
+	function openQuoteModal() {
+		if (data.securities.length === 0) {
+			toast.error('Najpierw dodaj papier wartościowy.');
+			return;
+		}
+		quoteForm = {
+			security_id: data.securities[0].id,
+			date: new Date().toISOString().slice(0, 10),
+			price: '0'
+		};
+		quoteModalOpen = true;
+	}
+
+	async function saveSecurity() {
+		saving = true;
+		try {
+			const apiUrl = resolveApiUrl();
+			const res = await fetch(`${apiUrl}/api/holdings/securities`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					symbol: securityForm.symbol,
+					isin: securityForm.isin || null,
+					name: securityForm.name,
+					asset_type: securityForm.asset_type,
+					currency: securityForm.currency
+				})
+			});
+			if (!res.ok) {
+				const d = await res.json().catch(() => ({ detail: res.statusText }));
+				throw new Error(d.detail ?? res.statusText);
+			}
+			securityModalOpen = false;
+			toast.success('Dodano papier wartościowy');
+			await invalidateAll();
+		} catch (err) {
+			if (err instanceof Error) toast.error(err.message);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function saveLot() {
+		saving = true;
+		try {
+			const apiUrl = resolveApiUrl();
+			const res = await fetch(`${apiUrl}/api/holdings/lots`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(lotForm)
+			});
+			if (!res.ok) {
+				const d = await res.json().catch(() => ({ detail: res.statusText }));
+				throw new Error(d.detail ?? res.statusText);
+			}
+			lotModalOpen = false;
+			toast.success('Dodano transakcję');
+			await invalidateAll();
+		} catch (err) {
+			if (err instanceof Error) toast.error(err.message);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function saveQuote() {
+		saving = true;
+		try {
+			const apiUrl = resolveApiUrl();
+			const res = await fetch(`${apiUrl}/api/holdings/securities/${quoteForm.security_id}/quotes`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ date: quoteForm.date, price: quoteForm.price })
+			});
+			if (!res.ok) {
+				const d = await res.json().catch(() => ({ detail: res.statusText }));
+				throw new Error(d.detail ?? res.statusText);
+			}
+			quoteModalOpen = false;
+			toast.success('Zapisano notowanie');
+			await invalidateAll();
+		} catch (err) {
+			if (err instanceof Error) toast.error(err.message);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function deleteSecurity(s: { id: number; symbol: string }) {
+		const ok = await confirm({
+			title: 'Usunąć papier wartościowy?',
+			message: `„${s.symbol}" zostanie trwale usunięty.`,
+			danger: true,
+			confirmText: 'Usuń'
+		});
+		if (!ok) return;
+		try {
+			const apiUrl = resolveApiUrl();
+			const res = await fetch(`${apiUrl}/api/holdings/securities/${s.id}`, {
+				method: 'DELETE'
+			});
+			if (!res.ok) {
+				const d = await res.json().catch(() => ({ detail: res.statusText }));
+				throw new Error(d.detail ?? res.statusText);
+			}
+			toast.success('Usunięto');
+			await invalidateAll();
+		} catch (err) {
+			if (err instanceof Error) toast.error(err.message);
+		}
+	}
+
+	function fmt(s: string): string {
+		const n = Number(s);
+		if (Number.isNaN(n)) return s;
+		return n.toLocaleString('pl-PL', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+	}
+
+	function fmtQty(s: string): string {
+		const n = Number(s);
+		if (Number.isNaN(n)) return s;
+		return n.toLocaleString('pl-PL', { maximumFractionDigits: 6 });
+	}
+</script>
+
+<svelte:head>
+	<title>Holdings | Finansowa Forteca</title>
+</svelte:head>
+
+<div class="space-y-6">
+	<div class="flex flex-wrap items-start justify-between gap-3">
+		<div>
+			<h1 class="h1">Holdings</h1>
+			<p class="text-sm text-surface-700-300">
+				Pozycje skonsolidowane po tickerze: ilość, średnia cena, zysk zrealizowany i niezrealizowany
+				na podstawie ręcznych notowań.
+			</p>
+		</div>
+		<div class="flex gap-2">
+			<button type="button" class="btn preset-tonal-surface" onclick={openSecurityModal}>
+				<Plus size={16} /><span>Nowy papier</span>
+			</button>
+			<button type="button" class="btn preset-tonal-surface" onclick={openQuoteModal}>
+				<BarChart size={16} /><span>Notowanie</span>
+			</button>
+			<button type="button" class="btn preset-filled-primary-500" onclick={openLotModal}>
+				<Plus size={16} /><span>Nowa transakcja</span>
+			</button>
+		</div>
+	</div>
+
+	{#if data.holdings.length === 0}
+		<div class="card preset-tonal-surface p-6 text-center text-sm text-surface-700-300">
+			Brak otwartych pozycji. Dodaj papier wartościowy i pierwszą transakcję.
+		</div>
+	{:else}
+		<div class="table-wrap">
+			<table class="table table-hover text-sm">
+				<thead>
+					<tr>
+						<th>Symbol</th>
+						<th>Nazwa</th>
+						<th class="text-right">Ilość</th>
+						<th class="text-right">Średnia cena</th>
+						<th class="text-right">Koszt nabycia</th>
+						<th class="text-right">Aktualna cena</th>
+						<th class="text-right">Wartość rynkowa</th>
+						<th class="text-right">Zysk niezreal.</th>
+						<th class="text-right">Zysk zreal.</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each data.holdings as h (h.security.id)}
+						<tr>
+							<td>
+								<div class="font-semibold">{h.security.symbol}</div>
+								{#if h.security.isin}
+									<div class="text-xs text-surface-600-400">{h.security.isin}</div>
+								{/if}
+							</td>
+							<td>{h.security.name}</td>
+							<td class="text-right">{fmtQty(h.quantity)}</td>
+							<td class="text-right">{fmt(h.average_cost)} {h.security.currency}</td>
+							<td class="text-right">{fmt(h.cost_basis)} {h.security.currency}</td>
+							<td class="text-right">
+								{#if h.latest_quote}
+									{fmt(h.latest_quote)}
+									{h.security.currency}
+									<div class="text-xs text-surface-600-400">{h.latest_quote_date}</div>
+								{:else}
+									<span class="text-surface-600-400">—</span>
+								{/if}
+							</td>
+							<td class="text-right">{fmt(h.market_value)} {h.security.currency}</td>
+							<td
+								class="text-right {Number(h.unrealized_gain) >= 0
+									? 'text-success-500'
+									: 'text-error-500'}"
+							>
+								{fmt(h.unrealized_gain)}
+							</td>
+							<td
+								class="text-right {Number(h.realized_gain) >= 0
+									? 'text-success-500'
+									: 'text-error-500'}"
+							>
+								{fmt(h.realized_gain)}
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
+
+	<section class="card preset-filled-surface-100-900 p-4 space-y-3">
+		<header class="flex items-center justify-between">
+			<h2 class="h3">Papiery wartościowe</h2>
+		</header>
+		{#if data.securities.length === 0}
+			<p class="text-sm text-surface-700-300">Brak papierów wartościowych.</p>
+		{:else}
+			<ul class="space-y-2">
+				{#each data.securities as s (s.id)}
+					<li class="flex items-center gap-3 px-3 py-2 rounded-container bg-surface-50-950 text-sm">
+						<span class="font-semibold w-16">{s.symbol}</span>
+						<span class="flex-1">{s.name}</span>
+						<span class="text-xs text-surface-600-400">{s.asset_type} · {s.currency}</span>
+						<button
+							type="button"
+							class="btn-icon btn-icon-sm"
+							aria-label="Usuń {s.symbol}"
+							onclick={() => deleteSecurity(s)}
+						>
+							<Trash2 size={14} />
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</section>
+</div>
+
+<Modal
+	open={securityModalOpen}
+	title="Nowy papier wartościowy"
+	onCancel={() => (securityModalOpen = false)}
+	onConfirm={saveSecurity}
+	confirmDisabled={saving}
+	confirmText={saving ? 'Zapisywanie...' : 'Zapisz'}
+>
+	<div class="flex flex-col gap-3">
+		<label class="label">
+			<span class="text-sm font-semibold">Ticker / Symbol</span>
+			<input type="text" bind:value={securityForm.symbol} maxlength="32" class="input" />
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">ISIN (opcjonalnie)</span>
+			<input type="text" bind:value={securityForm.isin} maxlength="12" class="input" />
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Nazwa</span>
+			<input type="text" bind:value={securityForm.name} maxlength="200" class="input" />
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Typ</span>
+			<select bind:value={securityForm.asset_type} class="select">
+				{#each ASSET_TYPES as t}
+					<option value={t.value}>{t.label}</option>
+				{/each}
+			</select>
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Waluta</span>
+			<input type="text" bind:value={securityForm.currency} maxlength="3" class="input" />
+		</label>
+	</div>
+</Modal>
+
+<Modal
+	open={lotModalOpen}
+	title="Nowa transakcja"
+	onCancel={() => (lotModalOpen = false)}
+	onConfirm={saveLot}
+	confirmDisabled={saving}
+	confirmText={saving ? 'Zapisywanie...' : 'Zapisz'}
+>
+	<div class="flex flex-col gap-3">
+		<label class="label">
+			<span class="text-sm font-semibold">Konto</span>
+			<select bind:value={lotForm.account_id} class="select">
+				{#each data.accounts as a}
+					<option value={a.id}>{a.name}</option>
+				{/each}
+			</select>
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Papier</span>
+			<select bind:value={lotForm.security_id} class="select">
+				{#each data.securities as s}
+					<option value={s.id}>{s.symbol} — {s.name}</option>
+				{/each}
+			</select>
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Strona</span>
+			<select bind:value={lotForm.side} class="select">
+				<option value="buy">Kupno</option>
+				<option value="sell">Sprzedaż</option>
+			</select>
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Ilość</span>
+			<input type="text" bind:value={lotForm.quantity} class="input" />
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Cena za sztukę</span>
+			<input type="text" bind:value={lotForm.price} class="input" />
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Prowizja</span>
+			<input type="text" bind:value={lotForm.fee} class="input" />
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Data</span>
+			<input type="date" bind:value={lotForm.date} class="input" />
+		</label>
+	</div>
+</Modal>
+
+<Modal
+	open={quoteModalOpen}
+	title="Nowe notowanie"
+	onCancel={() => (quoteModalOpen = false)}
+	onConfirm={saveQuote}
+	confirmDisabled={saving}
+	confirmText={saving ? 'Zapisywanie...' : 'Zapisz'}
+>
+	<div class="flex flex-col gap-3">
+		<label class="label">
+			<span class="text-sm font-semibold">Papier</span>
+			<select bind:value={quoteForm.security_id} class="select">
+				{#each data.securities as s}
+					<option value={s.id}>{s.symbol} — {s.name}</option>
+				{/each}
+			</select>
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Data</span>
+			<input type="date" bind:value={quoteForm.date} class="input" />
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Cena</span>
+			<input type="text" bind:value={quoteForm.price} class="input" />
+		</label>
+		<p class="text-xs text-surface-600-400">
+			Notowania na (papier, datę) są unikalne — kolejne wpisy dla tej samej daty nadpiszą cenę.
+		</p>
+	</div>
+</Modal>

--- a/src/routes/holdings/+page.ts
+++ b/src/routes/holdings/+page.ts
@@ -29,6 +29,15 @@ export interface AccountOption {
 	name: string;
 }
 
+interface AccountRow {
+	id: number;
+	name: string;
+	category: string;
+	is_active: boolean;
+}
+
+const INVESTMENT_CATEGORIES = new Set(['stock', 'bond', 'fund', 'etf']);
+
 export const load: PageLoad = async ({ fetch }) => {
 	const apiUrl = resolveApiUrl();
 	const [holdingsRes, securitiesRes, accountsRes] = await Promise.all([
@@ -41,10 +50,16 @@ export const load: PageLoad = async ({ fetch }) => {
 	if (!accountsRes.ok) throw error(accountsRes.status, 'Failed to load accounts');
 	const holdings = (await holdingsRes.json()) as { holdings: HoldingRow[] };
 	const securities = (await securitiesRes.json()) as { securities: SecurityRow[] };
-	const accountsData = (await accountsRes.json()) as { accounts: AccountOption[] };
+	const accountsPayload = (await accountsRes.json()) as {
+		assets: AccountRow[];
+		liabilities: AccountRow[];
+	};
+	const accounts = (accountsPayload.assets ?? [])
+		.filter((a) => a.is_active && INVESTMENT_CATEGORIES.has(a.category))
+		.map((a) => ({ id: a.id, name: a.name }));
 	return {
 		holdings: holdings.holdings,
 		securities: securities.securities,
-		accounts: accountsData.accounts.map((a) => ({ id: a.id, name: a.name }))
+		accounts
 	};
 };

--- a/src/routes/holdings/+page.ts
+++ b/src/routes/holdings/+page.ts
@@ -1,0 +1,50 @@
+import { error } from '@sveltejs/kit';
+import { resolveApiUrl } from '$lib/api';
+import type { PageLoad } from './$types';
+
+export interface SecurityRow {
+	id: number;
+	symbol: string;
+	isin: string | null;
+	name: string;
+	asset_type: string;
+	currency: string;
+	created_at: string;
+}
+
+export interface HoldingRow {
+	security: SecurityRow;
+	quantity: string;
+	average_cost: string;
+	cost_basis: string;
+	latest_quote: string | null;
+	latest_quote_date: string | null;
+	market_value: string;
+	unrealized_gain: string;
+	realized_gain: string;
+}
+
+export interface AccountOption {
+	id: number;
+	name: string;
+}
+
+export const load: PageLoad = async ({ fetch }) => {
+	const apiUrl = resolveApiUrl();
+	const [holdingsRes, securitiesRes, accountsRes] = await Promise.all([
+		fetch(`${apiUrl}/api/holdings`),
+		fetch(`${apiUrl}/api/holdings/securities`),
+		fetch(`${apiUrl}/api/accounts`)
+	]);
+	if (!holdingsRes.ok) throw error(holdingsRes.status, 'Failed to load holdings');
+	if (!securitiesRes.ok) throw error(securitiesRes.status, 'Failed to load securities');
+	if (!accountsRes.ok) throw error(accountsRes.status, 'Failed to load accounts');
+	const holdings = (await holdingsRes.json()) as { holdings: HoldingRow[] };
+	const securities = (await securitiesRes.json()) as { securities: SecurityRow[] };
+	const accountsData = (await accountsRes.json()) as { accounts: AccountOption[] };
+	return {
+		holdings: holdings.holdings,
+		securities: securities.securities,
+		accounts: accountsData.accounts.map((a) => ({ id: a.id, name: a.name }))
+	};
+};


### PR DESCRIPTION
## Motivation

Current investment tracking is account-level balances plus contribution transactions. Competitors expose holdings, lots, average cost, realized/unrealized gains, allocation by security, and live estimates.

## Implementation information

- New tables: `securities` (symbol/isin/name/asset_type/currency), `lots` (buy or sell, qty/price/fee/date per account+security), `price_quotes` (manual, unique on security_id+date). Schema baseline + additive migration.
- Pure cost-basis engine in `internal/holdings/costbasis.go` — weighted average. Buys roll the average forward including fee, sells take realized P&L against the running average and subtract the fee. 14 unit tests cover single buy, weighted average on repeat buys, partial sale, full sale zeroing average cost, fee-reduced gain, oversell error, unrealized/market value with/without quote, valid sides.
- Store + handler with full CRUD for securities, lots, manual price quotes (upsert on (security_id, date)). `GET /api/holdings` aggregates lots across accounts, attaches the latest quote per security, and returns one row per security with quantity / average cost / cost basis / market value / realized + unrealized gain.
- New SvelteKit `/holdings` page: holdings table consolidated by ticker, separate modals to add a security, a lot (buy/sell with fee), or a manual quote, plus an inline list of securities with delete.
- Nav route added (auto-available in the More sheet from #366).
- Out of scope (issue marks them optional/future): broker-CSV import, provider price integration, allocation-by-security-type chart on the metryki page.

Closes #400

> Changelog: feat(investments): holdings, lots, manual quotes