### PR TITLE
feat(scenarios): save and clone simulation inputs

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -6558,6 +6558,311 @@
         ]
       }
     },
+    "/api/scenarios": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "scenarios": {
+                      "items": {
+                        "properties": {
+                          "created_at": {
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "inputs_json": {},
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List saved simulation scenarios",
+        "tags": [
+          "scenarios"
+        ]
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "inputs_json": {},
+                  "kind": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "inputs_json": {},
+                    "kind": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Save a new scenario",
+        "tags": [
+          "scenarios"
+        ]
+      }
+    },
+    "/api/scenarios/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete a scenario",
+        "tags": [
+          "scenarios"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "inputs_json": {},
+                    "kind": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get a saved scenario",
+        "tags": [
+          "scenarios"
+        ]
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "inputs_json": {},
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "inputs_json": {},
+                    "kind": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Rename + replace inputs on a scenario",
+        "tags": [
+          "scenarios"
+        ]
+      }
+    },
+    "/api/scenarios/{id}/clone": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "inputs_json": {},
+                    "kind": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "format": "date-time",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Duplicate a scenario",
+        "tags": [
+          "scenarios"
+        ]
+      }
+    },
     "/api/simulations/monte-carlo": {
       "post": {
         "responses": {

--- a/backend-bb-tests/tests/test_scenarios.py
+++ b/backend-bb-tests/tests/test_scenarios.py
@@ -66,8 +66,8 @@ def test_scenarios_validation_rejects_bad_inputs(client: httpx.Client) -> None:
     cases = [
         ({"name": "", "kind": "retirement", "inputs_json": {"a": 1}}, "name"),
         ({"name": "x", "kind": "bogus", "inputs_json": {"a": 1}}, "kind"),
-        ({"name": "x", "kind": "retirement", "inputs_json": []}, "inputs"),
-        ({"name": "x", "kind": "retirement", "inputs_json": None}, "inputs"),
+        ({"name": "x", "kind": "retirement", "inputs_json": []}, "inputs_json"),
+        ({"name": "x", "kind": "retirement", "inputs_json": None}, "inputs_json"),
     ]
     for body, want_field in cases:
         r = client.post("/api/scenarios", json=body)

--- a/backend-bb-tests/tests/test_scenarios.py
+++ b/backend-bb-tests/tests/test_scenarios.py
@@ -1,0 +1,84 @@
+"""Smoke tests for /api/scenarios — create, list, clone, delete round-trip."""
+
+from __future__ import annotations
+
+import httpx
+
+
+def test_scenarios_round_trip(client: httpx.Client) -> None:
+    # Start empty.
+    r = client.get("/api/scenarios?kind=retirement")
+    assert r.status_code == 200, r.text
+    assert isinstance(r.json()["scenarios"], list)
+
+    inputs = {
+        "current_age": 35,
+        "retirement_age": 65,
+        "ike_ikze_accounts": [],
+        "ppk_accounts": [],
+        "brokerage_accounts": [],
+        "annual_return_rate": 7.0,
+        "limit_growth_rate": 5.0,
+        "expected_salary_growth": 3.0,
+        "inflation_rate": 3.0,
+    }
+
+    # Create.
+    r = client.post(
+        "/api/scenarios",
+        json={"name": "Plan A", "kind": "retirement", "inputs_json": inputs},
+    )
+    assert r.status_code == 201, r.text
+    created = r.json()
+    assert created["name"] == "Plan A"
+    assert created["kind"] == "retirement"
+    assert created["inputs_json"]["current_age"] == 35
+    sid = created["id"]
+
+    # Clone (no override name → " (copy)" suffix).
+    r = client.post(f"/api/scenarios/{sid}/clone", json={})
+    assert r.status_code == 201, r.text
+    clone = r.json()
+    assert clone["name"] == "Plan A (copy)"
+    assert clone["inputs_json"] == inputs
+    cid = clone["id"]
+
+    # List now has both, newest first by updated_at.
+    r = client.get("/api/scenarios?kind=retirement")
+    assert r.status_code == 200, r.text
+    names = [s["name"] for s in r.json()["scenarios"]]
+    assert "Plan A" in names
+    assert "Plan A (copy)" in names
+
+    # Clone with custom name.
+    r = client.post(f"/api/scenarios/{sid}/clone", json={"name": "Plan B"})
+    assert r.status_code == 201, r.text
+    assert r.json()["name"] == "Plan B"
+    bid = r.json()["id"]
+
+    # Delete all three so subsequent runs start clean.
+    for delete_id in (sid, cid, bid):
+        r = client.delete(f"/api/scenarios/{delete_id}")
+        assert r.status_code == 204, r.text
+
+
+def test_scenarios_validation_rejects_bad_inputs(client: httpx.Client) -> None:
+    cases = [
+        ({"name": "", "kind": "retirement", "inputs_json": {"a": 1}}, "name"),
+        ({"name": "x", "kind": "bogus", "inputs_json": {"a": 1}}, "kind"),
+        ({"name": "x", "kind": "retirement", "inputs_json": []}, "inputs"),
+        ({"name": "x", "kind": "retirement", "inputs_json": None}, "inputs"),
+    ]
+    for body, want_field in cases:
+        r = client.post("/api/scenarios", json=body)
+        assert r.status_code == 422, r.text
+        assert r.json()["detail"][0]["loc"][1] == want_field
+
+
+def test_scenarios_get_unknown_returns_404(client: httpx.Client) -> None:
+    r = client.get("/api/scenarios/999999")
+    assert r.status_code == 404, r.text
+    r = client.post("/api/scenarios/999999/clone", json={})
+    assert r.status_code == 404, r.text
+    r = client.delete("/api/scenarios/999999")
+    assert r.status_code == 404, r.text

--- a/backend-go/cmd/gen-openapi/routes.go
+++ b/backend-go/cmd/gen-openapi/routes.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
 	"github.com/Automaat/finance-buddy/backend-go/internal/salaries"
+	"github.com/Automaat/finance-buddy/backend-go/internal/scenarios"
 	"github.com/Automaat/finance-buddy/backend-go/internal/simulations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/snapshots"
 	"github.com/Automaat/finance-buddy/backend-go/internal/transactions"
@@ -60,6 +61,7 @@ func allRoutes() []apispec.Route {
 		investment.APISpec,
 		holdings.APISpec,
 		simulations.APISpec,
+		scenarios.APISpec,
 		transactions.APISpec,
 		recurring.APISpec,
 		debtpayments.APISpec,

--- a/backend-go/internal/db/migrate.go
+++ b/backend-go/internal/db/migrate.go
@@ -73,6 +73,35 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
 	if err := createHoldingsTables(ctx, pool); err != nil {
 		return err
 	}
+	if err := createSimulationScenariosTable(ctx, pool); err != nil {
+		return err
+	}
+	return nil
+}
+
+// createSimulationScenariosTable creates the simulation_scenarios table for
+// issue #547 on existing databases. New installs get it from schema.sql.
+// inputs_json is opaque to the backend — the simulations form serializes
+// its current state into it, so adding fields to the form doesn't require
+// a schema change.
+func createSimulationScenariosTable(ctx context.Context, pool *pgxpool.Pool) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS simulation_scenarios (
+			id serial PRIMARY KEY,
+			name varchar(200) NOT NULL,
+			kind varchar(40) NOT NULL,
+			inputs_json jsonb NOT NULL,
+			created_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc'),
+			updated_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc')
+		)`,
+		`CREATE INDEX IF NOT EXISTS ix_simulation_scenarios_kind_updated_at
+			ON simulation_scenarios (kind, updated_at DESC)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := pool.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("create simulation_scenarios: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/backend-go/internal/db/schema.sql
+++ b/backend-go/internal/db/schema.sql
@@ -748,6 +748,24 @@ CREATE TABLE public.recurring_transactions (
 
 
 --
+-- Name: simulation_scenarios; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.simulation_scenarios (
+    id serial PRIMARY KEY,
+    name character varying(200) NOT NULL,
+    kind character varying(40) NOT NULL,
+    inputs_json jsonb NOT NULL,
+    created_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc'),
+    updated_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc')
+);
+
+
+CREATE INDEX ix_simulation_scenarios_kind_updated_at
+    ON public.simulation_scenarios (kind, updated_at DESC);
+
+
+--
 -- Name: recurring_transactions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 

--- a/backend-go/internal/scenarios/errors.go
+++ b/backend-go/internal/scenarios/errors.go
@@ -1,0 +1,41 @@
+package scenarios
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+type validationError struct {
+	Field string
+	Msg   string
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("encode response", "err", err, "status", status)
+	}
+}
+
+func writeDetailError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidationError(w http.ResponseWriter, field, msg, input string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{
+				"type":  "value_error",
+				"loc":   []string{"body", field},
+				"msg":   msg,
+				"input": input,
+			},
+		},
+	})
+}
+
+func writePydanticError(w http.ResponseWriter, vErr *validationError) {
+	writeValidationError(w, vErr.Field, vErr.Msg, "")
+}

--- a/backend-go/internal/scenarios/handler.go
+++ b/backend-go/internal/scenarios/handler.go
@@ -1,0 +1,237 @@
+package scenarios
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// response mirrors the wire shape returned to the frontend. CreatedAt /
+// UpdatedAt are naive timestamps (no tz suffix) to stay consistent with
+// the rest of the API where the DB stores `timestamp without time zone`.
+type response struct {
+	ID         int             `json:"id"`
+	Name       string          `json:"name"`
+	Kind       string          `json:"kind"`
+	InputsJSON json.RawMessage `json:"inputs_json"`
+	CreatedAt  isoNaive        `json:"created_at"`
+	UpdatedAt  isoNaive        `json:"updated_at"`
+}
+
+type listResponse struct {
+	Scenarios []response `json:"scenarios"`
+}
+
+type createRequest struct {
+	Name       string          `json:"name"`
+	Kind       string          `json:"kind"`
+	InputsJSON json.RawMessage `json:"inputs_json"`
+}
+
+type updateRequest struct {
+	Name       string          `json:"name"`
+	InputsJSON json.RawMessage `json:"inputs_json"`
+}
+
+type cloneRequest struct {
+	Name string `json:"name"`
+}
+
+// Handler is the HTTP boundary for /api/scenarios.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewHandler wires the store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger}
+}
+
+// List serves GET /api/scenarios?kind=<kind>.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	kind := strings.TrimSpace(r.URL.Query().Get("kind"))
+	if kind != "" {
+		if _, ok := validKinds[kind]; !ok {
+			writeValidationError(w, "kind", "Unknown kind", kind)
+			return
+		}
+	}
+	rows, err := h.store.List(r.Context(), kind)
+	if err != nil {
+		h.logger.Error("scenarios list", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := make([]response, 0, len(rows))
+	for i := range rows {
+		out = append(out, toResponse(&rows[i]))
+	}
+	writeJSON(w, http.StatusOK, listResponse{Scenarios: out})
+}
+
+// Get serves GET /api/scenarios/{id}.
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	sc, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			writeDetailError(w, http.StatusNotFound, "Scenario not found")
+			return
+		}
+		h.logger.Error("scenarios get", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusOK, toResponse(sc))
+}
+
+// Create serves POST /api/scenarios.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	var req createRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxInputsBytes+4096)).Decode(&req); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	if vErr := validateCreate(req.Name, req.Kind, req.InputsJSON); vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	sc, err := h.store.Create(r.Context(), strings.TrimSpace(req.Name), req.Kind, req.InputsJSON)
+	if err != nil {
+		h.logger.Error("scenarios create", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toResponse(sc))
+}
+
+// Update serves PUT /api/scenarios/{id}.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	var req updateRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxInputsBytes+4096)).Decode(&req); err != nil {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
+	}
+	if vErr := validateUpdate(req.Name, req.InputsJSON); vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	sc, err := h.store.Update(r.Context(), id, strings.TrimSpace(req.Name), req.InputsJSON)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			writeDetailError(w, http.StatusNotFound, "Scenario not found")
+			return
+		}
+		h.logger.Error("scenarios update", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusOK, toResponse(sc))
+}
+
+// Clone serves POST /api/scenarios/{id}/clone. Body is optional — when
+// `name` is omitted or blank, the clone gets the source name with a
+// " (copy)" suffix.
+func (h *Handler) Clone(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	var req cloneRequest
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&req); err != nil {
+			writeValidationError(w, "body", "Invalid JSON body", err.Error())
+			return
+		}
+	}
+	if vErr := validateCloneName(req.Name); vErr != nil {
+		writePydanticError(w, vErr)
+		return
+	}
+	name := strings.TrimSpace(req.Name)
+	var (
+		sc  *Scenario
+		err error
+	)
+	if name == "" {
+		sc, err = h.store.CloneWithSuffix(r.Context(), id)
+	} else {
+		sc, err = h.store.Clone(r.Context(), id, name)
+	}
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			writeDetailError(w, http.StatusNotFound, "Scenario not found")
+			return
+		}
+		h.logger.Error("scenarios clone", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toResponse(sc))
+}
+
+// Delete serves DELETE /api/scenarios/{id}.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.Delete(r.Context(), id); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			writeDetailError(w, http.StatusNotFound, "Scenario not found")
+			return
+		}
+		h.logger.Error("scenarios delete", "err", err)
+		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func parseID(w http.ResponseWriter, r *http.Request) (int, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := strconv.Atoi(raw)
+	if err != nil || id <= 0 {
+		writeDetailError(w, http.StatusNotFound, "Scenario not found")
+		return 0, false
+	}
+	return id, true
+}
+
+func toResponse(sc *Scenario) response {
+	return response{
+		ID:         sc.ID,
+		Name:       sc.Name,
+		Kind:       sc.Kind,
+		InputsJSON: sc.InputsJSON,
+		CreatedAt:  isoNaive(sc.CreatedAt),
+		UpdatedAt:  isoNaive(sc.UpdatedAt),
+	}
+}
+
+// isoNaive marshals a time.Time as a naive ISO-8601 timestamp (no zone)
+// matching the rest of the codebase's `timestamp without time zone` columns.
+type isoNaive time.Time
+
+func (t isoNaive) MarshalJSON() ([]byte, error) {
+	return fmt.Appendf(nil, "%q", time.Time(t).UTC().Format("2006-01-02T15:04:05.999999")), nil
+}

