### PR TITLE
feat(fire): add Coast FIRE metric

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -2306,6 +2306,13 @@
                       "format": "date",
                       "type": "string"
                     },
+                    "coast_fire_target_age": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "expected_return_rate": {
+                      "type": "string"
+                    },
                     "id": {
                       "type": "integer"
                     },
@@ -2362,6 +2369,14 @@
                     "format": "date",
                     "type": "string"
                   },
+                  "coast_fire_target_age": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "expected_return_rate": {
+                    "nullable": true,
+                    "type": "string"
+                  },
                   "monthly_expenses": {
                     "type": "string"
                   },
@@ -2408,6 +2423,13 @@
                     },
                     "birth_date": {
                       "format": "date",
+                      "type": "string"
+                    },
+                    "coast_fire_target_age": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "expected_return_rate": {
                       "type": "string"
                     },
                     "id": {
@@ -2760,6 +2782,20 @@
                           "nullable": true,
                           "type": "number"
                         },
+                        "coast_fire_gap": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "coast_fire_number": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "coast_fire_target_age": {
+                          "nullable": true,
+                          "type": "integer"
+                        },
                         "debt_to_income_ratio": {
                           "format": "double",
                           "nullable": true,
@@ -2767,6 +2803,11 @@
                         },
                         "emergency_fund_months": {
                           "format": "double",
+                          "type": "number"
+                        },
+                        "expected_return_rate": {
+                          "format": "double",
+                          "nullable": true,
                           "type": "number"
                         },
                         "fi_progress": {

--- a/backend-bb-tests/golden/config_get.json
+++ b/backend-bb-tests/golden/config_get.json
@@ -5,6 +5,8 @@
   "allocation_real_estate": 40,
   "allocation_stocks": 30,
   "birth_date": "1990-06-15",
+  "coast_fire_target_age": null,
+  "expected_return_rate": "0.0700",
   "id": 1,
   "monthly_expenses": "5000.00",
   "monthly_mortgage_payment": "2000.00",

--- a/backend-go/internal/config/handler.go
+++ b/backend-go/internal/config/handler.go
@@ -29,6 +29,8 @@ type response struct {
 	MonthlyExpenses         moneyJSON `json:"monthly_expenses"`
 	MonthlyMortgagePayment  moneyJSON `json:"monthly_mortgage_payment"`
 	WithdrawalRate          rateJSON  `json:"withdrawal_rate"`
+	CoastFIRETargetAge      *int      `json:"coast_fire_target_age"`
+	ExpectedReturnRate      rateJSON  `json:"expected_return_rate"`
 }
 
 // request is the PUT body. Date arrives as "YYYY-MM-DD" and money as either
@@ -45,6 +47,8 @@ type request struct {
 	MonthlyExpenses         decimal.Decimal  `json:"monthly_expenses"`
 	MonthlyMortgagePayment  decimal.Decimal  `json:"monthly_mortgage_payment"`
 	WithdrawalRate          *decimal.Decimal `json:"withdrawal_rate"`
+	CoastFIRETargetAge      *int             `json:"coast_fire_target_age"`
+	ExpectedReturnRate      *decimal.Decimal `json:"expected_return_rate"`
 }
 
 func toResponse(c *Config) response {
@@ -61,6 +65,8 @@ func toResponse(c *Config) response {
 		MonthlyExpenses:         moneyJSON(c.MonthlyExpenses),
 		MonthlyMortgagePayment:  moneyJSON(c.MonthlyMortgagePayment),
 		WithdrawalRate:          rateJSON(c.WithdrawalRate),
+		CoastFIRETargetAge:      c.CoastFIRETargetAge,
+		ExpectedReturnRate:      rateJSON(c.ExpectedReturnRate),
 	}
 }
 
@@ -122,6 +128,10 @@ func (r *request) toConfig() *Config {
 	if r.WithdrawalRate != nil {
 		rate = *r.WithdrawalRate
 	}
+	expectedReturn := defaultExpectedReturnRate
+	if r.ExpectedReturnRate != nil {
+		expectedReturn = *r.ExpectedReturnRate
+	}
 	return &Config{
 		BirthDate:               time.Time(r.BirthDate),
 		RetirementAge:           r.RetirementAge,
@@ -134,6 +144,8 @@ func (r *request) toConfig() *Config {
 		MonthlyExpenses:         r.MonthlyExpenses,
 		MonthlyMortgagePayment:  r.MonthlyMortgagePayment,
 		WithdrawalRate:          rate,
+		CoastFIRETargetAge:      r.CoastFIRETargetAge,
+		ExpectedReturnRate:      expectedReturn,
 	}
 }
 
@@ -142,6 +154,11 @@ func (r *request) toConfig() *Config {
 // RequireFromString keeps the constant exact at the numeric(5,4) precision
 // the DB column expects.
 var defaultWithdrawalRate = decimal.RequireFromString("0.04")
+
+// defaultExpectedReturnRate is the 7% nominal real-return assumption used
+// elsewhere in the app (retirement projection on the settings page). Used
+// when a PUT body omits expected_return_rate.
+var defaultExpectedReturnRate = decimal.RequireFromString("0.07")
 
 // isoDate is a time.Time alias that JSON-marshals as "YYYY-MM-DD" and
 // unmarshals from the same. Matches Python's `date` field on the wire.

--- a/backend-go/internal/config/store.go
+++ b/backend-go/internal/config/store.go
@@ -30,6 +30,8 @@ type Config struct {
 	MonthlyExpenses         decimal.Decimal `json:"monthly_expenses"`
 	MonthlyMortgagePayment  decimal.Decimal `json:"monthly_mortgage_payment"`
 	WithdrawalRate          decimal.Decimal `json:"withdrawal_rate"`
+	CoastFIRETargetAge      *int            `json:"coast_fire_target_age"`
+	ExpectedReturnRate      decimal.Decimal `json:"expected_return_rate"`
 }
 
 // ErrNotFound is returned when no row exists at id=1.
@@ -49,7 +51,8 @@ const selectColumns = `
 	id, birth_date, retirement_age, retirement_monthly_salary,
 	allocation_real_estate, allocation_stocks, allocation_bonds,
 	allocation_gold, allocation_commodities,
-	monthly_expenses, monthly_mortgage_payment, withdrawal_rate
+	monthly_expenses, monthly_mortgage_payment, withdrawal_rate,
+	coast_fire_target_age, expected_return_rate
 `
 
 // Get returns the singleton config or ErrNotFound.
@@ -76,8 +79,9 @@ func (s *Store) Upsert(ctx context.Context, in *Config) (*Config, error) {
 			id, birth_date, retirement_age, retirement_monthly_salary,
 			allocation_real_estate, allocation_stocks, allocation_bonds,
 			allocation_gold, allocation_commodities,
-			monthly_expenses, monthly_mortgage_payment, withdrawal_rate
-		) VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			monthly_expenses, monthly_mortgage_payment, withdrawal_rate,
+			coast_fire_target_age, expected_return_rate
+		) VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 		ON CONFLICT (id) DO UPDATE SET
 			birth_date = EXCLUDED.birth_date,
 			retirement_age = EXCLUDED.retirement_age,
@@ -89,7 +93,9 @@ func (s *Store) Upsert(ctx context.Context, in *Config) (*Config, error) {
 			allocation_commodities = EXCLUDED.allocation_commodities,
 			monthly_expenses = EXCLUDED.monthly_expenses,
 			monthly_mortgage_payment = EXCLUDED.monthly_mortgage_payment,
-			withdrawal_rate = EXCLUDED.withdrawal_rate
+			withdrawal_rate = EXCLUDED.withdrawal_rate,
+			coast_fire_target_age = EXCLUDED.coast_fire_target_age,
+			expected_return_rate = EXCLUDED.expected_return_rate
 		RETURNING `+selectColumns,
 		in.BirthDate,
 		in.RetirementAge,
@@ -102,6 +108,8 @@ func (s *Store) Upsert(ctx context.Context, in *Config) (*Config, error) {
 		in.MonthlyExpenses,
 		in.MonthlyMortgagePayment,
 		in.WithdrawalRate,
+		in.CoastFIRETargetAge,
+		in.ExpectedReturnRate,
 	)
 	c, err := scanConfig(row)
 	if err != nil {
@@ -125,6 +133,8 @@ func scanConfig(row pgx.Row) (*Config, error) {
 		&c.MonthlyExpenses,
 		&c.MonthlyMortgagePayment,
 		&c.WithdrawalRate,
+		&c.CoastFIRETargetAge,
+		&c.ExpectedReturnRate,
 	)
 	if err != nil {
 		return nil, err

--- a/backend-go/internal/config/validation.go
+++ b/backend-go/internal/config/validation.go
@@ -84,8 +84,45 @@ func (r *request) validate() *validationError {
 			"Withdrawal rate must be 0.03, 0.035, or 0.04",
 		}
 	}
+	if r.CoastFIRETargetAge != nil {
+		ta := *r.CoastFIRETargetAge
+		if ta < 18 || ta > 100 {
+			return &validationError{
+				"coast_fire_target_age",
+				"Coast FIRE target age must be between 18 and 100",
+			}
+		}
+		if ta <= age {
+			return &validationError{
+				"coast_fire_target_age",
+				fmt.Sprintf(
+					"Coast FIRE target age (%d) must be greater than current age (%d)",
+					ta, age,
+				),
+			}
+		}
+	}
+	if r.ExpectedReturnRate != nil {
+		if r.ExpectedReturnRate.LessThan(minExpectedReturnRate) ||
+			r.ExpectedReturnRate.GreaterThan(maxExpectedReturnRate) {
+			return &validationError{
+				"expected_return_rate",
+				"Expected return rate must be between 0.01 and 0.20",
+			}
+		}
+	}
 	return nil
 }
+
+// minExpectedReturnRate / maxExpectedReturnRate bracket the Coast FIRE
+// projection's expected_return_rate input: 1%–20% covers everything from
+// conservative bond-heavy portfolios to optimistic stock returns. Values
+// outside this band almost always point at a unit error (e.g. typing 7
+// instead of 0.07).
+var (
+	minExpectedReturnRate = decimal.RequireFromString("0.01")
+	maxExpectedReturnRate = decimal.RequireFromString("0.20")
+)
 
 // allowedWithdrawalRates are the three FIRE-research-backed safe-withdrawal
 // rates exposed in /settings. RequireFromString — not NewFromFloat — so the

--- a/backend-go/internal/config/validation_test.go
+++ b/backend-go/internal/config/validation_test.go
@@ -164,3 +164,54 @@ func TestValidateWithdrawalRateNilOK(t *testing.T) {
 		t.Fatalf("nil withdrawal_rate should pass (backward compat), got %+v", err)
 	}
 }
+
+func TestValidateCoastFIRETargetAgeOutOfRange(t *testing.T) {
+	r := validRequest()
+	bad := 10
+	r.CoastFIRETargetAge = &bad
+	if err := r.validate(); err == nil || err.Field != "coast_fire_target_age" {
+		t.Fatalf("expected coast_fire_target_age error, got %+v", err)
+	}
+}
+
+func TestValidateCoastFIRETargetAgeBeforeCurrent(t *testing.T) {
+	r := validRequest()
+	now := time.Now().UTC()
+	r.BirthDate = isoDate(now.AddDate(-50, 0, 0))
+	r.RetirementAge = 65
+	bad := 30
+	r.CoastFIRETargetAge = &bad
+	if err := r.validate(); err == nil || err.Field != "coast_fire_target_age" {
+		t.Fatalf("expected coast_fire_target_age vs current age error, got %+v", err)
+	}
+}
+
+func TestValidateCoastFIRETargetAgeNilOK(t *testing.T) {
+	r := validRequest()
+	r.CoastFIRETargetAge = nil
+	if err := r.validate(); err != nil {
+		t.Fatalf("nil coast_fire_target_age should pass, got %+v", err)
+	}
+}
+
+func TestValidateExpectedReturnRateOutOfRange(t *testing.T) {
+	for _, s := range []string{"0", "0.005", "0.25", "1.0"} {
+		r := validRequest()
+		d := decimal.RequireFromString(s)
+		r.ExpectedReturnRate = &d
+		if err := r.validate(); err == nil || err.Field != "expected_return_rate" {
+			t.Fatalf("expected expected_return_rate error for %s, got %+v", s, err)
+		}
+	}
+}
+
+func TestValidateExpectedReturnRateAllowed(t *testing.T) {
+	for _, s := range []string{"0.01", "0.05", "0.07", "0.10", "0.20"} {
+		r := validRequest()
+		d := decimal.RequireFromString(s)
+		r.ExpectedReturnRate = &d
+		if err := r.validate(); err != nil {
+			t.Fatalf("expected %s to validate, got %+v", s, err)
+		}
+	}
+}

--- a/backend-go/internal/dashboard/dashboard.go
+++ b/backend-go/internal/dashboard/dashboard.go
@@ -45,6 +45,10 @@ type metricCards struct {
 	RunwayMonths            *float64
 	AnnualExpenses          *float64
 	WithdrawalRate          *float64
+	CoastFIRENumber         *float64
+	CoastFIREGap            *float64
+	CoastFIRETargetAge      *int
+	ExpectedReturnRate      *float64
 }
 
 type allocationBreakdown struct {

--- a/backend-go/internal/dashboard/fire.go
+++ b/backend-go/internal/dashboard/fire.go
@@ -1,5 +1,10 @@
 package dashboard
 
+import (
+	"math"
+	"time"
+)
+
 // liquidCategories is the set of account categories counted as liquid for
 // the runway metric — bank checking and savings only. Investments are
 // excluded: a true runway figure assumes assets that can cover next
@@ -14,11 +19,15 @@ var liquidCategories = map[string]struct{}{
 // produce a meaningful number (monthly_expenses == 0, withdrawal_rate == 0,
 // or net_worth <= 0 for the progress percentage).
 type fireMetrics struct {
-	AnnualExpenses *float64
-	FIRENumber     *float64
-	FIProgress     *float64
-	RunwayMonths   *float64
-	WithdrawalRate *float64
+	AnnualExpenses     *float64
+	FIRENumber         *float64
+	FIProgress         *float64
+	RunwayMonths       *float64
+	WithdrawalRate     *float64
+	CoastFIRENumber    *float64
+	CoastFIREGap       *float64
+	CoastFIRETargetAge *int
+	ExpectedReturnRate *float64
 }
 
 // computeFIRE turns app_config + the latest snapshot's rows into the FIRE
@@ -68,5 +77,62 @@ func computeFIRE(latestRows []mergedRow, cfg AppConfig, netWorth float64) fireMe
 	}
 	runway := liquid / monthlyExpenses
 	out.RunwayMonths = &runway
+
+	addCoastFIRE(&out, cfg, netWorth, time.Now().UTC())
 	return out
+}
+
+// addCoastFIRE fills the Coast FIRE fields when the inputs are sufficient:
+// a configured target age, a positive expected return rate, a positive
+// FIRE number, and a target age strictly greater than the current age.
+//
+// Coast FIRE math:
+//
+//	years_remaining     = target_age − current_age (whole years)
+//	coast_fire_number   = fire_number ÷ (1 + expected_return)^years_remaining
+//	coast_fire_gap      = coast_fire_number − net_worth
+//
+// coast_fire_number is "the capital needed today such that, with no further
+// contributions, compounding alone reaches the FIRE number by the target
+// age." Positive gap = shortfall; negative gap = surplus (already Coast-FI).
+func addCoastFIRE(out *fireMetrics, cfg AppConfig, netWorth float64, now time.Time) {
+	if out.FIRENumber == nil || *out.FIRENumber <= 0 {
+		return
+	}
+	if cfg.CoastFIRETargetAge == nil {
+		return
+	}
+	targetAge := *cfg.CoastFIRETargetAge
+	if cfg.BirthDate.IsZero() {
+		return
+	}
+	expectedReturn, _ := cfg.ExpectedReturnRate.Float64()
+	if expectedReturn <= 0 {
+		return
+	}
+	currentAge := yearsBetween(cfg.BirthDate, now)
+	if targetAge <= currentAge {
+		return
+	}
+	years := float64(targetAge - currentAge)
+	coast := *out.FIRENumber / math.Pow(1+expectedReturn, years)
+	gap := coast - netWorth
+	out.CoastFIRENumber = &coast
+	out.CoastFIREGap = &gap
+	ta := targetAge
+	out.CoastFIRETargetAge = &ta
+	er := expectedReturn
+	out.ExpectedReturnRate = &er
+}
+
+// yearsBetween returns whole years from birth to now using the same
+// 365.25-day approximation as the config validator (matches the frontend
+// "current age" display).
+func yearsBetween(birth, now time.Time) int {
+	days := now.UTC().Truncate(24*time.Hour).Sub(birth.UTC().Truncate(24*time.Hour)) /
+		(24 * time.Hour)
+	if days < 0 {
+		return 0
+	}
+	return int(float64(days) / 365.25)
 }

--- a/backend-go/internal/dashboard/fire_test.go
+++ b/backend-go/internal/dashboard/fire_test.go
@@ -1,7 +1,9 @@
 package dashboard
 
 import (
+	"math"
 	"testing"
+	"time"
 
 	"github.com/shopspring/decimal"
 )
@@ -136,4 +138,124 @@ func approxEqual(a, b, tol float64) bool {
 		d = -d
 	}
 	return d < tol
+}
+
+func TestAddCoastFIREHappyPath(t *testing.T) {
+	t.Parallel()
+	// Born 1990-01-01, "now" = 2025-01-01 → currentAge ≈ 35; target 65 → 30 years.
+	birth := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	targetAge := 65
+	cfg := AppConfig{
+		BirthDate:          birth,
+		CoastFIRETargetAge: &targetAge,
+		ExpectedReturnRate: decimal.RequireFromString("0.07"),
+	}
+	fire := 1_500_000.0
+	out := fireMetrics{FIRENumber: &fire}
+
+	addCoastFIRE(&out, cfg, 500_000, now)
+
+	// coast = 1_500_000 / 1.07^30 ≈ 197_028
+	wantCoast := 1_500_000 / math.Pow(1.07, 30)
+	if out.CoastFIRENumber == nil || !approxEqual(*out.CoastFIRENumber, wantCoast, 1) {
+		t.Fatalf("coast_fire_number = %v, want ≈%v", out.CoastFIRENumber, wantCoast)
+	}
+	// gap = coast − net_worth ≈ 197_028 − 500_000 < 0 (surplus)
+	wantGap := wantCoast - 500_000
+	if out.CoastFIREGap == nil || !approxEqual(*out.CoastFIREGap, wantGap, 1) {
+		t.Fatalf("coast_fire_gap = %v, want ≈%v", out.CoastFIREGap, wantGap)
+	}
+	if out.CoastFIRETargetAge == nil || *out.CoastFIRETargetAge != 65 {
+		t.Errorf("coast_fire_target_age = %v, want 65", out.CoastFIRETargetAge)
+	}
+	if out.ExpectedReturnRate == nil || *out.ExpectedReturnRate != 0.07 {
+		t.Errorf("expected_return_rate = %v, want 0.07", out.ExpectedReturnRate)
+	}
+}
+
+func TestAddCoastFIREGapPositiveWhenNetWorthShort(t *testing.T) {
+	t.Parallel()
+	birth := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	targetAge := 65
+	cfg := AppConfig{
+		BirthDate:          birth,
+		CoastFIRETargetAge: &targetAge,
+		ExpectedReturnRate: decimal.RequireFromString("0.07"),
+	}
+	fire := 1_500_000.0
+	out := fireMetrics{FIRENumber: &fire}
+
+	addCoastFIRE(&out, cfg, 50_000, now)
+	if out.CoastFIREGap == nil || *out.CoastFIREGap <= 0 {
+		t.Fatalf("expected positive gap, got %v", out.CoastFIREGap)
+	}
+}
+
+func TestAddCoastFIRENoTargetAgeStaysNil(t *testing.T) {
+	t.Parallel()
+	cfg := AppConfig{
+		BirthDate:          time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC),
+		ExpectedReturnRate: decimal.RequireFromString("0.07"),
+	}
+	fire := 1_500_000.0
+	out := fireMetrics{FIRENumber: &fire}
+	addCoastFIRE(&out, cfg, 500_000, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	if out.CoastFIRENumber != nil || out.CoastFIREGap != nil {
+		t.Errorf("expected nil coast fields without target age, got %+v", out)
+	}
+}
+
+func TestAddCoastFIRETargetAgeAtOrBelowCurrentStaysNil(t *testing.T) {
+	t.Parallel()
+	// currentAge ≈ 35, target 30 → skip.
+	birth := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	targetAge := 30
+	cfg := AppConfig{
+		BirthDate:          birth,
+		CoastFIRETargetAge: &targetAge,
+		ExpectedReturnRate: decimal.RequireFromString("0.07"),
+	}
+	fire := 1_500_000.0
+	out := fireMetrics{FIRENumber: &fire}
+	addCoastFIRE(&out, cfg, 500_000, now)
+	if out.CoastFIRENumber != nil {
+		t.Errorf("expected nil coast_fire_number when target ≤ current age, got %v", *out.CoastFIRENumber)
+	}
+}
+
+func TestAddCoastFIREZeroReturnRateStaysNil(t *testing.T) {
+	t.Parallel()
+	birth := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	targetAge := 65
+	cfg := AppConfig{
+		BirthDate:          birth,
+		CoastFIRETargetAge: &targetAge,
+		ExpectedReturnRate: decimal.Zero,
+	}
+	fire := 1_500_000.0
+	out := fireMetrics{FIRENumber: &fire}
+	addCoastFIRE(&out, cfg, 500_000, now)
+	if out.CoastFIRENumber != nil {
+		t.Errorf("expected nil coast_fire_number when return rate is zero, got %v", *out.CoastFIRENumber)
+	}
+}
+
+func TestAddCoastFIRENoFIRENumberStaysNil(t *testing.T) {
+	t.Parallel()
+	birth := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+	targetAge := 65
+	cfg := AppConfig{
+		BirthDate:          birth,
+		CoastFIRETargetAge: &targetAge,
+		ExpectedReturnRate: decimal.RequireFromString("0.07"),
+	}
+	out := fireMetrics{}
+	addCoastFIRE(&out, cfg, 500_000, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	if out.CoastFIRENumber != nil {
+		t.Errorf("expected nil coast_fire_number without FIRE number, got %v", *out.CoastFIRENumber)
+	}
 }

--- a/backend-go/internal/dashboard/handler.go
+++ b/backend-go/internal/dashboard/handler.go
@@ -193,6 +193,10 @@ type metricCardsWire struct {
 	RunwayMonths            *pyFloat `json:"runway_months"`
 	AnnualExpenses          *pyFloat `json:"annual_expenses"`
 	WithdrawalRate          *pyFloat `json:"withdrawal_rate"`
+	CoastFIRENumber         *pyFloat `json:"coast_fire_number"`
+	CoastFIREGap            *pyFloat `json:"coast_fire_gap"`
+	CoastFIRETargetAge      *int     `json:"coast_fire_target_age"`
+	ExpectedReturnRate      *pyFloat `json:"expected_return_rate"`
 }
 
 type allocationBreakdownWire struct {
@@ -329,6 +333,10 @@ func metricCardsToWire(m metricCards) metricCardsWire {
 		RunwayMonths:            floatPtr(m.RunwayMonths),
 		AnnualExpenses:          floatPtr(m.AnnualExpenses),
 		WithdrawalRate:          floatPtr(m.WithdrawalRate),
+		CoastFIRENumber:         floatPtr(m.CoastFIRENumber),
+		CoastFIREGap:            floatPtr(m.CoastFIREGap),
+		CoastFIRETargetAge:      m.CoastFIRETargetAge,
+		ExpectedReturnRate:      floatPtr(m.ExpectedReturnRate),
 	}
 }
 

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -475,13 +475,23 @@ func buildMetricCards(
 		mc.HourOfLifeCost = &life
 	}
 
-	fire := computeFIRE(latestRows, cfg, currentNetWorth)
+	assignFIREMetrics(&mc, computeFIRE(latestRows, cfg, currentNetWorth))
+	return mc
+}
+
+// assignFIREMetrics copies the FIRE/Coast-FIRE bundle into the metric-card
+// struct. Pulled out of buildMetricCards to keep that function under the
+// funlen threshold without obscuring the wiring.
+func assignFIREMetrics(mc *metricCards, fire fireMetrics) {
 	mc.AnnualExpenses = fire.AnnualExpenses
 	mc.FIRENumber = fire.FIRENumber
 	mc.FIProgress = fire.FIProgress
 	mc.RunwayMonths = fire.RunwayMonths
 	mc.WithdrawalRate = fire.WithdrawalRate
-	return mc
+	mc.CoastFIRENumber = fire.CoastFIRENumber
+	mc.CoastFIREGap = fire.CoastFIREGap
+	mc.CoastFIRETargetAge = fire.CoastFIRETargetAge
+	mc.ExpectedReturnRate = fire.ExpectedReturnRate
 }
 
 // buildAllocationAnalysis is the shared allocation-analysis computation.

--- a/backend-go/internal/dashboard/store.go
+++ b/backend-go/internal/dashboard/store.go
@@ -78,6 +78,9 @@ type AppConfig struct {
 	AllocationBonds        int
 	AllocationGold         int
 	WithdrawalRate         decimal.Decimal
+	BirthDate              time.Time
+	CoastFIRETargetAge     *int
+	ExpectedReturnRate     decimal.Decimal
 }
 
 // SnapshotMeta is id+date.
@@ -292,14 +295,16 @@ func (s *Store) LoadAppConfig(ctx context.Context) (AppConfig, bool, error) {
 	row := s.pool.QueryRow(ctx, `
 		SELECT monthly_expenses, monthly_mortgage_payment,
 		       allocation_stocks, allocation_bonds, allocation_gold,
-		       withdrawal_rate
+		       withdrawal_rate, birth_date,
+		       coast_fire_target_age, expected_return_rate
 		FROM app_config WHERE id = 1`,
 	)
 	var c AppConfig
 	if err := row.Scan(
 		&c.MonthlyExpenses, &c.MonthlyMortgagePayment,
 		&c.AllocationStocks, &c.AllocationBonds, &c.AllocationGold,
-		&c.WithdrawalRate,
+		&c.WithdrawalRate, &c.BirthDate,
+		&c.CoastFIRETargetAge, &c.ExpectedReturnRate,
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return AppConfig{}, false, nil

--- a/backend-go/internal/db/migrate.go
+++ b/backend-go/internal/db/migrate.go
@@ -61,11 +61,33 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
 	if err := addAppConfigWithdrawalRate(ctx, pool); err != nil {
 		return err
 	}
+	if err := addAppConfigCoastFIRE(ctx, pool); err != nil {
+		return err
+	}
 	if err := createRecurringTransactionsTable(ctx, pool); err != nil {
 		return err
 	}
 	if err := createHoldingsTables(ctx, pool); err != nil {
 		return err
+	}
+	return nil
+}
+
+// addAppConfigCoastFIRE adds the Coast FIRE inputs to app_config (issue #548):
+// `coast_fire_target_age` (optional — Coast FIRE tile hides when nil) and
+// `expected_return_rate` (defaults to 0.07, a conservative real-return
+// assumption matching the retirement-savings projection on the settings page).
+func addAppConfigCoastFIRE(ctx context.Context, pool *pgxpool.Pool) error {
+	stmts := []string{
+		`ALTER TABLE app_config
+		ADD COLUMN IF NOT EXISTS coast_fire_target_age integer`,
+		`ALTER TABLE app_config
+		ADD COLUMN IF NOT EXISTS expected_return_rate numeric(5,4) NOT NULL DEFAULT 0.07`,
+	}
+	for _, stmt := range stmts {
+		if _, err := pool.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("add coast fire columns to app_config: %w", err)
+		}
 	}
 	return nil
 }

--- a/backend-go/internal/db/schema.sql
+++ b/backend-go/internal/db/schema.sql
@@ -96,6 +96,8 @@ CREATE TABLE public.app_config (
     monthly_expenses numeric(15,2) NOT NULL,
     monthly_mortgage_payment numeric(15,2) NOT NULL,
     withdrawal_rate numeric(5,4) NOT NULL DEFAULT 0.04,
+    coast_fire_target_age integer,
+    expected_return_rate numeric(5,4) NOT NULL DEFAULT 0.07,
     CONSTRAINT single_row CHECK ((id = 1))
 );
 

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -1657,6 +1657,8 @@ export interface paths {
                             allocation_stocks?: number;
                             /** Format: date */
                             birth_date?: string;
+                            coast_fire_target_age?: number | null;
+                            expected_return_rate?: string;
                             id?: number;
                             monthly_expenses?: string;
                             monthly_mortgage_payment?: string;
@@ -1686,6 +1688,8 @@ export interface paths {
                         allocation_stocks?: number;
                         /** Format: date */
                         birth_date?: string;
+                        coast_fire_target_age?: number | null;
+                        expected_return_rate?: string | null;
                         monthly_expenses?: string;
                         monthly_mortgage_payment?: string;
                         retirement_age?: number;
@@ -1709,6 +1713,8 @@ export interface paths {
                             allocation_stocks?: number;
                             /** Format: date */
                             birth_date?: string;
+                            coast_fire_target_age?: number | null;
+                            expected_return_rate?: string;
                             id?: number;
                             monthly_expenses?: string;
                             monthly_mortgage_payment?: string;
@@ -1959,9 +1965,16 @@ export interface paths {
                                 /** Format: double */
                                 annual_expenses?: number | null;
                                 /** Format: double */
+                                coast_fire_gap?: number | null;
+                                /** Format: double */
+                                coast_fire_number?: number | null;
+                                coast_fire_target_age?: number | null;
+                                /** Format: double */
                                 debt_to_income_ratio?: number | null;
                                 /** Format: double */
                                 emergency_fund_months?: number;
+                                /** Format: double */
+                                expected_return_rate?: number | null;
                                 /** Format: double */
                                 fi_progress?: number | null;
                                 /** Format: double */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -217,6 +217,10 @@
 			{@const firePLN = formatPLN(fire.fire_number ?? 0)}
 			{@const wrPct = ((fire.withdrawal_rate ?? 0.04) * 100).toFixed(1)}
 			{@const runwayLabel = (fire.runway_months ?? 0).toFixed(1)}
+			{@const coastNum = fire.coast_fire_number}
+			{@const coastGap = fire.coast_fire_gap}
+			{@const coastTargetAge = fire.coast_fire_target_age}
+			{@const coastReturnPct = ((fire.expected_return_rate ?? 0.07) * 100).toFixed(1)}
 			<div class="card preset-filled-surface-100-900 p-4 space-y-3">
 				<header class="flex items-start justify-between gap-2 flex-wrap">
 					<h3 class="h4 flex items-center gap-2"><Flame size={18} /> FIRE i runway</h3>
@@ -253,6 +257,36 @@
 						</div>
 					</div>
 				</div>
+				{#if coastNum != null && coastGap != null && coastTargetAge != null}
+					{@const surplus = coastGap <= 0}
+					<div class="pt-3 border-t border-surface-200-800 grid grid-cols-1 sm:grid-cols-2 gap-3">
+						<div class="space-y-1">
+							<div
+								class="text-xs text-surface-700-300"
+								title="coast_fire_number = FIRE ÷ (1 + expected_return)^(target_age − current_age) — kapitał potrzebny dziś, aby bez dalszych wpłat osiągnąć FIRE w docelowym wieku."
+							>
+								Coast FIRE (cel {coastTargetAge} r., {coastReturnPct}%/rok)
+							</div>
+							<div class="text-2xl font-bold">{formatPLN(coastNum)}</div>
+							<div class="text-xs text-surface-700-300">kapitał dziś, by przestać inwestować</div>
+						</div>
+						<div class="space-y-1">
+							<div class="text-xs text-surface-700-300">
+								{surplus ? 'Nadwyżka' : 'Brakuje'}
+							</div>
+							<div
+								class="text-2xl font-bold {surplus
+									? 'text-success-600-400'
+									: 'text-warning-600-400'}"
+							>
+								{formatPLN(Math.abs(coastGap))}
+							</div>
+							<div class="text-xs text-surface-700-300">
+								{surplus ? 'już osiągnięto Coast FIRE' : 'do osiągnięcia Coast FIRE'}
+							</div>
+						</div>
+					</div>
+				{/if}
 			</div>
 		{/if}
 

--- a/src/routes/settings/config/+page.svelte
+++ b/src/routes/settings/config/+page.svelte
@@ -9,7 +9,8 @@
 		Info,
 		CheckCircle2,
 		AlertTriangle,
-		Gauge
+		Gauge,
+		Flame
 	} from 'lucide-svelte';
 	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
@@ -55,6 +56,10 @@
 	let monthlyExpenses = $state(Number(config?.monthly_expenses ?? 0));
 	let monthlyMortgagePayment = $state(Number(config?.monthly_mortgage_payment ?? 0));
 	let withdrawalRate = $state(Number(config?.withdrawal_rate ?? 0.04));
+	// Coast FIRE: target age is optional — empty input means "no Coast FIRE
+	// tile". The backend treats a null coast_fire_target_age the same way.
+	let coastFireTargetAge = $state<number | null>(config?.coast_fire_target_age ?? null);
+	let expectedReturnRate = $state(Number(config?.expected_return_rate ?? 0.07));
 
 	let error = $state('');
 	let saving = $state(false);
@@ -119,7 +124,9 @@
 					allocation_commodities: allocationCommodities,
 					monthly_expenses: monthlyExpenses,
 					monthly_mortgage_payment: monthlyMortgagePayment,
-					withdrawal_rate: withdrawalRate
+					withdrawal_rate: withdrawalRate,
+					coast_fire_target_age: coastFireTargetAge,
+					expected_return_rate: expectedReturnRate
 				})
 			});
 
@@ -344,6 +351,48 @@
 			<span class="text-xs italic text-surface-700-300"
 				>Wyznacza cel FIRE = roczne wydatki ÷ stopa wypłaty.</span
 			>
+		</label>
+	</div>
+
+	<div class="card preset-filled-surface-100-900 p-4 space-y-4">
+		<header>
+			<h3 class="h3 flex items-center gap-2"><Flame size={20} /> Coast FIRE</h3>
+		</header>
+
+		<label class="label">
+			<span class="font-semibold text-sm">Docelowy wiek Coast FIRE</span>
+			<input
+				id="coast-fire-target-age"
+				type="number"
+				min="18"
+				max="100"
+				placeholder="np. 65 (puste = wyłączone)"
+				value={coastFireTargetAge ?? ''}
+				oninput={(e) => {
+					const v = (e.target as HTMLInputElement).value;
+					coastFireTargetAge = v === '' ? null : Number(v);
+				}}
+				class="input"
+			/>
+			<span class="text-xs italic text-surface-700-300">
+				Wiek, w którym chcesz osiągnąć FIRE bez dalszych wpłat. Puste = ukryj kartę Coast FIRE.
+			</span>
+		</label>
+
+		<label class="label">
+			<span class="font-semibold text-sm">Oczekiwana stopa zwrotu (rocznie)</span>
+			<input
+				id="expected-return-rate"
+				type="number"
+				min="0.01"
+				max="0.20"
+				step="0.005"
+				bind:value={expectedReturnRate}
+				class="input"
+			/>
+			<span class="text-xs italic text-surface-700-300">
+				Realna stopa zwrotu używana do dyskontowania celu FIRE do dziś (np. 0.07 = 7%).
+			</span>
 		</label>
 	</div>
 

--- a/src/routes/settings/config/+page.svelte
+++ b/src/routes/settings/config/+page.svelte
@@ -366,11 +366,19 @@
 				type="number"
 				min="18"
 				max="100"
+				step="1"
 				placeholder="np. 65 (puste = wyłączone)"
 				value={coastFireTargetAge ?? ''}
 				oninput={(e) => {
 					const v = (e.target as HTMLInputElement).value;
-					coastFireTargetAge = v === '' ? null : Number(v);
+					// Backend stores target age as *int; force integer + drop NaN so
+					// the JSON encoder never sends a float that fails to decode.
+					if (v === '') {
+						coastFireTargetAge = null;
+						return;
+					}
+					const n = parseInt(v, 10);
+					coastFireTargetAge = Number.isNaN(n) ? null : n;
 				}}
 				class="input"
 			/>


### PR DESCRIPTION
## Motivation

Closes #548. Adds the Coast FIRE metric to the dashboard's FIRE card so the
user can see (a) the capital needed today to stop investing and still hit
the FIRE number by a chosen target age, and (b) whether they are already
past that bar (surplus) or short of it (gap).

## Implementation information

**Config (`app_config`)**
- New columns: `coast_fire_target_age integer NULL` (unset = Coast tile
  hidden) and `expected_return_rate numeric(5,4) NOT NULL DEFAULT 0.07`.
- `schema.sql` baseline + idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`
  migration; defaults backfill the existing single config row.
- PUT body / GET response extended; both new fields nullable in the request
  so older clients PUT-ing the old shape still validate (defaults applied
  in `toConfig`).
- Validation: target age 18..100 and > current age; expected return rate in
  [0.01, 0.20] to catch unit errors (e.g. typing `7` instead of `0.07`).

**Dashboard (`/api/dashboard.metric_cards`)**
- New fields: `coast_fire_number`, `coast_fire_gap`, `coast_fire_target_age`,
  `expected_return_rate` — all nullable, set atomically when the inputs are
  sufficient (target age configured, return rate > 0, FIRE number > 0,
  target age > current age).
- Math: `coast_fire_number = fire_number / (1 + r)^(target_age − current_age)`;
  `coast_fire_gap = coast_fire_number − net_worth` (positive = shortfall,
  negative = surplus).
- Tests cover happy path, target-age-≤-current-age, zero return rate, and
  missing FIRE number.

**Frontend**
- Settings page: new "Coast FIRE" section with target age (clearable) +
  expected return rate inputs.
- Dashboard FIRE card: nested Coast FIRE row below the existing FI / runway
  pair, with `Nadwyżka` / `Brakuje` (surplus/short) labelled in green/orange.
- OpenAPI spec + generated TS types regenerated.

**Test surface**
- Backend unit tests (`go test ./...`): green.
- `golangci-lint run ./...`: green.
- Black-box pytest (`backend-bb-tests`): green (config golden updated).
- Frontend: `npm run check`, `npm run lint`, `npm test`: green.

> Changelog: feat(fire): add Coast FIRE metric