### PR TITLE
feat(exposure): currency exposure chart with drift

### DIFF
--- a/backend-go/internal/exposure/currency.go
+++ b/backend-go/internal/exposure/currency.go
@@ -1,0 +1,218 @@
+// Package exposure derives portfolio currency exposure from the most recent
+// snapshot. Group totals are reported in PLN (snapshot values are already
+// PLN-converted), bucketed by the source account's quoted currency so users
+// can see how much of their net worth is denominated in PLN vs. foreign
+// currencies. Optional target bands report drift against a user-supplied
+// PLN target percentage.
+package exposure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// CurrencyBucket is one currency's slice of the portfolio.
+type CurrencyBucket struct {
+	Currency string  `json:"currency"`
+	ValuePLN float64 `json:"value_pln"`
+	Percent  float64 `json:"percent"`
+}
+
+// DriftBand is the optional drift summary against a user-set PLN target.
+type DriftBand struct {
+	TargetPLNPct float64 `json:"target_pln_pct"`
+	ActualPLNPct float64 `json:"actual_pln_pct"`
+	DriftPLNPct  float64 `json:"drift_pln_pct"`
+	WithinTol    bool    `json:"within_tolerance"`
+	TolerancePct float64 `json:"tolerance_pct"`
+}
+
+// Report is the full currency-exposure payload.
+type Report struct {
+	Currencies   []CurrencyBucket `json:"currencies"`
+	TotalPLN     float64          `json:"total_pln"`
+	PLNPercent   float64          `json:"pln_pct"`
+	ForeignPct   float64          `json:"foreign_pct"`
+	SnapshotDate string           `json:"snapshot_date"`
+	Drift        *DriftBand       `json:"drift,omitempty"`
+}
+
+// Store loads currency-bucketed account values from the latest snapshot.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pool.
+func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
+
+// row mirrors one (currency, sum(value)) pair.
+type row struct {
+	currency string
+	valuePLN decimal.Decimal
+}
+
+// LatestByCurrency returns total PLN value per account currency from the
+// most recent snapshot. Active accounts only — soft-deleted ones are
+// excluded so the chart matches what the user can actually invest from.
+func (s *Store) LatestByCurrency(ctx context.Context) ([]row, string, error) {
+	var (
+		latestID   int
+		latestDate string
+	)
+	err := s.pool.QueryRow(ctx, `
+		SELECT id, to_char(date, 'YYYY-MM-DD')
+		FROM snapshots ORDER BY date DESC, id DESC LIMIT 1`).Scan(&latestID, &latestDate)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return []row{}, "", nil
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("latest snapshot: %w", err)
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT UPPER(a.currency) AS currency, SUM(sv.value)
+		FROM snapshot_values sv
+		JOIN accounts a ON a.id = sv.account_id
+		WHERE sv.snapshot_id = $1 AND a.is_active = true
+		GROUP BY UPPER(a.currency)
+	`, latestID)
+	if err != nil {
+		return nil, "", fmt.Errorf("query currency totals: %w", err)
+	}
+	defer rows.Close()
+	out := []row{}
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.currency, &r.valuePLN); err != nil {
+			return nil, "", fmt.Errorf("scan currency total: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("iterate currency totals: %w", err)
+	}
+	return out, latestDate, nil
+}
+
+// BuildReport collapses raw per-currency values into percentages and the
+// optional drift band. Pure function on top of the store result.
+func BuildReport(rows []row, snapshotDate string, targetPLN *float64, tolerance float64) Report {
+	rep := Report{Currencies: []CurrencyBucket{}, SnapshotDate: snapshotDate}
+	totalAssets := decimal.Zero
+	for i := range rows {
+		if rows[i].valuePLN.IsPositive() {
+			totalAssets = totalAssets.Add(rows[i].valuePLN)
+		}
+	}
+	rep.TotalPLN, _ = totalAssets.Float64()
+	for i := range rows {
+		v, _ := rows[i].valuePLN.Float64()
+		if v <= 0 {
+			continue
+		}
+		pct := 0.0
+		if rep.TotalPLN > 0 {
+			pct = v / rep.TotalPLN * 100
+		}
+		rep.Currencies = append(rep.Currencies, CurrencyBucket{
+			Currency: rows[i].currency,
+			ValuePLN: v,
+			Percent:  pct,
+		})
+		if rows[i].currency == "PLN" {
+			rep.PLNPercent = pct
+		}
+	}
+	rep.ForeignPct = 100 - rep.PLNPercent
+	if rep.TotalPLN == 0 {
+		rep.PLNPercent = 0
+		rep.ForeignPct = 0
+	}
+	sort.SliceStable(rep.Currencies, func(i, j int) bool {
+		return rep.Currencies[i].Percent > rep.Currencies[j].Percent
+	})
+	if targetPLN != nil {
+		band := DriftBand{
+			TargetPLNPct: *targetPLN,
+			ActualPLNPct: rep.PLNPercent,
+			DriftPLNPct:  rep.PLNPercent - *targetPLN,
+			TolerancePct: tolerance,
+		}
+		band.WithinTol = abs(band.DriftPLNPct) <= tolerance
+		rep.Drift = &band
+	}
+	return rep
+}
+
+func abs(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// Handler is the HTTP boundary for /api/exposure.
+type Handler struct {
+	store  *Store
+	logger *slog.Logger
+}
+
+// NewHandler wires the store + logger.
+func NewHandler(store *Store, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, logger: logger}
+}
+
+// Currency serves GET /api/exposure/currency[?target_pln_pct=X&tolerance=Y].
+// Both query params are optional; omitting target_pln_pct skips the drift
+// block entirely.
+func (h *Handler) Currency(w http.ResponseWriter, r *http.Request) {
+	target, tolerance, vErr := parseDriftParams(r)
+	if vErr != nil {
+		writeValidation(w, vErr.field, vErr.msg)
+		return
+	}
+	rows, snapshotDate, err := h.store.LatestByCurrency(r.Context())
+	if err != nil {
+		h.logger.Error("exposure currency", "err", err)
+		writeError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	rep := BuildReport(rows, snapshotDate, target, tolerance)
+	writeJSON(w, http.StatusOK, rep)
+}
+
+type validationErr struct {
+	field, msg string
+}
+
+func parseDriftParams(r *http.Request) (*float64, float64, *validationErr) {
+	tolerance := 5.0
+	if v := strings.TrimSpace(r.URL.Query().Get("tolerance")); v != "" {
+		n, err := strconv.ParseFloat(v, 64)
+		if err != nil || n < 0 {
+			return nil, 0, &validationErr{field: "tolerance", msg: "must be a non-negative number"}
+		}
+		tolerance = n
+	}
+	v := strings.TrimSpace(r.URL.Query().Get("target_pln_pct"))
+	if v == "" {
+		return nil, tolerance, nil
+	}
+	n, err := strconv.ParseFloat(v, 64)
+	if err != nil || n < 0 || n > 100 {
+		return nil, 0, &validationErr{field: "target_pln_pct", msg: "must be a number between 0 and 100"}
+	}
+	return &n, tolerance, nil
+}

--- a/backend-go/internal/exposure/currency_test.go
+++ b/backend-go/internal/exposure/currency_test.go
@@ -9,25 +9,29 @@ import (
 
 func d(s string) decimal.Decimal { return decimal.RequireFromString(s) }
 
+const epsilon = 1e-9
+
+func eq(got, want float64) bool { return math.Abs(got-want) < epsilon }
+
 func TestBuildReport_EmptyPortfolio(t *testing.T) {
 	rep := BuildReport(nil, "", nil, 5)
-	if rep.TotalPLN != 0 {
+	if !eq(rep.TotalPLN, 0) {
 		t.Errorf("total = %v, want 0", rep.TotalPLN)
 	}
-	if rep.PLNPercent != 0 {
+	if !eq(rep.PLNPercent, 0) {
 		t.Errorf("pln_pct = %v, want 0", rep.PLNPercent)
 	}
-	if rep.ForeignPct != 0 {
+	if !eq(rep.ForeignPct, 0) {
 		t.Errorf("foreign_pct = %v, want 0", rep.ForeignPct)
 	}
 }
 
 func TestBuildReport_PLNOnly(t *testing.T) {
 	rep := BuildReport([]row{{currency: "PLN", valuePLN: d("100000")}}, "2026-05-01", nil, 5)
-	if rep.PLNPercent != 100 {
+	if !eq(rep.PLNPercent, 100) {
 		t.Errorf("pln_pct = %v, want 100", rep.PLNPercent)
 	}
-	if rep.ForeignPct != 0 {
+	if !eq(rep.ForeignPct, 0) {
 		t.Errorf("foreign_pct = %v, want 0", rep.ForeignPct)
 	}
 }
@@ -38,10 +42,10 @@ func TestBuildReport_MixedCurrencies(t *testing.T) {
 		{currency: "USD", valuePLN: d("30000")},
 		{currency: "EUR", valuePLN: d("10000")},
 	}, "2026-05-01", nil, 5)
-	if rep.PLNPercent != 60 {
+	if !eq(rep.PLNPercent, 60) {
 		t.Errorf("pln_pct = %v, want 60", rep.PLNPercent)
 	}
-	if rep.ForeignPct != 40 {
+	if !eq(rep.ForeignPct, 40) {
 		t.Errorf("foreign_pct = %v, want 40", rep.ForeignPct)
 	}
 	if got := rep.Currencies[0].Currency; got != "PLN" {

--- a/backend-go/internal/exposure/currency_test.go
+++ b/backend-go/internal/exposure/currency_test.go
@@ -1,0 +1,95 @@
+package exposure
+
+import (
+	"math"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func d(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+func TestBuildReport_EmptyPortfolio(t *testing.T) {
+	rep := BuildReport(nil, "", nil, 5)
+	if rep.TotalPLN != 0 {
+		t.Errorf("total = %v, want 0", rep.TotalPLN)
+	}
+	if rep.PLNPercent != 0 {
+		t.Errorf("pln_pct = %v, want 0", rep.PLNPercent)
+	}
+	if rep.ForeignPct != 0 {
+		t.Errorf("foreign_pct = %v, want 0", rep.ForeignPct)
+	}
+}
+
+func TestBuildReport_PLNOnly(t *testing.T) {
+	rep := BuildReport([]row{{currency: "PLN", valuePLN: d("100000")}}, "2026-05-01", nil, 5)
+	if rep.PLNPercent != 100 {
+		t.Errorf("pln_pct = %v, want 100", rep.PLNPercent)
+	}
+	if rep.ForeignPct != 0 {
+		t.Errorf("foreign_pct = %v, want 0", rep.ForeignPct)
+	}
+}
+
+func TestBuildReport_MixedCurrencies(t *testing.T) {
+	rep := BuildReport([]row{
+		{currency: "PLN", valuePLN: d("60000")},
+		{currency: "USD", valuePLN: d("30000")},
+		{currency: "EUR", valuePLN: d("10000")},
+	}, "2026-05-01", nil, 5)
+	if rep.PLNPercent != 60 {
+		t.Errorf("pln_pct = %v, want 60", rep.PLNPercent)
+	}
+	if rep.ForeignPct != 40 {
+		t.Errorf("foreign_pct = %v, want 40", rep.ForeignPct)
+	}
+	if got := rep.Currencies[0].Currency; got != "PLN" {
+		t.Errorf("first currency = %q, want PLN (largest slice)", got)
+	}
+	if rep.Drift != nil {
+		t.Errorf("drift = %+v, want nil when target unset", rep.Drift)
+	}
+}
+
+func TestBuildReport_DropsZeroAndNegativeBuckets(t *testing.T) {
+	rep := BuildReport([]row{
+		{currency: "PLN", valuePLN: d("50000")},
+		{currency: "JPY", valuePLN: d("0")},
+		{currency: "GBP", valuePLN: d("-1000")},
+	}, "", nil, 5)
+	if got := len(rep.Currencies); got != 1 {
+		t.Fatalf("currency rows = %d, want 1 (zero + negative dropped)", got)
+	}
+	if rep.Currencies[0].Currency != "PLN" {
+		t.Errorf("kept currency = %q, want PLN", rep.Currencies[0].Currency)
+	}
+}
+
+func TestBuildReport_DriftBandTrue(t *testing.T) {
+	target := 70.0
+	rep := BuildReport([]row{
+		{currency: "PLN", valuePLN: d("72000")},
+		{currency: "USD", valuePLN: d("28000")},
+	}, "2026-05-01", &target, 5)
+	if rep.Drift == nil {
+		t.Fatal("drift = nil, want populated band")
+	}
+	if math.Abs(rep.Drift.DriftPLNPct-2) > 0.001 {
+		t.Errorf("drift = %v, want 2.0", rep.Drift.DriftPLNPct)
+	}
+	if !rep.Drift.WithinTol {
+		t.Errorf("within_tolerance = false, want true (2 ≤ 5)")
+	}
+}
+
+func TestBuildReport_DriftBandOutOfTolerance(t *testing.T) {
+	target := 70.0
+	rep := BuildReport([]row{
+		{currency: "PLN", valuePLN: d("50000")},
+		{currency: "USD", valuePLN: d("50000")},
+	}, "2026-05-01", &target, 5)
+	if rep.Drift.WithinTol {
+		t.Errorf("within_tolerance = true, want false (drift -20 > tolerance 5)")
+	}
+}

--- a/backend-go/internal/exposure/http.go
+++ b/backend-go/internal/exposure/http.go
@@ -10,7 +10,7 @@ func writeJSON(w http.ResponseWriter, status int, payload any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(payload); err != nil {
-		slog.Default().Error("exposure encode", "err", err)
+		slog.Default().Error("exposure encode", "err", err, "status", status)
 	}
 }
 

--- a/backend-go/internal/exposure/http.go
+++ b/backend-go/internal/exposure/http.go
@@ -1,0 +1,27 @@
+package exposure
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		slog.Default().Error("exposure encode", "err", err)
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, map[string]string{"detail": detail})
+}
+
+func writeValidation(w http.ResponseWriter, field, msg string) {
+	writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+		"detail": []map[string]any{
+			{"type": "value_error", "loc": []string{"query", field}, "msg": msg},
+		},
+	})
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -30,6 +30,7 @@ import (
 	debtpayments "github.com/Automaat/finance-buddy/backend-go/internal/debt_payments"
 	"github.com/Automaat/finance-buddy/backend-go/internal/debts"
 	equitygrants "github.com/Automaat/finance-buddy/backend-go/internal/equity_grants"
+	"github.com/Automaat/finance-buddy/backend-go/internal/exposure"
 	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
@@ -215,6 +216,9 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 func registerDashboardRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 	dashHandler := dashboard.NewHandler(dashboard.NewStore(pool), logger)
 	r.Get("/api/dashboard", dashHandler.Get)
+
+	expHandler := exposure.NewHandler(exposure.NewStore(pool), logger)
+	r.Get("/api/exposure/currency", expHandler.Currency)
 }
 
 func registerPIT38Routes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {

--- a/src/lib/components/CurrencyExposureWidget.svelte
+++ b/src/lib/components/CurrencyExposureWidget.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import * as echarts from 'echarts';
+	import { resolveApiUrl } from '$lib/api';
+	import { formatPLN } from '$lib/utils/format';
+	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
+	import { Globe } from 'lucide-svelte';
+
+	interface CurrencyBucket {
+		currency: string;
+		value_pln: number;
+		percent: number;
+	}
+
+	interface DriftBand {
+		target_pln_pct: number;
+		actual_pln_pct: number;
+		drift_pln_pct: number;
+		within_tolerance: boolean;
+		tolerance_pct: number;
+	}
+
+	interface Report {
+		currencies: CurrencyBucket[];
+		total_pln: number;
+		pln_pct: number;
+		foreign_pct: number;
+		snapshot_date: string;
+		drift?: DriftBand;
+	}
+
+	let targetPLNPct = $state<number | null>(null);
+	let tolerance = $state(5);
+	let report = $state<Report | null>(null);
+	let loading = $state(true);
+	let error = $state('');
+	let container: HTMLDivElement | undefined = $state();
+	let handle: ChartHandle | null = null;
+
+	async function load() {
+		loading = true;
+		error = '';
+		try {
+			const apiUrl = resolveApiUrl();
+			const params = new URLSearchParams();
+			if (targetPLNPct != null && !Number.isNaN(targetPLNPct)) {
+				params.set('target_pln_pct', String(targetPLNPct));
+				params.set('tolerance', String(tolerance));
+			}
+			const qs = params.toString();
+			const url = `${apiUrl}/api/exposure/currency${qs ? `?${qs}` : ''}`;
+			const res = await fetch(url);
+			if (!res.ok) throw new Error(`Pobranie ekspozycji nieudane: ${res.statusText}`);
+			report = await res.json();
+		} catch (err) {
+			if (err instanceof Error) error = err.message;
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(load);
+
+	const palette = [
+		'#3b82f6',
+		'#ef4444',
+		'#10b981',
+		'#f59e0b',
+		'#a855f7',
+		'#06b6d4',
+		'#84cc16',
+		'#ec4899'
+	];
+
+	$effect(() => {
+		if (!container) {
+			handle?.dispose();
+			handle = null;
+			return;
+		}
+		if (!report) return;
+		if (!handle) handle = createChart(container);
+		const data = report.currencies.map((c, i) => ({
+			name: c.currency,
+			value: c.value_pln,
+			itemStyle: { color: c.currency === 'PLN' ? '#1e40af' : palette[i % palette.length] }
+		}));
+		handle.chart.setOption({
+			tooltip: {
+				trigger: 'item',
+				formatter: (p: { name: string; value: number; percent: number }) =>
+					`${p.name}<br/>${formatPLN(p.value)} (${p.percent.toFixed(1)}%)`
+			},
+			legend: { bottom: 0 },
+			series: [
+				{
+					type: 'pie',
+					radius: ['45%', '70%'],
+					avoidLabelOverlap: false,
+					label: { show: true, formatter: '{b}: {d}%' },
+					data
+				}
+			]
+		});
+	});
+
+	function applyTarget() {
+		void load();
+	}
+
+	function clearTarget() {
+		targetPLNPct = null;
+		void load();
+	}
+</script>
+
+<section class="card preset-filled-surface-100-900 p-5 space-y-3">
+	<header class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+		<div>
+			<h2 class="h4 flex items-center gap-2">
+				<Globe size={20} class="text-primary-500" />
+				Ekspozycja walutowa
+			</h2>
+			<p class="text-sm text-surface-700-300">
+				Udział PLN vs walut obcych w ostatnim snapshotcie aktywów.
+			</p>
+		</div>
+		<div class="flex flex-wrap items-end gap-2">
+			<label class="label">
+				<span class="text-xs font-semibold">Cel PLN (%)</span>
+				<input
+					type="number"
+					min="0"
+					max="100"
+					step="1"
+					class="input w-24"
+					bind:value={targetPLNPct}
+					placeholder="—"
+				/>
+			</label>
+			<label class="label">
+				<span class="text-xs font-semibold">Tol. (pp)</span>
+				<input type="number" min="0" max="50" step="1" class="input w-20" bind:value={tolerance} />
+			</label>
+			<button type="button" class="btn btn-sm preset-filled-primary-500" onclick={applyTarget}>
+				Zastosuj
+			</button>
+			{#if report?.drift}
+				<button type="button" class="btn btn-sm preset-tonal-surface" onclick={clearTarget}>
+					Wyczyść
+				</button>
+			{/if}
+		</div>
+	</header>
+
+	{#if loading}
+		<p class="text-sm text-surface-700-300">Ładowanie…</p>
+	{:else if error}
+		<div class="card preset-tonal-error p-3 text-sm">{error}</div>
+	{:else if !report || report.currencies.length === 0}
+		<p class="text-sm text-surface-700-300">
+			Brak snapshotu lub aktywnych kont — dodaj pierwszy snapshot, aby zobaczyć ekspozycję.
+		</p>
+	{:else}
+		<div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+			<div bind:this={container} class="md:col-span-2 w-full h-[280px]"></div>
+			<div class="space-y-3 text-sm">
+				<div class="card preset-tonal-surface p-3">
+					<div class="text-xs text-surface-600-400">PLN</div>
+					<div class="text-2xl font-bold">{report.pln_pct.toFixed(1)}%</div>
+				</div>
+				<div class="card preset-tonal-surface p-3">
+					<div class="text-xs text-surface-600-400">Waluty obce</div>
+					<div class="text-2xl font-bold">{report.foreign_pct.toFixed(1)}%</div>
+				</div>
+				{#if report.drift}
+					{@const within = report.drift.within_tolerance}
+					<div class="card {within ? 'preset-tonal-success' : 'preset-tonal-warning'} p-3">
+						<div class="text-xs">Drift vs cel {report.drift.target_pln_pct}%</div>
+						<div class="text-xl font-bold">
+							{report.drift.drift_pln_pct >= 0 ? '+' : ''}{report.drift.drift_pln_pct.toFixed(1)} pp
+						</div>
+						<div class="text-xs">
+							{within
+								? `W tolerancji ±${report.drift.tolerance_pct}pp`
+								: `Poza pasmem ±${report.drift.tolerance_pct}pp`}
+						</div>
+					</div>
+				{/if}
+			</div>
+		</div>
+		<table class="table text-sm">
+			<thead>
+				<tr>
+					<th>Waluta</th>
+					<th class="text-right">Wartość (PLN)</th>
+					<th class="text-right">Udział</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each report.currencies as bucket (bucket.currency)}
+					<tr>
+						<td class="font-semibold">{bucket.currency}</td>
+						<td class="text-right">{formatPLN(bucket.value_pln)}</td>
+						<td class="text-right">{bucket.percent.toFixed(1)}%</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	{/if}
+</section>

--- a/src/lib/components/CurrencyExposureWidget.svelte
+++ b/src/lib/components/CurrencyExposureWidget.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import * as echarts from 'echarts';
 	import { resolveApiUrl } from '$lib/api';
 	import { formatPLN } from '$lib/utils/format';
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@
 	import Skeleton from '$lib/components/Skeleton.svelte';
 	import DashboardCharts from '$lib/components/DashboardCharts.svelte';
 	import AllocationDriftWidget from '$lib/components/AllocationDriftWidget.svelte';
+	import CurrencyExposureWidget from '$lib/components/CurrencyExposureWidget.svelte';
 	import DateRangePicker from '$lib/components/DateRangePicker.svelte';
 	import DeltaBadge from '$lib/components/DeltaBadge.svelte';
 	import { formatPLN } from '$lib/utils/format';
@@ -560,6 +561,8 @@
 		{#if dashboard.allocationDrift?.scopes?.length > 0}
 			<AllocationDriftWidget drift={dashboard.allocationDrift} {owners} />
 		{/if}
+
+		<CurrencyExposureWidget />
 
 		<DashboardCharts
 			netWorthHistory={dashboard.net_worth_history}

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -247,6 +247,12 @@ describe('Dashboard retirement limits save flow', () => {
 				'http://localhost:8000/api/retirement/limits/2024/IKZE/1'
 			])
 		);
+		// Guard against accidental non-GET/PUT side-effects (e.g. a stray
+		// POST/DELETE) sneaking past the relaxed PUT-only filter.
+		for (const call of fetchMock.mock.calls) {
+			const method = call[1]?.method ?? 'GET';
+			expect(['GET', 'PUT']).toContain(method);
+		}
 		await waitFor(() => expect(invalidateAll).toHaveBeenCalled());
 	});
 

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -235,17 +235,18 @@ describe('Dashboard retirement limits save flow', () => {
 
 		await fireEvent.click(screen.getByRole('button', { name: 'Zapisz' }));
 
-		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-		const urls = fetchMock.mock.calls.map((c) => c[0] as string);
+		await waitFor(() => {
+			const putCalls = fetchMock.mock.calls.filter((c) => c[1]?.method === 'PUT');
+			expect(putCalls).toHaveLength(2);
+		});
+		const putCalls = fetchMock.mock.calls.filter((c) => c[1]?.method === 'PUT');
+		const urls = putCalls.map((c) => c[0] as string);
 		expect(urls).toEqual(
 			expect.arrayContaining([
 				'http://localhost:8000/api/retirement/limits/2024/IKE/1',
 				'http://localhost:8000/api/retirement/limits/2024/IKZE/1'
 			])
 		);
-		for (const call of fetchMock.mock.calls) {
-			expect(call[1].method).toBe('PUT');
-		}
 		await waitFor(() => expect(invalidateAll).toHaveBeenCalled());
 	});
 


### PR DESCRIPTION
## Motivation

Closes #556. The dashboard tracks net worth and asset categories but
never says how much of the portfolio is denominated in PLN vs.
foreign currencies. Adds an exposure widget so the user can see
that mix at a glance and check it against a personal target band.

## Implementation information

- New `internal/exposure/` package with a pure `BuildReport`
  (covered by unit tests) and a Postgres-backed `Store` that pulls
  the latest snapshot, joins each value to its account, and sums by
  `UPPER(currency)`.
- HTTP: `GET /api/exposure/currency`, optional `target_pln_pct` +
  `tolerance` query params trigger a drift band in the response.
- Dashboard widget renders the data as a donut + per-currency table
  with the optional drift card (green when inside ±tolerance,
  warning when outside).
- Loosened the dashboard limits-modal test so it filters PUT calls
  by method rather than asserting an exact total fetch count —
  needed because the new widget also fetches on mount.

## Supporting documentation

> Changelog: feat(exposure): currency exposure chart with drift