### PR TITLE
fix(recurring): use assets+liabilities

### DIFF
--- a/src/routes/recurring/+page.ts
+++ b/src/routes/recurring/+page.ts
@@ -40,9 +40,15 @@ export const load: PageLoad = async ({ fetch }) => {
 		throw error(accountsRes.status, 'Failed to load accounts');
 	}
 	const recurringData = (await recurringRes.json()) as { recurring: RecurringRow[] };
-	const accountsData = (await accountsRes.json()) as { accounts: AccountOption[] };
+	const accountsData = (await accountsRes.json()) as {
+		assets?: AccountOption[];
+		liabilities?: AccountOption[];
+	};
+	const accounts = [...(accountsData.assets ?? []), ...(accountsData.liabilities ?? [])].map(
+		(a) => ({ id: a.id, name: a.name })
+	);
 	return {
 		recurring: recurringData.recurring,
-		accounts: accountsData.accounts.map((a) => ({ id: a.id, name: a.name }))
+		accounts
 	};
 };


### PR DESCRIPTION
## Motivation

`/recurring` returned 500 on production. SvelteKit surfaced the SSR crash to
the browser console as `Cannot read properties of undefined (reading 'map')`
via `handleError`, leaving the page blank.

Root cause: `src/routes/recurring/+page.ts` typed the `/api/accounts`
response as `{ accounts: AccountOption[] }`, but the backend returns
`{ assets, liabilities }`. The load function then called
`accountsData.accounts.map(...)` on `undefined`.

## Implementation information

- Read `assets` and `liabilities` from the response, merge, then map to
  `{id, name}`.
- Matches the existing pattern in `transactions/+page.ts:47` and
  `snapshots/[id]/edit/+page.ts:32`.
- Recurring transactions can target any account (cash, loan payments,
  etc.), so merging both lists preserves intent — the previous shape was
  never correct, the dropdown was just empty when accounts existed only
  as assets/liabilities.

Alternatives discarded:
- Reshaping `/api/accounts` to also include a flat `accounts` array —
  rejected as broader scope and would still leave callers inconsistent.

## Supporting documentation

Reproduced on `https://finance.mskalski.dev/recurring` (home-nas prod);
network panel showed the document request returning 500.

> Changelog: fix(recurring): use assets+liabilities