### PR TITLE
feat(fire): add Barista FIRE metric

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -2302,6 +2302,10 @@
                     "allocation_stocks": {
                       "type": "integer"
                     },
+                    "barista_monthly_income": {
+                      "nullable": true,
+                      "type": "string"
+                    },
                     "birth_date": {
                       "format": "date",
                       "type": "string"
@@ -2365,6 +2369,10 @@
                   "allocation_stocks": {
                     "type": "integer"
                   },
+                  "barista_monthly_income": {
+                    "nullable": true,
+                    "type": "string"
+                  },
                   "birth_date": {
                     "format": "date",
                     "type": "string"
@@ -2420,6 +2428,10 @@
                     },
                     "allocation_stocks": {
                       "type": "integer"
+                    },
+                    "barista_monthly_income": {
+                      "nullable": true,
+                      "type": "string"
                     },
                     "birth_date": {
                       "format": "date",
@@ -2778,6 +2790,31 @@
                     "metric_cards": {
                       "properties": {
                         "annual_expenses": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "barista_annual_gap": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "barista_fi_progress": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "barista_fire_number": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "barista_monthly_income": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "barista_years_to_fi": {
                           "format": "double",
                           "nullable": true,
                           "type": "number"

--- a/backend-bb-tests/golden/config_get.json
+++ b/backend-bb-tests/golden/config_get.json
@@ -4,6 +4,7 @@
   "allocation_gold": 5,
   "allocation_real_estate": 40,
   "allocation_stocks": 30,
+  "barista_monthly_income": null,
   "birth_date": "1990-06-15",
   "coast_fire_target_age": null,
   "expected_return_rate": "0.0700",

--- a/backend-bb-tests/tests/test_config.py
+++ b/backend-bb-tests/tests/test_config.py
@@ -33,3 +33,27 @@ def test_get_config_required_fields(client: httpx.Client) -> None:
     }
     missing = required - body.keys()
     assert not missing, f"Config response is missing fields: {sorted(missing)}"
+
+
+def test_put_config_round_trip(client: httpx.Client) -> None:
+    # Round-trips the full config payload back through PUT. Regression guard
+    # against placeholder/column-list drift in the upsert SQL — if any column
+    # is missing from either the INSERT list, VALUES list, or RETURNING/scan,
+    # Postgres errors and this fails before the parity suite even runs.
+    #
+    # Seed allocations don't sum to 100% market, so we satisfy the validator
+    # by overriding them; the assertions below cover only the new FIRE fields.
+    body = client.get("/api/config").json()
+    body["allocation_stocks"] = 60
+    body["allocation_bonds"] = 30
+    body["allocation_gold"] = 5
+    body["allocation_commodities"] = 5
+    body["barista_monthly_income"] = "3000.00"
+    body["coast_fire_target_age"] = 65
+    body["expected_return_rate"] = "0.08"
+    response = client.put("/api/config", json=body)
+    assert response.status_code == 200, response.text
+    out = response.json()
+    assert out["barista_monthly_income"] == "3000.00"
+    assert out["coast_fire_target_age"] == 65
+    assert out["expected_return_rate"] == "0.0800"

--- a/backend-go/internal/config/handler.go
+++ b/backend-go/internal/config/handler.go
@@ -17,20 +17,21 @@ import (
 // Date is serialized as "YYYY-MM-DD". Decimal money fields are quoted JSON
 // strings with two decimals (Python Pydantic v2's default for Decimal).
 type response struct {
-	ID                      int       `json:"id"`
-	BirthDate               isoDate   `json:"birth_date"`
-	RetirementAge           int       `json:"retirement_age"`
-	RetirementMonthlySalary moneyJSON `json:"retirement_monthly_salary"`
-	AllocationRealEstate    int       `json:"allocation_real_estate"`
-	AllocationStocks        int       `json:"allocation_stocks"`
-	AllocationBonds         int       `json:"allocation_bonds"`
-	AllocationGold          int       `json:"allocation_gold"`
-	AllocationCommodities   int       `json:"allocation_commodities"`
-	MonthlyExpenses         moneyJSON `json:"monthly_expenses"`
-	MonthlyMortgagePayment  moneyJSON `json:"monthly_mortgage_payment"`
-	WithdrawalRate          rateJSON  `json:"withdrawal_rate"`
-	CoastFIRETargetAge      *int      `json:"coast_fire_target_age"`
-	ExpectedReturnRate      rateJSON  `json:"expected_return_rate"`
+	ID                      int        `json:"id"`
+	BirthDate               isoDate    `json:"birth_date"`
+	RetirementAge           int        `json:"retirement_age"`
+	RetirementMonthlySalary moneyJSON  `json:"retirement_monthly_salary"`
+	AllocationRealEstate    int        `json:"allocation_real_estate"`
+	AllocationStocks        int        `json:"allocation_stocks"`
+	AllocationBonds         int        `json:"allocation_bonds"`
+	AllocationGold          int        `json:"allocation_gold"`
+	AllocationCommodities   int        `json:"allocation_commodities"`
+	MonthlyExpenses         moneyJSON  `json:"monthly_expenses"`
+	MonthlyMortgagePayment  moneyJSON  `json:"monthly_mortgage_payment"`
+	WithdrawalRate          rateJSON   `json:"withdrawal_rate"`
+	CoastFIRETargetAge      *int       `json:"coast_fire_target_age"`
+	ExpectedReturnRate      rateJSON   `json:"expected_return_rate"`
+	BaristaMonthlyIncome    *moneyJSON `json:"barista_monthly_income"`
 }
 
 // request is the PUT body. Date arrives as "YYYY-MM-DD" and money as either
@@ -49,6 +50,7 @@ type request struct {
 	WithdrawalRate          *decimal.Decimal `json:"withdrawal_rate"`
 	CoastFIRETargetAge      *int             `json:"coast_fire_target_age"`
 	ExpectedReturnRate      *decimal.Decimal `json:"expected_return_rate"`
+	BaristaMonthlyIncome    *decimal.Decimal `json:"barista_monthly_income"`
 }
 
 func toResponse(c *Config) response {
@@ -67,7 +69,18 @@ func toResponse(c *Config) response {
 		WithdrawalRate:          rateJSON(c.WithdrawalRate),
 		CoastFIRETargetAge:      c.CoastFIRETargetAge,
 		ExpectedReturnRate:      rateJSON(c.ExpectedReturnRate),
+		BaristaMonthlyIncome:    moneyPtr(c.BaristaMonthlyIncome),
 	}
+}
+
+// moneyPtr lifts a nullable decimal into the JSON-wire moneyJSON pointer
+// shape — nil decimals become nil JSON, mirroring the *int CoastFIRE field.
+func moneyPtr(d *decimal.Decimal) *moneyJSON {
+	if d == nil {
+		return nil
+	}
+	m := moneyJSON(*d)
+	return &m
 }
 
 // Handler returns the chi-compatible HTTP handler for GET + PUT /api/config.
@@ -146,6 +159,7 @@ func (r *request) toConfig() *Config {
 		WithdrawalRate:          rate,
 		CoastFIRETargetAge:      r.CoastFIRETargetAge,
 		ExpectedReturnRate:      expectedReturn,
+		BaristaMonthlyIncome:    r.BaristaMonthlyIncome,
 	}
 }
 

--- a/backend-go/internal/config/store.go
+++ b/backend-go/internal/config/store.go
@@ -18,20 +18,21 @@ import (
 // Config mirrors backend/app/models/app_config.AppConfig — DB column names
 // and types kept identical for parity-suite assertions.
 type Config struct {
-	ID                      int             `json:"id"`
-	BirthDate               time.Time       `json:"birth_date"`
-	RetirementAge           int             `json:"retirement_age"`
-	RetirementMonthlySalary decimal.Decimal `json:"retirement_monthly_salary"`
-	AllocationRealEstate    int             `json:"allocation_real_estate"`
-	AllocationStocks        int             `json:"allocation_stocks"`
-	AllocationBonds         int             `json:"allocation_bonds"`
-	AllocationGold          int             `json:"allocation_gold"`
-	AllocationCommodities   int             `json:"allocation_commodities"`
-	MonthlyExpenses         decimal.Decimal `json:"monthly_expenses"`
-	MonthlyMortgagePayment  decimal.Decimal `json:"monthly_mortgage_payment"`
-	WithdrawalRate          decimal.Decimal `json:"withdrawal_rate"`
-	CoastFIRETargetAge      *int            `json:"coast_fire_target_age"`
-	ExpectedReturnRate      decimal.Decimal `json:"expected_return_rate"`
+	ID                      int              `json:"id"`
+	BirthDate               time.Time        `json:"birth_date"`
+	RetirementAge           int              `json:"retirement_age"`
+	RetirementMonthlySalary decimal.Decimal  `json:"retirement_monthly_salary"`
+	AllocationRealEstate    int              `json:"allocation_real_estate"`
+	AllocationStocks        int              `json:"allocation_stocks"`
+	AllocationBonds         int              `json:"allocation_bonds"`
+	AllocationGold          int              `json:"allocation_gold"`
+	AllocationCommodities   int              `json:"allocation_commodities"`
+	MonthlyExpenses         decimal.Decimal  `json:"monthly_expenses"`
+	MonthlyMortgagePayment  decimal.Decimal  `json:"monthly_mortgage_payment"`
+	WithdrawalRate          decimal.Decimal  `json:"withdrawal_rate"`
+	CoastFIRETargetAge      *int             `json:"coast_fire_target_age"`
+	ExpectedReturnRate      decimal.Decimal  `json:"expected_return_rate"`
+	BaristaMonthlyIncome    *decimal.Decimal `json:"barista_monthly_income"`
 }
 
 // ErrNotFound is returned when no row exists at id=1.
@@ -52,7 +53,8 @@ const selectColumns = `
 	allocation_real_estate, allocation_stocks, allocation_bonds,
 	allocation_gold, allocation_commodities,
 	monthly_expenses, monthly_mortgage_payment, withdrawal_rate,
-	coast_fire_target_age, expected_return_rate
+	coast_fire_target_age, expected_return_rate,
+	barista_monthly_income
 `
 
 // Get returns the singleton config or ErrNotFound.
@@ -80,8 +82,9 @@ func (s *Store) Upsert(ctx context.Context, in *Config) (*Config, error) {
 			allocation_real_estate, allocation_stocks, allocation_bonds,
 			allocation_gold, allocation_commodities,
 			monthly_expenses, monthly_mortgage_payment, withdrawal_rate,
-			coast_fire_target_age, expected_return_rate
-		) VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+			coast_fire_target_age, expected_return_rate,
+			barista_monthly_income
+		) VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 		ON CONFLICT (id) DO UPDATE SET
 			birth_date = EXCLUDED.birth_date,
 			retirement_age = EXCLUDED.retirement_age,
@@ -95,7 +98,8 @@ func (s *Store) Upsert(ctx context.Context, in *Config) (*Config, error) {
 			monthly_mortgage_payment = EXCLUDED.monthly_mortgage_payment,
 			withdrawal_rate = EXCLUDED.withdrawal_rate,
 			coast_fire_target_age = EXCLUDED.coast_fire_target_age,
-			expected_return_rate = EXCLUDED.expected_return_rate
+			expected_return_rate = EXCLUDED.expected_return_rate,
+			barista_monthly_income = EXCLUDED.barista_monthly_income
 		RETURNING `+selectColumns,
 		in.BirthDate,
 		in.RetirementAge,
@@ -110,6 +114,7 @@ func (s *Store) Upsert(ctx context.Context, in *Config) (*Config, error) {
 		in.WithdrawalRate,
 		in.CoastFIRETargetAge,
 		in.ExpectedReturnRate,
+		in.BaristaMonthlyIncome,
 	)
 	c, err := scanConfig(row)
 	if err != nil {
@@ -135,6 +140,7 @@ func scanConfig(row pgx.Row) (*Config, error) {
 		&c.WithdrawalRate,
 		&c.CoastFIRETargetAge,
 		&c.ExpectedReturnRate,
+		&c.BaristaMonthlyIncome,
 	)
 	if err != nil {
 		return nil, err

--- a/backend-go/internal/config/validation.go
+++ b/backend-go/internal/config/validation.go
@@ -111,6 +111,9 @@ func (r *request) validate() *validationError {
 			}
 		}
 	}
+	if r.BaristaMonthlyIncome != nil && r.BaristaMonthlyIncome.LessThan(decimal.Zero) {
+		return &validationError{"barista_monthly_income", "Value must be non-negative"}
+	}
 	return nil
 }
 

--- a/backend-go/internal/config/validation_test.go
+++ b/backend-go/internal/config/validation_test.go
@@ -215,3 +215,29 @@ func TestValidateExpectedReturnRateAllowed(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateBaristaMonthlyIncomeNegative(t *testing.T) {
+	r := validRequest()
+	d := decimal.NewFromInt(-1)
+	r.BaristaMonthlyIncome = &d
+	if err := r.validate(); err == nil || err.Field != "barista_monthly_income" {
+		t.Fatalf("expected barista_monthly_income error, got %+v", err)
+	}
+}
+
+func TestValidateBaristaMonthlyIncomeZeroOK(t *testing.T) {
+	r := validRequest()
+	d := decimal.Zero
+	r.BaristaMonthlyIncome = &d
+	if err := r.validate(); err != nil {
+		t.Fatalf("expected zero barista_monthly_income to validate, got %+v", err)
+	}
+}
+
+func TestValidateBaristaMonthlyIncomeNilOK(t *testing.T) {
+	r := validRequest()
+	r.BaristaMonthlyIncome = nil
+	if err := r.validate(); err != nil {
+		t.Fatalf("expected nil barista_monthly_income to validate, got %+v", err)
+	}
+}

--- a/backend-go/internal/dashboard/dashboard.go
+++ b/backend-go/internal/dashboard/dashboard.go
@@ -49,6 +49,11 @@ type metricCards struct {
 	CoastFIREGap            *float64
 	CoastFIRETargetAge      *int
 	ExpectedReturnRate      *float64
+	BaristaMonthlyIncome    *float64
+	BaristaAnnualGap        *float64
+	BaristaFIRENumber       *float64
+	BaristaFIProgress       *float64
+	BaristaYearsToFI        *float64
 }
 
 type allocationBreakdown struct {

--- a/backend-go/internal/dashboard/fire.go
+++ b/backend-go/internal/dashboard/fire.go
@@ -83,6 +83,14 @@ func computeFIRE(latestRows []mergedRow, cfg AppConfig, netWorth float64) fireMe
 	runway := liquid / monthlyExpenses
 	out.RunwayMonths = &runway
 
+	// Surface the configured expected return rate once when it's positive, so
+	// the wire field is independent of whether Coast or Barista FIRE actually
+	// consumed it. The UI uses this rate to label both years-to-FI captions.
+	if er, _ := cfg.ExpectedReturnRate.Float64(); er > 0 {
+		rate := er
+		out.ExpectedReturnRate = &rate
+	}
+
 	now := time.Now().UTC()
 	addCoastFIRE(&out, cfg, netWorth, now)
 	addBaristaFIRE(&out, cfg, netWorth)
@@ -183,8 +191,6 @@ func addCoastFIRE(out *fireMetrics, cfg AppConfig, netWorth float64, now time.Ti
 	out.CoastFIREGap = &gap
 	ta := targetAge
 	out.CoastFIRETargetAge = &ta
-	er := expectedReturn
-	out.ExpectedReturnRate = &er
 }
 
 // yearsBetween returns whole years from birth to now using the same

--- a/backend-go/internal/dashboard/fire.go
+++ b/backend-go/internal/dashboard/fire.go
@@ -19,15 +19,20 @@ var liquidCategories = map[string]struct{}{
 // produce a meaningful number (monthly_expenses == 0, withdrawal_rate == 0,
 // or net_worth <= 0 for the progress percentage).
 type fireMetrics struct {
-	AnnualExpenses     *float64
-	FIRENumber         *float64
-	FIProgress         *float64
-	RunwayMonths       *float64
-	WithdrawalRate     *float64
-	CoastFIRENumber    *float64
-	CoastFIREGap       *float64
-	CoastFIRETargetAge *int
-	ExpectedReturnRate *float64
+	AnnualExpenses       *float64
+	FIRENumber           *float64
+	FIProgress           *float64
+	RunwayMonths         *float64
+	WithdrawalRate       *float64
+	CoastFIRENumber      *float64
+	CoastFIREGap         *float64
+	CoastFIRETargetAge   *int
+	ExpectedReturnRate   *float64
+	BaristaMonthlyIncome *float64
+	BaristaAnnualGap     *float64
+	BaristaFIRENumber    *float64
+	BaristaFIProgress    *float64
+	BaristaYearsToFI     *float64
 }
 
 // computeFIRE turns app_config + the latest snapshot's rows into the FIRE
@@ -78,8 +83,65 @@ func computeFIRE(latestRows []mergedRow, cfg AppConfig, netWorth float64) fireMe
 	runway := liquid / monthlyExpenses
 	out.RunwayMonths = &runway
 
-	addCoastFIRE(&out, cfg, netWorth, time.Now().UTC())
+	now := time.Now().UTC()
+	addCoastFIRE(&out, cfg, netWorth, now)
+	addBaristaFIRE(&out, cfg, netWorth)
 	return out
+}
+
+// addBaristaFIRE fills the Barista FIRE fields when a part-time monthly
+// income is configured and the existing FIRE inputs are valid. Math:
+//
+//	barista_annual_gap   = max(0, annual_expenses − barista_annual_income)
+//	barista_fire_number  = barista_annual_gap ÷ withdrawal_rate
+//	barista_fi_progress  = net_worth ÷ barista_fire_number × 100
+//	barista_years_to_fi  = ln(barista_fire_number ÷ net_worth) ÷ ln(1 + r)
+//
+// The years-to-FI projection assumes no future contributions — compounding
+// alone of today's net worth at the expected return rate. This is the most
+// conservative projection that doesn't require yet-another configured
+// "monthly savings" input, and it lines up with how Coast FIRE uses
+// expected_return_rate.
+func addBaristaFIRE(out *fireMetrics, cfg AppConfig, netWorth float64) {
+	if out.AnnualExpenses == nil || out.WithdrawalRate == nil {
+		return
+	}
+	if cfg.BaristaMonthlyIncome == nil {
+		return
+	}
+	monthly, _ := cfg.BaristaMonthlyIncome.Float64()
+	if monthly < 0 {
+		return
+	}
+	baristaAnnual := monthly * 12
+	bm := monthly
+	out.BaristaMonthlyIncome = &bm
+
+	gap := *out.AnnualExpenses - baristaAnnual
+	if gap < 0 {
+		gap = 0
+	}
+	out.BaristaAnnualGap = &gap
+
+	fire := gap / *out.WithdrawalRate
+	out.BaristaFIRENumber = &fire
+	if fire > 0 && netWorth > 0 {
+		progress := netWorth / fire * 100
+		out.BaristaFIProgress = &progress
+	}
+
+	// Years-to-FI is only meaningful when (a) we still have ground to cover
+	// (net_worth < fire), (b) net worth is positive (log undefined at 0/
+	// negative), and (c) the projection has a positive growth rate.
+	if fire <= 0 || netWorth <= 0 || netWorth >= fire {
+		return
+	}
+	expectedReturn, _ := cfg.ExpectedReturnRate.Float64()
+	if expectedReturn <= 0 {
+		return
+	}
+	years := math.Log(fire/netWorth) / math.Log(1+expectedReturn)
+	out.BaristaYearsToFI = &years
 }
 
 // addCoastFIRE fills the Coast FIRE fields when the inputs are sufficient:

--- a/backend-go/internal/dashboard/fire_test.go
+++ b/backend-go/internal/dashboard/fire_test.go
@@ -169,8 +169,21 @@ func TestAddCoastFIREHappyPath(t *testing.T) {
 	if out.CoastFIRETargetAge == nil || *out.CoastFIRETargetAge != 65 {
 		t.Errorf("coast_fire_target_age = %v, want 65", out.CoastFIRETargetAge)
 	}
-	if out.ExpectedReturnRate == nil || *out.ExpectedReturnRate != 0.07 {
-		t.Errorf("expected_return_rate = %v, want 0.07", out.ExpectedReturnRate)
+}
+
+// TestComputeFIREExposesExpectedReturnRate guards the wire field that the
+// UI uses to label both Coast and Barista years-to-FI captions: the rate
+// must surface regardless of which feature consumed it.
+func TestComputeFIREExposesExpectedReturnRate(t *testing.T) {
+	t.Parallel()
+	cfg := AppConfig{
+		MonthlyExpenses:    decimal.NewFromInt(5000),
+		WithdrawalRate:     decimal.RequireFromString("0.04"),
+		ExpectedReturnRate: decimal.RequireFromString("0.06"),
+	}
+	got := computeFIRE(nil, cfg, 100_000)
+	if got.ExpectedReturnRate == nil || *got.ExpectedReturnRate != 0.06 {
+		t.Errorf("expected_return_rate = %v, want 0.06", got.ExpectedReturnRate)
 	}
 }
 

--- a/backend-go/internal/dashboard/fire_test.go
+++ b/backend-go/internal/dashboard/fire_test.go
@@ -244,6 +244,116 @@ func TestAddCoastFIREZeroReturnRateStaysNil(t *testing.T) {
 	}
 }
 
+func TestAddBaristaFIREHappyPath(t *testing.T) {
+	t.Parallel()
+	// Monthly expenses 5000 → annual 60000. Barista income 2000/mo → annual
+	// 24000. Gap = 36000. Withdrawal 0.04 → barista FIRE = 900000.
+	monthly := decimal.NewFromInt(2000)
+	cfg := AppConfig{
+		MonthlyExpenses:      decimal.NewFromInt(5000),
+		WithdrawalRate:       decimal.RequireFromString("0.04"),
+		ExpectedReturnRate:   decimal.RequireFromString("0.07"),
+		BaristaMonthlyIncome: &monthly,
+	}
+	got := computeFIRE(nil, cfg, 500_000)
+
+	if got.BaristaMonthlyIncome == nil || *got.BaristaMonthlyIncome != 2000 {
+		t.Fatalf("barista_monthly_income = %v, want 2000", got.BaristaMonthlyIncome)
+	}
+	if got.BaristaAnnualGap == nil || *got.BaristaAnnualGap != 36_000 {
+		t.Fatalf("barista_annual_gap = %v, want 36000", got.BaristaAnnualGap)
+	}
+	if got.BaristaFIRENumber == nil || *got.BaristaFIRENumber != 900_000 {
+		t.Fatalf("barista_fire_number = %v, want 900000", got.BaristaFIRENumber)
+	}
+	// progress = 500k / 900k * 100 ≈ 55.56%
+	if got.BaristaFIProgress == nil || !approxEqual(*got.BaristaFIProgress, 55.5555, 0.01) {
+		t.Errorf("barista_fi_progress = %v, want ≈55.56", got.BaristaFIProgress)
+	}
+	// years = log(900000/500000) / log(1.07) ≈ 8.69
+	wantYears := math.Log(900_000.0/500_000.0) / math.Log(1.07)
+	if got.BaristaYearsToFI == nil || !approxEqual(*got.BaristaYearsToFI, wantYears, 0.01) {
+		t.Errorf("barista_years_to_fi = %v, want ≈%v", got.BaristaYearsToFI, wantYears)
+	}
+}
+
+func TestAddBaristaFIREIncomeCoversAllExpenses(t *testing.T) {
+	t.Parallel()
+	// Barista income 6000/mo > expenses 5000/mo → gap clamps to 0,
+	// FIRE number = 0, progress + years-to-FI stay nil.
+	monthly := decimal.NewFromInt(6000)
+	cfg := AppConfig{
+		MonthlyExpenses:      decimal.NewFromInt(5000),
+		WithdrawalRate:       decimal.RequireFromString("0.04"),
+		ExpectedReturnRate:   decimal.RequireFromString("0.07"),
+		BaristaMonthlyIncome: &monthly,
+	}
+	got := computeFIRE(nil, cfg, 500_000)
+
+	if got.BaristaAnnualGap == nil || *got.BaristaAnnualGap != 0 {
+		t.Fatalf("barista_annual_gap = %v, want 0", got.BaristaAnnualGap)
+	}
+	if got.BaristaFIRENumber == nil || *got.BaristaFIRENumber != 0 {
+		t.Fatalf("barista_fire_number = %v, want 0", got.BaristaFIRENumber)
+	}
+	if got.BaristaFIProgress != nil {
+		t.Errorf("expected nil barista_fi_progress when fire = 0, got %v", *got.BaristaFIProgress)
+	}
+	if got.BaristaYearsToFI != nil {
+		t.Errorf("expected nil barista_years_to_fi when fire = 0, got %v", *got.BaristaYearsToFI)
+	}
+}
+
+func TestAddBaristaFIRENetWorthAlreadyAtTarget(t *testing.T) {
+	t.Parallel()
+	// Net worth already exceeds barista FIRE → years-to-FI nil (already there).
+	monthly := decimal.NewFromInt(2000)
+	cfg := AppConfig{
+		MonthlyExpenses:      decimal.NewFromInt(5000),
+		WithdrawalRate:       decimal.RequireFromString("0.04"),
+		ExpectedReturnRate:   decimal.RequireFromString("0.07"),
+		BaristaMonthlyIncome: &monthly,
+	}
+	got := computeFIRE(nil, cfg, 1_500_000)
+	if got.BaristaYearsToFI != nil {
+		t.Errorf("expected nil barista_years_to_fi when net worth ≥ target, got %v", *got.BaristaYearsToFI)
+	}
+	if got.BaristaFIProgress == nil || *got.BaristaFIProgress <= 100 {
+		t.Errorf("expected progress > 100%%, got %v", got.BaristaFIProgress)
+	}
+}
+
+func TestAddBaristaFIRENoIncomeStaysNil(t *testing.T) {
+	t.Parallel()
+	cfg := AppConfig{
+		MonthlyExpenses:    decimal.NewFromInt(5000),
+		WithdrawalRate:     decimal.RequireFromString("0.04"),
+		ExpectedReturnRate: decimal.RequireFromString("0.07"),
+	}
+	got := computeFIRE(nil, cfg, 500_000)
+	if got.BaristaFIRENumber != nil || got.BaristaAnnualGap != nil {
+		t.Errorf("expected nil barista fields without configured income, got %+v", got)
+	}
+}
+
+func TestAddBaristaFIREZeroReturnRateNoYears(t *testing.T) {
+	t.Parallel()
+	monthly := decimal.NewFromInt(2000)
+	cfg := AppConfig{
+		MonthlyExpenses:      decimal.NewFromInt(5000),
+		WithdrawalRate:       decimal.RequireFromString("0.04"),
+		ExpectedReturnRate:   decimal.Zero,
+		BaristaMonthlyIncome: &monthly,
+	}
+	got := computeFIRE(nil, cfg, 500_000)
+	if got.BaristaFIRENumber == nil {
+		t.Fatal("expected barista_fire_number set even without return rate")
+	}
+	if got.BaristaYearsToFI != nil {
+		t.Errorf("expected nil barista_years_to_fi when return rate ≤ 0, got %v", *got.BaristaYearsToFI)
+	}
+}
+
 func TestAddCoastFIRENoFIRENumberStaysNil(t *testing.T) {
 	t.Parallel()
 	birth := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/backend-go/internal/dashboard/handler.go
+++ b/backend-go/internal/dashboard/handler.go
@@ -197,6 +197,11 @@ type metricCardsWire struct {
 	CoastFIREGap            *pyFloat `json:"coast_fire_gap"`
 	CoastFIRETargetAge      *int     `json:"coast_fire_target_age"`
 	ExpectedReturnRate      *pyFloat `json:"expected_return_rate"`
+	BaristaMonthlyIncome    *pyFloat `json:"barista_monthly_income"`
+	BaristaAnnualGap        *pyFloat `json:"barista_annual_gap"`
+	BaristaFIRENumber       *pyFloat `json:"barista_fire_number"`
+	BaristaFIProgress       *pyFloat `json:"barista_fi_progress"`
+	BaristaYearsToFI        *pyFloat `json:"barista_years_to_fi"`
 }
 
 type allocationBreakdownWire struct {
@@ -337,6 +342,11 @@ func metricCardsToWire(m metricCards) metricCardsWire {
 		CoastFIREGap:            floatPtr(m.CoastFIREGap),
 		CoastFIRETargetAge:      m.CoastFIRETargetAge,
 		ExpectedReturnRate:      floatPtr(m.ExpectedReturnRate),
+		BaristaMonthlyIncome:    floatPtr(m.BaristaMonthlyIncome),
+		BaristaAnnualGap:        floatPtr(m.BaristaAnnualGap),
+		BaristaFIRENumber:       floatPtr(m.BaristaFIRENumber),
+		BaristaFIProgress:       floatPtr(m.BaristaFIProgress),
+		BaristaYearsToFI:        floatPtr(m.BaristaYearsToFI),
 	}
 }
 

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -492,6 +492,11 @@ func assignFIREMetrics(mc *metricCards, fire fireMetrics) {
 	mc.CoastFIREGap = fire.CoastFIREGap
 	mc.CoastFIRETargetAge = fire.CoastFIRETargetAge
 	mc.ExpectedReturnRate = fire.ExpectedReturnRate
+	mc.BaristaMonthlyIncome = fire.BaristaMonthlyIncome
+	mc.BaristaAnnualGap = fire.BaristaAnnualGap
+	mc.BaristaFIRENumber = fire.BaristaFIRENumber
+	mc.BaristaFIProgress = fire.BaristaFIProgress
+	mc.BaristaYearsToFI = fire.BaristaYearsToFI
 }
 
 // buildAllocationAnalysis is the shared allocation-analysis computation.

--- a/backend-go/internal/dashboard/store.go
+++ b/backend-go/internal/dashboard/store.go
@@ -81,6 +81,7 @@ type AppConfig struct {
 	BirthDate              time.Time
 	CoastFIRETargetAge     *int
 	ExpectedReturnRate     decimal.Decimal
+	BaristaMonthlyIncome   *decimal.Decimal
 }
 
 // SnapshotMeta is id+date.
@@ -296,7 +297,8 @@ func (s *Store) LoadAppConfig(ctx context.Context) (AppConfig, bool, error) {
 		SELECT monthly_expenses, monthly_mortgage_payment,
 		       allocation_stocks, allocation_bonds, allocation_gold,
 		       withdrawal_rate, birth_date,
-		       coast_fire_target_age, expected_return_rate
+		       coast_fire_target_age, expected_return_rate,
+		       barista_monthly_income
 		FROM app_config WHERE id = 1`,
 	)
 	var c AppConfig
@@ -305,6 +307,7 @@ func (s *Store) LoadAppConfig(ctx context.Context) (AppConfig, bool, error) {
 		&c.AllocationStocks, &c.AllocationBonds, &c.AllocationGold,
 		&c.WithdrawalRate, &c.BirthDate,
 		&c.CoastFIRETargetAge, &c.ExpectedReturnRate,
+		&c.BaristaMonthlyIncome,
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return AppConfig{}, false, nil

--- a/backend-go/internal/db/migrate.go
+++ b/backend-go/internal/db/migrate.go
@@ -64,11 +64,26 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
 	if err := addAppConfigCoastFIRE(ctx, pool); err != nil {
 		return err
 	}
+	if err := addAppConfigBaristaFIRE(ctx, pool); err != nil {
+		return err
+	}
 	if err := createRecurringTransactionsTable(ctx, pool); err != nil {
 		return err
 	}
 	if err := createHoldingsTables(ctx, pool); err != nil {
 		return err
+	}
+	return nil
+}
+
+// addAppConfigBaristaFIRE adds the Barista FIRE input to app_config (issue
+// #552): an optional `barista_monthly_income`. Nullable on purpose — when
+// unset the Barista FIRE tile is hidden, matching the Coast FIRE convention.
+func addAppConfigBaristaFIRE(ctx context.Context, pool *pgxpool.Pool) error {
+	if _, err := pool.Exec(ctx, `
+		ALTER TABLE app_config
+		ADD COLUMN IF NOT EXISTS barista_monthly_income numeric(15,2)`); err != nil {
+		return fmt.Errorf("add barista_monthly_income to app_config: %w", err)
 	}
 	return nil
 }

--- a/backend-go/internal/db/schema.sql
+++ b/backend-go/internal/db/schema.sql
@@ -98,6 +98,7 @@ CREATE TABLE public.app_config (
     withdrawal_rate numeric(5,4) NOT NULL DEFAULT 0.04,
     coast_fire_target_age integer,
     expected_return_rate numeric(5,4) NOT NULL DEFAULT 0.07,
+    barista_monthly_income numeric(15,2),
     CONSTRAINT single_row CHECK ((id = 1))
 );
 

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -1655,6 +1655,7 @@ export interface paths {
                             allocation_gold?: number;
                             allocation_real_estate?: number;
                             allocation_stocks?: number;
+                            barista_monthly_income?: string | null;
                             /** Format: date */
                             birth_date?: string;
                             coast_fire_target_age?: number | null;
@@ -1686,6 +1687,7 @@ export interface paths {
                         allocation_gold?: number;
                         allocation_real_estate?: number;
                         allocation_stocks?: number;
+                        barista_monthly_income?: string | null;
                         /** Format: date */
                         birth_date?: string;
                         coast_fire_target_age?: number | null;
@@ -1711,6 +1713,7 @@ export interface paths {
                             allocation_gold?: number;
                             allocation_real_estate?: number;
                             allocation_stocks?: number;
+                            barista_monthly_income?: string | null;
                             /** Format: date */
                             birth_date?: string;
                             coast_fire_target_age?: number | null;
@@ -1964,6 +1967,16 @@ export interface paths {
                             metric_cards?: {
                                 /** Format: double */
                                 annual_expenses?: number | null;
+                                /** Format: double */
+                                barista_annual_gap?: number | null;
+                                /** Format: double */
+                                barista_fi_progress?: number | null;
+                                /** Format: double */
+                                barista_fire_number?: number | null;
+                                /** Format: double */
+                                barista_monthly_income?: number | null;
+                                /** Format: double */
+                                barista_years_to_fi?: number | null;
                                 /** Format: double */
                                 coast_fire_gap?: number | null;
                                 /** Format: double */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -221,6 +221,10 @@
 			{@const coastGap = fire.coast_fire_gap}
 			{@const coastTargetAge = fire.coast_fire_target_age}
 			{@const coastReturnPct = ((fire.expected_return_rate ?? 0.07) * 100).toFixed(1)}
+			{@const baristaNum = fire.barista_fire_number}
+			{@const baristaProgress = fire.barista_fi_progress}
+			{@const baristaIncome = fire.barista_monthly_income}
+			{@const baristaYears = fire.barista_years_to_fi}
 			<div class="card preset-filled-surface-100-900 p-4 space-y-3">
 				<header class="flex items-start justify-between gap-2 flex-wrap">
 					<h3 class="h4 flex items-center gap-2"><Flame size={18} /> FIRE i runway</h3>
@@ -283,6 +287,40 @@
 							</div>
 							<div class="text-xs text-surface-700-300">
 								{surplus ? 'już osiągnięto Coast FIRE' : 'do osiągnięcia Coast FIRE'}
+							</div>
+						</div>
+					</div>
+				{/if}
+				{#if baristaNum != null && baristaIncome != null}
+					<div class="pt-3 border-t border-surface-200-800 space-y-2">
+						<div class="text-xs text-surface-700-300">
+							Praca dorywcza: {formatPLN(baristaIncome)}/mies.
+						</div>
+						<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+							<div class="space-y-1">
+								<div class="text-xs text-surface-700-300">FIRE — porównanie</div>
+								<div class="text-sm">
+									Klasyczne: <span class="font-bold">{firePLN}</span>
+								</div>
+								<div
+									class="text-sm"
+									title="barista_fire_number = max(0, annual_expenses − barista_annual_income) ÷ withdrawal_rate"
+								>
+									Barista: <span class="font-bold">{formatPLN(baristaNum)}</span>
+								</div>
+							</div>
+							<div class="space-y-1">
+								<div class="text-xs text-surface-700-300">Barista FI progress</div>
+								<div class="text-2xl font-bold">
+									{baristaProgress != null ? `${baristaProgress.toFixed(1)}%` : '—'}
+								</div>
+								{#if baristaYears != null}
+									<div class="text-xs text-surface-700-300">
+										FI za ~{baristaYears.toFixed(1)} lat (bez dopłat, {coastReturnPct}%/rok)
+									</div>
+								{:else if (baristaProgress ?? 0) >= 100}
+									<div class="text-xs text-success-600-400">już osiągnięto Barista FIRE</div>
+								{/if}
 							</div>
 						</div>
 					</div>

--- a/src/routes/settings/config/+page.svelte
+++ b/src/routes/settings/config/+page.svelte
@@ -60,6 +60,11 @@
 	// tile". The backend treats a null coast_fire_target_age the same way.
 	let coastFireTargetAge = $state<number | null>(config?.coast_fire_target_age ?? null);
 	let expectedReturnRate = $state(Number(config?.expected_return_rate ?? 0.07));
+	// Barista FIRE: monthly part-time income, nullable. Backend hides the
+	// tile when null. Money field arrives as a JSON string when present.
+	let baristaMonthlyIncome = $state<number | null>(
+		config?.barista_monthly_income != null ? Number(config.barista_monthly_income) : null
+	);
 
 	let error = $state('');
 	let saving = $state(false);
@@ -126,7 +131,8 @@
 					monthly_mortgage_payment: monthlyMortgagePayment,
 					withdrawal_rate: withdrawalRate,
 					coast_fire_target_age: coastFireTargetAge,
-					expected_return_rate: expectedReturnRate
+					expected_return_rate: expectedReturnRate,
+					barista_monthly_income: baristaMonthlyIncome
 				})
 			});
 
@@ -400,6 +406,37 @@
 			/>
 			<span class="text-xs italic text-surface-700-300">
 				Realna stopa zwrotu używana do dyskontowania celu FIRE do dziś (np. 0.07 = 7%).
+			</span>
+		</label>
+	</div>
+
+	<div class="card preset-filled-surface-100-900 p-4 space-y-4">
+		<header>
+			<h3 class="h3 flex items-center gap-2"><Flame size={20} /> Barista FIRE</h3>
+		</header>
+
+		<label class="label">
+			<span class="font-semibold text-sm">Miesięczny dochód z pracy dorywczej (PLN)</span>
+			<input
+				id="barista-monthly-income"
+				type="number"
+				min="0"
+				step="100"
+				placeholder="np. 3000 (puste = wyłączone)"
+				value={baristaMonthlyIncome ?? ''}
+				oninput={(e) => {
+					const v = (e.target as HTMLInputElement).value;
+					if (v === '') {
+						baristaMonthlyIncome = null;
+						return;
+					}
+					const n = Number(v);
+					baristaMonthlyIncome = Number.isNaN(n) ? null : n;
+				}}
+				class="input"
+			/>
+			<span class="text-xs italic text-surface-700-300">
+				Dochód z pracy na pół etatu pomniejsza wymagany kapitał. Puste = ukryj kartę Barista FIRE.
 			</span>
 		</label>
 	</div>


### PR DESCRIPTION
## Motivation

Closes #552. Adds Barista FIRE to the dashboard's FIRE card: users can
enter expected part-time monthly income, and the app recalculates the
required portfolio (lower than the classic FIRE number) plus a
compound-only years-to-FI projection. The classic FIRE and Barista FIRE
numbers render side by side so the trade-off is visible at a glance.

## Implementation information

**Config (`app_config`)**
- New column `barista_monthly_income numeric(15,2) NULL` (unset = tile hidden).
- `schema.sql` baseline + idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`
  migration mirror the Coast FIRE shape from #548.
- Validation: non-negative; nil OK (backward-compat for older PUT clients).
- Pre-existing column-list/placeholder drift bug in the upsert SQL was
  caught during self-review and fixed here; added a black-box
  ``test_put_config_round_trip`` regression so the next column addition
  fails CI before reaching the parity suite.

**Dashboard (`/api/dashboard.metric_cards`)**
- New fields: ``barista_monthly_income``, ``barista_annual_gap``,
  ``barista_fire_number``, ``barista_fi_progress``, ``barista_years_to_fi``.
- Math: ``gap = max(0, annual_expenses − barista_annual_income)``,
  ``fire = gap ÷ withdrawal_rate``, ``progress = net_worth ÷ fire × 100``,
  ``years_to_fi = ln(fire / net_worth) ÷ ln(1 + expected_return_rate)``.
- ``years_to_fi`` is compound-only (no future contributions) — same
  conservative assumption Coast FIRE uses; avoids introducing a new
  "monthly savings" config input the issue doesn't ask for.
- All fields nil-safe: barista income unset → all nil; income ≥ expenses →
  gap=0 / fire=0 / progress+years nil; net worth ≥ target → years nil.
- Tests cover happy path, income-covers-all, already-at-target,
  no-income-stays-nil, zero-return-rate-no-years.

**Frontend**
- Settings page: new "Barista FIRE" section with a clearable monthly-income input.
- Dashboard: Barista FIRE row nested under the existing FIRE card, with a
  side-by-side ``Klasyczne`` vs ``Barista`` comparison and the years-to-FI
  caption. Hidden when ``barista_fire_number`` is null.
- OpenAPI spec + TS types regenerated.

**Test surface**
- Backend unit tests (``go test ./...``): green.
- ``golangci-lint run ./...``: green.
- Black-box pytest (``backend-bb-tests``): 146 passed, 1 skipped.
- Frontend: ``npm run check``, ``npm run lint``, ``npm test``: green.

> Changelog: feat(fire): add Barista FIRE metric