### PR TITLE
feat(rules): source PL rule metadata

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -6319,6 +6319,68 @@
         ]
       }
     },
+    "/api/rules": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "rules": {
+                      "items": {
+                        "properties": {
+                          "category": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "effective_date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "last_checked_date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "source_url": {
+                            "type": "string"
+                          },
+                          "unit": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          },
+                          "year": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List Polish financial constants with source metadata",
+        "tags": [
+          "rules"
+        ]
+      }
+    },
     "/api/salaries": {
       "get": {
         "responses": {

--- a/backend-bb-tests/tests/test_rules.py
+++ b/backend-bb-tests/tests/test_rules.py
@@ -1,0 +1,49 @@
+"""Smoke tests for /api/rules — Polish constants metadata endpoint."""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+
+
+def test_rules_returns_metadata_shape(client: httpx.Client) -> None:
+    r = client.get("/api/rules")
+    assert r.status_code == 200, r.text
+    rules = r.json().get("rules", [])
+    assert len(rules) > 0
+    required = {
+        "key",
+        "name",
+        "category",
+        "value",
+        "unit",
+        "year",
+        "effective_date",
+        "source_url",
+        "last_checked_date",
+        "description",
+    }
+    for row in rules:
+        missing = required - row.keys()
+        assert not missing, f"rule {row.get('key')!r} missing {sorted(missing)}"
+        # Source URL must be an https link, never blank.
+        assert row["source_url"].startswith("https://"), row
+        # Dates must be naive YYYY-MM-DD.
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", row["effective_date"]), row
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", row["last_checked_date"]), row
+
+
+def test_rules_filter_by_category(client: httpx.Client) -> None:
+    r = client.get("/api/rules", params={"category": "ike_limit"})
+    assert r.status_code == 200, r.text
+    rules = r.json()["rules"]
+    assert len(rules) >= 1
+    for row in rules:
+        assert row["category"] == "ike_limit"
+
+
+def test_rules_unknown_category_returns_empty(client: httpx.Client) -> None:
+    r = client.get("/api/rules", params={"category": "bogus"})
+    assert r.status_code == 200, r.text
+    assert r.json()["rules"] == []

--- a/backend-go/cmd/gen-openapi/main.go
+++ b/backend-go/cmd/gen-openapi/main.go
@@ -166,7 +166,7 @@ func customizeScalar(_ string, t reflect.Type, _ reflect.StructTag, schema *open
 	case "pyFloat":
 		schema.Type = &openapi3.Types{"number"}
 		schema.Properties = nil
-	case "moneyJSON", "ppkRate", "rateJSON":
+	case "moneyJSON", "ppkRate", "rateJSON", "dimString":
 		schema.Type = &openapi3.Types{"string"}
 		schema.Properties = nil
 	case "isoDate":

--- a/backend-go/cmd/gen-openapi/routes.go
+++ b/backend-go/cmd/gen-openapi/routes.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/investment"
 	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
+	"github.com/Automaat/finance-buddy/backend-go/internal/rules"
 	"github.com/Automaat/finance-buddy/backend-go/internal/salaries"
 	"github.com/Automaat/finance-buddy/backend-go/internal/scenarios"
 	"github.com/Automaat/finance-buddy/backend-go/internal/simulations"
@@ -62,6 +63,7 @@ func allRoutes() []apispec.Route {
 		holdings.APISpec,
 		simulations.APISpec,
 		scenarios.APISpec,
+		rules.APISpec,
 		transactions.APISpec,
 		recurring.APISpec,
 		debtpayments.APISpec,

--- a/backend-go/internal/rules/handler.go
+++ b/backend-go/internal/rules/handler.go
@@ -1,0 +1,101 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// ruleWire mirrors a Rule on the JSON wire. Money/% values are quoted
+// strings (matches the rest of the codebase's decimal serialization
+// convention); dates are YYYY-MM-DD without timezone suffix.
+type ruleWire struct {
+	Key             string    `json:"key"`
+	Name            string    `json:"name"`
+	Category        string    `json:"category"`
+	Value           dimString `json:"value"`
+	Unit            string    `json:"unit"`
+	Year            int       `json:"year"`
+	EffectiveDate   isoDate   `json:"effective_date"`
+	SourceURL       string    `json:"source_url"`
+	LastCheckedDate isoDate   `json:"last_checked_date"`
+	Description     string    `json:"description"`
+}
+
+type listResponse struct {
+	Rules []ruleWire `json:"rules"`
+}
+
+// Handler is the HTTP boundary for /api/rules.
+type Handler struct {
+	logger *slog.Logger
+}
+
+// NewHandler wires the logger. No DB dependency — rules are code-defined.
+func NewHandler(logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{logger: logger}
+}
+
+// List serves GET /api/rules. Optional `?category=` filter restricts to
+// a single bucket (e.g. "ike_limit", "pit"); unknown categories return an
+// empty list rather than an error so the UI can probe without 422s.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	category := strings.TrimSpace(r.URL.Query().Get("category"))
+	var src []Rule
+	if category != "" {
+		src = ByCategory(category)
+	} else {
+		src = All()
+	}
+	out := make([]ruleWire, 0, len(src))
+	for i := range src {
+		out = append(out, toWire(&src[i]))
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(listResponse{Rules: out}); err != nil {
+		h.logger.Error("encode rules", "err", err)
+	}
+}
+
+func toWire(r *Rule) ruleWire {
+	return ruleWire{
+		Key:             r.Key,
+		Name:            r.Name,
+		Category:        r.Category,
+		Value:           dimString(r.Value),
+		Unit:            r.Unit,
+		Year:            r.Year,
+		EffectiveDate:   isoDate(r.EffectiveDate),
+		SourceURL:       r.SourceURL,
+		LastCheckedDate: isoDate(r.LastCheckedDate),
+		Description:     r.Description,
+	}
+}
+
+// dimString marshals a decimal.Decimal as a JSON string preserving its
+// stored precision (e.g. "28260", "0.12"). Distinct from the moneyJSON
+// helper elsewhere because we don't want forced 2-decimal padding — these
+// rules carry both monetary and percentage values.
+type dimString decimal.Decimal
+
+func (d dimString) MarshalJSON() ([]byte, error) {
+	v := decimal.Decimal(d)
+	return fmt.Appendf(nil, "%q", v.String()), nil
+}
+
+// isoDate marshals a time.Time as "YYYY-MM-DD" — naïve, no zone suffix,
+// matches the wire convention used by /api/config etc.
+type isoDate time.Time
+
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return fmt.Appendf(nil, "%q", time.Time(d).Format("2006-01-02")), nil
+}

--- a/backend-go/internal/rules/openapi.go
+++ b/backend-go/internal/rules/openapi.go
@@ -1,0 +1,12 @@
+package rules
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{
+		Method: "GET", Path: "/api/rules", Tag: "rules",
+		Summary:  "List Polish financial constants with source metadata",
+		Response: listResponse{},
+	},
+}

--- a/backend-go/internal/rules/rules.go
+++ b/backend-go/internal/rules/rules.go
@@ -1,0 +1,214 @@
+// Package rules is the typed source-of-truth for Polish financial constants
+// (PIT thresholds, PPK / IKE / IKZE limits, minimum wage, withholding tax)
+// surfaced to the UI alongside their citation metadata.
+//
+// Each rule carries the source URL, effective date, and last-checked date so
+// the simulations / settings views can show "where does this number come
+// from" — see issue #553. Issue #545 layers on top, replacing the duplicate
+// numeric literals scattered through the codebase with imports from here.
+package rules
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Rule describes one Polish financial constant with citation metadata.
+//
+// All exported fields are JSON-marshalable; see handler.go for the wire
+// shape. `Value` is a decimal.Decimal so percentage rates and money limits
+// keep exact precision (no float drift between input data and the form
+// that displays them).
+type Rule struct {
+	// Key is the stable code-side identifier (e.g. "ike_limit_2026") used
+	// by other Go packages that want to reference this rule. Doesn't change
+	// across years — see Year + EffectiveDate for the time anchor.
+	Key string
+
+	// Name is the short Polish-language label shown in the UI.
+	Name string
+
+	// Category groups related rules so the UI can render them in sections
+	// (e.g. "ike_limit", "pit", "ppk", "minimum_wage").
+	Category string
+
+	// Value is the canonical number. Unit explains what the number means
+	// (PLN, PLN/month, %, etc.) so the UI doesn't have to guess.
+	Value decimal.Decimal
+	Unit  string
+
+	// Year + EffectiveDate locate the rule in time. Year is the calendar
+	// year the rule applies to; EffectiveDate is when it took effect (may
+	// be mid-year for tax changes).
+	Year          int
+	EffectiveDate time.Time
+
+	// SourceURL points at the official source (sejm.gov.pl, mf.gov.pl,
+	// gov.pl, ZUS, etc.). LastCheckedDate is the date a maintainer last
+	// verified the value still matches the source.
+	SourceURL       string
+	LastCheckedDate time.Time
+
+	// Description is a longer Polish-language note explaining what the
+	// rule covers (e.g. "annual contribution cap for IKE accounts").
+	Description string
+}
+
+// lastChecked is the most-recent date a maintainer eyeballed the source
+// pages and confirmed each value below. Bumped in lockstep with PR review
+// when refreshing the table.
+var lastChecked = time.Date(2026, time.May, 24, 0, 0, 0, 0, time.UTC)
+
+// jan2026 is the EffectiveDate every 2026-anchored rule below uses (Polish
+// tax/contribution rules typically take effect on Jan 1). Pulled out so the
+// table reads as data rather than repeated time.Date calls.
+var jan2026 = time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// Polish2026 is the curated, year-anchored snapshot of Polish financial
+// constants used by the simulations and dashboard. The list is intentionally
+// short — it's the constants the app actually reads, not an exhaustive
+// gov.pl mirror. Add a row when another module starts depending on a
+// hand-coded literal; remove it only after every caller has migrated.
+var Polish2026 = []Rule{
+	{
+		Key:             "ike_limit_2026",
+		Name:            "Roczny limit wpłat IKE",
+		Category:        "ike_limit",
+		Value:           decimal.NewFromInt(28260),
+		Unit:            "PLN",
+		Year:            2026,
+		EffectiveDate:   jan2026,
+		SourceURL:       "https://www.gov.pl/web/finanse/limity-wplat-na-ike-i-ikze",
+		LastCheckedDate: lastChecked,
+		Description:     "Maksymalna roczna wpłata na konto IKE w 2026 r.",
+	},
+	{
+		Key:             "ikze_limit_2026",
+		Name:            "Roczny limit wpłat IKZE",
+		Category:        "ikze_limit",
+		Value:           decimal.NewFromInt(11304),
+		Unit:            "PLN",
+		Year:            2026,
+		EffectiveDate:   jan2026,
+		SourceURL:       "https://www.gov.pl/web/finanse/limity-wplat-na-ike-i-ikze",
+		LastCheckedDate: lastChecked,
+		Description:     "Maksymalna roczna wpłata na konto IKZE w 2026 r.",
+	},
+	{
+		Key:             "ikze_limit_b2b_2026",
+		Name:            "Roczny limit IKZE (samozatrudnieni)",
+		Category:        "ikze_limit",
+		Value:           decimal.NewFromInt(16956),
+		Unit:            "PLN",
+		Year:            2026,
+		EffectiveDate:   jan2026,
+		SourceURL:       "https://www.gov.pl/web/finanse/limity-wplat-na-ike-i-ikze",
+		LastCheckedDate: lastChecked,
+		Description:     "Podwyższony limit dla osób prowadzących pozarolniczą działalność gospodarczą.",
+	},
+	{
+		Key:             "ppk_below_threshold_2026",
+		Name:            "Próg wynagrodzenia PPK (1,2× minimalnej krajowej)",
+		Category:        "ppk",
+		Value:           decimal.NewFromInt(5767),
+		Unit:            "PLN/miesiąc",
+		Year:            2026,
+		EffectiveDate:   jan2026,
+		SourceURL:       "https://www.mojeppk.pl/",
+		LastCheckedDate: lastChecked,
+		Description:     "Pracownik zarabiający poniżej tego progu może obniżyć składkę pracownika z 2% do 0,5%.",
+	},
+	{
+		Key:             "minimum_wage_2026",
+		Name:            "Płaca minimalna brutto",
+		Category:        "minimum_wage",
+		Value:           decimal.NewFromInt(4806),
+		Unit:            "PLN/miesiąc",
+		Year:            2026,
+		EffectiveDate:   jan2026,
+		SourceURL:       "https://www.gov.pl/web/rodzina/place-minimalna",
+		LastCheckedDate: lastChecked,
+		Description:     "Minimalne wynagrodzenie obowiązujące w 2026 r.",
+	},
+	{
+		Key:             "pit_threshold_first_2026",
+		Name:            "Próg pierwszego progu PIT",
+		Category:        "pit",
+		Value:           decimal.NewFromInt(120000),
+		Unit:            "PLN",
+		Year:            2026,
+		EffectiveDate:   jan2026,
+		SourceURL:       "https://www.podatki.gov.pl/pit/abc-pit/skala-podatkowa/",
+		LastCheckedDate: lastChecked,
+		Description:     "Dochód, po przekroczeniu którego stosuje się drugi próg skali PIT.",
+	},
+	{
+		Key:             "pit_rate_first_2026",
+		Name:            "Stawka PIT — pierwszy próg",
+		Category:        "pit",
+		Value:           decimal.RequireFromString("0.12"),
+		Unit:            "udział",
+		Year:            2026,
+		EffectiveDate:   jan2026,
+		SourceURL:       "https://www.podatki.gov.pl/pit/abc-pit/skala-podatkowa/",
+		LastCheckedDate: lastChecked,
+		Description:     "Skala podatkowa: 12% do progu, pomniejszone o kwotę wolną.",
+	},
+	{
+		Key:             "pit_rate_second_2026",
+		Name:            "Stawka PIT — drugi próg",
+		Category:        "pit",
+		Value:           decimal.RequireFromString("0.32"),
+		Unit:            "udział",
+		Year:            2026,
+		EffectiveDate:   jan2026,
+		SourceURL:       "https://www.podatki.gov.pl/pit/abc-pit/skala-podatkowa/",
+		LastCheckedDate: lastChecked,
+		Description:     "Stawka stosowana do dochodu powyżej pierwszego progu.",
+	},
+	{
+		Key:             "capital_gains_tax_2026",
+		Name:            "Podatek Belki (od zysków kapitałowych)",
+		Category:        "capital_gains",
+		Value:           decimal.RequireFromString("0.19"),
+		Unit:            "udział",
+		Year:            2026,
+		EffectiveDate:   jan2026,
+		SourceURL:       "https://www.podatki.gov.pl/pit/abc-pit/podatki-od-zyskow-kapitalowych/",
+		LastCheckedDate: lastChecked,
+		Description:     "Zryczałtowany podatek od zysków z inwestycji (oszczędności, akcje, fundusze).",
+	},
+}
+
+// Get returns the rule for the given Key, or false if no rule matches.
+// Callers in other packages use this to swap hand-coded literals for
+// metadata-backed constants without round-tripping through the API.
+func Get(key string) (Rule, bool) {
+	for i := range Polish2026 {
+		if Polish2026[i].Key == key {
+			return Polish2026[i], true
+		}
+	}
+	return Rule{}, false
+}
+
+// All returns a defensive copy of the Polish2026 list so callers can sort
+// or filter it without mutating the package-level table.
+func All() []Rule {
+	out := make([]Rule, len(Polish2026))
+	copy(out, Polish2026)
+	return out
+}
+
+// ByCategory returns every rule whose Category matches. Preserves the
+// declaration order from Polish2026.
+func ByCategory(category string) []Rule {
+	out := make([]Rule, 0)
+	for i := range Polish2026 {
+		if Polish2026[i].Category == category {
+			out = append(out, Polish2026[i])
+		}
+	}
+	return out
+}

--- a/backend-go/internal/rules/rules_test.go
+++ b/backend-go/internal/rules/rules_test.go
@@ -1,0 +1,176 @@
+package rules
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAllReturnsDefensiveCopy(t *testing.T) {
+	t.Parallel()
+	first := All()
+	if len(first) == 0 {
+		t.Fatal("expected at least one rule")
+	}
+	origName := first[0].Name
+	first[0].Name = "MUTATED"
+	second := All()
+	if second[0].Name == "MUTATED" {
+		t.Errorf("All() must return a defensive copy — mutation leaked back to Polish2026 (orig %q)", origName)
+	}
+}
+
+func TestRuleKeysAreUnique(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]struct{}, len(Polish2026))
+	for i := range Polish2026 {
+		k := Polish2026[i].Key
+		if _, dup := seen[k]; dup {
+			t.Errorf("duplicate Key %q in Polish2026", k)
+		}
+		seen[k] = struct{}{}
+	}
+}
+
+func TestGetByKey(t *testing.T) {
+	t.Parallel()
+	r, ok := Get("ike_limit_2026")
+	if !ok {
+		t.Fatal("ike_limit_2026 must resolve")
+	}
+	if r.Category != "ike_limit" {
+		t.Errorf("category = %q, want ike_limit", r.Category)
+	}
+	if _, ok := Get("nope"); ok {
+		t.Error("unknown key must return ok=false")
+	}
+}
+
+func TestByCategoryFiltersAndPreservesOrder(t *testing.T) {
+	t.Parallel()
+	pit := ByCategory("pit")
+	if len(pit) < 2 {
+		t.Fatalf("expected at least 2 pit rules, got %d", len(pit))
+	}
+	for _, r := range pit {
+		if r.Category != "pit" {
+			t.Errorf("ByCategory leaked %q row", r.Category)
+		}
+	}
+}
+
+// decodeRawList decodes the wire payload into the loose map[string]any
+// shape so the test doesn't depend on dimString/isoDate UnmarshalJSON
+// implementations (they're write-only on purpose).
+func decodeRawList(t *testing.T, payload []byte) []map[string]any {
+	t.Helper()
+	var raw struct {
+		Rules []map[string]any `json:"rules"`
+	}
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return raw.Rules
+}
+
+func TestHandlerListReturnsAllRules(t *testing.T) {
+	t.Parallel()
+	h := NewHandler(nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/rules", http.NoBody)
+	rec := httptest.NewRecorder()
+	h.List(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	rows := decodeRawList(t, rec.Body.Bytes())
+	if len(rows) != len(Polish2026) {
+		t.Errorf("rules = %d, want %d", len(rows), len(Polish2026))
+	}
+}
+
+func TestHandlerListFiltersByCategory(t *testing.T) {
+	t.Parallel()
+	h := NewHandler(nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/rules?category=pit", http.NoBody)
+	rec := httptest.NewRecorder()
+	h.List(rec, req)
+	rows := decodeRawList(t, rec.Body.Bytes())
+	for _, r := range rows {
+		if r["category"] != "pit" {
+			t.Errorf("got non-pit row: %+v", r)
+		}
+	}
+}
+
+func TestHandlerListUnknownCategoryReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	h := NewHandler(nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/rules?category=bogus", http.NoBody)
+	rec := httptest.NewRecorder()
+	h.List(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (probing must not 422)", rec.Code)
+	}
+	rows := decodeRawList(t, rec.Body.Bytes())
+	if len(rows) != 0 {
+		t.Errorf("unknown category should return empty, got %d", len(rows))
+	}
+}
+
+// TestSerializationMetadataShape is the contract test the issue asks for:
+// every wire row must carry the four metadata fields the UI needs
+// (source_url, effective_date, last_checked_date, year), plus value/unit.
+func TestSerializationMetadataShape(t *testing.T) {
+	t.Parallel()
+	h := NewHandler(nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/rules", http.NoBody)
+	rec := httptest.NewRecorder()
+	h.List(rec, req)
+	var raw struct {
+		Rules []map[string]any `json:"rules"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(raw.Rules) == 0 {
+		t.Fatal("expected at least one rule")
+	}
+	required := []string{
+		"key", "name", "category", "value", "unit", "year",
+		"effective_date", "source_url", "last_checked_date", "description",
+	}
+	for _, row := range raw.Rules {
+		for _, k := range required {
+			if _, ok := row[k]; !ok {
+				t.Errorf("rule %v missing field %q", row["key"], k)
+			}
+		}
+	}
+}
+
+// TestSerializationDateAndValueFormats guards the wire formats the UI
+// depends on: dates as YYYY-MM-DD (no zone), values as quoted strings so
+// JSON-number coercion can't lose precision.
+func TestSerializationDateAndValueFormats(t *testing.T) {
+	t.Parallel()
+	h := NewHandler(nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/rules?category=ike_limit", http.NoBody)
+	rec := httptest.NewRecorder()
+	h.List(rec, req)
+	body := rec.Body.String()
+	if !strings.Contains(body, `"value":"28260"`) {
+		t.Errorf("expected value to be quoted-string %q, got: %s", "28260", body)
+	}
+	if !strings.Contains(body, `"effective_date":"2026-01-01"`) {
+		t.Errorf("expected effective_date YYYY-MM-DD, got: %s", body)
+	}
+	if !strings.Contains(body, `"last_checked_date":"`) {
+		t.Errorf("expected last_checked_date string, got: %s", body)
+	}
+	// Source URL must be a https://gov.pl-family link, not blank.
+	if !strings.Contains(body, `"source_url":"https://`) {
+		t.Errorf("expected source_url to start with https://, got: %s", body)
+	}
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/investment"
 	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
+	"github.com/Automaat/finance-buddy/backend-go/internal/rules"
 	"github.com/Automaat/finance-buddy/backend-go/internal/salaries"
 	"github.com/Automaat/finance-buddy/backend-go/internal/scenarios"
 	"github.com/Automaat/finance-buddy/backend-go/internal/simulations"
@@ -203,6 +204,9 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	r.Put("/api/scenarios/{id}", scHandler.Update)
 	r.Delete("/api/scenarios/{id}", scHandler.Delete)
 	r.Post("/api/scenarios/{id}/clone", scHandler.Clone)
+
+	rulesHandler := rules.NewHandler(logger)
+	r.Get("/api/rules", rulesHandler.List)
 }
 
 func registerDashboardRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -4207,6 +4207,57 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/rules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Polish financial constants with source metadata */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rules?: {
+                                category?: string;
+                                description?: string;
+                                /** Format: date */
+                                effective_date?: string;
+                                key?: string;
+                                /** Format: date */
+                                last_checked_date?: string;
+                                name?: string;
+                                source_url?: string;
+                                unit?: string;
+                                value?: string;
+                                year?: number;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/salaries": {
         parameters: {
             query?: never;

--- a/src/routes/settings/config/+page.svelte
+++ b/src/routes/settings/config/+page.svelte
@@ -10,7 +10,9 @@
 		CheckCircle2,
 		AlertTriangle,
 		Gauge,
-		Flame
+		Flame,
+		BookOpen,
+		ExternalLink
 	} from 'lucide-svelte';
 	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
@@ -82,6 +84,33 @@
 
 	let error = $state('');
 	let saving = $state(false);
+
+	// Polish-rules sources (#553) — loaded once on mount, displayed read-only
+	// in a card at the bottom so users can audit where the app's hardcoded
+	// constants come from. Failure is silent: the card just stays hidden.
+	interface PLRule {
+		key: string;
+		name: string;
+		category: string;
+		value: string;
+		unit: string;
+		year: number;
+		effective_date: string;
+		source_url: string;
+		last_checked_date: string;
+		description: string;
+	}
+	let plRules: PLRule[] = $state([]);
+	$effect(() => {
+		fetch(`${apiUrl}/api/rules`)
+			.then((r) => (r.ok ? r.json() : { rules: [] }))
+			.then((b) => {
+				plRules = (b.rules ?? []) as PLRule[];
+			})
+			.catch(() => {
+				plRules = [];
+			});
+	});
 
 	const marketSum = $derived(
 		allocationStocks + allocationBonds + allocationGold + allocationCommodities
@@ -557,4 +586,57 @@
 	>
 		{saving ? 'Zapisywanie...' : 'Zapisz konfigurację'}
 	</button>
+
+	{#if plRules.length > 0}
+		<div class="card preset-filled-surface-100-900 p-4 space-y-3">
+			<header>
+				<h3 class="h3 flex items-center gap-2">
+					<BookOpen size={20} /> Źródła stałych PL ({plRules[0].year})
+				</h3>
+				<p class="text-xs italic text-surface-700-300 mt-1">
+					Polskie wartości graniczne używane przez symulacje i dashboard. Każda pozycja wskazuje
+					oficjalne źródło i datę ostatniej weryfikacji przez maintainera.
+				</p>
+			</header>
+			<div class="overflow-x-auto">
+				<table class="table w-full text-sm">
+					<thead>
+						<tr>
+							<th class="text-left">Nazwa</th>
+							<th class="text-right">Wartość</th>
+							<th class="text-left">Obowiązuje od</th>
+							<th class="text-left">Ostatnia weryfikacja</th>
+							<th class="text-left">Źródło</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each plRules as r (r.key)}
+							<tr>
+								<td>
+									<div class="font-semibold">{r.name}</div>
+									<div class="text-xs text-surface-700-300">{r.description}</div>
+								</td>
+								<td class="text-right whitespace-nowrap">
+									{r.value}
+									<span class="text-xs text-surface-700-300">{r.unit}</span>
+								</td>
+								<td class="whitespace-nowrap">{r.effective_date}</td>
+								<td class="whitespace-nowrap">{r.last_checked_date}</td>
+								<td>
+									<a
+										href={r.source_url}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="text-primary-600-400 underline inline-flex items-center gap-1"
+									>
+										link <ExternalLink size={12} />
+									</a>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	{/if}
 </div>


### PR DESCRIPTION
## Motivation

Closes #553. The app sprinkles Polish financial constants (IKE/IKZE limits,
PIT thresholds, PPK salary cap, minimum wage, capital-gains tax) through
the codebase without explaining where the numbers come from. This adds a
typed, citation-carrying source so users — and reviewers — can audit
"where does this 28,260 PLN figure come from" without grep-archaeology.
Sets the groundwork for #545 (centralize the literals).

## Implementation information

**Backend**
- New ``backend-go/internal/rules`` package with a ``Rule`` struct (key,
  name, category, value, unit, year, effective_date, source_url,
  last_checked_date, description) and a curated ``Polish2026`` table of 9
  constants. Helpers: ``Get(key)``, ``All()`` (defensive copy),
  ``ByCategory(category)``.
- ``GET /api/rules`` with optional ``?category=`` filter (unknown category
  returns empty, not 422 — UI can probe).
- OpenAPI registration + scalar override so ``dimString`` serializes as a
  quoted string on the wire (same convention as moneyJSON/rateJSON).

**Frontend**
- Settings page renders a read-only "Źródła stałych PL" table at the
  bottom with name + value/unit + effective_date + last_checked_date +
  source link (target=_blank rel=noopener noreferrer).

**Tests (acceptance bullet 3)**
- Go: ``rules_test.go`` covers Get/All/ByCategory, key uniqueness,
  serialization shape (every wire row exposes all 10 fields), date/value
  string formats, category filter, unknown-category empty.
- Black-box: ``test_rules.py`` smoke-tests the wire shape end-to-end.
- ``golangci-lint``, ``go test``, ``npm run check`` / ``lint`` / ``test``:
  green. ``backend-bb-tests``: 152 passed, 1 skipped.

> Changelog: feat(rules): source PL rule metadata