--- a/backend-go/internal/scenarios/handler.go
+++ b/backend-go/internal/scenarios/handler.go
@@ -157,11 +157,12 @@ func (h *Handler) Clone(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req cloneRequest
-	if r.ContentLength > 0 {
-		if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&req); err != nil {
-			writeValidationError(w, "body", "Invalid JSON body", err.Error())
-			return
-		}
+	// Body is required by the OpenAPI spec (Request type is declared on the
+	// clone route). EOF / empty body is tolerated so clients can send {} or
+	// nothing at all — both mean "use the default suffixed name".
+	if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		writeValidationError(w, "body", "Invalid JSON body", err.Error())
+		return
 	}
 	if vErr := validateCloneName(req.Name); vErr != nil {
 		writePydanticError(w, vErr)

--- a/backend-go/internal/scenarios/openapi.go
+++ b/backend-go/internal/scenarios/openapi.go
@@ -1,0 +1,42 @@
+package scenarios
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{
+		Method: "GET", Path: "/api/scenarios", Tag: "scenarios",
+		Summary:  "List saved simulation scenarios",
+		Response: listResponse{},
+	},
+	{
+		Method: "GET", Path: "/api/scenarios/{id}", Tag: "scenarios",
+		Summary:  "Get a saved scenario",
+		Response: response{},
+	},
+	{
+		Method: "POST", Path: "/api/scenarios", Tag: "scenarios",
+		Summary:  "Save a new scenario",
+		Request:  createRequest{},
+		Response: response{},
+		Status:   201,
+	},
+	{
+		Method: "PUT", Path: "/api/scenarios/{id}", Tag: "scenarios",
+		Summary:  "Rename + replace inputs on a scenario",
+		Request:  updateRequest{},
+		Response: response{},
+	},
+	{
+		Method: "POST", Path: "/api/scenarios/{id}/clone", Tag: "scenarios",
+		Summary:  "Duplicate a scenario",
+		Request:  cloneRequest{},
+		Response: response{},
+		Status:   201,
+	},
+	{
+		Method: "DELETE", Path: "/api/scenarios/{id}", Tag: "scenarios",
+		Summary: "Delete a scenario",
+		Status:  204,
+	},
+}

