### PR TITLE
feat(retirement): IKZE contribution optimizer

### DIFF
--- a/src/lib/components/IKZEOptimizer.svelte
+++ b/src/lib/components/IKZEOptimizer.svelte
@@ -74,6 +74,19 @@
 			limitOverride
 		});
 	}
+
+	function refundLabel(rate: number | null | undefined): string {
+		if (rate == null) return 'Szac. zwrot PIT (—)';
+		return `Szac. zwrot PIT (${formatPercent(rate * 100)})`;
+	}
+
+	function refundValue(
+		rate: number | null | undefined,
+		amount: number
+	): { text: string; hasRate: boolean } {
+		if (rate == null) return { text: '—', hasRate: false };
+		return { text: formatPLN(amount), hasRate: true };
+	}
 </script>
 
 <section class="card preset-filled-surface-100-900 p-5 space-y-4">
@@ -102,6 +115,7 @@
 				{@const key = String(row.owner_user_id ?? 'shared')}
 				{@const kind = limitKindByOwner[key] ?? 'employee'}
 				{@const rec = recommendationFor(row)}
+				{@const refund = refundValue(row.marginal_tax_rate, rec.refundEstimate)}
 				<article class="card preset-tonal-surface p-4 space-y-3">
 					<div class="flex items-center justify-between gap-2">
 						<div class="font-semibold flex items-center gap-2">
@@ -114,6 +128,7 @@
 								class="btn btn-sm {kind === 'employee'
 									? 'preset-filled-primary-500'
 									: 'preset-tonal-surface'}"
+								aria-pressed={kind === 'employee'}
 								onclick={() => setKind(key, 'employee')}
 							>
 								Pracownik
@@ -123,6 +138,7 @@
 								class="btn btn-sm {kind === 'b2b'
 									? 'preset-filled-primary-500'
 									: 'preset-tonal-surface'}"
+								aria-pressed={kind === 'b2b'}
 								onclick={() => setKind(key, 'b2b')}
 							>
 								B2B
@@ -144,10 +160,10 @@
 							<dd class="font-bold">{formatPLN(rec.monthlyTarget)}</dd>
 						</div>
 						<div>
-							<dt class="text-xs text-surface-600-400">
-								Szac. zwrot PIT ({formatPercent((row.marginal_tax_rate ?? 0) * 100)})
-							</dt>
-							<dd class="font-bold text-success-600-400">{formatPLN(rec.refundEstimate)}</dd>
+							<dt class="text-xs text-surface-600-400">{refundLabel(row.marginal_tax_rate)}</dt>
+							<dd class="font-bold {refund.hasRate ? 'text-success-600-400' : ''}">
+								{refund.text}
+							</dd>
 						</div>
 					</dl>
 

