### PR TITLE
feat(fire): project FI date from savings + assets

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -2334,6 +2334,10 @@
                     "monthly_mortgage_payment": {
                       "type": "string"
                     },
+                    "monthly_savings": {
+                      "nullable": true,
+                      "type": "string"
+                    },
                     "retirement_age": {
                       "type": "integer"
                     },
@@ -2407,6 +2411,10 @@
                   "monthly_mortgage_payment": {
                     "type": "string"
                   },
+                  "monthly_savings": {
+                    "nullable": true,
+                    "type": "string"
+                  },
                   "retirement_age": {
                     "type": "integer"
                   },
@@ -2475,6 +2483,10 @@
                       "type": "string"
                     },
                     "monthly_mortgage_payment": {
+                      "type": "string"
+                    },
+                    "monthly_savings": {
+                      "nullable": true,
                       "type": "string"
                     },
                     "retirement_age": {
@@ -2905,6 +2917,15 @@
                           "nullable": true,
                           "type": "number"
                         },
+                        "fi_projected_date": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "fi_years_remaining": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
                         "fire_number": {
                           "format": "double",
                           "nullable": true,
@@ -2934,6 +2955,11 @@
                           "type": "number"
                         },
                         "lean_fire_number": {
+                          "format": "double",
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "monthly_savings": {
                           "format": "double",
                           "nullable": true,
                           "type": "number"

--- a/backend-bb-tests/golden/config_get.json
+++ b/backend-bb-tests/golden/config_get.json
@@ -13,6 +13,7 @@
   "lean_monthly_expenses": null,
   "monthly_expenses": "5000.00",
   "monthly_mortgage_payment": "2000.00",
+  "monthly_savings": null,
   "retirement_age": 65,
   "retirement_monthly_salary": "8000.00",
   "withdrawal_rate": "0.0400"

--- a/backend-go/internal/config/handler.go
+++ b/backend-go/internal/config/handler.go
@@ -34,6 +34,7 @@ type response struct {
 	BaristaMonthlyIncome    *moneyJSON `json:"barista_monthly_income"`
 	LeanMonthlyExpenses     *moneyJSON `json:"lean_monthly_expenses"`
 	FatMonthlyExpenses      *moneyJSON `json:"fat_monthly_expenses"`
+	MonthlySavings          *moneyJSON `json:"monthly_savings"`
 }
 
 // request is the PUT body. Date arrives as "YYYY-MM-DD" and money as either
@@ -55,6 +56,7 @@ type request struct {
 	BaristaMonthlyIncome    *decimal.Decimal `json:"barista_monthly_income"`
 	LeanMonthlyExpenses     *decimal.Decimal `json:"lean_monthly_expenses"`
 	FatMonthlyExpenses      *decimal.Decimal `json:"fat_monthly_expenses"`
+	MonthlySavings          *decimal.Decimal `json:"monthly_savings"`
 }
 
 func toResponse(c *Config) response {
@@ -76,6 +78,7 @@ func toResponse(c *Config) response {
 		BaristaMonthlyIncome:    moneyPtr(c.BaristaMonthlyIncome),
 		LeanMonthlyExpenses:     moneyPtr(c.LeanMonthlyExpenses),
 		FatMonthlyExpenses:      moneyPtr(c.FatMonthlyExpenses),
+		MonthlySavings:          moneyPtr(c.MonthlySavings),
 	}
 }
 
@@ -168,6 +171,7 @@ func (r *request) toConfig() *Config {
 		BaristaMonthlyIncome:    r.BaristaMonthlyIncome,
 		LeanMonthlyExpenses:     r.LeanMonthlyExpenses,
 		FatMonthlyExpenses:      r.FatMonthlyExpenses,
+		MonthlySavings:          r.MonthlySavings,
 	}
 }
 

--- a/backend-go/internal/config/store.go
+++ b/backend-go/internal/config/store.go
@@ -35,6 +35,7 @@ type Config struct {
 	BaristaMonthlyIncome    *decimal.Decimal `json:"barista_monthly_income"`
 	LeanMonthlyExpenses     *decimal.Decimal `json:"lean_monthly_expenses"`
 	FatMonthlyExpenses      *decimal.Decimal `json:"fat_monthly_expenses"`
+	MonthlySavings          *decimal.Decimal `json:"monthly_savings"`
 }
 
 // ErrNotFound is returned when no row exists at id=1.
@@ -57,7 +58,8 @@ const selectColumns = `
 	monthly_expenses, monthly_mortgage_payment, withdrawal_rate,
 	coast_fire_target_age, expected_return_rate,
 	barista_monthly_income,
-	lean_monthly_expenses, fat_monthly_expenses
+	lean_monthly_expenses, fat_monthly_expenses,
+	monthly_savings
 `
 
 // Get returns the singleton config or ErrNotFound.
@@ -87,8 +89,9 @@ func (s *Store) Upsert(ctx context.Context, in *Config) (*Config, error) {
 			monthly_expenses, monthly_mortgage_payment, withdrawal_rate,
 			coast_fire_target_age, expected_return_rate,
 			barista_monthly_income,
-			lean_monthly_expenses, fat_monthly_expenses
-		) VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+			lean_monthly_expenses, fat_monthly_expenses,
+			monthly_savings
+		) VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
 		ON CONFLICT (id) DO UPDATE SET
 			birth_date = EXCLUDED.birth_date,
 			retirement_age = EXCLUDED.retirement_age,
