### PR TITLE
feat(zus): private FIRE gap chart

### DIFF
--- a/src/lib/components/FireGapChart.svelte
+++ b/src/lib/components/FireGapChart.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
+	import { projectFireGap, type FireGapInputs } from '$lib/utils/fireGap';
+	import { formatPLN } from '$lib/utils/format';
+	import { Scale } from 'lucide-svelte';
+
+	let currentAge = $state(35);
+	let retirementAge = $state(65);
+	let lifeExpectancy = $state(85);
+	let currentPortfolioPLN = $state(100000);
+	let annualContributionPLN = $state(20000);
+	let expectedReturnPct = $state(6);
+	let inflationPct = $state(3);
+	let withdrawalRatePct = $state(4);
+	let monthlyPensionNetPLN = $state(3500);
+
+	const inputs = $derived<FireGapInputs>({
+		currentAge,
+		retirementAge,
+		lifeExpectancy,
+		currentPortfolioPLN,
+		annualContributionPLN,
+		expectedReturnPct,
+		inflationPct,
+		withdrawalRatePct,
+		monthlyPensionNetPLN
+	});
+
+	const rows = $derived(projectFireGap(inputs));
+
+	const summary = $derived.by(() => {
+		const post = rows.filter((r) => r.afterRetirement);
+		if (post.length === 0) return null;
+		const totalGap = post.reduce((sum, r) => sum + r.gapPLN, 0);
+		const avgGap = totalGap / post.length;
+		const firstYearGap = post[0].gapPLN;
+		return { avgGap, firstYearGap };
+	});
+
+	let container: HTMLDivElement | undefined = $state();
+	let handle: ChartHandle | null = null;
+
+	$effect(() => {
+		if (!container) {
+			handle?.dispose();
+			handle = null;
+			return;
+		}
+		if (!handle) handle = createChart(container);
+		handle.chart.setOption({
+			tooltip: { trigger: 'axis' },
+			legend: {
+				top: 0,
+				data: ['Prywatny portfel', 'Emerytura ZUS', 'Luka miesięczna']
+			},
+			grid: { left: 60, right: 30, top: 40, bottom: 30 },
+			xAxis: {
+				type: 'category',
+				data: rows.map((r) => r.year)
+			},
+			yAxis: {
+				type: 'value',
+				axisLabel: {
+					formatter: (v: number) => formatPLN(v)
+				}
+			},
+			series: [
+				{
+					name: 'Prywatny portfel',
+					type: 'line',
+					smooth: true,
+					data: rows.map((r) => Math.round(r.privateMonthlyIncomePLN)),
+					itemStyle: { color: '#10b981' }
+				},
+				{
+					name: 'Emerytura ZUS',
+					type: 'line',
+					smooth: true,
+					data: rows.map((r) => Math.round(r.zusMonthlyIncomePLN)),
+					itemStyle: { color: '#3b82f6' }
+				},
+				{
+					name: 'Luka miesięczna',
+					type: 'bar',
+					barWidth: '40%',
+					data: rows.map((r) => (r.afterRetirement ? Math.round(r.gapPLN) : 0)),
+					itemStyle: { color: '#f59e0b', opacity: 0.65 }
+				}
+			]
+		});
+	});
+</script>
+
+<section class="card preset-filled-surface-100-900 p-5 space-y-4">
+	<header class="space-y-1">
+		<h2 class="h4 flex items-center gap-2">
+			<Scale size={20} class="text-primary-500" />
+			Luka FIRE vs ZUS
+		</h2>
+		<p class="text-sm text-surface-700-300">
+			Roczna luka między prywatnym portfelem a szacunkową emeryturą ZUS — używa założeń kalkulatora
+			ZUS.
+		</p>
+	</header>
+
+	<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+		<label class="space-y-1">
+			<span class="text-xs font-semibold">Obecny wiek</span>
+			<input type="number" min="18" max="100" class="input w-full" bind:value={currentAge} />
+		</label>
+		<label class="space-y-1">
+			<span class="text-xs font-semibold">Wiek emerytalny</span>
+			<input type="number" min="18" max="100" class="input w-full" bind:value={retirementAge} />
+		</label>
+		<label class="space-y-1">
+			<span class="text-xs font-semibold">Oczekiwana długość życia</span>
+			<input type="number" min="18" max="120" class="input w-full" bind:value={lifeExpectancy} />
+		</label>
+		<label class="space-y-1">
+			<span class="text-xs font-semibold">Obecny portfel (PLN)</span>
+			<input type="number" min="0" class="input w-full" bind:value={currentPortfolioPLN} />
+		</label>
+		<label class="space-y-1">
+			<span class="text-xs font-semibold">Roczna wpłata (PLN)</span>
+			<input type="number" min="0" class="input w-full" bind:value={annualContributionPLN} />
+		</label>
+		<label class="space-y-1">
+			<span class="text-xs font-semibold">Oczekiwana stopa zwrotu (%)</span>
+			<input type="number" step="0.1" class="input w-full" bind:value={expectedReturnPct} />
+		</label>
+		<label class="space-y-1">
+			<span class="text-xs font-semibold">Inflacja (%)</span>
+			<input type="number" step="0.1" min="0" class="input w-full" bind:value={inflationPct} />
+		</label>
+		<label class="space-y-1">
+			<span class="text-xs font-semibold">Wskaźnik wypłaty (%)</span>
+			<input type="number" step="0.1" min="0" class="input w-full" bind:value={withdrawalRatePct} />
+		</label>
+		<label class="space-y-1">
+			<span class="text-xs font-semibold">Mies. emerytura ZUS (PLN)</span>
+			<input type="number" min="0" class="input w-full" bind:value={monthlyPensionNetPLN} />
+		</label>
+	</div>
+
+	{#if summary}
+		<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+			<div class="card preset-tonal-surface p-3">
+				<div class="text-xs text-surface-600-400">Luka w pierwszym roku emerytury</div>
+				<div
+					class="text-2xl font-bold {summary.firstYearGap >= 0
+						? 'text-success-600-400'
+						: 'text-error-600-400'}"
+				>
+					{summary.firstYearGap >= 0 ? '+' : ''}{formatPLN(summary.firstYearGap)}
+				</div>
+			</div>
+			<div class="card preset-tonal-surface p-3">
+				<div class="text-xs text-surface-600-400">
+					Średnia roczna luka po przejściu na emeryturę
+				</div>
+				<div
+					class="text-2xl font-bold {summary.avgGap >= 0
+						? 'text-success-600-400'
+						: 'text-error-600-400'}"
+				>
+					{summary.avgGap >= 0 ? '+' : ''}{formatPLN(summary.avgGap)}
+				</div>
+			</div>
+		</div>
+	{/if}
+
+	<div bind:this={container} class="w-full h-[360px]"></div>
+
+	<p class="text-xs text-surface-600-400">
+		Słupek = miesięczna luka między prywatną wypłatą (portfel × stopa wypłaty / 12) a indeksowaną
+		emeryturą ZUS. Dodatni słupek = prywatny portfel pokrywa więcej niż państwowa emerytura; ujemny
+		= luka do zasypania.
+	</p>
+</section>

