### PR TITLE
feat(scenarios): compare scenarios side by side

### DIFF
--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -458,7 +458,14 @@
 	<h1 class="h1">Symulacje Emerytalne</h1>
 
 	<div class="card preset-filled-surface-100-900 p-4 space-y-3">
-		<h2 class="h3">Zapisane scenariusze</h2>
+		<div class="flex items-center justify-between flex-wrap gap-2">
+			<h2 class="h3">Zapisane scenariusze</h2>
+			{#if scenarios.length >= 2}
+				<a href="/simulations/compare" class="btn btn-sm preset-tonal-primary">
+					Porównaj scenariusze →
+				</a>
+			{/if}
+		</div>
 		<div class="flex flex-wrap items-end gap-2">
 			<label class="label flex-1 min-w-[200px]">
 				<span class="text-sm font-semibold">Nazwa</span>

--- a/src/routes/simulations/compare/+page.svelte
+++ b/src/routes/simulations/compare/+page.svelte
@@ -1,0 +1,444 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { resolveApiUrl } from '$lib/api';
+	import { GitCompareArrows, ArrowLeft } from 'lucide-svelte';
+
+	interface RetirementScenarioInputs {
+		current_age: number;
+		retirement_age: number;
+		ike_ikze_accounts: unknown[];
+		ppk_accounts: unknown[];
+		brokerage_accounts: unknown[];
+		annual_return_rate: number;
+		limit_growth_rate: number;
+		expected_salary_growth: number;
+		inflation_rate: number;
+	}
+
+	interface SavedScenario {
+		id: number;
+		name: string;
+		kind: string;
+		inputs_json: RetirementScenarioInputs;
+		created_at: string;
+		updated_at: string;
+	}
+
+	interface SimulationSummary {
+		total_final_balance: number;
+		total_contributions: number;
+		total_returns: number;
+		total_tax_savings: number;
+		estimated_monthly_income: number;
+		estimated_monthly_income_today: number;
+		years_until_retirement: number;
+	}
+
+	interface ComparisonRow {
+		scenario: SavedScenario;
+		summary: SimulationSummary;
+		fiDate: Date;
+		successRate: number; // 0..∞ ratio of final balance to required capital
+	}
+
+	const apiUrl = resolveApiUrl();
+
+	let scenarios: SavedScenario[] = $state([]);
+	let selected: Set<number> = $state(new Set());
+	let loading = $state(false);
+	let error = $state('');
+	let results: ComparisonRow[] = $state([]);
+	let requiredCapital = $state(0);
+
+	const selectedCount = $derived(selected.size);
+	const canCompare = $derived(selectedCount >= 2 && !loading);
+
+	async function loadScenarios() {
+		try {
+			const r = await fetch(`${apiUrl}/api/scenarios?kind=retirement`);
+			if (!r.ok) throw new Error(`HTTP ${r.status}`);
+			const body = await r.json();
+			scenarios = (body.scenarios ?? []) as SavedScenario[];
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Nie udało się pobrać scenariuszy';
+		}
+	}
+
+	async function loadRequiredCapital() {
+		try {
+			const r = await fetch(`${apiUrl}/api/config`);
+			if (!r.ok) return;
+			const cfg = await r.json();
+			const monthly = Number(cfg.monthly_expenses ?? 0);
+			const wr = Number(cfg.withdrawal_rate ?? 0.04);
+			requiredCapital = wr > 0 ? (monthly * 12) / wr : 0;
+		} catch {
+			requiredCapital = 0;
+		}
+	}
+
+	function toggle(id: number) {
+		// Reassign so Svelte 5 sees the Set change.
+		const next = new Set(selected);
+		if (next.has(id)) next.delete(id);
+		else next.add(id);
+		selected = next;
+	}
+
+	function inputsToRequestBody(inputs: RetirementScenarioInputs): unknown {
+		// The /simulations/retirement endpoint expects the same shape the main
+		// simulations page POSTs. The saved scenario stores that shape verbatim
+		// (camelCase converted to snake_case in saveCurrentScenario), so the
+		// payload is largely a direct echo. ike_ikze_accounts arrays already
+		// carry the form's per-row fields — re-key the ones that differ from
+		// the API contract.
+		const reMap = (rows: unknown[], fn: (a: Record<string, unknown>) => unknown) =>
+			(rows ?? []).map((r) => fn(r as Record<string, unknown>));
+		return {
+			current_age: inputs.current_age,
+			retirement_age: inputs.retirement_age,
+			ike_ikze_accounts: reMap(inputs.ike_ikze_accounts, (a) => ({
+				enabled: a.enabled,
+				wrapper: a.wrapper,
+				owner_user_id: a.ownerUserId ?? a.owner_user_id,
+				balance: a.balance,
+				auto_fill_limit: a.autoFill ?? a.auto_fill_limit,
+				monthly_contribution: a.monthly ?? a.monthly_contribution,
+				tax_rate: a.taxRate ?? a.tax_rate
+			})),
+			// Mirror the main simulations page: only enabled PPK rows are sent so
+			// disabled-but-saved configs don't distort the comparison.
+			ppk_accounts: reMap(
+				(inputs.ppk_accounts ?? []).filter((a) => (a as Record<string, unknown>).enabled !== false),
+				(a) => ({
+					owner_user_id: a.ownerUserId ?? a.owner_user_id,
+					enabled: true,
+					starting_balance: a.balance ?? a.starting_balance,
+					monthly_gross_salary: a.salary ?? a.monthly_gross_salary,
+					employee_rate: a.employeeRate ?? a.employee_rate,
+					employer_rate: a.employerRate ?? a.employer_rate,
+					salary_below_threshold: a.belowThreshold ?? a.salary_below_threshold,
+					include_welcome_bonus: a.includeSubsidies ?? a.include_welcome_bonus,
+					include_annual_subsidy: a.includeSubsidies ?? a.include_annual_subsidy
+				})
+			),
+			brokerage_accounts: reMap(inputs.brokerage_accounts, (a) => ({
+				enabled: a.enabled,
+				owner_user_id: a.ownerUserId ?? a.owner_user_id,
+				balance: a.balance,
+				monthly_contribution: a.monthly ?? a.monthly_contribution
+			})),
+			annual_return_rate: inputs.annual_return_rate,
+			limit_growth_rate: inputs.limit_growth_rate,
+			expected_salary_growth: inputs.expected_salary_growth,
+			inflation_rate: inputs.inflation_rate
+		};
+	}
+
+	async function compareSelected() {
+		if (!canCompare) return;
+		loading = true;
+		error = '';
+		results = [];
+		try {
+			const chosen = scenarios.filter((s) => selected.has(s.id));
+			// allSettled so one bad scenario doesn't blank the whole comparison —
+			// the failed names are surfaced via `error` while the OK rows still
+			// render the table.
+			const settled = await Promise.allSettled(
+				chosen.map(async (s) => {
+					const r = await fetch(`${apiUrl}/api/simulations/retirement`, {
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json' },
+						body: JSON.stringify(inputsToRequestBody(s.inputs_json))
+					});
+					if (!r.ok) throw new Error(`${s.name}: HTTP ${r.status}`);
+					const body = await r.json();
+					return { scenario: s, summary: body.summary as SimulationSummary };
+				})
+			);
+			const errs: string[] = [];
+			const ok = settled.flatMap((res, i) => {
+				if (res.status === 'fulfilled') return [res.value];
+				errs.push(`${chosen[i].name}: ${res.reason}`);
+				return [];
+			});
+			if (errs.length) error = errs.join('; ');
+			const today = new Date();
+			results = ok.map(({ scenario, summary }) => {
+				const fiDate = new Date(
+					today.getFullYear() + summary.years_until_retirement,
+					today.getMonth(),
+					1
+				);
+				const successRate = requiredCapital > 0 ? summary.total_final_balance / requiredCapital : 0;
+				return { scenario, summary, fiDate, successRate };
+			});
+		} catch (err) {
+			error = err instanceof Error ? err.message : String(err);
+		} finally {
+			loading = false;
+		}
+	}
+
+	function fmtPLN(v: number): string {
+		return v.toLocaleString('pl-PL', { maximumFractionDigits: 0 }) + ' PLN';
+	}
+
+	function fmtDate(d: Date): string {
+		return d.toLocaleDateString('pl-PL', { year: 'numeric', month: 'long' });
+	}
+
+	function fmtPct(v: number): string {
+		return (v * 100).toFixed(1) + '%';
+	}
+
+	// Per-row min/max for color-coding so differences are easy to scan.
+	// "Higher is better" rows get green=max, orange=min; "lower is better"
+	// rows (years_until_retirement, fiDate) invert.
+	type Direction = 'higher' | 'lower';
+
+	function rowExtreme(values: number[], direction: Direction): { min: number; max: number } {
+		const min = Math.min(...values);
+		const max = Math.max(...values);
+		return direction === 'higher' ? { min, max } : { min: max, max: min };
+	}
+
+	function cellClass(value: number, extremes: { min: number; max: number }): string {
+		if (results.length < 2) return '';
+		if (value === extremes.max && extremes.max !== extremes.min)
+			return 'text-success-600-400 font-semibold';
+		if (value === extremes.min && extremes.max !== extremes.min)
+			return 'text-warning-600-400 font-semibold';
+		return '';
+	}
+
+	const yearsExtremes = $derived(
+		results.length
+			? rowExtreme(
+					results.map((r) => r.summary.years_until_retirement),
+					'lower'
+				)
+			: { min: 0, max: 0 }
+	);
+	const balanceExtremes = $derived(
+		results.length
+			? rowExtreme(
+					results.map((r) => r.summary.total_final_balance),
+					'higher'
+				)
+			: { min: 0, max: 0 }
+	);
+	const incomeExtremes = $derived(
+		results.length
+			? rowExtreme(
+					results.map((r) => r.summary.estimated_monthly_income_today),
+					'higher'
+				)
+			: { min: 0, max: 0 }
+	);
+	const successExtremes = $derived(
+		results.length
+			? rowExtreme(
+					results.map((r) => r.successRate),
+					'higher'
+				)
+			: { min: 0, max: 0 }
+	);
+
+	onMount(() => {
+		loadScenarios();
+		loadRequiredCapital();
+	});
+</script>
+
+<svelte:head>
+	<title>Porównanie scenariuszy | Symulacje</title>
+</svelte:head>
+
+<div class="space-y-4">
+	<div class="flex items-center gap-2">
+		<a href="/simulations" class="btn btn-sm preset-tonal-surface">
+			<ArrowLeft size={16} />
+			Wróć
+		</a>
+		<h1 class="h1 flex items-center gap-2">
+			<GitCompareArrows size={28} /> Porównanie scenariuszy
+		</h1>
+	</div>
+
+	<div class="card preset-filled-surface-100-900 p-4 space-y-3">
+		<h2 class="h3">Wybierz scenariusze do porównania</h2>
+		{#if scenarios.length === 0}
+			<p class="text-sm text-surface-700-300 italic">
+				Brak zapisanych scenariuszy. Wróć do
+				<a class="underline" href="/simulations">Symulacji</a> i zapisz przynajmniej dwa.
+			</p>
+		{:else}
+			<ul class="space-y-1">
+				{#each scenarios as s (s.id)}
+					<li class="flex items-center gap-2">
+						<input
+							id={`sc-${s.id}`}
+							type="checkbox"
+							class="checkbox"
+							checked={selected.has(s.id)}
+							onchange={() => toggle(s.id)}
+						/>
+						<label for={`sc-${s.id}`} class="text-sm cursor-pointer flex-1">
+							{s.name}
+						</label>
+						<span class="text-xs text-surface-700-300">
+							{new Date(s.updated_at + 'Z').toLocaleDateString('pl-PL')}
+						</span>
+					</li>
+				{/each}
+			</ul>
+			<div class="flex items-center gap-2 flex-wrap">
+				<button
+					type="button"
+					class="btn preset-filled-primary-500"
+					onclick={compareSelected}
+					disabled={!canCompare}
+				>
+					{loading ? 'Liczenie...' : `Porównaj zaznaczone (${selectedCount})`}
+				</button>
+				{#if selectedCount === 1}
+					<span class="text-xs text-surface-700-300">Wybierz co najmniej dwa scenariusze</span>
+				{/if}
+			</div>
+		{/if}
+		{#if error}
+			<div class="card preset-filled-error-500 p-3 text-sm">{error}</div>
+		{/if}
+	</div>
+
+	{#if results.length >= 2}
+		<div class="card preset-filled-surface-100-900 p-4 space-y-3 overflow-x-auto">
+			<h2 class="h3">Wyniki porównania</h2>
+			<table class="table w-full text-sm">
+				<thead>
+					<tr>
+						<th class="text-left">Metryka</th>
+						{#each results as r (r.scenario.id)}
+							<th class="text-right">{r.scenario.name}</th>
+						{/each}
+					</tr>
+				</thead>
+				<tbody>
+					<tr class="font-semibold preset-tonal-surface">
+						<td colspan={results.length + 1}>Założenia</td>
+					</tr>
+					<tr>
+						<td>Obecny wiek</td>
+						{#each results as r (r.scenario.id)}
+							<td class="text-right">{r.scenario.inputs_json.current_age ?? '—'}</td>
+						{/each}
+					</tr>
+					<tr>
+						<td>Wiek emerytalny</td>
+						{#each results as r (r.scenario.id)}
+							<td class="text-right">{r.scenario.inputs_json.retirement_age ?? '—'}</td>
+						{/each}
+					</tr>
+					<tr>
+						<td>Roczna stopa zwrotu</td>
+						{#each results as r (r.scenario.id)}
+							<td class="text-right">
+								{(r.scenario.inputs_json.annual_return_rate ?? 0).toFixed(1)}%
+							</td>
+						{/each}
+					</tr>
+					<tr>
+						<td>Inflacja</td>
+						{#each results as r (r.scenario.id)}
+							<td class="text-right">
+								{(r.scenario.inputs_json.inflation_rate ?? 0).toFixed(1)}%
+							</td>
+						{/each}
+					</tr>
+					<tr class="font-semibold preset-tonal-surface">
+						<td colspan={results.length + 1}>Wyniki</td>
+					</tr>
+					<tr>
+						<td>Lata do emerytury</td>
+						{#each results as r (r.scenario.id)}
+							<td class="text-right {cellClass(r.summary.years_until_retirement, yearsExtremes)}">
+								{r.summary.years_until_retirement}
+							</td>
+						{/each}
+					</tr>
+					<tr>
+						<td>Data FI (m-c/rok)</td>
+						{#each results as r (r.scenario.id)}
+							<td class="text-right">{fmtDate(r.fiDate)}</td>
+						{/each}
+					</tr>
+					{#if requiredCapital > 0}
+						<tr>
+							<td title="annual_expenses ÷ withdrawal_rate (z konfiguracji)">Wymagany kapitał</td>
+							{#each results as r (r.scenario.id)}
+								<td class="text-right">{fmtPLN(requiredCapital)}</td>
+							{/each}
+						</tr>
+					{/if}
+					<tr>
+						<td>Wartość końcowa portfela</td>
+						{#each results as r (r.scenario.id)}
+							<td class="text-right {cellClass(r.summary.total_final_balance, balanceExtremes)}">
+								{fmtPLN(r.summary.total_final_balance)}
+							</td>
+						{/each}
+					</tr>
+					{#if requiredCapital > 0}
+						<tr>
+							<td title="Wartość końcowa portfela ÷ wymagany kapitał × 100%">
+								Pokrycie celu (success)
+							</td>
+							{#each results as r (r.scenario.id)}
+								<td class="text-right {cellClass(r.successRate, successExtremes)}">
+									{fmtPct(r.successRate)}
+								</td>
+							{/each}
+						</tr>
+					{/if}
+					<tr>
+						<td>Wpłaty łącznie</td>
+						{#each results as r (r.scenario.id)}
+							<td class="text-right">{fmtPLN(r.summary.total_contributions)}</td>
+						{/each}
+					</tr>
+					<tr>
+						<td>Zwroty łącznie</td>
+						{#each results as r (r.scenario.id)}
+							<td class="text-right">{fmtPLN(r.summary.total_returns)}</td>
+						{/each}
+					</tr>
+					<tr>
+						<td>Miesięczny dochód (nominalny)</td>
+						{#each results as r (r.scenario.id)}
+							<td class="text-right">{fmtPLN(r.summary.estimated_monthly_income)}</td>
+						{/each}
+					</tr>
+					<tr>
+						<td>Miesięczny dochód (dzisiejszej wartości)</td>
+						{#each results as r (r.scenario.id)}
+							<td
+								class="text-right {cellClass(
+									r.summary.estimated_monthly_income_today,
+									incomeExtremes
+								)}"
+							>
+								{fmtPLN(r.summary.estimated_monthly_income_today)}
+							</td>
+						{/each}
+					</tr>
+				</tbody>
+			</table>
+			<p class="text-xs text-surface-700-300 italic">
+				Zielony = najlepszy wynik w danej kategorii; pomarańczowy = najsłabszy. „Pokrycie celu"
+				liczone względem FIRE number z konfiguracji.
+			</p>
+		</div>
+	{/if}
+</div>

--- a/src/routes/simulations/compare/+page.svelte
+++ b/src/routes/simulations/compare/+page.svelte
@@ -152,7 +152,7 @@
 						headers: { 'Content-Type': 'application/json' },
 						body: JSON.stringify(inputsToRequestBody(s.inputs_json))
 					});
-					if (!r.ok) throw new Error(`${s.name}: HTTP ${r.status}`);
+					if (!r.ok) throw new Error(`HTTP ${r.status}`);
 					const body = await r.json();
 					return { scenario: s, summary: body.summary as SimulationSummary };
 				})
@@ -160,7 +160,8 @@
 			const errs: string[] = [];
 			const ok = settled.flatMap((res, i) => {
 				if (res.status === 'fulfilled') return [res.value];
-				errs.push(`${chosen[i].name}: ${res.reason}`);
+				const reason = res.reason instanceof Error ? res.reason.message : String(res.reason);
+				errs.push(`${chosen[i].name}: ${reason}`);
 				return [];
 			});
 			if (errs.length) error = errs.join('; ');
@@ -191,6 +192,15 @@
 
 	function fmtPct(v: number): string {
 		return (v * 100).toFixed(1) + '%';
+	}
+
+	// Backend returns naive UTC strings; new Date() would re-anchor those to
+	// the browser's local zone. Append Z when missing so the rendered moment
+	// matches the server clock. Guarded so a future migration to suffixed
+	// strings doesn't double-up.
+	function fmtUpdatedAt(s: string): string {
+		const utc = s.endsWith('Z') ? s : s + 'Z';
+		return new Date(utc).toLocaleDateString('pl-PL');
 	}
 
 	// Per-row min/max for color-coding so differences are easy to scan.
@@ -245,6 +255,30 @@
 				)
 			: { min: 0, max: 0 }
 	);
+	const contributionsExtremes = $derived(
+		results.length
+			? rowExtreme(
+					results.map((r) => r.summary.total_contributions),
+					'higher'
+				)
+			: { min: 0, max: 0 }
+	);
+	const returnsExtremes = $derived(
+		results.length
+			? rowExtreme(
+					results.map((r) => r.summary.total_returns),
+					'higher'
+				)
+			: { min: 0, max: 0 }
+	);
+	const nominalIncomeExtremes = $derived(
+		results.length
+			? rowExtreme(
+					results.map((r) => r.summary.estimated_monthly_income),
+					'higher'
+				)
+			: { min: 0, max: 0 }
+	);
 
 	onMount(() => {
 		loadScenarios();
@@ -289,7 +323,7 @@
 							{s.name}
 						</label>
 						<span class="text-xs text-surface-700-300">
-							{new Date(s.updated_at + 'Z').toLocaleDateString('pl-PL')}
+							{fmtUpdatedAt(s.updated_at)}
 						</span>
 					</li>
 				{/each}
@@ -405,19 +439,32 @@
 					<tr>
 						<td>Wpłaty łącznie</td>
 						{#each results as r (r.scenario.id)}
-							<td class="text-right">{fmtPLN(r.summary.total_contributions)}</td>
+							<td
+								class="text-right {cellClass(r.summary.total_contributions, contributionsExtremes)}"
+							>
+								{fmtPLN(r.summary.total_contributions)}
+							</td>
 						{/each}
 					</tr>
 					<tr>
 						<td>Zwroty łącznie</td>
 						{#each results as r (r.scenario.id)}
-							<td class="text-right">{fmtPLN(r.summary.total_returns)}</td>
+							<td class="text-right {cellClass(r.summary.total_returns, returnsExtremes)}">
+								{fmtPLN(r.summary.total_returns)}
+							</td>
 						{/each}
 					</tr>
 					<tr>
 						<td>Miesięczny dochód (nominalny)</td>
 						{#each results as r (r.scenario.id)}
-							<td class="text-right">{fmtPLN(r.summary.estimated_monthly_income)}</td>
+							<td
+								class="text-right {cellClass(
+									r.summary.estimated_monthly_income,
+									nominalIncomeExtremes
+								)}"
+							>
+								{fmtPLN(r.summary.estimated_monthly_income)}
+							</td>
 						{/each}
 					</tr>
 					<tr>

--- a/src/routes/simulations/compare/page.test.ts
+++ b/src/routes/simulations/compare/page.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import Page from './+page.svelte';
+
+beforeAll(() => {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn()
+		}))
+	});
+});
+
+vi.mock('$env/dynamic/public', () => ({
+	env: {
+		PUBLIC_API_URL_BROWSER: 'http://localhost:8000',
+		PUBLIC_API_URL: 'http://localhost:8000'
+	}
+}));
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+function scenarioFixture(id: number, name: string) {
+	return {
+		id,
+		name,
+		kind: 'retirement',
+		created_at: '2026-01-01T00:00:00',
+		updated_at: '2026-01-01T00:00:00',
+		inputs_json: {
+			current_age: 35,
+			retirement_age: 65,
+			ike_ikze_accounts: [],
+			ppk_accounts: [],
+			brokerage_accounts: [],
+			annual_return_rate: 7.0,
+			limit_growth_rate: 5.0,
+			expected_salary_growth: 3.0,
+			inflation_rate: 3.0
+		}
+	};
+}
+
+describe('Compare scenarios page', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('renders the empty-state message when no scenarios are saved', async () => {
+		const fetchMock = vi.fn().mockImplementation((url: string) => {
+			if (url.includes('/api/scenarios')) {
+				return Promise.resolve({ ok: true, json: async () => ({ scenarios: [] }) });
+			}
+			return Promise.resolve({
+				ok: true,
+				json: async () => ({ monthly_expenses: 5000, withdrawal_rate: 0.04 })
+			});
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		render(Page);
+		await waitFor(() => expect(screen.getByText(/Brak zapisanych scenariuszy/)).toBeTruthy());
+	});
+
+	it('compares two selected scenarios and renders the results table', async () => {
+		const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+			if (url.includes('/api/scenarios')) {
+				return Promise.resolve({
+					ok: true,
+					json: async () => ({
+						scenarios: [scenarioFixture(1, 'Plan A'), scenarioFixture(2, 'Plan B')]
+					})
+				});
+			}
+			if (url.includes('/api/config')) {
+				return Promise.resolve({
+					ok: true,
+					json: async () => ({ monthly_expenses: 5000, withdrawal_rate: 0.04 })
+				});
+			}
+			if (url.includes('/api/simulations/retirement') && init?.method === 'POST') {
+				return Promise.resolve({
+					ok: true,
+					json: async () => ({
+						summary: {
+							total_final_balance: 1_000_000,
+							total_contributions: 500_000,
+							total_returns: 500_000,
+							total_tax_savings: 0,
+							estimated_monthly_income: 3000,
+							estimated_monthly_income_today: 1500,
+							years_until_retirement: 30
+						}
+					})
+				});
+			}
+			return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		render(Page);
+
+		// Wait for scenarios to load + checkboxes to render.
+		await waitFor(() => expect(screen.getByText('Plan A')).toBeTruthy());
+
+		const checkboxes = screen.getAllByRole('checkbox');
+		await fireEvent.click(checkboxes[0]);
+		await fireEvent.click(checkboxes[1]);
+
+		const button = screen.getByRole('button', { name: /Porównaj zaznaczone/ });
+		await fireEvent.click(button);
+
+		await waitFor(() => expect(screen.getByText('Wyniki porównania')).toBeTruthy());
+		// Two retirement POSTs fired.
+		const simCalls = fetchMock.mock.calls.filter(([u]) =>
+			String(u).includes('/api/simulations/retirement')
+		);
+		expect(simCalls).toHaveLength(2);
+	});
+});

--- a/src/routes/simulations/compare/page.test.ts
+++ b/src/routes/simulations/compare/page.test.ts
@@ -71,6 +71,72 @@ describe('Compare scenarios page', () => {
 		await waitFor(() => expect(screen.getByText(/Brak zapisanych scenariuszy/)).toBeTruthy());
 	});
 
+	it('still renders the table when one scenario sim fails (partial-success)', async () => {
+		let callCount = 0;
+		const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+			if (url.includes('/api/scenarios')) {
+				return Promise.resolve({
+					ok: true,
+					json: async () => ({
+						scenarios: [
+							scenarioFixture(1, 'Plan A'),
+							scenarioFixture(2, 'Plan B'),
+							scenarioFixture(3, 'Plan C')
+						]
+					})
+				});
+			}
+			if (url.includes('/api/config')) {
+				return Promise.resolve({
+					ok: true,
+					json: async () => ({ monthly_expenses: 5000, withdrawal_rate: 0.04 })
+				});
+			}
+			if (url.includes('/api/simulations/retirement') && init?.method === 'POST') {
+				callCount += 1;
+				// Second sim POST fails; the other two succeed.
+				if (callCount === 2) {
+					return Promise.resolve({
+						ok: false,
+						status: 500,
+						json: async () => ({ detail: 'boom' })
+					});
+				}
+				return Promise.resolve({
+					ok: true,
+					json: async () => ({
+						summary: {
+							total_final_balance: 1_000_000,
+							total_contributions: 500_000,
+							total_returns: 500_000,
+							total_tax_savings: 0,
+							estimated_monthly_income: 3000,
+							estimated_monthly_income_today: 1500,
+							years_until_retirement: 30
+						}
+					})
+				});
+			}
+			return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		render(Page);
+
+		await waitFor(() => expect(screen.getByText('Plan A')).toBeTruthy());
+		const checkboxes = screen.getAllByRole('checkbox');
+		await fireEvent.click(checkboxes[0]);
+		await fireEvent.click(checkboxes[1]);
+		await fireEvent.click(checkboxes[2]);
+
+		const button = screen.getByRole('button', { name: /Porównaj zaznaczone/ });
+		await fireEvent.click(button);
+
+		// Results table still rendered (≥2 successful scenarios).
+		await waitFor(() => expect(screen.getByText('Wyniki porównania')).toBeTruthy());
+		// Error banner mentions the failed scenario name (Plan B was call 2).
+		expect(screen.getByText(/Plan B: HTTP 500/)).toBeTruthy();
+	});
+
 	it('compares two selected scenarios and renders the results table', async () => {
 		const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
 			if (url.includes('/api/scenarios')) {


### PR DESCRIPTION
## Motivation

Closes #549. Saved scenarios from #547 are useful only if you can put them
next to each other. This adds a comparison view that runs N selected
retirement scenarios through the existing simulation endpoint and renders
a side-by-side table covering FI date, required capital, success rate, and
the key assumptions that drive the spread.

## Implementation information

**Frontend only — no backend changes.**

- New page at ``src/routes/simulations/compare/+page.svelte``.
- Loads scenarios from ``GET /api/scenarios?kind=retirement`` and the FIRE
  number from ``GET /api/config`` (``monthly_expenses × 12 ÷ withdrawal_rate``).
- Checkbox-select 2+ scenarios → button enabled → fires parallel POSTs to
  ``/api/simulations/retirement``. Uses ``Promise.allSettled`` so one failed
  scenario doesn't blank the whole table; failed names surface in the
  error banner while successful rows still render.
- Inputs are re-mapped from the saved camelCase form shape to the
  backend's snake_case keys (matching what the main simulations page
  already does). Disabled PPK rows are filtered, matching the main page.
- Table columns: one per scenario. Rows: assumptions (current age,
  retirement age, return rate, inflation) + results (years to FI, FI
  date, required capital, final balance, success = balance ÷ required
  capital, contributions, returns, monthly income nominal/today).
- Per-row min/max coloured: green = best, orange = worst. "Lower is
  better" rows (years to FI) invert the color convention.
- Link from the main simulations page → compare view, shown once 2+
  scenarios exist.

**Tests**

- ``compare/page.test.ts`` covers the empty state and a 2-scenario compare
  flow including parallel POSTs and table rendering.
- ``npm test``: 454 passed.
- ``npm run check`` / ``npm run lint``: green.

> Changelog: feat(scenarios): compare scenarios side by side