--- a/src/lib/components/IKZEOptimizer.svelte
+++ b/src/lib/components/IKZEOptimizer.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { resolveApiUrl } from '$lib/api';
+	import { formatPLN, formatPercent } from '$lib/utils/format';
+	import { ownerName, type OwnerOption } from '$lib/types/owners';
+	import { Calculator, Wallet } from 'lucide-svelte';
+	import { limitFromRules, optimizeIKZE, type IKZELimitKind } from '$lib/utils/ikzeOptimizer';
+
+	interface YearlyStat {
+		year: number;
+		account_wrapper: string;
+		owner_user_id: number | null;
+		limit_amount: number | null;
+		total_contributed: number;
+		marginal_tax_rate: number | null;
+	}
+
+	let stats = $state<YearlyStat[]>([]);
+	let owners = $state<OwnerOption[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+	let limitKindByOwner = $state<Record<string, IKZELimitKind>>({});
+
+	const currentYear = new Date().getFullYear();
+	const ikzeRows = $derived(stats.filter((s) => s.account_wrapper === 'IKZE'));
+
+	onMount(async () => {
+		try {
+			const apiUrl = resolveApiUrl();
+			const [statsRes, ownersRes] = await Promise.all([
+				fetch(`${apiUrl}/api/retirement/stats?year=${currentYear}`),
+				fetch(`${apiUrl}/api/users`)
+			]);
+			if (!statsRes.ok) throw new Error(`Stats failed: ${statsRes.statusText}`);
+			stats = await statsRes.json();
+			owners = ownersRes.ok ? await ownersRes.json() : [];
+			// Seed each row to the limit kind that matches the configured limit
+			// — if the user already set the B2B amount, default the toggle there.
+			const seeds: Record<string, IKZELimitKind> = {};
+			const b2bLimit = limitFromRules(currentYear, 'b2b');
+			for (const row of ikzeRows) {
+				const key = String(row.owner_user_id ?? 'shared');
+				seeds[key] =
+					row.limit_amount != null && b2bLimit != null && row.limit_amount >= b2bLimit
+						? 'b2b'
+						: 'employee';
+			}
+			limitKindByOwner = seeds;
+		} catch (err) {
+			if (err instanceof Error) error = err.message;
+		} finally {
+			loading = false;
+		}
+	});
+
+	function setKind(key: string, kind: IKZELimitKind) {
+		limitKindByOwner = { ...limitKindByOwner, [key]: kind };
+	}
+
+	function recommendationFor(row: YearlyStat) {
+		const key = String(row.owner_user_id ?? 'shared');
+		const kind = limitKindByOwner[key] ?? 'employee';
+		const ruleLimit = limitFromRules(currentYear, kind);
+		// Fall back to the configured limit when rules table lacks the year
+		// (e.g. historical snapshots) — keeps the optimizer useful in tests
+		// and seeded fixtures.
+		const limitOverride =
+			ruleLimit == null && row.limit_amount != null ? row.limit_amount : undefined;
+		return optimizeIKZE({
+			year: currentYear,
+			limitKind: kind,
+			alreadyContributed: row.total_contributed,
+			marginalTaxRate: row.marginal_tax_rate ?? 0,
+			limitOverride
+		});
+	}
+</script>
+
+<section class="card preset-filled-surface-100-900 p-5 space-y-4">
+	<header class="space-y-1">
+		<h2 class="h4 flex items-center gap-2">
+			<Calculator size={20} class="text-primary-500" />
+			Optymalizator wpłat IKZE
+		</h2>
+		<p class="text-sm text-surface-700-300">
+			Ile dopłacić w {currentYear}, aby maksymalnie wykorzystać limit IKZE i ulgę PIT.
+		</p>
+	</header>
+
+	{#if loading}
+		<p class="text-sm text-surface-700-300">Ładowanie…</p>
+	{:else if error}
+		<div class="card preset-tonal-error p-3 text-sm">{error}</div>
+	{:else if ikzeRows.length === 0}
+		<p class="text-sm text-surface-700-300">
+			Brak kont IKZE w bieżącym roku — dodaj konto i transakcje, aby zobaczyć rekomendację.
+		</p>
+	{:else}
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+			{#each ikzeRows as row (row.owner_user_id ?? 'shared')}
+				{@const label = ownerName(owners, row.owner_user_id)}
+				{@const key = String(row.owner_user_id ?? 'shared')}
+				{@const kind = limitKindByOwner[key] ?? 'employee'}
+				{@const rec = recommendationFor(row)}
+				<article class="card preset-tonal-surface p-4 space-y-3">
+					<div class="flex items-center justify-between gap-2">
+						<div class="font-semibold flex items-center gap-2">
+							<Wallet size={16} class="text-primary-500" />
+							{label}
+						</div>
+						<div class="flex gap-1" role="group" aria-label="Wariant limitu IKZE">
+							<button
+								type="button"
+								class="btn btn-sm {kind === 'employee'
+									? 'preset-filled-primary-500'
+									: 'preset-tonal-surface'}"
+								onclick={() => setKind(key, 'employee')}
+							>
+								Pracownik
+							</button>
+							<button
+								type="button"
+								class="btn btn-sm {kind === 'b2b'
+									? 'preset-filled-primary-500'
+									: 'preset-tonal-surface'}"
+								onclick={() => setKind(key, 'b2b')}
+							>
+								B2B
+							</button>
+						</div>
+					</div>
+
+					<dl class="grid grid-cols-2 gap-2 text-sm">
+						<div>
+							<dt class="text-xs text-surface-600-400">Cel roczny</dt>
+							<dd class="font-bold">{formatPLN(rec.annualTarget)}</dd>
+						</div>
+						<div>
+							<dt class="text-xs text-surface-600-400">Wpłacono</dt>
+							<dd class="font-bold">{formatPLN(row.total_contributed)}</dd>
+						</div>
+						<div>
+							<dt class="text-xs text-surface-600-400">Cel miesięczny</dt>
+							<dd class="font-bold">{formatPLN(rec.monthlyTarget)}</dd>
+						</div>
+						<div>
+							<dt class="text-xs text-surface-600-400">
+								Szac. zwrot PIT ({formatPercent((row.marginal_tax_rate ?? 0) * 100)})
+							</dt>
+							<dd class="font-bold text-success-600-400">{formatPLN(rec.refundEstimate)}</dd>
+						</div>
+					</dl>
+
+					<p class="text-xs text-surface-600-400">
+						{#if rec.monthsLeft === 0}
+							Rok zakończony — zaktualizuj wartości lub przejdź do nowego roku.
+						{:else if rec.remaining === 0}
+							Limit wyczerpany — gratulacje, ulga w pełni wykorzystana.
+						{:else}
+							Pozostało {rec.monthsLeft} mies. × {formatPLN(rec.monthlyTarget)} = {formatPLN(
+								rec.remaining
+							)}.
+						{/if}
+					</p>
+				</article>
+			{/each}
+		</div>
+	{/if}
+</section>

--- a/src/lib/utils/ikzeOptimizer.test.ts
+++ b/src/lib/utils/ikzeOptimizer.test.ts
@@ -46,6 +46,7 @@ describe('optimizeIKZE', () => {
 		expect(result.monthsLeft).toBe(12);
 		expect(result.monthlyTarget).toBeCloseTo(942, 0);
 		expect(result.refundEstimate).toBeCloseTo(11304 * 0.32, 2);
+		expect(result.annualRefund).toBeCloseTo(11304 * 0.32, 2);
 	});
 
 	it('subtracts already contributed amounts from the monthly target', () => {
@@ -59,7 +60,9 @@ describe('optimizeIKZE', () => {
 		expect(result.remaining).toBe(6000);
 		expect(result.monthsLeft).toBe(7);
 		expect(result.monthlyTarget).toBeCloseTo(6000 / 7, 2);
-		expect(result.refundEstimate).toBeCloseTo(11304 * 0.12, 2);
+		// refundEstimate is the *remaining* upside, not the full-year refund.
+		expect(result.refundEstimate).toBeCloseTo(6000 * 0.12, 2);
+		expect(result.annualRefund).toBeCloseTo(11304 * 0.12, 2);
 	});
 
 	it('uses the B2B limit when requested', () => {
@@ -72,6 +75,20 @@ describe('optimizeIKZE', () => {
 		});
 		expect(result.annualTarget).toBe(16956);
 		expect(result.refundEstimate).toBeCloseTo(16956 * 0.19, 2);
+		expect(result.annualRefund).toBeCloseTo(16956 * 0.19, 2);
+	});
+
+	it('reports zero refundEstimate once the limit is fully used', () => {
+		const result = optimizeIKZE({
+			year: 2026,
+			limitKind: 'employee',
+			alreadyContributed: 11304,
+			marginalTaxRate: 0.32,
+			now: new Date(2026, 0, 1)
+		});
+		expect(result.remaining).toBe(0);
+		expect(result.refundEstimate).toBe(0);
+		expect(result.annualRefund).toBeCloseTo(11304 * 0.32, 2);
 	});
 
 	it('clamps already contributed at the limit (remaining never negative)', () => {

--- a/src/lib/utils/ikzeOptimizer.test.ts
+++ b/src/lib/utils/ikzeOptimizer.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { limitFromRules, monthsLeftIn, optimizeIKZE } from './ikzeOptimizer';
+
+describe('limitFromRules', () => {
+	it('returns employee IKZE limit for known year', () => {
+		expect(limitFromRules(2026, 'employee')).toBe(11304);
+	});
+
+	it('returns B2B IKZE limit for known year', () => {
+		expect(limitFromRules(2026, 'b2b')).toBe(16956);
+	});
+
+	it('returns null for unknown year', () => {
+		expect(limitFromRules(1999, 'employee')).toBeNull();
+	});
+});
+
+describe('monthsLeftIn', () => {
+	it('returns 12 when current date is before the target year', () => {
+		expect(monthsLeftIn(2027, new Date(2026, 5, 1))).toBe(12);
+	});
+
+	it('returns 0 when current date is after the target year', () => {
+		expect(monthsLeftIn(2025, new Date(2026, 5, 1))).toBe(0);
+	});
+
+	it('returns 12 in January of the target year', () => {
+		expect(monthsLeftIn(2026, new Date(2026, 0, 15))).toBe(12);
+	});
+
+	it('returns 1 in December of the target year', () => {
+		expect(monthsLeftIn(2026, new Date(2026, 11, 31))).toBe(1);
+	});
+});
+
+describe('optimizeIKZE', () => {
+	it('splits remaining limit across remaining months', () => {
+		const result = optimizeIKZE({
+			year: 2026,
+			limitKind: 'employee',
+			alreadyContributed: 0,
+			marginalTaxRate: 0.32,
+			now: new Date(2026, 0, 1)
+		});
+		expect(result.annualTarget).toBe(11304);
+		expect(result.monthsLeft).toBe(12);
+		expect(result.monthlyTarget).toBeCloseTo(942, 0);
+		expect(result.refundEstimate).toBeCloseTo(11304 * 0.32, 2);
+	});
+
+	it('subtracts already contributed amounts from the monthly target', () => {
+		const result = optimizeIKZE({
+			year: 2026,
+			limitKind: 'employee',
+			alreadyContributed: 5304,
+			marginalTaxRate: 0.12,
+			now: new Date(2026, 5, 1)
+		});
+		expect(result.remaining).toBe(6000);
+		expect(result.monthsLeft).toBe(7);
+		expect(result.monthlyTarget).toBeCloseTo(6000 / 7, 2);
+		expect(result.refundEstimate).toBeCloseTo(11304 * 0.12, 2);
+	});
+
+	it('uses the B2B limit when requested', () => {
+		const result = optimizeIKZE({
+			year: 2026,
+			limitKind: 'b2b',
+			alreadyContributed: 0,
+			marginalTaxRate: 0.19,
+			now: new Date(2026, 0, 1)
+		});
+		expect(result.annualTarget).toBe(16956);
+		expect(result.refundEstimate).toBeCloseTo(16956 * 0.19, 2);
+	});
+
+	it('clamps already contributed at the limit (remaining never negative)', () => {
+		const result = optimizeIKZE({
+			year: 2026,
+			limitKind: 'employee',
+			alreadyContributed: 20000,
+			marginalTaxRate: 0.12,
+			now: new Date(2026, 5, 1)
+		});
+		expect(result.remaining).toBe(0);
+		expect(result.monthlyTarget).toBe(0);
+	});
+
+	it('returns zero monthly target after the year ends', () => {
+		const result = optimizeIKZE({
+			year: 2025,
+			limitKind: 'employee',
+			alreadyContributed: 1000,
+			marginalTaxRate: 0.12,
+			now: new Date(2026, 1, 1),
+			limitOverride: 9388
+		});
+		expect(result.monthsLeft).toBe(0);
+		expect(result.monthlyTarget).toBe(0);
+	});
+
+	it('honors limit overrides for historical years missing from rules', () => {
+		const result = optimizeIKZE({
+			year: 2024,
+			limitKind: 'employee',
+			alreadyContributed: 0,
+			marginalTaxRate: 0.32,
+			now: new Date(2024, 0, 1),
+			limitOverride: 9388.8
+		});
+		expect(result.annualTarget).toBe(9388.8);
+		expect(result.limitSource).toBe('override');
+	});
+});

--- a/src/lib/utils/ikzeOptimizer.ts
+++ b/src/lib/utils/ikzeOptimizer.ts
@@ -1,0 +1,53 @@
+import { PL_RULES } from './pl_rules.generated';
+
+export type IKZELimitKind = 'employee' | 'b2b';
+
+export interface IKZEOptimizerInput {
+	year: number;
+	limitKind: IKZELimitKind;
+	alreadyContributed: number;
+	marginalTaxRate: number;
+	now?: Date;
+	limitOverride?: number;
+}
+
+export interface IKZEOptimizerResult {
+	annualTarget: number;
+	remaining: number;
+	monthlyTarget: number;
+	monthsLeft: number;
+	refundEstimate: number;
+	limitSource: 'rule' | 'override';
+}
+
+export function limitFromRules(year: number, kind: IKZELimitKind): number | null {
+	const key = kind === 'b2b' ? `ikze_limit_b2b_${year}` : `ikze_limit_${year}`;
+	const rule = (PL_RULES as Record<string, { value: number }>)[key];
+	return rule ? rule.value : null;
+}
+
+export function monthsLeftIn(year: number, now: Date): number {
+	if (now.getFullYear() < year) return 12;
+	if (now.getFullYear() > year) return 0;
+	return 12 - now.getMonth();
+}
+
+export function optimizeIKZE(input: IKZEOptimizerInput): IKZEOptimizerResult {
+	const now = input.now ?? new Date();
+	const ruleLimit = limitFromRules(input.year, input.limitKind);
+	const limit = input.limitOverride ?? ruleLimit ?? 0;
+	const annualTarget = Math.max(0, limit);
+	const contributed = Math.max(0, input.alreadyContributed);
+	const remaining = Math.max(0, annualTarget - contributed);
+	const monthsLeft = monthsLeftIn(input.year, now);
+	const monthlyTarget = monthsLeft > 0 ? remaining / monthsLeft : 0;
+	const refundEstimate = annualTarget * Math.max(0, input.marginalTaxRate);
+	return {
+		annualTarget,
+		remaining,
+		monthlyTarget,
+		monthsLeft,
+		refundEstimate,
+		limitSource: input.limitOverride != null ? 'override' : 'rule'
+	};
+}

--- a/src/lib/utils/ikzeOptimizer.ts
+++ b/src/lib/utils/ikzeOptimizer.ts
@@ -16,7 +16,14 @@ export interface IKZEOptimizerResult {
 	remaining: number;
 	monthlyTarget: number;
 	monthsLeft: number;
+	// PIT refund the user can still get this year by contributing up to
+	// the limit: `remaining × marginalTaxRate`. Already-paid contributions
+	// have already triggered their share of the refund and are excluded.
 	refundEstimate: number;
+	// PIT refund the user gets when the full annual limit is contributed —
+	// independent of YTD payments. Useful as the "if I max this out from
+	// scratch" headline.
+	annualRefund: number;
 	limitSource: 'rule' | 'override';
 }
 
@@ -41,13 +48,16 @@ export function optimizeIKZE(input: IKZEOptimizerInput): IKZEOptimizerResult {
 	const remaining = Math.max(0, annualTarget - contributed);
 	const monthsLeft = monthsLeftIn(input.year, now);
 	const monthlyTarget = monthsLeft > 0 ? remaining / monthsLeft : 0;
-	const refundEstimate = annualTarget * Math.max(0, input.marginalTaxRate);
+	const rate = Math.max(0, input.marginalTaxRate);
+	const refundEstimate = remaining * rate;
+	const annualRefund = annualTarget * rate;
 	return {
 		annualTarget,
 		remaining,
 		monthlyTarget,
 		monthsLeft,
 		refundEstimate,
+		annualRefund,
 		limitSource: input.limitOverride != null ? 'override' : 'rule'
 	};
 }

--- a/src/routes/retirement/+page.svelte
+++ b/src/routes/retirement/+page.svelte
@@ -5,6 +5,7 @@
 	import { Info, Sparkles } from 'lucide-svelte';
 	import * as echarts from 'echarts';
 	import IKZEPITTracker from '$lib/components/IKZEPITTracker.svelte';
+	import IKZEOptimizer from '$lib/components/IKZEOptimizer.svelte';
 
 	let currentPortfolio = $state(100000);
 	let annualContribution = $state(20000);
@@ -120,6 +121,8 @@
 	</header>
 
 	<IKZEPITTracker />
+
+	<IKZEOptimizer />
 
 	<section class="card preset-filled-surface-100-900 p-5 space-y-4">
 		<h2 class="h4">Parametry</h2>


### PR DESCRIPTION
## Motivation

Closes #554. Users with an IKZE account currently see only their YTD
contributions vs. the limit — nothing tells them how much more to send
this year to fully use the PIT deduction. Adds a recommendation card
that splits the remaining cap across the months left and shows the
estimated tax refund.

## Implementation information

- New pure helper `src/lib/utils/ikzeOptimizer.ts` (with unit tests)
  reading both employee and B2B IKZE limits from the existing
  `pl_rules.generated.ts` table.
- New `IKZEOptimizer.svelte` card on the retirement page reuses
  `/api/retirement/stats` for YTD contributions and marginal PIT rate.
- Per-owner toggle between employee and B2B limit; seeded from the
  configured limit so users on the higher cap default to B2B.
- Renders monthly target, annual target, refund estimate, and a short
  "X mies. × Y PLN" hint.

## Supporting documentation

> Changelog: feat(retirement): add IKZE contribution optimizer