--- a/backend-go/internal/scenarios/store.go
+++ b/backend-go/internal/scenarios/store.go
@@ -1,0 +1,196 @@
+// Package scenarios implements the /api/scenarios endpoints — saved
+// simulation input bundles.
+//
+// inputs_json is opaque to the backend: the simulations form decides what
+// to serialize, the backend round-trips it. Adding fields to the form
+// doesn't require a schema migration.
+package scenarios
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Scenario is the persisted form of one saved simulation input bundle.
+type Scenario struct {
+	ID         int
+	Name       string
+	Kind       string
+	InputsJSON json.RawMessage
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// ErrNotFound is returned when no row matches the supplied id.
+var ErrNotFound = errors.New("scenario not found")
+
+// Store is the persistence boundary for simulation_scenarios.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+const selectColumns = `
+	id, name, kind, inputs_json, created_at, updated_at
+`
+
+// List returns every scenario sorted by updated_at desc, optionally
+// filtered by kind. An empty kind returns all scenarios.
+func (s *Store) List(ctx context.Context, kind string) ([]Scenario, error) {
+	var (
+		rows pgx.Rows
+		err  error
+	)
+	if kind == "" {
+		rows, err = s.pool.Query(ctx,
+			`SELECT `+selectColumns+` FROM simulation_scenarios ORDER BY updated_at DESC, id DESC`,
+		)
+	} else {
+		rows, err = s.pool.Query(ctx,
+			`SELECT `+selectColumns+` FROM simulation_scenarios WHERE kind = $1 ORDER BY updated_at DESC, id DESC`,
+			kind,
+		)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("select scenarios: %w", err)
+	}
+	defer rows.Close()
+	out := []Scenario{}
+	for rows.Next() {
+		sc, err := scanScenario(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan scenario: %w", err)
+		}
+		out = append(out, *sc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate scenarios: %w", err)
+	}
+	return out, nil
+}
+
+// Get returns one scenario or ErrNotFound.
+func (s *Store) Get(ctx context.Context, id int) (*Scenario, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+selectColumns+` FROM simulation_scenarios WHERE id = $1`, id,
+	)
+	sc, err := scanScenario(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("select scenario: %w", err)
+	}
+	return sc, nil
+}
+
+// Create inserts a new scenario.
+func (s *Store) Create(ctx context.Context, name, kind string, inputs json.RawMessage) (*Scenario, error) {
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO simulation_scenarios (name, kind, inputs_json)
+		VALUES ($1, $2, $3)
+		RETURNING `+selectColumns,
+		name, kind, inputs,
+	)
+	created, err := scanScenario(row)
+	if err != nil {
+		return nil, fmt.Errorf("insert scenario: %w", err)
+	}
+	return created, nil
+}
+
+// Update replaces name and inputs_json. kind is immutable — changing it would
+// stash a scenario in a list it doesn't belong to.
+func (s *Store) Update(ctx context.Context, id int, name string, inputs json.RawMessage) (*Scenario, error) {
+	row := s.pool.QueryRow(ctx, `
+		UPDATE simulation_scenarios
+		SET name = $1, inputs_json = $2, updated_at = (now() at time zone 'utc')
+		WHERE id = $3
+		RETURNING `+selectColumns,
+		name, inputs, id,
+	)
+	updated, err := scanScenario(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("update scenario: %w", err)
+	}
+	return updated, nil
+}
+
+// Clone reads scenario `id`, then inserts a copy with `name` overriding the
+// source name. Atomic in a single statement so concurrent deletes can't
+// produce a half-clone.
+func (s *Store) Clone(ctx context.Context, id int, name string) (*Scenario, error) {
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO simulation_scenarios (name, kind, inputs_json)
+		SELECT $1, kind, inputs_json
+		FROM simulation_scenarios WHERE id = $2
+		RETURNING `+selectColumns,
+		name, id,
+	)
+	created, err := scanScenario(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("clone scenario: %w", err)
+	}
+	return created, nil
+}
+
+// CloneWithSuffix copies row `id` and suffixes the new name with " (copy)",
+// truncated so the result fits within maxNameLen. Single statement —
+// eliminates the Get+Clone race window the handler used to have when no
+// override name was supplied.
+func (s *Store) CloneWithSuffix(ctx context.Context, id int) (*Scenario, error) {
+	const suffix = " (copy)"
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO simulation_scenarios (name, kind, inputs_json)
+		SELECT left(name, $2) || $3, kind, inputs_json
+		FROM simulation_scenarios WHERE id = $1
+		RETURNING `+selectColumns,
+		id, maxNameLen-len(suffix), suffix,
+	)
+	created, err := scanScenario(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("clone scenario: %w", err)
+	}
+	return created, nil
+}
+
+// Delete removes the scenario (hard delete).
+func (s *Store) Delete(ctx context.Context, id int) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM simulation_scenarios WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete scenario: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func scanScenario(row pgx.Row) (*Scenario, error) {
+	var sc Scenario
+	if err := row.Scan(
+		&sc.ID, &sc.Name, &sc.Kind, &sc.InputsJSON, &sc.CreatedAt, &sc.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	return &sc, nil
+}

--- a/backend-go/internal/scenarios/validation.go
+++ b/backend-go/internal/scenarios/validation.go
@@ -1,0 +1,91 @@
+package scenarios
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// validKinds enumerates the simulation kinds the frontend can save under.
+// Keeping this list closed means a typo in `kind` is a 422 instead of a
+// silent bucket nobody loads from.
+var validKinds = map[string]struct{}{
+	"retirement":         {},
+	"mortgage-vs-invest": {},
+	"wibor":              {},
+	"monte-carlo":        {},
+}
+
+const (
+	maxNameLen     = 200
+	maxInputsBytes = 64 * 1024
+)
+
+// validateCreate checks the create/update payload. First-error-wins matches
+// the rest of the codebase's Pydantic-style error shape.
+func validateCreate(name, kind string, inputs json.RawMessage) *validationError {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return &validationError{"name", "Name must not be empty"}
+	}
+	if len(trimmed) > maxNameLen {
+		return &validationError{"name", "Name must be at most 200 characters"}
+	}
+	if kind == "" {
+		return &validationError{"kind", "Kind is required"}
+	}
+	if _, ok := validKinds[kind]; !ok {
+		return &validationError{"kind", "Kind must be one of: monte-carlo, mortgage-vs-invest, retirement, wibor"}
+	}
+	if len(inputs) == 0 || string(inputs) == "null" {
+		return &validationError{"inputs", "Inputs must be a JSON object"}
+	}
+	if len(inputs) > maxInputsBytes {
+		return &validationError{"inputs", "Inputs payload exceeds 64 KiB"}
+	}
+	// Require an object — not a bare array/scalar — so the consumer can keep
+	// growing the shape without ambiguity at the top level.
+	var probe any
+	if err := json.Unmarshal(inputs, &probe); err != nil {
+		return &validationError{"inputs", "Inputs must be valid JSON"}
+	}
+	if _, ok := probe.(map[string]any); !ok {
+		return &validationError{"inputs", "Inputs must be a JSON object"}
+	}
+	return nil
+}
+
+// validateUpdate is the rename-and-replace-inputs path; kind stays whatever
+// the existing row already holds.
+func validateUpdate(name string, inputs json.RawMessage) *validationError {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return &validationError{"name", "Name must not be empty"}
+	}
+	if len(trimmed) > maxNameLen {
+		return &validationError{"name", "Name must be at most 200 characters"}
+	}
+	if len(inputs) == 0 || string(inputs) == "null" {
+		return &validationError{"inputs", "Inputs must be a JSON object"}
+	}
+	if len(inputs) > maxInputsBytes {
+		return &validationError{"inputs", "Inputs payload exceeds 64 KiB"}
+	}
+	var probe any
+	if err := json.Unmarshal(inputs, &probe); err != nil {
+		return &validationError{"inputs", "Inputs must be valid JSON"}
+	}
+	if _, ok := probe.(map[string]any); !ok {
+		return &validationError{"inputs", "Inputs must be a JSON object"}
+	}
+	return nil
+}
+
+// validateCloneName accepts an optional override name; empty falls back to
+// the handler suffixing the source name in `Clone`. Length cap still applies.
+func validateCloneName(name string) *validationError {
+	trimmed := strings.TrimSpace(name)
+	if len(trimmed) > maxNameLen {
+		return &validationError{"name", "Name must be at most 200 characters"}
+	}
+	return nil
+}