@@ -105,7 +108,8 @@ func (s *Store) Upsert(ctx context.Context, in *Config) (*Config, error) {
 			expected_return_rate = EXCLUDED.expected_return_rate,
 			barista_monthly_income = EXCLUDED.barista_monthly_income,
 			lean_monthly_expenses = EXCLUDED.lean_monthly_expenses,
-			fat_monthly_expenses = EXCLUDED.fat_monthly_expenses
+			fat_monthly_expenses = EXCLUDED.fat_monthly_expenses,
+			monthly_savings = EXCLUDED.monthly_savings
 		RETURNING `+selectColumns,
 		in.BirthDate,
 		in.RetirementAge,
@@ -123,6 +127,7 @@ func (s *Store) Upsert(ctx context.Context, in *Config) (*Config, error) {
 		in.BaristaMonthlyIncome,
 		in.LeanMonthlyExpenses,
 		in.FatMonthlyExpenses,
+		in.MonthlySavings,
 	)
 	c, err := scanConfig(row)
 	if err != nil {
@@ -151,6 +156,7 @@ func scanConfig(row pgx.Row) (*Config, error) {
 		&c.BaristaMonthlyIncome,
 		&c.LeanMonthlyExpenses,
 		&c.FatMonthlyExpenses,
+		&c.MonthlySavings,
 	)
 	if err != nil {
 		return nil, err

--- a/backend-go/internal/config/validation.go
+++ b/backend-go/internal/config/validation.go
@@ -128,6 +128,7 @@ func requireNonNegative(r *request) *validationError {
 		{"barista_monthly_income", r.BaristaMonthlyIncome},
 		{"lean_monthly_expenses", r.LeanMonthlyExpenses},
 		{"fat_monthly_expenses", r.FatMonthlyExpenses},
+		{"monthly_savings", r.MonthlySavings},
 	}
 	for _, c := range checks {
 		if c.val != nil && c.val.LessThan(decimal.Zero) {

--- a/backend-go/internal/dashboard/dashboard.go
+++ b/backend-go/internal/dashboard/dashboard.go
@@ -62,6 +62,9 @@ type metricCards struct {
 	LeanFIProgress          *float64
 	FatFIRENumber           *float64
 	FatFIProgress           *float64
+	MonthlySavings          *float64
+	FIYearsRemaining        *float64
+	FIProjectedDate         *string
 }
 
 type allocationBreakdown struct {

--- a/backend-go/internal/dashboard/fire.go
+++ b/backend-go/internal/dashboard/fire.go
@@ -41,6 +41,9 @@ type fireMetrics struct {
 	LeanFIProgress       *float64
 	FatFIRENumber        *float64
 	FatFIProgress        *float64
+	MonthlySavings       *float64
+	FIYearsRemaining     *float64
+	FIProjectedDate      *string
 }
 
 // bridgeTargetAge is the age the bridge-to-60 metric projects to — IKE
@@ -128,7 +131,67 @@ func computeFIRE(latestRows []mergedRow, cfg AppConfig, netWorth float64) fireMe
 	addCoastFIRE(&out, cfg, netWorth, now)
 	addBaristaFIRE(&out, cfg, netWorth)
 	addBridgeToAccessAge(&out, latestRows, cfg, netWorth, now)
+	addFIProjection(&out, cfg, netWorth, now)
 	return out
+}
+
+// addFIProjection fills FIYearsRemaining + FIProjectedDate from net worth,
+// FIRE number, monthly savings, and expected real return. Closed form of
+// the annuity-future-value equation:
+//
+//	NW × (1+r)^t + S × ((1+r)^t − 1) ÷ r = FIRE
+//	→ t = ln((FIRE × r + S) ÷ (NW × r + S)) ÷ ln(1 + r)
+//
+// Edge cases (return early without setting the projection fields → empty
+// state on the frontend):
+//   - monthly_savings is null OR ≤ 0 → "configure savings" empty state
+//   - FIRE number missing → base inputs incomplete; nothing to project
+//   - net worth ≥ FIRE → already at FI: years = 0, date = today
+//   - r ≤ 0 → degrades to linear (FIRE − NW) ÷ S years
+//   - r > 0 with negative net worth large enough that NW×r + S ≤ 0 → leave nil
+func addFIProjection(out *fireMetrics, cfg AppConfig, netWorth float64, now time.Time) {
+	if cfg.MonthlySavings == nil {
+		return
+	}
+	monthly, _ := cfg.MonthlySavings.Float64()
+	if monthly <= 0 {
+		return
+	}
+	out.MonthlySavings = &monthly
+	if out.FIRENumber == nil {
+		return
+	}
+	fire := *out.FIRENumber
+	if fire <= 0 {
+		return
+	}
+
+	annualSavings := monthly * 12
+	years := 0.0
+	if netWorth >= fire {
+		years = 0
+	} else {
+		r := 0.0
+		if out.ExpectedReturnRate != nil {
+			r = *out.ExpectedReturnRate
+		}
+		if r <= 0 {
+			years = (fire - netWorth) / annualSavings
+		} else {
+			num := fire*r + annualSavings
+			den := netWorth*r + annualSavings
+			if den <= 0 || num <= 0 {
+				return
+			}
+			years = math.Log(num/den) / math.Log(1+r)
+		}
+	}
+	if math.IsNaN(years) || math.IsInf(years, 0) || years < 0 {
+		return
+	}
+	out.FIYearsRemaining = &years
+	date := now.AddDate(0, int(math.Round(years*12)), 0).Format("2006-01")
+	out.FIProjectedDate = &date
 }
 
 // addFIREBands fills the Lean / Fat FIRE bands when configured. Math is the

--- a/backend-go/internal/dashboard/fire_test.go
+++ b/backend-go/internal/dashboard/fire_test.go
@@ -345,6 +345,107 @@ func TestAddFIREBandsZeroMonthlyStaysNil(t *testing.T) {
 	}
 }
 
+func TestAddFIProjectionHappyPath(t *testing.T) {
+	t.Parallel()
+	// monthly=5000 → annual=60000 → fire=60000/0.04=1.5M.
+	// Savings 4000/mo = 48k/yr. r=0.07. NW=200k.
+	// t = ln((1.5M×0.07 + 48k) / (200k×0.07 + 48k)) / ln(1.07)
+	//   = ln(153000 / 62000) / ln(1.07) ≈ ln(2.4677) / 0.0677 ≈ 13.36 years
+	savings := decimal.NewFromInt(4000)
+	cfg := AppConfig{
+		MonthlyExpenses:    decimal.NewFromInt(5000),
+		WithdrawalRate:     decimal.RequireFromString("0.04"),
+		ExpectedReturnRate: decimal.RequireFromString("0.07"),
+		MonthlySavings:     &savings,
+	}
+	got := computeFIRE(nil, cfg, 200_000)
+	if got.FIYearsRemaining == nil {
+		t.Fatal("expected fi_years_remaining set")
+	}
+	want := math.Log((1_500_000.0*0.07+48_000)/(200_000.0*0.07+48_000)) / math.Log(1.07)
+	if !approxEqual(*got.FIYearsRemaining, want, 0.01) {
+		t.Errorf("fi_years_remaining = %v, want ≈%v", *got.FIYearsRemaining, want)
+	}
+	if got.FIProjectedDate == nil {
+		t.Error("expected fi_projected_date set")
+	}
+	if got.MonthlySavings == nil || *got.MonthlySavings != 4000 {
+		t.Errorf("monthly_savings = %v, want 4000", got.MonthlySavings)
+	}
+}
+
+func TestAddFIProjectionZeroReturnLinear(t *testing.T) {
+	t.Parallel()
+	// r=0 → t = (fire − NW) / annualSavings = (1.5M − 0) / 60k = 25 years.
+	savings := decimal.NewFromInt(5000)
+	cfg := AppConfig{
+		MonthlyExpenses:    decimal.NewFromInt(5000),
+		WithdrawalRate:     decimal.RequireFromString("0.04"),
+		ExpectedReturnRate: decimal.Zero,
+		MonthlySavings:     &savings,
+	}
+	got := computeFIRE(nil, cfg, 0)
+	if got.FIYearsRemaining == nil || !approxEqual(*got.FIYearsRemaining, 25.0, 0.001) {
+		t.Fatalf("fi_years_remaining = %v, want 25", got.FIYearsRemaining)
+	}
+}
+
+func TestAddFIProjectionAlreadyAtFI(t *testing.T) {
+	t.Parallel()
+	savings := decimal.NewFromInt(1000)
+	cfg := AppConfig{
+		MonthlyExpenses:    decimal.NewFromInt(5000),
+		WithdrawalRate:     decimal.RequireFromString("0.04"),
+		ExpectedReturnRate: decimal.RequireFromString("0.07"),
+		MonthlySavings:     &savings,
+	}
+	got := computeFIRE(nil, cfg, 2_000_000)
+	if got.FIYearsRemaining == nil || *got.FIYearsRemaining != 0 {
+		t.Errorf("fi_years_remaining = %v, want 0 (already past FI)", got.FIYearsRemaining)
+	}
+}
+
+func TestAddFIProjectionNoSavingsStaysNil(t *testing.T) {
+	t.Parallel()
+	cfg := AppConfig{
+		MonthlyExpenses: decimal.NewFromInt(5000),
+		WithdrawalRate:  decimal.RequireFromString("0.04"),
+		// MonthlySavings unset → empty state.
+	}
+	got := computeFIRE(nil, cfg, 200_000)
+	if got.FIYearsRemaining != nil || got.FIProjectedDate != nil || got.MonthlySavings != nil {
+		t.Errorf("expected nil FI projection without monthly_savings, got %+v", got)
+	}
+}
+
+func TestAddFIProjectionZeroSavingsStaysNil(t *testing.T) {
+	t.Parallel()
+	zero := decimal.Zero
+	cfg := AppConfig{
+		MonthlyExpenses: decimal.NewFromInt(5000),
+		WithdrawalRate:  decimal.RequireFromString("0.04"),
+		MonthlySavings:  &zero,
+	}
+	got := computeFIRE(nil, cfg, 200_000)
+	if got.FIYearsRemaining != nil {
+		t.Errorf("expected nil fi_years_remaining for zero savings, got %v", *got.FIYearsRemaining)
+	}
+}
+
+func TestAddFIProjectionNoFIRENumberStaysNil(t *testing.T) {
+	t.Parallel()
+	savings := decimal.NewFromInt(4000)
+	cfg := AppConfig{
+		MonthlyExpenses: decimal.Zero, // → no FIRE number
+		WithdrawalRate:  decimal.RequireFromString("0.04"),
+		MonthlySavings:  &savings,
+	}
+	got := computeFIRE(nil, cfg, 200_000)
+	if got.FIYearsRemaining != nil {
+		t.Errorf("expected nil fi_years_remaining without FIRE number, got %v", *got.FIYearsRemaining)
+	}
+}
+
 func TestLockedWrapperValueOfFiltersCorrectly(t *testing.T) {
 	t.Parallel()
 	rows := []mergedRow{

--- a/backend-go/internal/dashboard/handler.go
+++ b/backend-go/internal/dashboard/handler.go
@@ -210,6 +210,9 @@ type metricCardsWire struct {
 	LeanFIProgress          *pyFloat `json:"lean_fi_progress"`
 	FatFIRENumber           *pyFloat `json:"fat_fire_number"`
 	FatFIProgress           *pyFloat `json:"fat_fi_progress"`
+	MonthlySavings          *pyFloat `json:"monthly_savings"`
+	FIYearsRemaining        *pyFloat `json:"fi_years_remaining"`
+	FIProjectedDate         *string  `json:"fi_projected_date"`
 }
 
 type allocationBreakdownWire struct {
@@ -363,6 +366,9 @@ func metricCardsToWire(m metricCards) metricCardsWire {
 		LeanFIProgress:          floatPtr(m.LeanFIProgress),
 		FatFIRENumber:           floatPtr(m.FatFIRENumber),
 		FatFIProgress:           floatPtr(m.FatFIProgress),
+		MonthlySavings:          floatPtr(m.MonthlySavings),
+		FIYearsRemaining:        floatPtr(m.FIYearsRemaining),
+		FIProjectedDate:         m.FIProjectedDate,
 	}
 }
 

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -505,6 +505,9 @@ func assignFIREMetrics(mc *metricCards, fire fireMetrics) {
 	mc.LeanFIProgress = fire.LeanFIProgress
 	mc.FatFIRENumber = fire.FatFIRENumber
 	mc.FatFIProgress = fire.FatFIProgress
+	mc.MonthlySavings = fire.MonthlySavings
+	mc.FIYearsRemaining = fire.FIYearsRemaining
+	mc.FIProjectedDate = fire.FIProjectedDate
 }
 
 // buildAllocationAnalysis is the shared allocation-analysis computation.

--- a/backend-go/internal/dashboard/store.go
+++ b/backend-go/internal/dashboard/store.go
@@ -84,6 +84,7 @@ type AppConfig struct {
 	BaristaMonthlyIncome   *decimal.Decimal
 	LeanMonthlyExpenses    *decimal.Decimal
 	FatMonthlyExpenses     *decimal.Decimal
+	MonthlySavings         *decimal.Decimal
 }
 
 // SnapshotMeta is id+date.
@@ -301,7 +302,8 @@ func (s *Store) LoadAppConfig(ctx context.Context) (AppConfig, bool, error) {
 		       withdrawal_rate, birth_date,
 		       coast_fire_target_age, expected_return_rate,
 		       barista_monthly_income,
-		       lean_monthly_expenses, fat_monthly_expenses
+		       lean_monthly_expenses, fat_monthly_expenses,
+		       monthly_savings
 		FROM app_config WHERE id = 1`,
 	)
 	var c AppConfig