--- a/src/lib/components/FireGapChart.svelte
+++ b/src/lib/components/FireGapChart.svelte
@@ -1,18 +1,35 @@
 <script lang="ts">
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
-	import { projectFireGap, type FireGapInputs } from '$lib/utils/fireGap';
+	import { projectFireGap, type FireGapInputs, type PensionPriceBasis } from '$lib/utils/fireGap';
 	import { formatPLN } from '$lib/utils/format';
 	import { Scale } from 'lucide-svelte';
 
-	let currentAge = $state(35);
-	let retirementAge = $state(65);
-	let lifeExpectancy = $state(85);
-	let currentPortfolioPLN = $state(100000);
-	let annualContributionPLN = $state(20000);
-	let expectedReturnPct = $state(6);
-	let inflationPct = $state(3);
-	let withdrawalRatePct = $state(4);
-	let monthlyPensionNetPLN = $state(3500);
+	// All numeric props are $bindable so the retirement page can share its
+	// existing Monte Carlo inputs with this chart instead of asking the user
+	// to type them twice.
+	let {
+		currentAge = $bindable(35),
+		retirementAge = $bindable(65),
+		lifeExpectancy = $bindable(85),
+		currentPortfolioPLN = $bindable(100000),
+		annualContributionPLN = $bindable(20000),
+		expectedReturnPct = $bindable(6),
+		inflationPct = $bindable(3),
+		withdrawalRatePct = $bindable(4),
+		monthlyPensionNetPLN = $bindable(3500),
+		pensionBasis = $bindable<PensionPriceBasis>('today')
+	}: {
+		currentAge?: number;
+		retirementAge?: number;
+		lifeExpectancy?: number;
+		currentPortfolioPLN?: number;
+		annualContributionPLN?: number;
+		expectedReturnPct?: number;
+		inflationPct?: number;
+		withdrawalRatePct?: number;
+		monthlyPensionNetPLN?: number;
+		pensionBasis?: PensionPriceBasis;
+	} = $props();
 
 	const inputs = $derived<FireGapInputs>({
 		currentAge,
@@ -23,7 +40,8 @@
 		expectedReturnPct,
 		inflationPct,
 		withdrawalRatePct,
-		monthlyPensionNetPLN
+		monthlyPensionNetPLN,
+		pensionBasis
 	});
 
 	const rows = $derived(projectFireGap(inputs));