--- a/backend-go/internal/scenarios/validation.go
+++ b/backend-go/internal/scenarios/validation.go
@@ -37,19 +37,19 @@ func validateCreate(name, kind string, inputs json.RawMessage) *validationError 
 		return &validationError{"kind", "Kind must be one of: monte-carlo, mortgage-vs-invest, retirement, wibor"}
 	}
 	if len(inputs) == 0 || string(inputs) == "null" {
-		return &validationError{"inputs", "Inputs must be a JSON object"}
+		return &validationError{"inputs_json", "Inputs must be a JSON object"}
 	}
 	if len(inputs) > maxInputsBytes {
-		return &validationError{"inputs", "Inputs payload exceeds 64 KiB"}
+		return &validationError{"inputs_json", "Inputs payload exceeds 64 KiB"}
 	}
 	// Require an object — not a bare array/scalar — so the consumer can keep
 	// growing the shape without ambiguity at the top level.
 	var probe any
 	if err := json.Unmarshal(inputs, &probe); err != nil {
-		return &validationError{"inputs", "Inputs must be valid JSON"}
+		return &validationError{"inputs_json", "Inputs must be valid JSON"}
 	}
 	if _, ok := probe.(map[string]any); !ok {
-		return &validationError{"inputs", "Inputs must be a JSON object"}
+		return &validationError{"inputs_json", "Inputs must be a JSON object"}
 	}
 	return nil
 }
@@ -65,17 +65,17 @@ func validateUpdate(name string, inputs json.RawMessage) *validationError {
 		return &validationError{"name", "Name must be at most 200 characters"}
 	}
 	if len(inputs) == 0 || string(inputs) == "null" {
-		return &validationError{"inputs", "Inputs must be a JSON object"}
+		return &validationError{"inputs_json", "Inputs must be a JSON object"}
 	}
 	if len(inputs) > maxInputsBytes {
-		return &validationError{"inputs", "Inputs payload exceeds 64 KiB"}
+		return &validationError{"inputs_json", "Inputs payload exceeds 64 KiB"}
 	}
 	var probe any
 	if err := json.Unmarshal(inputs, &probe); err != nil {
-		return &validationError{"inputs", "Inputs must be valid JSON"}
+		return &validationError{"inputs_json", "Inputs must be valid JSON"}
 	}
 	if _, ok := probe.(map[string]any); !ok {
-		return &validationError{"inputs", "Inputs must be a JSON object"}
+		return &validationError{"inputs_json", "Inputs must be a JSON object"}
 	}
 	return nil
 }

