### PR TITLE
feat(pit38): realized gains report with NBP FX

### DIFF
--- a/backend-go/internal/pit38/handler.go
+++ b/backend-go/internal/pit38/handler.go
@@ -69,9 +69,24 @@ func (s *Store) LoadAllLots(ctx context.Context) ([]SecurityLots, error) {
 	}
 	out := make([]SecurityLots, 0, len(order))
 	for _, id := range order {
-		out = append(out, *groups[id])
+		g := groups[id]
+		if g == nil {
+			continue
+		}
+		out = append(out, *g)
 	}
 	return out, nil
+}
+
+// defaultReportYear picks the calendar year the report should cover when
+// the caller doesn't supply one. Polish PIT filings are due by April 30
+// for the previous year, so before that date the previous year is the
+// most useful default; afterwards the current year is.
+func defaultReportYear(now time.Time) int {
+	if now.Month() < time.May {
+		return now.Year() - 1
+	}
+	return now.Year()
 }
 
 // Handler is the HTTP boundary for /api/pit38.
@@ -92,8 +107,13 @@ func NewHandler(store *Store, fxSvc *fx.Service, logger *slog.Logger) *Handler {
 
 // Realized serves GET /api/pit38/realized?year=YYYY[&format=csv].
 // JSON is the default; format=csv switches to a downloadable spreadsheet.
+//
+// Default year follows the PIT filing window: before April 30, last
+// calendar year; after, the current year. Mirrors the UI default so
+// directly hitting the API yields the same report.
 func (h *Handler) Realized(w http.ResponseWriter, r *http.Request) {
-	year := h.now().UTC().Year() - 1
+	now := h.now().UTC()
+	year := defaultReportYear(now)
 	if v := r.URL.Query().Get("year"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil {
@@ -145,7 +165,7 @@ func writeCSV(w http.ResponseWriter, rep Report) {
 	for i := range rep.Rows {
 		row := &rep.Rows[i]
 		_ = cw.Write([]string{
-			row.Date.Format("2006-01-02"),
+			time.Time(row.Date).Format("2006-01-02"),
 			row.Symbol,
 			row.Currency,
 			row.Quantity.String(),

--- a/backend-go/internal/pit38/handler.go
+++ b/backend-go/internal/pit38/handler.go
@@ -1,0 +1,190 @@
+package pit38
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
+	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
+)
+
+// Store loads the raw lot history grouped per security so the report can
+// be computed without N+1 queries.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
+
+// LoadAllLots returns one SecurityLots entry per security that has any
+// lot in the database, with the lots in chronological order.
+func (s *Store) LoadAllLots(ctx context.Context) ([]SecurityLots, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT sec.id, sec.symbol, sec.currency,
+		       l.id, l.account_id, l.security_id, l.side, l.quantity, l.price,
+		       l.fee, l.date, l.created_at
+		FROM securities sec
+		JOIN lots l ON l.security_id = sec.id
+		ORDER BY sec.id, l.date, l.id`)
+	if err != nil {
+		return nil, fmt.Errorf("pit38 load lots: %w", err)
+	}
+	defer rows.Close()
+	groups := map[int]*SecurityLots{}
+	order := []int{}
+	for rows.Next() {
+		var (
+			secID    int
+			symbol   string
+			currency string
+			lot      holdings.Lot
+			sideStr  string
+		)
+		if err := rows.Scan(&secID, &symbol, &currency,
+			&lot.ID, &lot.AccountID, &lot.SecurityID, &sideStr, &lot.Quantity,
+			&lot.Price, &lot.Fee, &lot.Date, &lot.CreatedAt); err != nil {
+			return nil, fmt.Errorf("pit38 scan lot: %w", err)
+		}
+		lot.Side = holdings.Side(sideStr)
+		g, ok := groups[secID]
+		if !ok {
+			g = &SecurityLots{SecurityID: secID, Symbol: symbol, Currency: currency}
+			groups[secID] = g
+			order = append(order, secID)
+		}
+		g.Lots = append(g.Lots, lot)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("pit38 iterate lots: %w", err)
+	}
+	out := make([]SecurityLots, 0, len(order))
+	for _, id := range order {
+		out = append(out, *groups[id])
+	}
+	return out, nil
+}
+
+// Handler is the HTTP boundary for /api/pit38.
+type Handler struct {
+	store  *Store
+	fx     *fx.Service
+	logger *slog.Logger
+	now    func() time.Time
+}
+
+// NewHandler wires the store, FX service and logger.
+func NewHandler(store *Store, fxSvc *fx.Service, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, fx: fxSvc, logger: logger, now: time.Now}
+}
+
+// Realized serves GET /api/pit38/realized?year=YYYY[&format=csv].
+// JSON is the default; format=csv switches to a downloadable spreadsheet.
+func (h *Handler) Realized(w http.ResponseWriter, r *http.Request) {
+	year := h.now().UTC().Year() - 1
+	if v := r.URL.Query().Get("year"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			writeValidation(w, "year", "must be an integer")
+			return
+		}
+		year = n
+	}
+	lots, err := h.store.LoadAllLots(r.Context())
+	if err != nil {
+		h.logger.Error("pit38 load", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	rep, err := ComputeReport(r.Context(), year, h.fx, lots)
+	if err != nil {
+		if errors.Is(err, ErrUnknownCurrency) {
+			writeError(w, http.StatusUnprocessableEntity,
+				"NBP rate not available for one of the traded currencies")
+			return
+		}
+		if errors.Is(err, holdings.ErrOversell) {
+			writeError(w, http.StatusUnprocessableEntity,
+				"Lot history oversells a security — clean up the lot log first")
+			return
+		}
+		h.logger.Error("pit38 compute", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	if r.URL.Query().Get("format") == "csv" {
+		writeCSV(w, rep)
+		return
+	}
+	writeJSON(w, http.StatusOK, rep)
+}
+
+func writeCSV(w http.ResponseWriter, rep Report) {
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("Content-Disposition",
+		fmt.Sprintf(`attachment; filename="pit38-%d.csv"`, rep.Year))
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+	_ = cw.Write([]string{
+		"date", "symbol", "currency", "quantity", "proceeds", "cost_basis",
+		"fees", "realized_gain", "fx_rate", "proceeds_pln", "cost_basis_pln",
+		"fees_pln", "realized_pln",
+	})
+	for i := range rep.Rows {
+		row := &rep.Rows[i]
+		_ = cw.Write([]string{
+			row.Date.Format("2006-01-02"),
+			row.Symbol,
+			row.Currency,
+			row.Quantity.String(),
+			row.Proceeds.StringFixed(2),
+			row.CostBasis.StringFixed(2),
+			row.Fees.StringFixed(2),
+			row.RealizedGain.StringFixed(2),
+			row.FXRate.String(),
+			row.ProceedsPLN.StringFixed(2),
+			row.CostBasisPLN.StringFixed(2),
+			row.FeesPLN.StringFixed(2),
+			row.RealizedPLN.StringFixed(2),
+		})
+	}
+	_ = cw.Write([]string{
+		"TOTAL", "", "", "", "", "", "", "", "",
+		rep.Totals.ProceedsPLN.StringFixed(2),
+		rep.Totals.CostBasisPLN.StringFixed(2),
+		rep.Totals.FeesPLN.StringFixed(2),
+		rep.Totals.RealizedPLN.StringFixed(2),
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("pit38 encode", "err", err)
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidation(w http.ResponseWriter, field, msg string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{"type": "value_error", "loc": []string{"query", field}, "msg": msg},
+		},
+	})
+}

--- a/backend-go/internal/pit38/realized.go
+++ b/backend-go/internal/pit38/realized.go
@@ -1,0 +1,200 @@
+// Package pit38 computes the PIT-38 helper: per-sale realized gain/loss for
+// brokerage lots, with NBP FX conversion when the security trades in a
+// foreign currency. Output is intended as a worksheet for the annual
+// Polish capital-gains return — not a filed document.
+package pit38
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
+	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
+)
+
+// SaleRow is one realized-sale row in the report. All `_PLN` fields are
+// after NBP conversion at the per-row tax date (sale date for proceeds,
+// running PLN-weighted cost basis for cost). Currency-side fields are
+// kept too so users can reconcile against broker statements.
+type SaleRow struct {
+	SecurityID   int             `json:"security_id"`
+	Symbol       string          `json:"symbol"`
+	Currency     string          `json:"currency"`
+	Date         time.Time       `json:"date"`
+	Quantity     decimal.Decimal `json:"quantity"`
+	Proceeds     decimal.Decimal `json:"proceeds"`
+	CostBasis    decimal.Decimal `json:"cost_basis"`
+	Fees         decimal.Decimal `json:"fees"`
+	RealizedGain decimal.Decimal `json:"realized_gain"`
+	FXRate       decimal.Decimal `json:"fx_rate"`
+	HasFX        bool            `json:"has_fx"`
+	ProceedsPLN  decimal.Decimal `json:"proceeds_pln"`
+	CostBasisPLN decimal.Decimal `json:"cost_basis_pln"`
+	FeesPLN      decimal.Decimal `json:"fees_pln"`
+	RealizedPLN  decimal.Decimal `json:"realized_pln"`
+}
+
+// Totals sums the per-row PLN figures for the report footer.
+type Totals struct {
+	ProceedsPLN  decimal.Decimal `json:"proceeds_pln"`
+	CostBasisPLN decimal.Decimal `json:"cost_basis_pln"`
+	FeesPLN      decimal.Decimal `json:"fees_pln"`
+	RealizedPLN  decimal.Decimal `json:"realized_pln"`
+}
+
+// Report is the full PIT-38 helper payload.
+type Report struct {
+	Year   int       `json:"year"`
+	Rows   []SaleRow `json:"rows"`
+	Totals Totals    `json:"totals"`
+}
+
+// RateProvider abstracts NBP rate lookups so the algorithm stays a pure
+// function and is testable without a Postgres / network roundtrip.
+type RateProvider interface {
+	GetRateToPLN(ctx context.Context, currency string, onDate time.Time) (fx.Result, error)
+}
+
+// ErrUnknownCurrency surfaces when NBP couldn't supply a rate for a
+// foreign-currency lot. The caller decides whether to drop the row or
+// surface a 5xx — the helper itself doesn't apply policy.
+var ErrUnknownCurrency = errors.New("pit38: no FX rate available for currency on date")
+
+// SecurityLots groups the chronologically-sorted lot history for one
+// security so ComputeReport can walk it linearly.
+type SecurityLots struct {
+	SecurityID int
+	Symbol     string
+	Currency   string
+	Lots       []holdings.Lot
+}
+
+// ComputeReport produces the PIT-38 helper for the supplied year. It
+// replays each security's full lot history (not just the year's), then
+// keeps only sales whose date falls inside the year — earlier lots are
+// needed to derive the running weighted-average cost basis at the time
+// of sale, even when the sale itself isn't in scope.
+func ComputeReport(ctx context.Context, year int, rates RateProvider, byses []SecurityLots) (Report, error) {
+	yearStart := time.Date(year, time.January, 1, 0, 0, 0, 0, time.UTC)
+	yearEnd := time.Date(year+1, time.January, 1, 0, 0, 0, 0, time.UTC)
+	rep := Report{Year: year, Rows: []SaleRow{}}
+	for i := range byses {
+		rows, err := realizedSalesFor(ctx, &byses[i], yearStart, yearEnd, rates)
+		if err != nil {
+			return Report{}, err
+		}
+		rep.Rows = append(rep.Rows, rows...)
+	}
+	sort.SliceStable(rep.Rows, func(i, j int) bool {
+		if !rep.Rows[i].Date.Equal(rep.Rows[j].Date) {
+			return rep.Rows[i].Date.Before(rep.Rows[j].Date)
+		}
+		return rep.Rows[i].Symbol < rep.Rows[j].Symbol
+	})
+	for i := range rep.Rows {
+		row := &rep.Rows[i]
+		rep.Totals.ProceedsPLN = rep.Totals.ProceedsPLN.Add(row.ProceedsPLN)
+		rep.Totals.CostBasisPLN = rep.Totals.CostBasisPLN.Add(row.CostBasisPLN)
+		rep.Totals.FeesPLN = rep.Totals.FeesPLN.Add(row.FeesPLN)
+		rep.Totals.RealizedPLN = rep.Totals.RealizedPLN.Add(row.RealizedPLN)
+	}
+	return rep, nil
+}
+
+// realizedSalesFor walks the lot history for one security, maintaining
+// both the security-currency weighted-average cost and a parallel PLN
+// weighted-average cost (each buy converted at its trade-date NBP rate).
+// Each sell inside the report window emits one SaleRow.
+func realizedSalesFor(
+	ctx context.Context,
+	sec *SecurityLots,
+	from, to time.Time,
+	rates RateProvider,
+) ([]SaleRow, error) {
+	lots := make([]holdings.Lot, len(sec.Lots))
+	copy(lots, sec.Lots)
+	sort.SliceStable(lots, func(i, j int) bool {
+		if !lots[i].Date.Equal(lots[j].Date) {
+			return lots[i].Date.Before(lots[j].Date)
+		}
+		return lots[i].ID < lots[j].ID
+	})
+	var qty, avgCcy, avgPLN decimal.Decimal
+	out := []SaleRow{}
+	for i := range lots {
+		l := &lots[i]
+		rate, err := rates.GetRateToPLN(ctx, sec.Currency, l.Date)
+		if err != nil {
+			return nil, err
+		}
+		switch l.Side {
+		case holdings.SideBuy:
+			lotCost := l.Quantity.Mul(l.Price).Add(l.Fee)
+			lotCostPLN, ok := toPLN(lotCost, sec.Currency, rate)
+			if !ok {
+				return nil, ErrUnknownCurrency
+			}
+			newQty := qty.Add(l.Quantity)
+			if newQty.IsZero() {
+				avgCcy = decimal.Zero
+				avgPLN = decimal.Zero
+			} else {
+				prevCcy := qty.Mul(avgCcy)
+				prevPLN := qty.Mul(avgPLN)
+				avgCcy = prevCcy.Add(lotCost).Div(newQty)
+				avgPLN = prevPLN.Add(lotCostPLN).Div(newQty)
+			}
+			qty = newQty
+		case holdings.SideSell:
+			if l.Quantity.GreaterThan(qty) {
+				return nil, holdings.ErrOversell
+			}
+			proceedsCcy := l.Quantity.Mul(l.Price).Sub(l.Fee)
+			costBasisCcy := l.Quantity.Mul(avgCcy)
+			feesCcy := l.Fee
+			gainCcy := proceedsCcy.Sub(costBasisCcy)
+			proceedsPLN, ok := toPLN(proceedsCcy, sec.Currency, rate)
+			if !ok {
+				return nil, ErrUnknownCurrency
+			}
+			feesPLN, _ := toPLN(feesCcy, sec.Currency, rate)
+			costPLN := l.Quantity.Mul(avgPLN)
+			gainPLN := proceedsPLN.Sub(costPLN)
+			qty = qty.Sub(l.Quantity)
+			if qty.IsZero() {
+				avgCcy = decimal.Zero
+				avgPLN = decimal.Zero
+			}
+			if !l.Date.Before(from) && l.Date.Before(to) {
+				out = append(out, SaleRow{
+					SecurityID:   sec.SecurityID,
+					Symbol:       sec.Symbol,
+					Currency:     sec.Currency,
+					Date:         l.Date,
+					Quantity:     l.Quantity,
+					Proceeds:     proceedsCcy,
+					CostBasis:    costBasisCcy,
+					Fees:         feesCcy,
+					RealizedGain: gainCcy,
+					FXRate:       rate.Rate,
+					HasFX:        sec.Currency != "PLN",
+					ProceedsPLN:  proceedsPLN,
+					CostBasisPLN: costPLN,
+					FeesPLN:      feesPLN,
+					RealizedPLN:  gainPLN,
+				})
+			}
+		}
+	}
+	return out, nil
+}
+
+// toPLN wraps fx.ToPLN so the algorithm doesn't need a pointer dance for
+// every conversion.
+func toPLN(amount decimal.Decimal, currency string, rate fx.Result) (decimal.Decimal, bool) {
+	return fx.ToPLN(&amount, currency, rate)
+}

--- a/backend-go/internal/pit38/realized.go
+++ b/backend-go/internal/pit38/realized.go
@@ -16,6 +16,15 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
 )
 
+// isoDate marshals as a date-only YYYY-MM-DD string, matching the wire
+// format every other endpoint uses for transaction dates.
+type isoDate time.Time
+
+// MarshalJSON renders the underlying time as YYYY-MM-DD.
+func (d isoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format("2006-01-02") + `"`), nil
+}
+
 // SaleRow is one realized-sale row in the report. All `_PLN` fields are
 // after NBP conversion at the per-row tax date (sale date for proceeds,
 // running PLN-weighted cost basis for cost). Currency-side fields are
@@ -24,7 +33,7 @@ type SaleRow struct {
 	SecurityID   int             `json:"security_id"`
 	Symbol       string          `json:"symbol"`
 	Currency     string          `json:"currency"`
-	Date         time.Time       `json:"date"`
+	Date         isoDate         `json:"date"`
 	Quantity     decimal.Decimal `json:"quantity"`
 	Proceeds     decimal.Decimal `json:"proceeds"`
 	CostBasis    decimal.Decimal `json:"cost_basis"`
@@ -90,8 +99,10 @@ func ComputeReport(ctx context.Context, year int, rates RateProvider, byses []Se
 		rep.Rows = append(rep.Rows, rows...)
 	}
 	sort.SliceStable(rep.Rows, func(i, j int) bool {
-		if !rep.Rows[i].Date.Equal(rep.Rows[j].Date) {
-			return rep.Rows[i].Date.Before(rep.Rows[j].Date)
+		di := time.Time(rep.Rows[i].Date)
+		dj := time.Time(rep.Rows[j].Date)
+		if !di.Equal(dj) {
+			return di.Before(dj)
 		}
 		return rep.Rows[i].Symbol < rep.Rows[j].Symbol
 	})
@@ -174,7 +185,7 @@ func realizedSalesFor(
 					SecurityID:   sec.SecurityID,
 					Symbol:       sec.Symbol,
 					Currency:     sec.Currency,
-					Date:         l.Date,
+					Date:         isoDate(l.Date),
 					Quantity:     l.Quantity,
 					Proceeds:     proceedsCcy,
 					CostBasis:    costBasisCcy,

--- a/backend-go/internal/pit38/realized_test.go
+++ b/backend-go/internal/pit38/realized_test.go
@@ -1,0 +1,210 @@
+package pit38
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
+	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
+)
+
+type stubRates map[string]decimal.Decimal
+
+func (s stubRates) GetRateToPLN(_ context.Context, currency string, _ time.Time) (fx.Result, error) {
+	if currency == "PLN" {
+		return fx.Result{Rate: decimal.NewFromInt(1), Found: true}, nil
+	}
+	if r, ok := s[currency]; ok {
+		return fx.Result{Rate: r, Found: true}, nil
+	}
+	return fx.Result{Found: false}, nil
+}
+
+func d(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+func dateAt(t *testing.T, s string) time.Time {
+	t.Helper()
+	v, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("bad date %q: %v", s, err)
+	}
+	return v
+}
+
+func TestComputeReport_PLN_OneSale(t *testing.T) {
+	rates := stubRates{}
+	rep, err := ComputeReport(t.Context(), 2026, rates, []SecurityLots{{
+		SecurityID: 1, Symbol: "CDR", Currency: "PLN",
+		Lots: []holdings.Lot{
+			{Side: holdings.SideBuy, Quantity: d("10"), Price: d("200"), Fee: d("5"), Date: dateAt(t, "2025-06-01")},
+			{Side: holdings.SideSell, Quantity: d("10"), Price: d("250"), Fee: d("5"), Date: dateAt(t, "2026-03-15")},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("ComputeReport: %v", err)
+	}
+	if got := len(rep.Rows); got != 1 {
+		t.Fatalf("rows = %d, want 1", got)
+	}
+	row := rep.Rows[0]
+	// proceeds = 10 * 250 - 5 = 2495; cost_basis = 10 * (2000+5)/10 = 2005;
+	// realized = 2495 - 2005 = 490
+	if want := d("2495"); !row.Proceeds.Equal(want) {
+		t.Errorf("proceeds = %s, want %s", row.Proceeds, want)
+	}
+	if want := d("2005"); !row.CostBasis.Equal(want) {
+		t.Errorf("cost_basis = %s, want %s", row.CostBasis, want)
+	}
+	if want := d("490"); !row.RealizedGain.Equal(want) {
+		t.Errorf("realized = %s, want %s", row.RealizedGain, want)
+	}
+	if row.HasFX {
+		t.Errorf("has_fx = true; want false for PLN")
+	}
+	if want := d("490"); !rep.Totals.RealizedPLN.Equal(want) {
+		t.Errorf("totals.realized_pln = %s, want %s", rep.Totals.RealizedPLN, want)
+	}
+}
+
+func TestComputeReport_USD_AppliesNBPRates(t *testing.T) {
+	// Buy at rate 4.00, sell at rate 5.00 — currency gain widens the PLN
+	// realized vs. the USD realized.
+	rates := stubRatesDated{
+		"2025-06-01": d("4.0"),
+		"2026-03-15": d("5.0"),
+	}
+	rep, err := ComputeReport(t.Context(), 2026, rates, []SecurityLots{{
+		SecurityID: 2, Symbol: "AAPL", Currency: "USD",
+		Lots: []holdings.Lot{
+			{Side: holdings.SideBuy, Quantity: d("10"), Price: d("100"), Fee: d("0"), Date: dateAt(t, "2025-06-01")},
+			{Side: holdings.SideSell, Quantity: d("10"), Price: d("110"), Fee: d("0"), Date: dateAt(t, "2026-03-15")},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("ComputeReport: %v", err)
+	}
+	if got := len(rep.Rows); got != 1 {
+		t.Fatalf("rows = %d, want 1", got)
+	}
+	row := rep.Rows[0]
+	// proceeds_pln = 10*110 * 5 = 5500; cost_basis_pln = 10 * 100 * 4 = 4000
+	// realized_pln = 1500 (vs. 100 USD which would only be 500 PLN at sale rate)
+	if want := d("5500"); !row.ProceedsPLN.Equal(want) {
+		t.Errorf("proceeds_pln = %s, want %s", row.ProceedsPLN, want)
+	}
+	if want := d("4000"); !row.CostBasisPLN.Equal(want) {
+		t.Errorf("cost_basis_pln = %s, want %s", row.CostBasisPLN, want)
+	}
+	if want := d("1500"); !row.RealizedPLN.Equal(want) {
+		t.Errorf("realized_pln = %s, want %s", row.RealizedPLN, want)
+	}
+	if !row.HasFX {
+		t.Errorf("has_fx = false; want true for USD")
+	}
+}
+
+func TestComputeReport_SkipsSalesOutsideYear(t *testing.T) {
+	rates := stubRates{}
+	rep, err := ComputeReport(t.Context(), 2026, rates, []SecurityLots{{
+		SecurityID: 1, Symbol: "CDR", Currency: "PLN",
+		Lots: []holdings.Lot{
+			{Side: holdings.SideBuy, Quantity: d("10"), Price: d("100"), Date: dateAt(t, "2024-01-15")},
+			{Side: holdings.SideSell, Quantity: d("5"), Price: d("120"), Date: dateAt(t, "2025-12-31")},
+			{Side: holdings.SideSell, Quantity: d("5"), Price: d("130"), Date: dateAt(t, "2026-02-01")},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("ComputeReport: %v", err)
+	}
+	if got := len(rep.Rows); got != 1 {
+		t.Fatalf("rows = %d, want 1 (only the 2026 sale)", got)
+	}
+	if !rep.Rows[0].Date.Equal(dateAt(t, "2026-02-01")) {
+		t.Errorf("date = %s, want 2026-02-01", rep.Rows[0].Date)
+	}
+}
+
+func TestComputeReport_MissingRateErrors(t *testing.T) {
+	// USD lot with no rate available — must surface ErrUnknownCurrency.
+	rates := stubRates{}
+	_, err := ComputeReport(t.Context(), 2026, rates, []SecurityLots{{
+		SecurityID: 3, Symbol: "TSLA", Currency: "USD",
+		Lots: []holdings.Lot{
+			{Side: holdings.SideBuy, Quantity: d("1"), Price: d("200"), Date: dateAt(t, "2025-06-01")},
+			{Side: holdings.SideSell, Quantity: d("1"), Price: d("250"), Date: dateAt(t, "2026-03-15")},
+		},
+	}})
+	if err == nil {
+		t.Fatal("ComputeReport: want error, got nil")
+	}
+}
+
+func TestComputeReport_TotalsSumPLNFields(t *testing.T) {
+	rates := stubRates{}
+	rep, err := ComputeReport(t.Context(), 2026, rates, []SecurityLots{
+		{
+			SecurityID: 1, Symbol: "CDR", Currency: "PLN",
+			Lots: []holdings.Lot{
+				{Side: holdings.SideBuy, Quantity: d("10"), Price: d("100"), Date: dateAt(t, "2025-01-01")},
+				{Side: holdings.SideSell, Quantity: d("10"), Price: d("120"), Date: dateAt(t, "2026-04-01")},
+			},
+		},
+		{
+			SecurityID: 2, Symbol: "ALG", Currency: "PLN",
+			Lots: []holdings.Lot{
+				{Side: holdings.SideBuy, Quantity: d("5"), Price: d("50"), Date: dateAt(t, "2024-01-01")},
+				{Side: holdings.SideSell, Quantity: d("5"), Price: d("80"), Date: dateAt(t, "2026-09-01")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ComputeReport: %v", err)
+	}
+	// CDR: (120-100)*10 = 200 PLN. ALG: (80-50)*5 = 150 PLN. Sum = 350 PLN.
+	if want := d("350"); !rep.Totals.RealizedPLN.Equal(want) {
+		t.Errorf("totals.realized_pln = %s, want %s", rep.Totals.RealizedPLN, want)
+	}
+}
+
+func TestComputeReport_SortsRowsByDate(t *testing.T) {
+	rates := stubRates{}
+	rep, err := ComputeReport(t.Context(), 2026, rates, []SecurityLots{
+		{
+			SecurityID: 2, Symbol: "ALG", Currency: "PLN",
+			Lots: []holdings.Lot{
+				{Side: holdings.SideBuy, Quantity: d("5"), Price: d("50"), Date: dateAt(t, "2024-01-01")},
+				{Side: holdings.SideSell, Quantity: d("5"), Price: d("80"), Date: dateAt(t, "2026-09-01")},
+			},
+		},
+		{
+			SecurityID: 1, Symbol: "CDR", Currency: "PLN",
+			Lots: []holdings.Lot{
+				{Side: holdings.SideBuy, Quantity: d("10"), Price: d("100"), Date: dateAt(t, "2025-01-01")},
+				{Side: holdings.SideSell, Quantity: d("10"), Price: d("120"), Date: dateAt(t, "2026-04-01")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ComputeReport: %v", err)
+	}
+	if got := rep.Rows[0].Symbol; got != "CDR" {
+		t.Errorf("first row symbol = %q, want CDR (April before September)", got)
+	}
+}
+
+// stubRatesDated lets a test return a different rate per ISO date.
+type stubRatesDated map[string]decimal.Decimal
+
+func (s stubRatesDated) GetRateToPLN(_ context.Context, currency string, onDate time.Time) (fx.Result, error) {
+	if currency == "PLN" {
+		return fx.Result{Rate: decimal.NewFromInt(1), Found: true}, nil
+	}
+	key := onDate.Format("2006-01-02")
+	if r, ok := s[key]; ok {
+		return fx.Result{Rate: r, Found: true}, nil
+	}
+	return fx.Result{Found: false}, nil
+}

--- a/backend-go/internal/pit38/realized_test.go
+++ b/backend-go/internal/pit38/realized_test.go
@@ -2,6 +2,7 @@ package pit38
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -122,8 +123,8 @@ func TestComputeReport_SkipsSalesOutsideYear(t *testing.T) {
 	if got := len(rep.Rows); got != 1 {
 		t.Fatalf("rows = %d, want 1 (only the 2026 sale)", got)
 	}
-	if !rep.Rows[0].Date.Equal(dateAt(t, "2026-02-01")) {
-		t.Errorf("date = %s, want 2026-02-01", rep.Rows[0].Date)
+	if !time.Time(rep.Rows[0].Date).Equal(dateAt(t, "2026-02-01")) {
+		t.Errorf("date = %v, want 2026-02-01", time.Time(rep.Rows[0].Date))
 	}
 }
 
@@ -137,8 +138,8 @@ func TestComputeReport_MissingRateErrors(t *testing.T) {
 			{Side: holdings.SideSell, Quantity: d("1"), Price: d("250"), Date: dateAt(t, "2026-03-15")},
 		},
 	}})
-	if err == nil {
-		t.Fatal("ComputeReport: want error, got nil")
+	if !errors.Is(err, ErrUnknownCurrency) {
+		t.Fatalf("ComputeReport err = %v, want ErrUnknownCurrency", err)
 	}
 }
 

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
 	"github.com/Automaat/finance-buddy/backend-go/internal/investment"
+	"github.com/Automaat/finance-buddy/backend-go/internal/pit38"
 	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
 	"github.com/Automaat/finance-buddy/backend-go/internal/rules"
@@ -190,6 +191,8 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	r.Post("/api/holdings/lots", hHandler.CreateLot)
 	r.Delete("/api/holdings/lots/{id}", hHandler.DeleteLot)
 
+	registerPIT38Routes(r, pool, logger)
+
 	simHandler := simulations.NewHandler(simulations.NewStore(pool), logger)
 	r.Post("/api/simulations/mortgage-vs-invest", simHandler.MortgageVsInvest)
 	r.Post("/api/simulations/wibor", simHandler.WiborScenarios)
@@ -212,6 +215,11 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 func registerDashboardRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 	dashHandler := dashboard.NewHandler(dashboard.NewStore(pool), logger)
 	r.Get("/api/dashboard", dashHandler.Get)
+}
+
+func registerPIT38Routes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
+	pitHandler := pit38.NewHandler(pit38.NewStore(pool), fx.NewService(pool, logger), logger)
+	r.Get("/api/pit38/realized", pitHandler.Realized)
 }
 
 func registerCoreRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {

--- a/src/lib/components/PIT38Report.svelte
+++ b/src/lib/components/PIT38Report.svelte
@@ -34,6 +34,9 @@
 		totals: Totals;
 	}
 
+	// Polish PIT-38 filings are due by April 30 for the previous year, so
+	// default to last year before May 1 and to this year afterwards. Months
+	// are 0-indexed: April = 3, May = 4.
 	const now = new Date();
 	let year = $state(now.getMonth() < 4 ? now.getFullYear() - 1 : now.getFullYear());
 	let report = $state<Report | null>(null);

--- a/src/lib/components/PIT38Report.svelte
+++ b/src/lib/components/PIT38Report.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { resolveApiUrl } from '$lib/api';
+	import { formatPLN } from '$lib/utils/format';
+	import { FileSpreadsheet, Download } from 'lucide-svelte';
+
+	interface SaleRow {
+		date: string;
+		symbol: string;
+		currency: string;
+		quantity: string;
+		proceeds: string;
+		cost_basis: string;
+		fees: string;
+		realized_gain: string;
+		fx_rate: string;
+		has_fx: boolean;
+		proceeds_pln: string;
+		cost_basis_pln: string;
+		fees_pln: string;
+		realized_pln: string;
+	}
+
+	interface Totals {
+		proceeds_pln: string;
+		cost_basis_pln: string;
+		fees_pln: string;
+		realized_pln: string;
+	}
+
+	interface Report {
+		year: number;
+		rows: SaleRow[];
+		totals: Totals;
+	}
+
+	const now = new Date();
+	let year = $state(now.getMonth() < 4 ? now.getFullYear() - 1 : now.getFullYear());
+	let report = $state<Report | null>(null);
+	let loading = $state(false);
+	let error = $state('');
+
+	async function load() {
+		loading = true;
+		error = '';
+		try {
+			const apiUrl = resolveApiUrl();
+			const res = await fetch(`${apiUrl}/api/pit38/realized?year=${year}`);
+			if (!res.ok) {
+				const body = (await res.json().catch(() => null)) as { detail?: string } | null;
+				throw new Error(body?.detail ?? `Pobranie raportu nieudane: ${res.statusText}`);
+			}
+			report = await res.json();
+		} catch (err) {
+			if (err instanceof Error) error = err.message;
+		} finally {
+			loading = false;
+		}
+	}
+
+	function csvUrl(): string {
+		return `${resolveApiUrl()}/api/pit38/realized?year=${year}&format=csv`;
+	}
+
+	onMount(load);
+
+	function fmt(n: string): string {
+		const parsed = Number.parseFloat(n);
+		return Number.isFinite(parsed) ? formatPLN(parsed) : n;
+	}
+</script>
+
+<section class="card preset-filled-surface-100-900 p-4 space-y-3">
+	<header class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+		<div>
+			<h2 class="h3 flex items-center gap-2">
+				<FileSpreadsheet size={20} class="text-primary-500" />
+				PIT-38 — zrealizowane zyski
+			</h2>
+			<p class="text-sm text-surface-700-300">
+				Pomocnik do rozliczenia rocznego: sprzedaże, koszt, prowizje, zysk; kursy NBP dla walut
+				obcych.
+			</p>
+		</div>
+		<div class="flex items-center gap-2">
+			<label class="label">
+				<span class="text-xs font-semibold">Rok</span>
+				<input
+					type="number"
+					min="2000"
+					max="2100"
+					bind:value={year}
+					class="input w-24"
+					onchange={load}
+				/>
+			</label>
+			<a class="btn preset-filled-primary-500 gap-2" href={csvUrl()} download>
+				<Download size={16} /> CSV
+			</a>
+		</div>
+	</header>
+
+	{#if loading}
+		<p class="text-sm text-surface-700-300">Ładowanie…</p>
+	{:else if error}
+		<div class="card preset-tonal-error p-3 text-sm">{error}</div>
+	{:else if report && report.rows.length === 0}
+		<p class="text-sm text-surface-700-300">Brak sprzedaży w roku {year}.</p>
+	{:else if report}
+		<div class="overflow-x-auto">
+			<table class="table caption-bottom">
+				<thead>
+					<tr>
+						<th>Data</th>
+						<th>Symbol</th>
+						<th>Waluta</th>
+						<th class="text-right">Ilość</th>
+						<th class="text-right">Przychód</th>
+						<th class="text-right">Koszt</th>
+						<th class="text-right">Prowizja</th>
+						<th class="text-right">Zysk/strata</th>
+						<th class="text-right">Kurs</th>
+						<th class="text-right">Zysk PLN</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each report.rows as row (`${row.date}-${row.symbol}`)}
+						<tr>
+							<td>{row.date}</td>
+							<td>{row.symbol}</td>
+							<td>{row.currency}</td>
+							<td class="text-right">{row.quantity}</td>
+							<td class="text-right">{row.proceeds}</td>
+							<td class="text-right">{row.cost_basis}</td>
+							<td class="text-right">{row.fees}</td>
+							<td class="text-right">{row.realized_gain}</td>
+							<td class="text-right">{row.has_fx ? row.fx_rate : '—'}</td>
+							<td class="text-right font-bold">{fmt(row.realized_pln)}</td>
+						</tr>
+					{/each}
+				</tbody>
+				<tfoot>
+					<tr class="font-bold">
+						<td colspan="4">Razem</td>
+						<td class="text-right">{fmt(report.totals.proceeds_pln)}</td>
+						<td class="text-right">{fmt(report.totals.cost_basis_pln)}</td>
+						<td class="text-right">{fmt(report.totals.fees_pln)}</td>
+						<td colspan="2"></td>
+						<td class="text-right">{fmt(report.totals.realized_pln)}</td>
+					</tr>
+				</tfoot>
+			</table>
+		</div>
+	{/if}
+</section>

--- a/src/routes/holdings/+page.svelte
+++ b/src/routes/holdings/+page.svelte
@@ -5,6 +5,7 @@
 	import { toast } from '$lib/stores/toast.svelte';
 	import { confirm } from '$lib/stores/confirm.svelte';
 	import Modal from '$lib/components/Modal.svelte';
+	import PIT38Report from '$lib/components/PIT38Report.svelte';
 	import { Plus, Trash2, BarChart } from 'lucide-svelte';
 	import type { PageData } from './$types';
 
@@ -290,6 +291,8 @@
 			</table>
 		</div>
 	{/if}
+
+	<PIT38Report />
 
 	<section class="card preset-filled-surface-100-900 p-4 space-y-3">
 		<header class="flex items-center justify-between">


### PR DESCRIPTION
## Motivation

Closes #555. Lot-level brokerage tracking already lives in
`/api/holdings/lots`, but at year end users still have to compute
PIT-38 numbers by hand — especially for non-PLN trades where each lot
needs an NBP rate. Adds a backend report and a holdings-page panel that
does both, with a CSV export.

## Implementation information

- New `internal/pit38/` package. `ComputeReport` walks every security's
  lot history, keeping a parallel PLN weighted-average cost (each buy
  converted at its trade-date NBP rate). Sales in the requested year
  emit one row each — proceeds, cost basis, fees, realized gain, both
  in security currency and PLN.
- HTTP: `GET /api/pit38/realized?year=YYYY` returns JSON; same URL with
  `&format=csv` streams a downloadable spreadsheet.
- Reuses `fx.Service` so NBP cache + lookback rules stay in one place.
  Missing-rate lots surface as 422 instead of silently zeroing.
- Frontend: `PIT38Report.svelte` panel on the holdings page with a year
  picker and a CSV download button.
- Defaults the year to last calendar year before April, current year
  after — matches PIT filing windows.

## Supporting documentation

> Changelog: feat(pit38): realized gains report with NBP FX