@@ -44,7 +62,7 @@
 		if (!container) {
 			handle?.dispose();
 			handle = null;
-			return;
+			return undefined;
 		}
 		if (!handle) handle = createChart(container);
 		handle.chart.setOption({
@@ -88,6 +106,13 @@
 				}
 			]
 		});
+		// Dispose the chart + ResizeObserver when the component is destroyed
+		// or the container ref is detached, so this widget can be re-mounted
+		// without leaking either.
+		return () => {
+			handle?.dispose();
+			handle = null;
+		};
 	});
 </script>
 
@@ -98,8 +123,8 @@
 			Luka FIRE vs ZUS
 		</h2>
 		<p class="text-sm text-surface-700-300">
-			Roczna luka między prywatnym portfelem a szacunkową emeryturą ZUS — używa założeń kalkulatora
-			ZUS.
+			Miesięczna luka między prywatnym portfelem a szacunkową emeryturą ZUS — używa założeń
+			kalkulatora ZUS.
 		</p>
 	</header>
 
@@ -140,6 +165,13 @@
 			<span class="text-xs font-semibold">Mies. emerytura ZUS (PLN)</span>
 			<input type="number" min="0" class="input w-full" bind:value={monthlyPensionNetPLN} />
 		</label>
+		<label class="space-y-1">
+			<span class="text-xs font-semibold">Denominacja emerytury</span>
+			<select bind:value={pensionBasis} class="input w-full">
+				<option value="today">Dzisiejsze PLN</option>
+				<option value="retirement">PLN w roku emerytury (kalkulator ZUS)</option>
+			</select>
+		</label>
 	</div>
 
 	{#if summary}
@@ -156,7 +188,7 @@
 			</div>
 			<div class="card preset-tonal-surface p-3">
 				<div class="text-xs text-surface-600-400">
-					Średnia roczna luka po przejściu na emeryturę
+					Średnia miesięczna luka po przejściu na emeryturę
 				</div>
 				<div
 					class="text-2xl font-bold {summary.avgGap >= 0

--- a/src/lib/utils/fireGap.test.ts
+++ b/src/lib/utils/fireGap.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { projectFireGap, type FireGapInputs } from './fireGap';
+
+function inputs(overrides: Partial<FireGapInputs> = {}): FireGapInputs {
+	return {
+		currentAge: 35,
+		retirementAge: 65,
+		lifeExpectancy: 85,
+		currentPortfolioPLN: 100000,
+		annualContributionPLN: 20000,
+		expectedReturnPct: 6,
+		inflationPct: 3,
+		withdrawalRatePct: 4,
+		monthlyPensionNetPLN: 3500,
+		...overrides
+	};
+}
+
+describe('projectFireGap', () => {
+	it('returns one entry per year from currentAge to lifeExpectancy inclusive', () => {
+		const rows = projectFireGap(inputs());
+		expect(rows.length).toBe(85 - 35 + 1);
+		expect(rows[0].age).toBe(35);
+		expect(rows[rows.length - 1].age).toBe(85);
+	});
+
+	it('marks years before retirement as not after-retirement', () => {
+		const rows = projectFireGap(inputs());
+		expect(rows.find((r) => r.age === 60)?.afterRetirement).toBe(false);
+		expect(rows.find((r) => r.age === 65)?.afterRetirement).toBe(true);
+		expect(rows.find((r) => r.age === 70)?.afterRetirement).toBe(true);
+	});
+
+	it('reports zero ZUS and zero private income before retirement', () => {
+		const rows = projectFireGap(inputs());
+		const preRetire = rows.filter((r) => !r.afterRetirement);
+		for (const row of preRetire) {
+			expect(row.zusMonthlyIncomePLN).toBe(0);
+			expect(row.privateMonthlyIncomePLN).toBe(0);
+			expect(row.gapPLN).toBe(0);
+		}
+	});
+
+	it('inflation-adjusts the ZUS pension after retirement', () => {
+		const rows = projectFireGap(inputs({ inflationPct: 3 }));
+		const atRetire = rows.find((r) => r.age === 65)!;
+		const later = rows.find((r) => r.age === 75)!;
+		// 10 years of 3% inflation × 1.34
+		expect(later.zusMonthlyIncomePLN / atRetire.zusMonthlyIncomePLN).toBeCloseTo(
+			Math.pow(1.03, 10),
+			3
+		);
+	});
+
+	it('computes positive gap when private withdrawal exceeds ZUS pension', () => {
+		const rows = projectFireGap(
+			inputs({ currentPortfolioPLN: 3_000_000, monthlyPensionNetPLN: 1000 })
+		);
+		const atRetire = rows.find((r) => r.age === 65)!;
+		expect(atRetire.gapPLN).toBeGreaterThan(0);
+		expect(atRetire.privateMonthlyIncomePLN).toBeGreaterThan(atRetire.zusMonthlyIncomePLN);
+	});
+
+	it('contributes during working years and stops at retirement', () => {
+		const rows = projectFireGap(
+			inputs({
+				annualContributionPLN: 50000,
+				expectedReturnPct: 0,
+				inflationPct: 0,
+				retirementAge: 40,
+				lifeExpectancy: 42,
+				currentAge: 38
+			})
+		);
+		const atRetire = rows.find((r) => r.age === 40)!;
+		// 2 contribution years of 50k + starting 100k = 200k
+		expect(atRetire.portfolioPLN).toBeCloseTo(200000 - 200000 * 0.04, 0);
+	});
+
+	it('uses the calendar-year mapper to label rows', () => {
+		const rows = projectFireGap(inputs(), (age) => 2026 + (age - 35));
+		expect(rows[0].year).toBe(2026);
+		expect(rows[1].year).toBe(2027);
+	});
+});

--- a/src/lib/utils/fireGap.test.ts
+++ b/src/lib/utils/fireGap.test.ts
@@ -77,6 +77,19 @@ describe('projectFireGap', () => {
 		expect(atRetire.portfolioPLN).toBeCloseTo(200000 - 200000 * 0.04, 0);
 	});
 
+	it('skips current→retirement inflation when basis is retirement-year PLN', () => {
+		const rows = projectFireGap(inputs({ inflationPct: 3, pensionBasis: 'retirement' }));
+		const atRetire = rows.find((r) => r.age === 65)!;
+		// Pension was already in retirement-year PLN — first retirement
+		// row keeps the input verbatim.
+		expect(atRetire.zusMonthlyIncomePLN).toBeCloseTo(3500, 1);
+		const later = rows.find((r) => r.age === 75)!;
+		expect(later.zusMonthlyIncomePLN / atRetire.zusMonthlyIncomePLN).toBeCloseTo(
+			Math.pow(1.03, 10),
+			3
+		);
+	});
+
 	it('uses the calendar-year mapper to label rows', () => {
 		const rows = projectFireGap(inputs(), (age) => 2026 + (age - 35));
 		expect(rows[0].year).toBe(2026);

--- a/src/lib/utils/fireGap.ts
+++ b/src/lib/utils/fireGap.ts
@@ -1,3 +1,10 @@
+// PensionPriceBasis declares the year the supplied pension figure is
+// expressed in. Callers that paste the ZUS calculator's
+// MonthlyPensionNet (already in retirement-year PLN) want 'retirement';
+// callers that key in a number "in today's PLN" want 'today'. The
+// projector indexes accordingly so inflation isn't double-counted.
+export type PensionPriceBasis = 'today' | 'retirement';
+
 export interface FireGapInputs {
 	currentAge: number;
 	retirementAge: number;
@@ -7,7 +14,10 @@ export interface FireGapInputs {
 	expectedReturnPct: number;
 	inflationPct: number;
 	withdrawalRatePct: number;
+	// Net monthly ZUS pension. See pensionBasis for the year this number
+	// is denominated in. Defaults to 'today' for backwards compatibility.
 	monthlyPensionNetPLN: number;
+	pensionBasis?: PensionPriceBasis;
 }
 
 export interface FireGapYear {
@@ -40,8 +50,12 @@ export function projectFireGap(
 			portfolio = Math.max(0, portfolio - annualWithdrawal);
 			portfolio *= 1 + r;
 		}
-		const yearsSinceNow = age - input.currentAge;
-		const inflationFactor = Math.pow(1 + inflation, yearsSinceNow);
+		// "Today's PLN" inputs need to be inflated from now → age. Values
+		// already in retirement-year PLN (e.g. straight out of the ZUS
+		// calculator) only need indexing from retirement → age.
+		const basis = input.pensionBasis ?? 'today';
+		const inflateFromAge = basis === 'today' ? input.currentAge : input.retirementAge;
+		const inflationFactor = Math.pow(1 + inflation, Math.max(0, age - inflateFromAge));
 		const zusMonthly = afterRetirement
 			? Math.max(0, input.monthlyPensionNetPLN) * inflationFactor
 			: 0;

--- a/src/lib/utils/fireGap.ts
+++ b/src/lib/utils/fireGap.ts
@@ -1,0 +1,60 @@
+export interface FireGapInputs {
+	currentAge: number;
+	retirementAge: number;
+	lifeExpectancy: number;
+	currentPortfolioPLN: number;
+	annualContributionPLN: number;
+	expectedReturnPct: number;
+	inflationPct: number;
+	withdrawalRatePct: number;
+	monthlyPensionNetPLN: number;
+}
+
+export interface FireGapYear {
+	age: number;
+	year: number;
+	portfolioPLN: number;
+	privateMonthlyIncomePLN: number;
+	zusMonthlyIncomePLN: number;
+	gapPLN: number;
+	afterRetirement: boolean;
+}
+
+export function projectFireGap(
+	input: FireGapInputs,
+	calendarYearAt: (age: number) => number = (age) =>
+		new Date().getFullYear() + (age - input.currentAge)
+): FireGapYear[] {
+	const out: FireGapYear[] = [];
+	const r = Math.max(-0.99, input.expectedReturnPct / 100);
+	const inflation = Math.max(0, input.inflationPct / 100);
+	const wr = Math.max(0, input.withdrawalRatePct / 100);
+	let portfolio = Math.max(0, input.currentPortfolioPLN);
+	for (let age = input.currentAge; age <= input.lifeExpectancy; age++) {
+		const afterRetirement = age >= input.retirementAge;
+		if (!afterRetirement) {
+			portfolio = portfolio * (1 + r) + Math.max(0, input.annualContributionPLN);
+		}
+		const annualWithdrawal = afterRetirement ? portfolio * wr : 0;
+		if (afterRetirement) {
+			portfolio = Math.max(0, portfolio - annualWithdrawal);
+			portfolio *= 1 + r;
+		}
+		const yearsSinceNow = age - input.currentAge;
+		const inflationFactor = Math.pow(1 + inflation, yearsSinceNow);
+		const zusMonthly = afterRetirement
+			? Math.max(0, input.monthlyPensionNetPLN) * inflationFactor
+			: 0;
+		const privateMonthly = annualWithdrawal / 12;
+		out.push({
+			age,
+			year: calendarYearAt(age),
+			portfolioPLN: portfolio,
+			privateMonthlyIncomePLN: privateMonthly,
+			zusMonthlyIncomePLN: zusMonthly,
+			gapPLN: privateMonthly - zusMonthly,
+			afterRetirement
+		});
+	}
+	return out;
+}

--- a/src/routes/retirement/+page.svelte
+++ b/src/routes/retirement/+page.svelte
@@ -6,6 +6,7 @@
 	import * as echarts from 'echarts';
 	import IKZEPITTracker from '$lib/components/IKZEPITTracker.svelte';
 	import IKZEOptimizer from '$lib/components/IKZEOptimizer.svelte';
+	import FireGapChart from '$lib/components/FireGapChart.svelte';
 
 	let currentPortfolio = $state(100000);
 	let annualContribution = $state(20000);
@@ -123,6 +124,15 @@
 	<IKZEPITTracker />
 
 	<IKZEOptimizer />
+
+	<FireGapChart
+		bind:currentAge
+		bind:retirementAge
+		bind:lifeExpectancy
+		bind:currentPortfolioPLN={currentPortfolio}
+		bind:annualContributionPLN={annualContribution}
+		bind:expectedReturnPct={expectedReturn}
+	/>
 
 	<section class="card preset-filled-surface-100-900 p-5 space-y-4">
 		<h2 class="h4">Parametry</h2>


### PR DESCRIPTION
## Motivation

Closes #560. The retirement page runs Monte Carlo and tracks IKZE
contributions but never compares the private portfolio's expected
withdrawal against the user's projected ZUS pension — so a user
can't see whether their savings actually overtake the state
pension once they retire.

## Implementation information

- Pure projector in `src/lib/utils/fireGap.ts` runs year-by-year
  from current age to life expectancy: compounds the portfolio
  during working years, applies the SWR after retirement, and
  inflation-indexes the ZUS pension forward.
- Unit tests cover working-year zeros, inflation indexing, the
  positive-gap path, the contribution stop at retirement, and the
  custom calendar-year mapper.
- `FireGapChart.svelte` renders the projection — two lines
  (private and ZUS monthly income) plus orange bars for the gap.
  Two summary cards highlight the first-year and average gap.
- Slots into the retirement page below the IKZE PIT tracker.

## Supporting documentation

> Changelog: feat(zus): private FIRE gap chart