@@ -312,6 +314,7 @@ func (s *Store) LoadAppConfig(ctx context.Context) (AppConfig, bool, error) {
 		&c.CoastFIRETargetAge, &c.ExpectedReturnRate,
 		&c.BaristaMonthlyIncome,
 		&c.LeanMonthlyExpenses, &c.FatMonthlyExpenses,
+		&c.MonthlySavings,
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return AppConfig{}, false, nil

--- a/backend-go/internal/db/migrate.go
+++ b/backend-go/internal/db/migrate.go
@@ -70,6 +70,9 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
 	if err := addAppConfigFIREBands(ctx, pool); err != nil {
 		return err
 	}
+	if err := addAppConfigMonthlySavings(ctx, pool); err != nil {
+		return err
+	}
 	if err := createRecurringTransactionsTable(ctx, pool); err != nil {
 		return err
 	}
@@ -104,6 +107,18 @@ func createSimulationScenariosTable(ctx context.Context, pool *pgxpool.Pool) err
 		if _, err := pool.Exec(ctx, stmt); err != nil {
 			return fmt.Errorf("create simulation_scenarios: %w", err)
 		}
+	}
+	return nil
+}
+
+// addAppConfigMonthlySavings adds the monthly_savings input feeding the
+// projected-FI-date metric (issue #551). Nullable — when unset, the FI
+// projection tile shows an empty state asking the user to configure it.
+func addAppConfigMonthlySavings(ctx context.Context, pool *pgxpool.Pool) error {
+	if _, err := pool.Exec(ctx, `
+		ALTER TABLE app_config
+		ADD COLUMN IF NOT EXISTS monthly_savings numeric(15,2)`); err != nil {
+		return fmt.Errorf("add monthly_savings to app_config: %w", err)
 	}
 	return nil
 }