--- a/backend-go/internal/scenarios/validation_test.go
+++ b/backend-go/internal/scenarios/validation_test.go
@@ -1,0 +1,106 @@
+package scenarios
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestValidateCreateAcceptsObject(t *testing.T) {
+	t.Parallel()
+	if err := validateCreate("Plan A", "retirement", json.RawMessage(`{"a":1}`)); err != nil {
+		t.Fatalf("expected valid, got %+v", err)
+	}
+}
+
+func TestValidateCreateEmptyName(t *testing.T) {
+	t.Parallel()
+	cases := []string{"", "   ", "\t\n"}
+	for _, n := range cases {
+		if err := validateCreate(n, "retirement", json.RawMessage(`{}`)); err == nil || err.Field != "name" {
+			t.Errorf("expected name error for %q, got %+v", n, err)
+		}
+	}
+}
+
+func TestValidateCreateLongName(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("a", maxNameLen+1)
+	if err := validateCreate(long, "retirement", json.RawMessage(`{}`)); err == nil || err.Field != "name" {
+		t.Fatalf("expected name error for over-length, got %+v", err)
+	}
+}
+
+func TestValidateCreateBadKind(t *testing.T) {
+	t.Parallel()
+	if err := validateCreate("Plan", "bogus", json.RawMessage(`{}`)); err == nil || err.Field != "kind" {
+		t.Fatalf("expected kind error, got %+v", err)
+	}
+}
+
+func TestValidateCreateMissingKind(t *testing.T) {
+	t.Parallel()
+	if err := validateCreate("Plan", "", json.RawMessage(`{}`)); err == nil || err.Field != "kind" {
+		t.Fatalf("expected kind error, got %+v", err)
+	}
+}
+
+func TestValidateCreateInputsMustBeObject(t *testing.T) {
+	t.Parallel()
+	cases := []string{`null`, `[]`, `42`, `"x"`, `true`}
+	for _, in := range cases {
+		err := validateCreate("Plan", "retirement", json.RawMessage(in))
+		if err == nil || err.Field != "inputs" {
+			t.Errorf("expected inputs error for %q, got %+v", in, err)
+		}
+	}
+}
+
+func TestValidateCreateInputsMissing(t *testing.T) {
+	t.Parallel()
+	if err := validateCreate("Plan", "retirement", nil); err == nil || err.Field != "inputs" {
+		t.Fatalf("expected inputs error for nil payload, got %+v", err)
+	}
+}
+
+func TestValidateCreateInputsTooLarge(t *testing.T) {
+	t.Parallel()
+	// Build a JSON object that exceeds maxInputsBytes.
+	pad := strings.Repeat("a", maxInputsBytes)
+	body := []byte(`{"x":"` + pad + `"}`)
+	if err := validateCreate("Plan", "retirement", body); err == nil || err.Field != "inputs" {
+		t.Fatalf("expected inputs over-size error, got %+v", err)
+	}
+}
+
+func TestValidateUpdateEmptyName(t *testing.T) {
+	t.Parallel()
+	if err := validateUpdate("", json.RawMessage(`{}`)); err == nil || err.Field != "name" {
+		t.Fatalf("expected name error, got %+v", err)
+	}
+}
+
+func TestValidateUpdateInputsMustBeObject(t *testing.T) {
+	t.Parallel()
+	if err := validateUpdate("Plan", json.RawMessage(`[]`)); err == nil || err.Field != "inputs" {
+		t.Fatalf("expected inputs error, got %+v", err)
+	}
+}
+
+func TestValidateCloneNameOptional(t *testing.T) {
+	t.Parallel()
+	if err := validateCloneName(""); err != nil {
+		t.Errorf("empty clone name should pass, got %+v", err)
+	}
+	if err := validateCloneName("Custom name"); err != nil {
+		t.Errorf("valid clone name should pass, got %+v", err)
+	}
+}
+
+func TestValidateCloneNameTooLong(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("a", maxNameLen+1)
+	if err := validateCloneName(long); err == nil || err.Field != "name" {
+		t.Fatalf("expected name length error, got %+v", err)
+	}
+}

