### PR TITLE
feat(fire): model bridge-to-60 capital

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -2819,6 +2819,25 @@
                           "nullable": true,
                           "type": "number"
                         },
+                        "bridge_capital_gap": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "bridge_capital_needed": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "bridge_liquid_capital": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "bridge_years": {
+                          "nullable": true,
+                          "type": "integer"
+                        },
                         "coast_fire_gap": {
                           "format": "double",
                           "nullable": true,

--- a/backend-go/internal/dashboard/dashboard.go
+++ b/backend-go/internal/dashboard/dashboard.go
@@ -54,6 +54,10 @@ type metricCards struct {
 	BaristaFIRENumber       *float64
 	BaristaFIProgress       *float64
 	BaristaYearsToFI        *float64
+	BridgeYears             *int
+	BridgeCapitalNeeded     *float64
+	BridgeLiquidCapital     *float64
+	BridgeCapitalGap        *float64
 }
 
 type allocationBreakdown struct {

--- a/backend-go/internal/dashboard/fire.go
+++ b/backend-go/internal/dashboard/fire.go
@@ -33,6 +33,26 @@ type fireMetrics struct {
 	BaristaFIRENumber    *float64
 	BaristaFIProgress    *float64
 	BaristaYearsToFI     *float64
+	BridgeYears          *int
+	BridgeCapitalNeeded  *float64
+	BridgeLiquidCapital  *float64
+	BridgeCapitalGap     *float64
+}
+
+// wrapperAccessAge is the age at which Polish IKE/PPK retirement wrappers
+// become accessible without tax penalty. IKZE is technically age 65, but
+// 60 is the bridge-FIRE target the issue calls out (#546) and matches IKE
+// + PPK which are the two largest wrappers most users hold.
+const wrapperAccessAge = 60
+
+// lockedWrapperCategories enumerates the account wrappers excluded from
+// bridge-to-60 liquid capital — money in these wrappers can't be tapped
+// before wrapperAccessAge without tax penalty, so it doesn't count toward
+// the capital needed to bridge to access age.
+var lockedWrapperCategories = map[string]struct{}{
+	"IKE":  {},
+	"IKZE": {},
+	"PPK":  {},
 }
 
 // computeFIRE turns app_config + the latest snapshot's rows into the FIRE
@@ -94,7 +114,73 @@ func computeFIRE(latestRows []mergedRow, cfg AppConfig, netWorth float64) fireMe
 	now := time.Now().UTC()
 	addCoastFIRE(&out, cfg, netWorth, now)
 	addBaristaFIRE(&out, cfg, netWorth)
+	addBridgeToAccessAge(&out, latestRows, cfg, netWorth, now)
 	return out
+}
+
+// addBridgeToAccessAge fills the bridge-to-60 fields: how much liquid /
+// taxable capital is needed to cover expenses until Polish IKE/PPK access
+// age, and how much liquid capital (net worth minus locked-wrapper balances)
+// is currently available against that target. Math:
+//
+//	bridge_years         = max(0, wrapperAccessAge − current_age)
+//	bridge_capital_needed = annual_expenses × bridge_years
+//	bridge_liquid_capital = net_worth − Σ(IKE + IKZE + PPK asset balances)
+//	bridge_capital_gap    = bridge_capital_needed − bridge_liquid_capital
+//
+// The needed figure is intentionally conservative — no growth assumption,
+// since bridge capital is typically held in lower-volatility instruments
+// (bonds, savings) where compounding doesn't materially change the result
+// over the short bridge horizon.
+//
+// All fields stay nil when the user is already at/past access age, the
+// birth date is unset, or monthly expenses aren't configured (in which
+// case AnnualExpenses is nil and the bridge math has no meaningful input).
+func addBridgeToAccessAge(out *fireMetrics, latestRows []mergedRow, cfg AppConfig, netWorth float64, now time.Time) {
+	if out.AnnualExpenses == nil {
+		return
+	}
+	if cfg.BirthDate.IsZero() {
+		return
+	}
+	currentAge := yearsBetween(cfg.BirthDate, now)
+	years := wrapperAccessAge - currentAge
+	if years <= 0 {
+		return
+	}
+	out.BridgeYears = &years
+
+	needed := *out.AnnualExpenses * float64(years)
+	out.BridgeCapitalNeeded = &needed
+
+	locked := lockedWrapperValueOf(latestRows)
+	liquid := netWorth - locked
+	out.BridgeLiquidCapital = &liquid
+
+	gap := needed - liquid
+	out.BridgeCapitalGap = &gap
+}
+
+// lockedWrapperValueOf sums latest-snapshot active asset-account values
+// whose account_wrapper is one of the Polish locked retirement wrappers
+// (IKE/IKZE/PPK). Mirrors retirementValueOf's filter shape — the two are
+// not identical: a non-wrapper account can be marked purpose=retirement,
+// and a wrapper account can theoretically be missing the retirement
+// purpose tag, so each metric uses the predicate that matches its meaning.
+func lockedWrapperValueOf(latestRows []mergedRow) float64 {
+	total := 0.0
+	for _, r := range latestRows {
+		if r.AccountID == nil || r.AccType == nil || *r.AccType != "asset" {
+			continue
+		}
+		if r.Wrapper == nil {
+			continue
+		}
+		if _, ok := lockedWrapperCategories[*r.Wrapper]; ok {
+			total += r.Value
+		}
+	}
+	return total
 }
 
 // addBaristaFIRE fills the Barista FIRE fields when a part-time monthly

--- a/backend-go/internal/dashboard/fire.go
+++ b/backend-go/internal/dashboard/fire.go
@@ -39,15 +39,17 @@ type fireMetrics struct {
 	BridgeCapitalGap     *float64
 }
 
-// wrapperAccessAge is the age at which Polish IKE/PPK retirement wrappers
-// become accessible without tax penalty. IKZE is technically age 65, but
-// 60 is the bridge-FIRE target the issue calls out (#546) and matches IKE
-// + PPK which are the two largest wrappers most users hold.
-const wrapperAccessAge = 60
+// bridgeTargetAge is the age the bridge-to-60 metric projects to — IKE
+// and PPK unlock at 60, IKZE technically at 65. We use 60 as the single
+// bridge horizon because it's what the issue (#546) titled the metric
+// after and matches the two largest wrappers most users hold; the IKZE
+// over-count is small relative to the bridge horizon and intentionally
+// conservative (over-estimates liquid capital, not under-).
+const bridgeTargetAge = 60
 
 // lockedWrapperCategories enumerates the account wrappers excluded from
 // bridge-to-60 liquid capital — money in these wrappers can't be tapped
-// before wrapperAccessAge without tax penalty, so it doesn't count toward
+// before bridgeTargetAge without tax penalty, so it doesn't count toward
 // the capital needed to bridge to access age.
 var lockedWrapperCategories = map[string]struct{}{
 	"IKE":  {},
@@ -123,7 +125,7 @@ func computeFIRE(latestRows []mergedRow, cfg AppConfig, netWorth float64) fireMe
 // age, and how much liquid capital (net worth minus locked-wrapper balances)
 // is currently available against that target. Math:
 //
-//	bridge_years         = max(0, wrapperAccessAge − current_age)
+//	bridge_years         = max(0, bridgeTargetAge − current_age)
 //	bridge_capital_needed = annual_expenses × bridge_years
 //	bridge_liquid_capital = net_worth − Σ(IKE + IKZE + PPK asset balances)
 //	bridge_capital_gap    = bridge_capital_needed − bridge_liquid_capital
@@ -144,7 +146,7 @@ func addBridgeToAccessAge(out *fireMetrics, latestRows []mergedRow, cfg AppConfi
 		return
 	}
 	currentAge := yearsBetween(cfg.BirthDate, now)
-	years := wrapperAccessAge - currentAge
+	years := bridgeTargetAge - currentAge
 	if years <= 0 {
 		return
 	}

--- a/backend-go/internal/dashboard/fire_test.go
+++ b/backend-go/internal/dashboard/fire_test.go
@@ -20,6 +20,20 @@ func newAccountRow(category, accType string, value float64) mergedRow {
 	}
 }
 
+func newWrapperRow(wrapper string, value float64) mergedRow {
+	w := wrapper
+	t := "asset"
+	c := "stock"
+	id := 1
+	return mergedRow{
+		AccountID: &id,
+		AccType:   &t,
+		Category:  &c,
+		Wrapper:   &w,
+		Value:     value,
+	}
+}
+
 func TestComputeFIREHappyPath(t *testing.T) {
 	t.Parallel()
 	rows := []mergedRow{
@@ -129,6 +143,129 @@ func TestComputeFIRELiquidExcludesNonBank(t *testing.T) {
 	// Only the bank-asset row counts: 10000 / 2000 = 5.
 	if got.RunwayMonths == nil || *got.RunwayMonths != 5 {
 		t.Errorf("runway = %v, want 5", got.RunwayMonths)
+	}
+}
+
+func TestAddBridgeToAccessAgeHappyPath(t *testing.T) {
+	t.Parallel()
+	// currentAge ≈ 35 on 2025-01-01 → bridge_years = 25.
+	// annual_expenses = 60_000 → needed = 1_500_000.
+	// 200k IKE + 100k PPK + 50k IKZE = 350k locked → liquid = net_worth − 350k.
+	rows := []mergedRow{
+		newWrapperRow("IKE", 200_000),
+		newWrapperRow("PPK", 100_000),
+		newWrapperRow("IKZE", 50_000),
+		newAccountRow("bank", "asset", 80_000),
+		newAccountRow("stock", "asset", 100_000),
+	}
+	cfg := AppConfig{
+		MonthlyExpenses: decimal.NewFromInt(5000),
+		WithdrawalRate:  decimal.RequireFromString("0.04"),
+		BirthDate:       time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	var out fireMetrics
+	annual := 60_000.0
+	out.AnnualExpenses = &annual
+
+	addBridgeToAccessAge(&out, rows, cfg, 800_000, now)
+
+	if out.BridgeYears == nil || *out.BridgeYears != 25 {
+		t.Fatalf("bridge_years = %v, want 25", out.BridgeYears)
+	}
+	if out.BridgeCapitalNeeded == nil || *out.BridgeCapitalNeeded != 1_500_000 {
+		t.Fatalf("bridge_capital_needed = %v, want 1500000", out.BridgeCapitalNeeded)
+	}
+	// liquid = 800_000 − 350_000 = 450_000
+	if out.BridgeLiquidCapital == nil || *out.BridgeLiquidCapital != 450_000 {
+		t.Fatalf("bridge_liquid_capital = %v, want 450000", out.BridgeLiquidCapital)
+	}
+	// gap = needed − liquid = 1_500_000 − 450_000 = 1_050_000
+	if out.BridgeCapitalGap == nil || *out.BridgeCapitalGap != 1_050_000 {
+		t.Fatalf("bridge_capital_gap = %v, want 1050000", out.BridgeCapitalGap)
+	}
+}
+
+func TestAddBridgeToAccessAgePastAccessAgeStaysNil(t *testing.T) {
+	t.Parallel()
+	cfg := AppConfig{
+		BirthDate: time.Date(1960, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	var out fireMetrics
+	annual := 60_000.0
+	out.AnnualExpenses = &annual
+	addBridgeToAccessAge(&out, nil, cfg, 800_000, now)
+	if out.BridgeYears != nil {
+		t.Errorf("bridge_years should be nil at/past access age, got %v", *out.BridgeYears)
+	}
+	if out.BridgeCapitalNeeded != nil {
+		t.Errorf("bridge_capital_needed should be nil at/past access age, got %v", *out.BridgeCapitalNeeded)
+	}
+}
+
+func TestAddBridgeToAccessAgeNoBirthDateStaysNil(t *testing.T) {
+	t.Parallel()
+	var out fireMetrics
+	annual := 60_000.0
+	out.AnnualExpenses = &annual
+	addBridgeToAccessAge(&out, nil, AppConfig{}, 800_000, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	if out.BridgeYears != nil {
+		t.Errorf("bridge_years should be nil without birth date, got %v", *out.BridgeYears)
+	}
+}
+
+func TestAddBridgeToAccessAgeNoExpensesStaysNil(t *testing.T) {
+	t.Parallel()
+	cfg := AppConfig{
+		BirthDate: time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	var out fireMetrics // AnnualExpenses nil
+	addBridgeToAccessAge(&out, nil, cfg, 800_000, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	if out.BridgeYears != nil {
+		t.Errorf("bridge_years should be nil without configured expenses, got %v", *out.BridgeYears)
+	}
+}
+
+func TestAddBridgeToAccessAgeLiquidCanBeNegative(t *testing.T) {
+	t.Parallel()
+	// All net worth is locked in wrappers → liquid goes negative (a real
+	// possibility for someone whose only assets are IKE/PPK + a mortgage).
+	rows := []mergedRow{newWrapperRow("IKE", 100_000)}
+	cfg := AppConfig{BirthDate: time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)}
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	var out fireMetrics
+	annual := 60_000.0
+	out.AnnualExpenses = &annual
+
+	addBridgeToAccessAge(&out, rows, cfg, 50_000, now)
+	// liquid = 50_000 − 100_000 = −50_000 (allowed; surfaces real shortfall)
+	if out.BridgeLiquidCapital == nil || *out.BridgeLiquidCapital != -50_000 {
+		t.Errorf("bridge_liquid_capital = %v, want -50000", out.BridgeLiquidCapital)
+	}
+}
+
+func TestLockedWrapperValueOfFiltersCorrectly(t *testing.T) {
+	t.Parallel()
+	rows := []mergedRow{
+		newWrapperRow("IKE", 100_000),
+		newWrapperRow("IKZE", 50_000),
+		newWrapperRow("PPK", 30_000),
+		newWrapperRow("Regular", 200_000), // not locked
+		newAccountRow("bank", "asset", 80_000),
+	}
+	// Add a non-asset wrapper row (e.g., liability) — should not count.
+	liab := "liability"
+	w := "IKE"
+	cat := "housing"
+	id := 99
+	rows = append(rows, mergedRow{
+		AccountID: &id, AccType: &liab, Category: &cat, Wrapper: &w, Value: 500_000,
+	})
+	got := lockedWrapperValueOf(rows)
+	want := 100_000.0 + 50_000.0 + 30_000.0
+	if got != want {
+		t.Errorf("lockedWrapperValueOf = %v, want %v", got, want)
 	}
 }
 

--- a/backend-go/internal/dashboard/handler.go
+++ b/backend-go/internal/dashboard/handler.go
@@ -202,6 +202,10 @@ type metricCardsWire struct {
 	BaristaFIRENumber       *pyFloat `json:"barista_fire_number"`
 	BaristaFIProgress       *pyFloat `json:"barista_fi_progress"`
 	BaristaYearsToFI        *pyFloat `json:"barista_years_to_fi"`
+	BridgeYears             *int     `json:"bridge_years"`
+	BridgeCapitalNeeded     *pyFloat `json:"bridge_capital_needed"`
+	BridgeLiquidCapital     *pyFloat `json:"bridge_liquid_capital"`
+	BridgeCapitalGap        *pyFloat `json:"bridge_capital_gap"`
 }
 
 type allocationBreakdownWire struct {
@@ -347,6 +351,10 @@ func metricCardsToWire(m metricCards) metricCardsWire {
 		BaristaFIRENumber:       floatPtr(m.BaristaFIRENumber),
 		BaristaFIProgress:       floatPtr(m.BaristaFIProgress),
 		BaristaYearsToFI:        floatPtr(m.BaristaYearsToFI),
+		BridgeYears:             m.BridgeYears,
+		BridgeCapitalNeeded:     floatPtr(m.BridgeCapitalNeeded),
+		BridgeLiquidCapital:     floatPtr(m.BridgeLiquidCapital),
+		BridgeCapitalGap:        floatPtr(m.BridgeCapitalGap),
 	}
 }
 

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -497,6 +497,10 @@ func assignFIREMetrics(mc *metricCards, fire fireMetrics) {
 	mc.BaristaFIRENumber = fire.BaristaFIRENumber
 	mc.BaristaFIProgress = fire.BaristaFIProgress
 	mc.BaristaYearsToFI = fire.BaristaYearsToFI
+	mc.BridgeYears = fire.BridgeYears
+	mc.BridgeCapitalNeeded = fire.BridgeCapitalNeeded
+	mc.BridgeLiquidCapital = fire.BridgeLiquidCapital
+	mc.BridgeCapitalGap = fire.BridgeCapitalGap
 }
 
 // buildAllocationAnalysis is the shared allocation-analysis computation.

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -1978,6 +1978,13 @@ export interface paths {
                                 /** Format: double */
                                 barista_years_to_fi?: number | null;
                                 /** Format: double */
+                                bridge_capital_gap?: number | null;
+                                /** Format: double */
+                                bridge_capital_needed?: number | null;
+                                /** Format: double */
+                                bridge_liquid_capital?: number | null;
+                                bridge_years?: number | null;
+                                /** Format: double */
                                 coast_fire_gap?: number | null;
                                 /** Format: double */
                                 coast_fire_number?: number | null;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -225,6 +225,10 @@
 			{@const baristaProgress = fire.barista_fi_progress}
 			{@const baristaIncome = fire.barista_monthly_income}
 			{@const baristaYears = fire.barista_years_to_fi}
+			{@const bridgeYears = fire.bridge_years}
+			{@const bridgeNeeded = fire.bridge_capital_needed}
+			{@const bridgeLiquid = fire.bridge_liquid_capital}
+			{@const bridgeGap = fire.bridge_capital_gap}
 			<div class="card preset-filled-surface-100-900 p-4 space-y-3">
 				<header class="flex items-start justify-between gap-2 flex-wrap">
 					<h3 class="h4 flex items-center gap-2"><Flame size={18} /> FIRE i runway</h3>
@@ -321,6 +325,46 @@
 								{:else if (baristaProgress ?? 0) >= 100}
 									<div class="text-xs text-success-600-400">już osiągnięto Barista FIRE</div>
 								{/if}
+							</div>
+						</div>
+					</div>
+				{/if}
+				{#if bridgeYears != null && bridgeNeeded != null && bridgeLiquid != null && bridgeGap != null}
+					{@const bridgeSurplus = bridgeGap < 0}
+					{@const bridgeExact = bridgeGap === 0}
+					{@const bridgeOK = bridgeGap <= 0}
+					<div class="pt-3 border-t border-surface-200-800 space-y-2">
+						<div
+							class="text-xs text-surface-700-300"
+							title="bridge_capital_needed = annual_expenses × (60 − current_age)&#10;bridge_liquid_capital = wartość netto − (IKE + IKZE + PPK)&#10;bridge_capital_gap = needed − liquid (dodatni = niedobór, ujemny = nadwyżka)"
+						>
+							Bridge do 60 ({bridgeYears} lat)
+						</div>
+						<div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+							<div class="space-y-1">
+								<div class="text-xs text-surface-700-300">Potrzebne</div>
+								<div class="text-xl font-bold">{formatPLN(bridgeNeeded)}</div>
+								<div class="text-xs text-surface-700-300">wydatki × lata do 60</div>
+							</div>
+							<div class="space-y-1">
+								<div class="text-xs text-surface-700-300">Płynne</div>
+								<div class="text-xl font-bold">{formatPLN(bridgeLiquid)}</div>
+								<div class="text-xs text-surface-700-300">netto bez IKE/IKZE/PPK</div>
+							</div>
+							<div class="space-y-1">
+								<div class="text-xs text-surface-700-300">
+									{#if bridgeSurplus}Nadwyżka{:else if bridgeExact}Pokryty{:else}Brakuje{/if}
+								</div>
+								<div
+									class="text-xl font-bold {bridgeOK
+										? 'text-success-600-400'
+										: 'text-warning-600-400'}"
+								>
+									{formatPLN(Math.abs(bridgeGap))}
+								</div>
+								<div class="text-xs text-surface-700-300">
+									{bridgeOK ? 'mostek pokryty' : 'do uzbierania w aktywach płynnych'}
+								</div>
 							</div>
 						</div>
 					</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -105,6 +105,16 @@
 			toast.error('Nie udało się zapisać limitów. Spróbuj ponownie później.');
 		}
 	}
+
+	// Polish plural form of "rok" (year). 1 → rok; 2–4 (except 12–14) → lata;
+	// everything else → lat. Inline because it's the only spot that needs it.
+	function plYears(n: number): string {
+		if (n === 1) return 'rok';
+		const last = n % 10;
+		const lastTwo = n % 100;
+		if (last >= 2 && last <= 4 && (lastTwo < 12 || lastTwo > 14)) return 'lata';
+		return 'lat';
+	}
 </script>
 
 <svelte:head>
@@ -333,12 +343,14 @@
 					{@const bridgeSurplus = bridgeGap < 0}
 					{@const bridgeExact = bridgeGap === 0}
 					{@const bridgeOK = bridgeGap <= 0}
+					{@const bridgeYearsLabel = plYears(bridgeYears)}
 					<div class="pt-3 border-t border-surface-200-800 space-y-2">
 						<div
 							class="text-xs text-surface-700-300"
 							title="bridge_capital_needed = annual_expenses × (60 − current_age)&#10;bridge_liquid_capital = wartość netto − (IKE + IKZE + PPK)&#10;bridge_capital_gap = needed − liquid (dodatni = niedobór, ujemny = nadwyżka)"
 						>
-							Bridge do 60 ({bridgeYears} lat)
+							Bridge do 60 ({bridgeYears}
+							{bridgeYearsLabel})
 						</div>
 						<div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
 							<div class="space-y-1">


### PR DESCRIPTION
## Motivation

Closes #546. Polish IKE/IKZE/PPK retirement wrappers are locked until
roughly age 60. A FIRE plan that includes those balances toward "I can stop
working today" misleads anyone retiring before 60 — they need liquid /
taxable capital to bridge the years until the wrappers unlock.

This adds a bridge-to-60 tile to the dashboard FIRE card showing capital
required, liquid capital available (net worth excluding locked wrappers),
and the gap or surplus.

## Implementation information

**Backend (`backend-go/internal/dashboard/fire.go`)**

- New constant `wrapperAccessAge = 60` and `lockedWrapperCategories =
  {IKE, IKZE, PPK}`.
- `addBridgeToAccessAge` populates four new `metric_cards` fields when
  the user has a birth date, configured monthly expenses, and is under 60:
  - `bridge_years` — `60 − current_age`
  - `bridge_capital_needed` — `annual_expenses × bridge_years`
  - `bridge_liquid_capital` — `net_worth − Σ(IKE+IKZE+PPK asset balances)`
  - `bridge_capital_gap` — `needed − liquid` (positive = shortfall)
- `lockedWrapperValueOf` is a separate filter from `retirementValueOf`:
  "wrapper-locked" and "purpose=retirement" can diverge (a regular
  brokerage marked retirement, a wrapper missing the purpose tag), so each
  metric uses the predicate that matches its meaning.
- All fields nil-safe: pre-60 user with no expenses configured / no birth
  date / already past 60 → tile hidden. Liquid capital is allowed to go
  negative — surfaces the real shortfall for someone whose only assets are
  in locked wrappers.
- Unit tests cover happy path, past-access-age, missing birth date,
  missing expenses, negative liquid, and wrapper-filter correctness.

**Frontend (`src/routes/+page.svelte`)**

- New "Bridge do 60 (N lat)" section nested inside the existing FIRE
  card, after Coast and Barista. Three-column layout: Needed / Liquid /
  Gap-or-Surplus with the same color-coded warning/success treatment used
  by Coast FIRE.
- Hidden when any of the four bridge fields is null.

**Scope note**

This PR adds a dedicated bridge metric. The existing `fire_number` /
`fi_progress` / Coast / Barista numbers still compare against the full
net worth (locked wrappers included) — adjusting those would change the
behavior of three existing tiles and is out of scope here. The bridge
tile is the answer to "how much liquid capital do I need until 60."

**Test surface**

- `go test ./...`: green.
- `golangci-lint run ./...`: green.
- Black-box pytest (`backend-bb-tests`): 146 passed, 1 skipped.
- Frontend: `npm run check`, `npm run lint`, `npm test`: green.
- OpenAPI spec + TS types regenerated.

> Changelog: feat(fire): model bridge-to-60 capital