--- a/backend-go/internal/db/schema.sql
+++ b/backend-go/internal/db/schema.sql
@@ -101,6 +101,7 @@ CREATE TABLE public.app_config (
     barista_monthly_income numeric(15,2),
     lean_monthly_expenses numeric(15,2),
     fat_monthly_expenses numeric(15,2),
+    monthly_savings numeric(15,2),
     CONSTRAINT single_row CHECK ((id = 1))
 );
 

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -1665,6 +1665,7 @@ export interface paths {
                             lean_monthly_expenses?: string | null;
                             monthly_expenses?: string;
                             monthly_mortgage_payment?: string;
+                            monthly_savings?: string | null;
                             retirement_age?: number;
                             retirement_monthly_salary?: string;
                             withdrawal_rate?: string;
@@ -1698,6 +1699,7 @@ export interface paths {
                         lean_monthly_expenses?: string | null;
                         monthly_expenses?: string;
                         monthly_mortgage_payment?: string;
+                        monthly_savings?: string | null;
                         retirement_age?: number;
                         retirement_monthly_salary?: string;
                         withdrawal_rate?: string | null;
@@ -1727,6 +1729,7 @@ export interface paths {
                             lean_monthly_expenses?: string | null;
                             monthly_expenses?: string;
                             monthly_mortgage_payment?: string;
+                            monthly_savings?: string | null;
                             retirement_age?: number;
                             retirement_monthly_salary?: string;
                             withdrawal_rate?: string;
@@ -2007,6 +2010,9 @@ export interface paths {
                                 fat_fire_number?: number | null;
                                 /** Format: double */
                                 fi_progress?: number | null;
+                                fi_projected_date?: string | null;
+                                /** Format: double */
+                                fi_years_remaining?: number | null;
                                 /** Format: double */
                                 fire_number?: number | null;
                                 /** Format: double */
@@ -2021,6 +2027,8 @@ export interface paths {
                                 lean_fi_progress?: number | null;
                                 /** Format: double */
                                 lean_fire_number?: number | null;
+                                /** Format: double */
+                                monthly_savings?: number | null;
                                 mortgage_months_left?: number;
                                 /** Format: double */
                                 mortgage_remaining?: number;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -241,6 +241,9 @@
 			{@const leanProgress = fire.lean_fi_progress}
 			{@const fatFire = fire.fat_fire_number}
 			{@const fatProgress = fire.fat_fi_progress}
+			{@const fiYears = fire.fi_years_remaining}
+			{@const fiDate = fire.fi_projected_date}
+			{@const monthlySavings = fire.monthly_savings}
 			{@const bridgeYears = fire.bridge_years}
 			{@const bridgeNeeded = fire.bridge_capital_needed}
 			{@const bridgeLiquid = fire.bridge_liquid_capital}
@@ -351,6 +354,38 @@
 									</div>
 								</div>
 							{/if}
+						</div>
+					</div>
+				{/if}
+				{#if fiYears != null && fiDate != null && monthlySavings != null}
+					{@const [year, month] = fiDate.split('-')}
+					<div class="pt-3 border-t border-surface-200-800 grid grid-cols-1 sm:grid-cols-2 gap-3">
+						<div class="space-y-1">
+							<div
+								class="text-xs text-surface-700-300"
+								title="t = ln((FIRE×r + S) ÷ (NW×r + S)) ÷ ln(1+r)&#10;NW = wartość netto · S = roczne oszczędności · r = expected_return_rate · FIRE = roczne wydatki ÷ withdrawal_rate"
+							>
+								Prognozowana data FI
+							</div>
+							<div class="text-2xl font-bold">{month}/{year}</div>
+							<div class="text-xs text-surface-700-300">
+								~{fiYears.toFixed(1)} lat · oszczędności {formatPLN(monthlySavings)}/mies.
+							</div>
+						</div>
+						<div class="space-y-1">
+							<div class="text-xs text-surface-700-300">Lata do FI</div>
+							<div class="text-2xl font-bold">{fiYears.toFixed(1)}</div>
+							<div class="text-xs text-surface-700-300">
+								przy {coastReturnPct}%/rok zwrotu i bieżących wpłatach
+							</div>
+						</div>
+					</div>
+				{:else if monthlySavings == null && hasBase}
+					<div class="pt-3 border-t border-surface-200-800 text-sm text-surface-700-300">
+						<div class="font-semibold mb-1">Prognozowana data FI</div>
+						<div class="italic">
+							Wprowadź miesięczne oszczędności w
+							<a href="/settings/config" class="underline">konfiguracji</a>, aby zobaczyć datę FI.
 						</div>
 					</div>
 				{/if}

--- a/src/routes/settings/config/+page.svelte
+++ b/src/routes/settings/config/+page.svelte
@@ -74,6 +74,11 @@
 	let fatMonthlyExpenses = $state<number | null>(
 		config?.fat_monthly_expenses != null ? Number(config.fat_monthly_expenses) : null
 	);
+	// Monthly savings: drives the projected-FI-date metric. Null = empty
+	// state ("set monthly savings to see FI date"); backend hides the tile.
+	let monthlySavings = $state<number | null>(
+		config?.monthly_savings != null ? Number(config.monthly_savings) : null
+	);
 
 	let error = $state('');
 	let saving = $state(false);
@@ -143,7 +148,8 @@
 					expected_return_rate: expectedReturnRate,
 					barista_monthly_income: baristaMonthlyIncome,
 					lean_monthly_expenses: leanMonthlyExpenses,
-					fat_monthly_expenses: fatMonthlyExpenses
+					fat_monthly_expenses: fatMonthlyExpenses,
+					monthly_savings: monthlySavings
 				})
 			});
 
@@ -504,6 +510,38 @@
 				}}
 				class="input"
 			/>