--- a/backend-go/internal/scenarios/validation_test.go
+++ b/backend-go/internal/scenarios/validation_test.go
@@ -50,7 +50,7 @@ func TestValidateCreateInputsMustBeObject(t *testing.T) {
 	cases := []string{`null`, `[]`, `42`, `"x"`, `true`}
 	for _, in := range cases {
 		err := validateCreate("Plan", "retirement", json.RawMessage(in))
-		if err == nil || err.Field != "inputs" {
+		if err == nil || err.Field != "inputs_json" {
 			t.Errorf("expected inputs error for %q, got %+v", in, err)
 		}
 	}
@@ -58,7 +58,7 @@ func TestValidateCreateInputsMustBeObject(t *testing.T) {
 
 func TestValidateCreateInputsMissing(t *testing.T) {
 	t.Parallel()
-	if err := validateCreate("Plan", "retirement", nil); err == nil || err.Field != "inputs" {
+	if err := validateCreate("Plan", "retirement", nil); err == nil || err.Field != "inputs_json" {
 		t.Fatalf("expected inputs error for nil payload, got %+v", err)
 	}
 }
@@ -68,7 +68,7 @@ func TestValidateCreateInputsTooLarge(t *testing.T) {
 	// Build a JSON object that exceeds maxInputsBytes.
 	pad := strings.Repeat("a", maxInputsBytes)
 	body := []byte(`{"x":"` + pad + `"}`)
-	if err := validateCreate("Plan", "retirement", body); err == nil || err.Field != "inputs" {
+	if err := validateCreate("Plan", "retirement", body); err == nil || err.Field != "inputs_json" {
 		t.Fatalf("expected inputs over-size error, got %+v", err)
 	}
 }
@@ -82,7 +82,7 @@ func TestValidateUpdateEmptyName(t *testing.T) {
 
 func TestValidateUpdateInputsMustBeObject(t *testing.T) {
 	t.Parallel()
-	if err := validateUpdate("Plan", json.RawMessage(`[]`)); err == nil || err.Field != "inputs" {
+	if err := validateUpdate("Plan", json.RawMessage(`[]`)); err == nil || err.Field != "inputs_json" {
 		t.Fatalf("expected inputs error, got %+v", err)
 	}
 }

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
 	"github.com/Automaat/finance-buddy/backend-go/internal/salaries"
+	"github.com/Automaat/finance-buddy/backend-go/internal/scenarios"
 	"github.com/Automaat/finance-buddy/backend-go/internal/simulations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/snapshots"
 	"github.com/Automaat/finance-buddy/backend-go/internal/transactions"
@@ -194,6 +195,14 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	r.Post("/api/simulations/retirement", simHandler.Retirement)
 	r.Get("/api/simulations/prefill", simHandler.Prefill)
 	r.Post("/api/simulations/monte-carlo", simHandler.MonteCarlo)
+
+	scHandler := scenarios.NewHandler(scenarios.NewStore(pool), logger)
+	r.Get("/api/scenarios", scHandler.List)
+	r.Post("/api/scenarios", scHandler.Create)
+	r.Get("/api/scenarios/{id}", scHandler.Get)
+	r.Put("/api/scenarios/{id}", scHandler.Update)
+	r.Delete("/api/scenarios/{id}", scHandler.Delete)
+	r.Post("/api/scenarios/{id}/clone", scHandler.Clone)
 }
 
 func registerDashboardRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -4396,6 +4396,248 @@ export interface paths {
         };
         trace?: never;
     };
+    "/api/scenarios": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List saved simulation scenarios */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            scenarios?: {
+                                /** Format: date-time */
+                                created_at?: string;
+                                id?: number;
+                                inputs_json?: unknown;
+                                kind?: string;
+                                name?: string;
+                                /** Format: date-time */
+                                updated_at?: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Save a new scenario */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        inputs_json?: unknown;
+                        kind?: string;
+                        name?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: date-time */
+                            created_at?: string;
+                            id?: number;
+                            inputs_json?: unknown;
+                            kind?: string;
+                            name?: string;
+                            /** Format: date-time */
+                            updated_at?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/scenarios/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a saved scenario */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: date-time */
+                            created_at?: string;
+                            id?: number;
+                            inputs_json?: unknown;
+                            kind?: string;
+                            name?: string;
+                            /** Format: date-time */
+                            updated_at?: string;
+                        };
+                    };
+                };
+            };
+        };
+        /** Rename + replace inputs on a scenario */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        inputs_json?: unknown;
+                        name?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: date-time */
+                            created_at?: string;
+                            id?: number;
+                            inputs_json?: unknown;
+                            kind?: string;
+                            name?: string;
+                            /** Format: date-time */
+                            updated_at?: string;
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        /** Delete a scenario */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/scenarios/{id}/clone": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Duplicate a scenario */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        name?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: date-time */
+                            created_at?: string;
+                            id?: number;
+                            inputs_json?: unknown;
+                            kind?: string;
+                            name?: string;
+                            /** Format: date-time */
+                            updated_at?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/simulations/monte-carlo": {
         parameters: {
             query?: never;

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -132,6 +132,144 @@
 	let loading = $state(false);
 	let error = $state('');
 
+	// --- Saved scenarios (issue #547) ---
+	interface RetirementScenarioInputs {
+		current_age: number;
+		retirement_age: number;
+		ike_ikze_accounts: IkeIkzeConfig[];
+		ppk_accounts: PpkConfig[];
+		brokerage_accounts: BrokerageConfig[];
+		annual_return_rate: number;
+		limit_growth_rate: number;
+		expected_salary_growth: number;
+		inflation_rate: number;
+	}
+
+	interface SavedScenario {
+		id: number;
+		name: string;
+		kind: string;
+		inputs_json: RetirementScenarioInputs;
+		created_at: string;
+		updated_at: string;
+	}
+
+	let scenarios: SavedScenario[] = $state([]);
+	let scenarioName = $state('');
+	let scenarioBusy = $state(false);
+	let scenarioError = $state('');
+
+	function snapshotInputs(): RetirementScenarioInputs {
+		return {
+			current_age: currentAge,
+			retirement_age: retirementAge,
+			ike_ikze_accounts: ikeIkzeAccounts.map((a) => ({ ...a })),
+			ppk_accounts: ppkAccounts.map((a) => ({ ...a })),
+			brokerage_accounts: brokerageAccounts.map((a) => ({ ...a })),
+			annual_return_rate: annualReturnRate,
+			limit_growth_rate: limitGrowthRate,
+			expected_salary_growth: expectedSalaryGrowth,
+			inflation_rate: inflationRate
+		};
+	}
+
+	function applyInputs(inputs: RetirementScenarioInputs) {
+		currentAge = inputs.current_age;
+		retirementAge = inputs.retirement_age;
+		ikeIkzeAccounts = (inputs.ike_ikze_accounts ?? []).map((a) => ({ ...a }));
+		ppkAccounts = (inputs.ppk_accounts ?? []).map((a) => ({ ...a }));
+		brokerageAccounts = (inputs.brokerage_accounts ?? []).map((a) => ({ ...a }));
+		annualReturnRate = inputs.annual_return_rate;
+		limitGrowthRate = inputs.limit_growth_rate;
+		expectedSalaryGrowth = inputs.expected_salary_growth;
+		inflationRate = inputs.inflation_rate;
+	}
+
+	async function loadScenarios() {
+		try {
+			const r = await fetch(`${resolveApiUrl()}/api/scenarios?kind=retirement`);
+			if (!r.ok) throw new Error(`HTTP ${r.status}`);
+			const body = await r.json();
+			scenarios = (body.scenarios ?? []) as SavedScenario[];
+		} catch (err) {
+			console.error('Failed to load scenarios:', err);
+			scenarioError = err instanceof Error ? err.message : 'Nie udało się pobrać scenariuszy';
+		}
+	}
+
+	async function saveCurrentScenario() {
+		const trimmed = scenarioName.trim();
+		if (!trimmed) {
+			scenarioError = 'Wprowadź nazwę scenariusza';
+			return;
+		}
+		scenarioBusy = true;
+		scenarioError = '';
+		try {
+			const r = await fetch(`${resolveApiUrl()}/api/scenarios`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					name: trimmed,
+					kind: 'retirement',
+					inputs_json: snapshotInputs()
+				})
+			});
+			if (!r.ok) {
+				const body = await r.json().catch(() => ({}));
+				throw new Error(body.detail?.[0]?.msg ?? `HTTP ${r.status}`);
+			}
+			scenarioName = '';
+			await loadScenarios();
+		} catch (err) {
+			scenarioError = err instanceof Error ? err.message : String(err);
+		} finally {
+			scenarioBusy = false;
+		}
+	}
+
+	async function cloneScenario(id: number) {
+		scenarioBusy = true;
+		scenarioError = '';
+		try {
+			const r = await fetch(`${resolveApiUrl()}/api/scenarios/${id}/clone`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({})
+			});
+			if (!r.ok) throw new Error(`HTTP ${r.status}`);
+			await loadScenarios();
+		} catch (err) {
+			scenarioError = err instanceof Error ? err.message : String(err);
+		} finally {
+			scenarioBusy = false;
+		}
+	}
+
+	function loadScenarioIntoForm(s: SavedScenario) {
+		applyInputs(s.inputs_json);
+		scenarioError = '';
+	}
+
+	async function deleteScenario(id: number) {
+		if (!confirm('Usunąć ten scenariusz?')) return;
+		scenarioBusy = true;
+		scenarioError = '';
+		try {
+			const r = await fetch(`${resolveApiUrl()}/api/scenarios/${id}`, { method: 'DELETE' });
+			if (!r.ok && r.status !== 204) throw new Error(`HTTP ${r.status}`);
+			await loadScenarios();
+		} catch (err) {
+			scenarioError = err instanceof Error ? err.message : String(err);
+		} finally {
+			scenarioBusy = false;
+		}
+	}
+
+	onMount(() => {
+		loadScenarios();
+	});
+
 	// Charts
 	const MILESTONE_AGES = [60, 65, 70];
 	let chartContainer: HTMLDivElement | undefined = $state();
