### PR TITLE
feat(optimizer): rank next PLN allocation

### DIFF
--- a/src/lib/nav/routes.ts
+++ b/src/lib/nav/routes.ts
@@ -13,13 +13,15 @@ import {
 	Settings,
 	Target,
 	Repeat,
-	Briefcase
+	Briefcase,
+	Compass
 } from 'lucide-svelte';
 
 export const NAV_ROUTES = [
 	{ href: '/', label: 'Dashboard', icon: LayoutDashboard },
 	{ href: '/metryki', label: 'Metryki', icon: TrendingUp },
 	{ href: '/simulations', label: 'Symulacje', icon: Sparkles },
+	{ href: '/optimizer', label: 'Optymalizator', icon: Compass },
 	{ href: '/retirement', label: 'Emerytura', icon: Dices },
 	{ href: '/accounts', label: 'Konta', icon: Wallet },
 	{ href: '/transactions', label: 'Transakcje', icon: ArrowRightLeft },

--- a/src/lib/utils/allocationOptimizer.test.ts
+++ b/src/lib/utils/allocationOptimizer.test.ts
@@ -11,6 +11,7 @@ function baseInputs(overrides: Partial<OptionInputs> = {}): OptionInputs {
 		brokerage: 0
 	};
 	return {
+		amountPLN: 1000,
 		marginalPitRate: 0.32,
 		ikzeRemainingPLN: 5000,
 		ikeRemainingPLN: 10000,
@@ -91,6 +92,28 @@ describe('rankOptions', () => {
 			expect(option.factors.length).toBeGreaterThan(0);
 			expect(option.name).toBeTruthy();
 		}
+	});
+
+	it('scales IKZE benefit when the planned amount exceeds the remaining limit', () => {
+		// Identical inputs; only amount changes. With remaining = 1000 and
+		// amount = 1000 → full coverage; amount = 5000 → 20% coverage.
+		const full = rankOptions(
+			baseInputs({ ikzeRemainingPLN: 1000, amountPLN: 1000, liquidityNeedScore: 0 })
+		).find((r) => r.option === 'ikze')!;
+		const partial = rankOptions(
+			baseInputs({ ikzeRemainingPLN: 1000, amountPLN: 5000, liquidityNeedScore: 0 })
+		).find((r) => r.option === 'ikze')!;
+		// liquidity + drift factors don't depend on coverage, so the
+		// difference is exactly the cap-bound factors × (1 − coverage).
+		expect(partial.total).toBeLessThan(full.total);
+		expect(partial.factors[0].label).toMatch(/część 20%/);
+	});
+
+	it('renames the mortgage factor without the gwarantowanie typo', () => {
+		const ranked = rankOptions(baseInputs({ mortgageRemainingPLN: 100000, amountPLN: 1000 }));
+		const m = ranked.find((r) => r.option === 'mortgage')!;
+		expect(m.factors.some((f) => /gwarantowane/.test(f.label))).toBe(true);
+		expect(m.factors.some((f) => /gwarantowanie/.test(f.label))).toBe(false);
 	});
 
 	it('applies capital gains tax to brokerage expected return', () => {

--- a/src/lib/utils/allocationOptimizer.test.ts
+++ b/src/lib/utils/allocationOptimizer.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { rankOptions, type OptionInputs, type OptionKey } from './allocationOptimizer';
+
+function baseInputs(overrides: Partial<OptionInputs> = {}): OptionInputs {
+	const drift: Record<OptionKey, number> = {
+		ikze: 0,
+		ike: 0,
+		ppk: 0,
+		mortgage: 0,
+		bonds: 0,
+		brokerage: 0
+	};
+	return {
+		marginalPitRate: 0.32,
+		ikzeRemainingPLN: 5000,
+		ikeRemainingPLN: 10000,
+		ppkEmployerMatchRate: 0.015,
+		ppkMatched: true,
+		mortgageAPRPct: 7,
+		mortgageRemainingPLN: 200000,
+		bondsYieldPct: 6,
+		brokerageReturnPct: 7,
+		allocationDrift: drift,
+		liquidityNeedScore: 0,
+		...overrides
+	};
+}
+
+describe('rankOptions', () => {
+	it('puts IKZE at top when marginal rate is high and liquidity not needed', () => {
+		const ranked = rankOptions(baseInputs());
+		expect(ranked[0].option).toBe('ikze');
+	});
+
+	it('drops IKZE to the bottom of available list when limit exhausted', () => {
+		const ranked = rankOptions(baseInputs({ ikzeRemainingPLN: 0 }));
+		const ikze = ranked.find((r) => r.option === 'ikze');
+		expect(ikze?.available).toBe(false);
+		expect(ikze?.availabilityReason).toMatch(/Limit IKZE/);
+		expect(ranked[ranked.length - 1].option).toBe('ikze');
+	});
+
+	it('marks PPK unavailable when no active match', () => {
+		const ranked = rankOptions(baseInputs({ ppkMatched: false }));
+		const ppk = ranked.find((r) => r.option === 'ppk');
+		expect(ppk?.available).toBe(false);
+	});
+
+	it('marks mortgage unavailable when no remaining principal', () => {
+		const ranked = rankOptions(baseInputs({ mortgageRemainingPLN: 0 }));
+		const m = ranked.find((r) => r.option === 'mortgage');
+		expect(m?.available).toBe(false);
+	});
+
+	it('penalizes illiquid options when liquidity need is high', () => {
+		const liquid = rankOptions(baseInputs({ liquidityNeedScore: 0 }));
+		const illiquid = rankOptions(baseInputs({ liquidityNeedScore: 5 }));
+		const ikzeLiquid = liquid.find((r) => r.option === 'ikze')!;
+		const ikzeIlliquid = illiquid.find((r) => r.option === 'ikze')!;
+		expect(ikzeIlliquid.total).toBeLessThan(ikzeLiquid.total);
+		const brokerageLiquid = liquid.find((r) => r.option === 'brokerage')!;
+		const brokerageIlliquid = illiquid.find((r) => r.option === 'brokerage')!;
+		// Brokerage is fully liquid → no penalty.
+		expect(brokerageIlliquid.total).toBe(brokerageLiquid.total);
+	});
+
+	it('boosts the option whose category is most under target (positive drift)', () => {
+		const skew: Record<OptionKey, number> = {
+			ikze: 0,
+			ike: 0,
+			ppk: 0,
+			mortgage: 0,
+			bonds: 10,
+			brokerage: 0
+		};
+		// Strip the IKZE/PPK incentives so bonds wins on drift alone.
+		const ranked = rankOptions(
+			baseInputs({
+				marginalPitRate: 0,
+				ppkMatched: false,
+				mortgageRemainingPLN: 0,
+				allocationDrift: skew
+			})
+		);
+		expect(ranked[0].option).toBe('bonds');
+	});
+
+	it('reports score factors for every option', () => {
+		const ranked = rankOptions(baseInputs());
+		for (const option of ranked) {
+			expect(option.factors.length).toBeGreaterThan(0);
+			expect(option.name).toBeTruthy();
+		}
+	});
+
+	it('applies capital gains tax to brokerage expected return', () => {
+		const ranked = rankOptions(
+			baseInputs({
+				marginalPitRate: 0,
+				ppkMatched: false,
+				mortgageRemainingPLN: 0,
+				bondsYieldPct: 0,
+				brokerageReturnPct: 10,
+				liquidityNeedScore: 0
+			})
+		);
+		const brokerage = ranked.find((r) => r.option === 'brokerage');
+		// 10% × (1 − 0.19) = 8.1pp from yield; allocation drift adds 0; liquidity adds 0.
+		expect(brokerage!.total).toBeCloseTo(8.1, 1);
+	});
+});

--- a/src/lib/utils/allocationOptimizer.ts
+++ b/src/lib/utils/allocationOptimizer.ts
@@ -3,6 +3,11 @@ import { PL_RULES } from './pl_rules.generated';
 export type OptionKey = 'ikze' | 'ike' | 'ppk' | 'mortgage' | 'bonds' | 'brokerage';
 
 export interface OptionInputs {
+	// Amount the user plans to contribute. Used to scale benefit factors
+	// for options whose tax/APR upside applies only up to their remaining
+	// limit — e.g. paying 5000 PLN into IKZE with 1000 PLN of remaining
+	// limit converts only 20% of the deposit into a deductible amount.
+	amountPLN: number;
 	marginalPitRate: number;
 	ikzeRemainingPLN: number;
 	ikeRemainingPLN: number;
@@ -64,10 +69,32 @@ function pp(rate: number): number {
 	return rate * 100;
 }
 
+// limitCoverage is the share of the user's planned deposit that fits
+// inside a per-option contribution cap. Anything above the cap delivers
+// none of the tax-side benefit and is silently re-routed to a taxable
+// account, so the scorer multiplies cap-bound factors by this ratio
+// instead of overstating the value.
+function limitCoverage(amount: number, remaining: number): number {
+	if (amount <= 0) return 0;
+	return Math.max(0, Math.min(1, remaining / amount));
+}
+
+function partialLabel(coverage: number, base: string): string {
+	if (coverage >= 1) return base;
+	return `${base} (część ${Math.round(coverage * 100)}%)`;
+}
+
 function scoreIKZE(input: OptionInputs): OptionScore {
+	const coverage = limitCoverage(input.amountPLN, input.ikzeRemainingPLN);
 	const factors: ScoreFactor[] = [
-		{ label: 'Ulga PIT (zwrot)', pp: pp(input.marginalPitRate) },
-		{ label: 'Belka nie pobierana', pp: pp(capitalGainsTax * 0.3) },
+		{
+			label: partialLabel(coverage, 'Ulga PIT (zwrot)'),
+			pp: pp(input.marginalPitRate) * coverage
+		},
+		{
+			label: partialLabel(coverage, 'Belka nie pobierana'),
+			pp: pp(capitalGainsTax * 0.3) * coverage
+		},
 		driftFactor('ikze', input.allocationDrift),
 		liquidityFactor('ikze', input.liquidityNeedScore)
 	];
@@ -82,8 +109,12 @@ function scoreIKZE(input: OptionInputs): OptionScore {
 }
 
 function scoreIKE(input: OptionInputs): OptionScore {
+	const coverage = limitCoverage(input.amountPLN, input.ikeRemainingPLN);
 	const factors: ScoreFactor[] = [
-		{ label: 'Belka uniknięta', pp: pp(capitalGainsTax * 0.5) },
+		{
+			label: partialLabel(coverage, 'Belka uniknięta'),
+			pp: pp(capitalGainsTax * 0.5) * coverage
+		},
 		driftFactor('ike', input.allocationDrift),
 		liquidityFactor('ike', input.liquidityNeedScore)
 	];
@@ -116,8 +147,12 @@ function scorePPK(input: OptionInputs): OptionScore {
 }
 
 function scoreMortgage(input: OptionInputs): OptionScore {
+	const coverage = limitCoverage(input.amountPLN, input.mortgageRemainingPLN);
 	const factors: ScoreFactor[] = [
-		{ label: 'Odsetki gwarantowanie oszczędzone', pp: input.mortgageAPRPct },
+		{
+			label: partialLabel(coverage, 'Odsetki gwarantowane oszczędzone'),
+			pp: input.mortgageAPRPct * coverage
+		},
 		driftFactor('mortgage', input.allocationDrift),
 		liquidityFactor('mortgage', input.liquidityNeedScore)
 	];

--- a/src/lib/utils/allocationOptimizer.ts
+++ b/src/lib/utils/allocationOptimizer.ts
@@ -1,0 +1,180 @@
+import { PL_RULES } from './pl_rules.generated';
+
+export type OptionKey = 'ikze' | 'ike' | 'ppk' | 'mortgage' | 'bonds' | 'brokerage';
+
+export interface OptionInputs {
+	marginalPitRate: number;
+	ikzeRemainingPLN: number;
+	ikeRemainingPLN: number;
+	ppkEmployerMatchRate: number;
+	ppkMatched: boolean;
+	mortgageAPRPct: number;
+	mortgageRemainingPLN: number;
+	bondsYieldPct: number;
+	brokerageReturnPct: number;
+	allocationDrift: Record<OptionKey, number>;
+	liquidityNeedScore: number;
+}
+
+export interface ScoreFactor {
+	label: string;
+	pp: number;
+}
+
+export interface OptionScore {
+	option: OptionKey;
+	name: string;
+	available: boolean;
+	availabilityReason?: string;
+	factors: ScoreFactor[];
+	total: number;
+}
+
+export const OPTION_NAMES: Record<OptionKey, string> = {
+	ikze: 'IKZE',
+	ike: 'IKE',
+	ppk: 'PPK',
+	mortgage: 'Nadpłata hipoteki',
+	bonds: 'Obligacje skarbowe',
+	brokerage: 'Konto maklerskie'
+};
+
+const capitalGainsTax = PL_RULES['capital_gains_tax_2026']?.value ?? 0.19;
+
+const LIQUIDITY_BASE: Record<OptionKey, number> = {
+	brokerage: 0,
+	bonds: -1,
+	ike: -3,
+	ikze: -5,
+	ppk: -5,
+	mortgage: -4
+};
+
+function liquidityFactor(option: OptionKey, liquidityNeed: number): ScoreFactor {
+	const base = LIQUIDITY_BASE[option];
+	const value = base * Math.max(0, Math.min(5, liquidityNeed));
+	return { label: 'Płynność', pp: value };
+}
+
+function driftFactor(option: OptionKey, drift: Record<OptionKey, number>): ScoreFactor {
+	return { label: 'Dryft alokacji', pp: drift[option] ?? 0 };
+}
+
+function pp(rate: number): number {
+	return rate * 100;
+}
+
+function scoreIKZE(input: OptionInputs): OptionScore {
+	const factors: ScoreFactor[] = [
+		{ label: 'Ulga PIT (zwrot)', pp: pp(input.marginalPitRate) },
+		{ label: 'Belka nie pobierana', pp: pp(capitalGainsTax * 0.3) },
+		driftFactor('ikze', input.allocationDrift),
+		liquidityFactor('ikze', input.liquidityNeedScore)
+	];
+	return {
+		option: 'ikze',
+		name: OPTION_NAMES.ikze,
+		available: input.ikzeRemainingPLN > 0,
+		availabilityReason: input.ikzeRemainingPLN > 0 ? undefined : 'Limit IKZE wyczerpany',
+		factors,
+		total: factors.reduce((sum, f) => sum + f.pp, 0)
+	};
+}
+
+function scoreIKE(input: OptionInputs): OptionScore {
+	const factors: ScoreFactor[] = [
+		{ label: 'Belka uniknięta', pp: pp(capitalGainsTax * 0.5) },
+		driftFactor('ike', input.allocationDrift),
+		liquidityFactor('ike', input.liquidityNeedScore)
+	];
+	return {
+		option: 'ike',
+		name: OPTION_NAMES.ike,
+		available: input.ikeRemainingPLN > 0,
+		availabilityReason: input.ikeRemainingPLN > 0 ? undefined : 'Limit IKE wyczerpany',
+		factors,
+		total: factors.reduce((sum, f) => sum + f.pp, 0)
+	};
+}
+
+function scorePPK(input: OptionInputs): OptionScore {
+	const factors: ScoreFactor[] = [
+		{ label: 'Dopłata pracodawcy', pp: pp(input.ppkEmployerMatchRate) },
+		driftFactor('ppk', input.allocationDrift),
+		liquidityFactor('ppk', input.liquidityNeedScore)
+	];
+	return {
+		option: 'ppk',
+		name: OPTION_NAMES.ppk,
+		available: input.ppkMatched,
+		availabilityReason: input.ppkMatched
+			? undefined
+			: 'Brak aktywnego PPK lub limit pracodawcy wykorzystany',
+		factors,
+		total: factors.reduce((sum, f) => sum + f.pp, 0)
+	};
+}
+
+function scoreMortgage(input: OptionInputs): OptionScore {
+	const factors: ScoreFactor[] = [
+		{ label: 'Odsetki gwarantowanie oszczędzone', pp: input.mortgageAPRPct },
+		driftFactor('mortgage', input.allocationDrift),
+		liquidityFactor('mortgage', input.liquidityNeedScore)
+	];
+	return {
+		option: 'mortgage',
+		name: OPTION_NAMES.mortgage,
+		available: input.mortgageRemainingPLN > 0,
+		availabilityReason:
+			input.mortgageRemainingPLN > 0 ? undefined : 'Brak otwartego kredytu hipotecznego',
+		factors,
+		total: factors.reduce((sum, f) => sum + f.pp, 0)
+	};
+}
+
+function scoreBonds(input: OptionInputs): OptionScore {
+	const netYieldPct = input.bondsYieldPct * (1 - capitalGainsTax);
+	const factors: ScoreFactor[] = [
+		{ label: 'Oczekiwany zysk netto', pp: netYieldPct },
+		driftFactor('bonds', input.allocationDrift),
+		liquidityFactor('bonds', input.liquidityNeedScore)
+	];
+	return {
+		option: 'bonds',
+		name: OPTION_NAMES.bonds,
+		available: true,
+		factors,
+		total: factors.reduce((sum, f) => sum + f.pp, 0)
+	};
+}
+
+function scoreBrokerage(input: OptionInputs): OptionScore {
+	const netReturnPct = input.brokerageReturnPct * (1 - capitalGainsTax);
+	const factors: ScoreFactor[] = [
+		{ label: 'Oczekiwany zysk po Belce', pp: netReturnPct },
+		driftFactor('brokerage', input.allocationDrift),
+		liquidityFactor('brokerage', input.liquidityNeedScore)
+	];
+	return {
+		option: 'brokerage',
+		name: OPTION_NAMES.brokerage,
+		available: true,
+		factors,
+		total: factors.reduce((sum, f) => sum + f.pp, 0)
+	};
+}
+
+export function rankOptions(input: OptionInputs): OptionScore[] {
+	const all = [
+		scoreIKZE(input),
+		scoreIKE(input),
+		scorePPK(input),
+		scoreMortgage(input),
+		scoreBonds(input),
+		scoreBrokerage(input)
+	];
+	return all.sort((a, b) => {
+		if (a.available !== b.available) return a.available ? -1 : 1;
+		return b.total - a.total;
+	});
+}

--- a/src/routes/optimizer/+page.svelte
+++ b/src/routes/optimizer/+page.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+	import { rankOptions, type OptionInputs, type OptionKey } from '$lib/utils/allocationOptimizer';
+	import { formatPLN } from '$lib/utils/format';
+	import { Compass, TrendingUp } from 'lucide-svelte';
+
+	let amount = $state(1000);
+	let marginalPitRate = $state(0.32);
+	let ikzeRemainingPLN = $state(5000);
+	let ikeRemainingPLN = $state(15000);
+	let ppkEmployerMatchRate = $state(0.015);
+	let ppkMatched = $state(true);
+	let mortgageAPRPct = $state(7);
+	let mortgageRemainingPLN = $state(0);
+	let bondsYieldPct = $state(6.75);
+	let brokerageReturnPct = $state(7);
+	let liquidityNeedScore = $state(1);
+
+	type DriftEntry = { key: OptionKey; label: string; pp: number };
+	let drift = $state<DriftEntry[]>([
+		{ key: 'ikze', label: 'IKZE', pp: 0 },
+		{ key: 'ike', label: 'IKE', pp: 0 },
+		{ key: 'ppk', label: 'PPK', pp: 0 },
+		{ key: 'mortgage', label: 'Nadpłata hipoteki', pp: 0 },
+		{ key: 'bonds', label: 'Obligacje', pp: 0 },
+		{ key: 'brokerage', label: 'Maklerskie', pp: 0 }
+	]);
+
+	const inputs = $derived<OptionInputs>({
+		marginalPitRate,
+		ikzeRemainingPLN,
+		ikeRemainingPLN,
+		ppkEmployerMatchRate,
+		ppkMatched,
+		mortgageAPRPct,
+		mortgageRemainingPLN,
+		bondsYieldPct,
+		brokerageReturnPct,
+		allocationDrift: Object.fromEntries(drift.map((d) => [d.key, d.pp])) as Record<
+			OptionKey,
+			number
+		>,
+		liquidityNeedScore
+	});
+
+	const ranked = $derived(rankOptions(inputs));
+
+	function impactPLN(scorePP: number): number {
+		return (amount * scorePP) / 100;
+	}
+</script>
+
+<svelte:head>
+	<title>Optymalizator | Finansowa Forteca</title>
+</svelte:head>
+
+<div class="space-y-6">
+	<header class="space-y-1">
+		<h1 class="h2 flex items-center gap-2">
+			<Compass size={24} class="text-primary-500" />
+			Optymalizator następnych 1000 PLN
+		</h1>
+		<p class="text-surface-700-300 text-sm">
+			Porównaj IKZE, IKE, PPK, nadpłatę hipoteki, obligacje i maklerskie — ranking według
+			oczekiwanej korzyści w pkt. proc.
+		</p>
+	</header>
+
+	<section class="card preset-filled-surface-100-900 p-5 space-y-4">
+		<h2 class="h4">Parametry</h2>
+		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+			<label class="space-y-1">
+				<span class="text-xs font-semibold">Kwota (PLN)</span>
+				<input type="number" min="0" class="input w-full" bind:value={amount} />
+			</label>
+			<label class="space-y-1">
+				<span class="text-xs font-semibold">Krańcowa stawka PIT (np. 0.32)</span>
+				<input
+					type="number"
+					min="0"
+					max="1"
+					step="0.01"
+					class="input w-full"
+					bind:value={marginalPitRate}
+				/>
+			</label>
+			<label class="space-y-1">
+				<span class="text-xs font-semibold">Pozostały limit IKZE (PLN)</span>
+				<input type="number" min="0" class="input w-full" bind:value={ikzeRemainingPLN} />
+			</label>
+			<label class="space-y-1">
+				<span class="text-xs font-semibold">Pozostały limit IKE (PLN)</span>
+				<input type="number" min="0" class="input w-full" bind:value={ikeRemainingPLN} />
+			</label>
+			<label class="space-y-1 flex flex-col">
+				<span class="text-xs font-semibold">PPK aktywne</span>
+				<select bind:value={ppkMatched} class="input">
+					<option value={true}>Tak</option>
+					<option value={false}>Nie</option>
+				</select>
+			</label>
+			<label class="space-y-1">
+				<span class="text-xs font-semibold">Stawka pracodawcy PPK (np. 0.015)</span>
+				<input
+					type="number"
+					min="0"
+					max="1"
+					step="0.001"
+					class="input w-full"
+					bind:value={ppkEmployerMatchRate}
+				/>
+			</label>
+			<label class="space-y-1">
+				<span class="text-xs font-semibold">APR kredytu hipotecznego (%)</span>
+				<input type="number" min="0" step="0.1" class="input w-full" bind:value={mortgageAPRPct} />
+			</label>
+			<label class="space-y-1">
+				<span class="text-xs font-semibold">Pozostały kapitał hipoteki (PLN)</span>
+				<input type="number" min="0" class="input w-full" bind:value={mortgageRemainingPLN} />
+			</label>
+			<label class="space-y-1">
+				<span class="text-xs font-semibold">Oczekiwany zysk obligacji (% brutto)</span>
+				<input type="number" min="0" step="0.1" class="input w-full" bind:value={bondsYieldPct} />
+			</label>
+			<label class="space-y-1">
+				<span class="text-xs font-semibold">Oczekiwany zwrot maklerskiego (% brutto)</span>
+				<input
+					type="number"
+					min="0"
+					step="0.1"
+					class="input w-full"
+					bind:value={brokerageReturnPct}
+				/>
+			</label>
+			<label class="space-y-1">
+				<span class="text-xs font-semibold">Potrzeba płynności (0-5)</span>
+				<input
+					type="number"
+					min="0"
+					max="5"
+					step="1"
+					class="input w-full"
+					bind:value={liquidityNeedScore}
+				/>
+			</label>
+		</div>
+
+		<h3 class="h5">Dryft alokacji (pp, „+” = pod celem)</h3>
+		<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+			{#each drift as d (d.key)}
+				<label class="space-y-1">
+					<span class="text-xs font-semibold">{d.label}</span>
+					<input type="number" step="0.5" class="input w-full" bind:value={d.pp} />
+				</label>
+			{/each}
+		</div>
+	</section>
+
+	<section class="card preset-filled-surface-100-900 p-5 space-y-3">
+		<h2 class="h4 flex items-center gap-2">
+			<TrendingUp size={20} class="text-primary-500" />
+			Ranking
+		</h2>
+		<ol class="space-y-3">
+			{#each ranked as r, idx (r.option)}
+				<li class="card preset-tonal-surface p-4 space-y-2 {r.available ? '' : 'opacity-60'}">
+					<header class="flex flex-wrap items-baseline justify-between gap-2">
+						<div class="flex items-baseline gap-3">
+							<span class="text-2xl font-bold">{idx + 1}.</span>
+							<span class="text-lg font-semibold">{r.name}</span>
+							{#if !r.available}
+								<span class="badge preset-tonal-warning">{r.availabilityReason}</span>
+							{/if}
+						</div>
+						<div class="text-right">
+							<div class="text-xs text-surface-600-400">Wynik</div>
+							<div class="text-xl font-bold">{r.total.toFixed(1)} pp</div>
+							<div class="text-xs text-surface-600-400">
+								≈ {formatPLN(impactPLN(r.total))}/rok przy {formatPLN(amount)}
+							</div>
+						</div>
+					</header>
+					<dl class="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
+						{#each r.factors as f (f.label)}
+							<div>
+								<dt class="text-surface-600-400">{f.label}</dt>
+								<dd class="font-semibold {f.pp >= 0 ? '' : 'text-error-600-400'}">
+									{f.pp >= 0 ? '+' : ''}{f.pp.toFixed(1)} pp
+								</dd>
+							</div>
+						{/each}
+					</dl>
+				</li>
+			{/each}
+		</ol>
+		<p class="text-xs text-surface-600-400">
+			Wynik wyrażony w pkt. proc. odnosi się do kwoty wpłaty: 5 pp ≈ 5% nadwyżki w pierwszym roku.
+			Tę kalkulację należy traktować jako szybką orientację — Belka, ulga IKZE i dopłata PPK są
+			przybliżeniami. Złoty standard to indywidualny rachunek z doradcą.
+		</p>
+	</section>
+</div>

--- a/src/routes/optimizer/+page.svelte
+++ b/src/routes/optimizer/+page.svelte
@@ -26,6 +26,7 @@
 	]);
 
 	const inputs = $derived<OptionInputs>({
+		amountPLN: amount,
 		marginalPitRate,
 		ikzeRemainingPLN,
 		ikeRemainingPLN,


### PR DESCRIPTION
## Motivation

Closes #557. "Where do I send the next 1000 zł?" is a recurring
question — the dashboard tracks net worth but never compares
destinations. Adds a side-by-side ranking of IKZE / IKE / PPK /
mortgage overpayment / bonds / brokerage so the user can see which
one wins for their current parameters and why.

## Implementation information

- Pure scorer in `src/lib/utils/allocationOptimizer.ts` returns one
  `OptionScore` per destination with its factors broken out (tax
  relief, employer match, APR, expected return after Belka, drift,
  liquidity). Unit tests cover the typical winners, availability
  gating, and the brokerage capital-gains adjustment.
- Score is expressed in percentage points so the UI can translate
  it back into PLN of first-year benefit for any input amount.
- New `/optimizer` route exposes every input the scorer accepts and
  renders the ranked list with all factor cards visible — the user
  can see exactly why an option won or lost.
- Sidebar nav gets a new "Optymalizator" entry between Symulacje and
  Emerytura.

## Supporting documentation

> Changelog: feat(optimizer): rank next PLN allocation