+		</label>
+	</div>
+
+	<div class="card preset-filled-surface-100-900 p-4 space-y-4">
+		<header>
+			<h3 class="h3 flex items-center gap-2"><Flame size={20} /> Projekcja daty FI</h3>
+		</header>
+
+		<label class="label">
+			<span class="font-semibold text-sm">Miesięczne oszczędności (PLN)</span>
+			<input
+				id="monthly-savings"
+				type="number"
+				min="0"
+				step="100"
+				placeholder="np. 4000 (puste = ukryj kartę)"
+				value={monthlySavings ?? ''}
+				oninput={(e) => {
+					const v = (e.target as HTMLInputElement).value;
+					if (v === '') {
+						monthlySavings = null;
+						return;
+					}
+					const n = Number(v);
+					monthlySavings = Number.isNaN(n) ? null : n;
+				}}
+				class="input"
+			/>
+			<span class="text-xs italic text-surface-700-300">
+				Kwota odkładana co miesiąc. Razem z wartością netto, FIRE i oczekiwaną stopą zwrotu wyznacza
+				prognozowaną datę FI.
+			</span>
 		</label>
 	</div>
 


### PR DESCRIPTION
## Motivation

Closes #551. The dashboard already shows the FIRE number; users want to
know **when** they'd hit it. This adds a projected FI date + years-to-FI
tile driven by net worth, monthly savings, FIRE number, and the
configured expected return rate. When monthly savings isn't set, an empty
state explains what to configure rather than showing a misleading zero.