@@ -309,6 +447,74 @@
 
 <div class="space-y-4">
 	<h1 class="h1">Symulacje Emerytalne</h1>
+
+	<div class="card preset-filled-surface-100-900 p-4 space-y-3">
+		<h2 class="h3">Zapisane scenariusze</h2>
+		<div class="flex flex-wrap items-end gap-2">
+			<label class="label flex-1 min-w-[200px]">
+				<span class="text-sm font-semibold">Nazwa</span>
+				<input
+					type="text"
+					maxlength="200"
+					placeholder="np. Plan A — 7% zwrotu"
+					bind:value={scenarioName}
+					disabled={scenarioBusy}
+					class="input"
+				/>
+			</label>
+			<button
+				type="button"
+				class="btn preset-filled-primary-500"
+				onclick={saveCurrentScenario}
+				disabled={scenarioBusy || scenarioName.trim() === ''}
+			>
+				Zapisz bieżący
+			</button>
+		</div>
+		{#if scenarioError}
+			<div class="text-sm text-error-600-400">{scenarioError}</div>
+		{/if}
+		{#if scenarios.length === 0}
+			<p class="text-sm text-surface-700-300 italic">
+				Brak zapisanych scenariuszy. Skonfiguruj symulację powyżej i kliknij „Zapisz bieżący".
+			</p>
+		{:else}
+			<ul class="divide-y divide-surface-200-800">
+				{#each scenarios as s (s.id)}
+					<li class="py-2 flex flex-wrap items-center gap-2">
+						<span class="flex-1 min-w-[180px] text-sm font-semibold">{s.name}</span>
+						<span class="text-xs text-surface-700-300">
+							{new Date(s.updated_at).toLocaleString('pl-PL')}
+						</span>
+						<button
+							type="button"
+							class="btn btn-sm preset-tonal-primary"
+							onclick={() => loadScenarioIntoForm(s)}
+							disabled={scenarioBusy}
+						>
+							Wczytaj
+						</button>
+						<button
+							type="button"
+							class="btn btn-sm preset-tonal-surface"
+							onclick={() => cloneScenario(s.id)}
+							disabled={scenarioBusy}
+						>
+							Duplikuj
+						</button>
+						<button
+							type="button"
+							class="btn btn-sm preset-tonal-error"
+							onclick={() => deleteScenario(s.id)}
+							disabled={scenarioBusy}
+						>
+							Usuń
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
 
 	<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
 		<div class="card preset-filled-surface-100-900 p-5 space-y-4">

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -186,6 +186,7 @@
 	}
 
 	async function loadScenarios() {
+		scenarioError = '';
 		try {
 			const r = await fetch(`${resolveApiUrl()}/api/scenarios?kind=retirement`);
 			if (!r.ok) throw new Error(`HTTP ${r.status}`);
@@ -195,6 +196,14 @@
 			console.error('Failed to load scenarios:', err);
 			scenarioError = err instanceof Error ? err.message : 'Nie udało się pobrać scenariuszy';
 		}
+	}
+
+	// Backend returns naive UTC strings ("2026-05-24T18:00:00"); new Date()
+	// would interpret those as local time and shift the displayed instant.
+	// Force a UTC parse so the formatted label matches the server clock.
+	function formatScenarioTimestamp(s: string): string {
+		const utc = s.endsWith('Z') ? s : s + 'Z';
+		return new Date(utc).toLocaleString('pl-PL');
 	}
 
 	async function saveCurrentScenario() {
@@ -476,7 +485,7 @@
 		{/if}
 		{#if scenarios.length === 0}
 			<p class="text-sm text-surface-700-300 italic">
-				Brak zapisanych scenariuszy. Skonfiguruj symulację powyżej i kliknij „Zapisz bieżący".
+				Brak zapisanych scenariuszy. Skonfiguruj symulację powyżej i kliknij „Zapisz bieżący”.
 			</p>
 		{:else}
 			<ul class="divide-y divide-surface-200-800">
@@ -484,7 +493,7 @@
 					<li class="py-2 flex flex-wrap items-center gap-2">
 						<span class="flex-1 min-w-[180px] text-sm font-semibold">{s.name}</span>
 						<span class="text-xs text-surface-700-300">
-							{new Date(s.updated_at).toLocaleString('pl-PL')}
+							{formatScenarioTimestamp(s.updated_at)}
 						</span>
 						<button
 							type="button"

--- a/src/routes/simulations/page.test.ts
+++ b/src/routes/simulations/page.test.ts
@@ -84,51 +84,72 @@ describe('Simulations Page — run simulation', () => {
 	});
 
 	it('POSTs request body and renders the results section on success', async () => {
-		const fetchMock = vi.fn().mockResolvedValue({
-			ok: true,
-			statusText: 'OK',
-			json: async () => ({
-				simulations: [
-					{
-						account_name: 'IKE Marcin',
-						starting_balance: 1000,
-						total_contributions: 5000,
-						total_returns: 700,
-						total_tax_savings: 0,
-						final_balance: 6700,
-						yearly_projections: [
-							{
-								year: 2026,
-								age: 35,
-								annual_contribution: 1000,
-								balance_end_of_year: 2000,
-								cumulative_contributions: 1000,
-								cumulative_returns: 0,
-								annual_limit: 5000,
-								limit_utilized_pct: 20,
-								tax_savings: 0
-							}
-						]
-					}
-				],
-				summary: {
-					total_final_balance: 6700,
+		const simulationsBody = {
+			simulations: [
+				{
+					account_name: 'IKE Marcin',
+					starting_balance: 1000,
 					total_contributions: 5000,
 					total_returns: 700,
 					total_tax_savings: 0,
-					estimated_monthly_income: 200,
-					estimated_monthly_income_today: 150,
-					years_until_retirement: 30
+					final_balance: 6700,
+					yearly_projections: [
+						{
+							year: 2026,
+							age: 35,
+							annual_contribution: 1000,
+							balance_end_of_year: 2000,
+							cumulative_contributions: 1000,
+							cumulative_returns: 0,
+							annual_limit: 5000,
+							limit_utilized_pct: 20,
+							tax_savings: 0
+						}
+					]
 				}
-			})
+			],
+			summary: {
+				total_final_balance: 6700,
+				total_contributions: 5000,
+				total_returns: 700,
+				total_tax_savings: 0,
+				estimated_monthly_income: 200,
+				estimated_monthly_income_today: 150,
+				years_until_retirement: 30
+			}
+		};
+		// Route by URL: onMount triggers GET /api/scenarios; the click triggers
+		// POST /api/simulations/retirement. The two share a fetch stub so each
+		// call is dispatched to its own response.
+		const fetchMock = vi.fn().mockImplementation((url: string) => {
+			if (url.includes('/api/scenarios')) {
+				return Promise.resolve({
+					ok: true,
+					statusText: 'OK',
+					json: async () => ({ scenarios: [] })
+				});
+			}
+			return Promise.resolve({
+				ok: true,
+				statusText: 'OK',
+				json: async () => simulationsBody
+			});
 		});
 		vi.stubGlobal('fetch', fetchMock);
 
 		render(Page, { props: { data: mockData } });
 		await fireEvent.click(screen.getByRole('button', { name: 'Uruchom symulację' }));
 
-		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-		const [url, init] = fetchMock.mock.calls[0];
+		await waitFor(() => {
+			const simCall = fetchMock.mock.calls.find(([u]) =>
+				String(u).includes('/api/simulations/retirement')
+			);
+			expect(simCall).toBeTruthy();
+		});
+		const simCall = fetchMock.mock.calls.find(([u]) =>
+			String(u).includes('/api/simulations/retirement')
+		)!;
+		const [url, init] = simCall;
 		expect(url).toBe('http://localhost:8000/api/simulations/retirement');
 		expect((init as RequestInit).method).toBe('POST');
 		const body = JSON.parse((init as RequestInit).body as string);
@@ -172,7 +193,11 @@ describe('Simulations Page — run simulation', () => {
 	});
 
 	it('blocks simulation when PPK employee rate is out of range', async () => {
-		const fetchMock = vi.fn();
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			statusText: 'OK',
+			json: async () => ({ scenarios: [] })
+		});
 		vi.stubGlobal('fetch', fetchMock);
 
 		render(Page, { props: { data: mockData } });
@@ -197,11 +222,19 @@ describe('Simulations Page — run simulation', () => {
 				screen.getByText(/PPK Marcin: Składka pracownika musi być w zakresie 0\.5-4%/)
 			).toBeTruthy()
 		);
-		expect(fetchMock).not.toHaveBeenCalled();
+		// Local validation should keep the POST from going out.
+		const simCall = fetchMock.mock.calls.find(([u]) =>
+			String(u).includes('/api/simulations/retirement')
+		);
+		expect(simCall).toBeUndefined();
 	});
 
 	it('blocks simulation when PPK employer rate is out of range', async () => {
-		const fetchMock = vi.fn();
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			statusText: 'OK',
+			json: async () => ({ scenarios: [] })
+		});
 		vi.stubGlobal('fetch', fetchMock);
 
 		render(Page, { props: { data: mockData } });
@@ -224,11 +257,19 @@ describe('Simulations Page — run simulation', () => {
 				screen.getByText(/PPK Marcin: Składka pracodawcy musi być w zakresie 1\.5-4%/)
 			).toBeTruthy()
 		);
-		expect(fetchMock).not.toHaveBeenCalled();
+		// Local validation should keep the POST from going out.
+		const simCall = fetchMock.mock.calls.find(([u]) =>
+			String(u).includes('/api/simulations/retirement')
+		);
+		expect(simCall).toBeUndefined();
 	});
 
 	it('blocks simulation when salary above threshold but belowThreshold checked', async () => {
-		const fetchMock = vi.fn();
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			statusText: 'OK',
+			json: async () => ({ scenarios: [] })
+		});
 		vi.stubGlobal('fetch', fetchMock);
 
 		render(Page, { props: { data: mockData } });
@@ -256,6 +297,10 @@ describe('Simulations Page — run simulation', () => {
 		await waitFor(() =>
 			expect(screen.getByText(/PPK Marcin: Wynagrodzenie przekracza próg/)).toBeTruthy()
 		);
-		expect(fetchMock).not.toHaveBeenCalled();
+		// Local validation should keep the POST from going out.
+		const simCall = fetchMock.mock.calls.find(([u]) =>
+			String(u).includes('/api/simulations/retirement')
+		);
+		expect(simCall).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Motivation

Closes #547. Today the simulations page is amnesiac — every visit re-enters
parameters from scratch. This adds saved scenarios: name a parameter
bundle, reload it later, and duplicate it as a starting point for variants
without losing the original.

## Implementation information

**Backend**
- New table ``simulation_scenarios`` (id, name, kind, inputs_json jsonb,
  created_at, updated_at) — added to ``schema.sql`` baseline + idempotent
  ``CREATE TABLE IF NOT EXISTS`` migration. ``inputs_json`` is opaque to the
  backend so adding form fields doesn't need a schema change.
- New ``backend-go/internal/scenarios`` package mirrors the goals/recurring
  shape (store + handler + validation + errors + openapi + tests).
- Six endpoints: ``GET /api/scenarios`` (kind-filterable), ``GET /:id``,
  ``POST``, ``PUT /:id`` (rename + replace inputs), ``POST /:id/clone``,
  ``DELETE /:id``.
- Clone is atomic: a single ``INSERT INTO ... SELECT FROM ...`` so concurrent
  deletes can't produce a half-clone. The no-name path uses an equally
  atomic ``CloneWithSuffix`` variant that builds " (copy)" suffix in SQL
  (eliminates the Get→suffix→Clone race the first draft had).
- Validation: name 1–200 chars, kind in {retirement, mortgage-vs-invest,
  wibor, monte-carlo}, inputs must be a JSON object ≤ 64 KiB.

**Frontend**
- ``/simulations`` page gains a "Zapisane scenariusze" panel above the form:
  text input + Zapisz bieżący button to save the current form snapshot;
  list of saved scenarios with Wczytaj / Duplikuj / Usuń actions.
- ``loadScenarioIntoForm`` restores all form state from a saved bundle.
- Only retirement scenarios are wired to the UI today; the other kinds are
  accepted by the API so future issues can wire them in.

**Tests**
- Backend unit tests for validation.
- Black-box ``test_scenarios.py``: round-trip (create → clone → list → delete),
  validation failures, 404 on unknown ids.
- Frontend page tests updated to route fetch by URL — they used to assume
  one call per click; mounting now also fires the scenarios load.

**Quality gates**
- ``go test ./...``, ``golangci-lint run ./...``: green.
- ``backend-bb-tests``: 149 passed, 1 skipped.
- ``npm run check``, ``npm run lint``, ``npm test``: green.

> Changelog: feat(scenarios): save and clone simulation inputs