## Implementation information

**Config**
- New nullable column ``monthly_savings`` on ``app_config`` (schema baseline
  + ``ADD COLUMN IF NOT EXISTS`` migration). Validator extends the
  ``requireNonNegative`` bundle.

**Dashboard**
- ``addFIProjection`` in ``fire.go`` solves the annuity-future-value equation
  in closed form:
  ``t = ln((FIRE×r + S) / (NW×r + S)) / ln(1+r)``
  with linear ``(FIRE − NW) / S`` fallback when ``r ≤ 0`` and zero-years
  fast-path when ``NW ≥ FIRE``.
- Three new ``metric_cards`` fields: ``monthly_savings``,
  ``fi_years_remaining``, ``fi_projected_date`` (YYYY-MM string, naïve so
  no timezone shift).
- Returns early (nil) when savings is unset, ≤ 0, or FIRE number is
  missing — drives the frontend empty state.

**Frontend**
- Settings page adds a "Projekcja daty FI" section with the monthly-savings
  input (clearable; empty = null).
- Dashboard FIRE card renders a 2-column FI-date / years-to-FI tile when
  the projection is complete, or an italic empty-state link to settings
  when only ``monthly_savings`` is missing.

**Tests**
- Unit tests cover happy path, r=0 linear, already-at-FI, no-savings,
  zero-savings, no-FIRE-number.
- Golden config_get updated.
- Backend ``go test`` / ``golangci-lint``: green.
- Frontend ``npm run check`` / ``lint`` / ``test``: green.
- Black-box pytest: 149 passed, 1 skipped.

> Changelog: feat(fire): project FI date from savings + assets