### PR TITLE
feat(montecarlo): add allocation inputs

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -7003,6 +7003,40 @@
               "application/json": {
                 "schema": {
                   "properties": {
+                    "assumptions": {
+                      "properties": {
+                        "allocation": {
+                          "nullable": true,
+                          "properties": {
+                            "bonds_pct": {
+                              "format": "double",
+                              "type": "number"
+                            },
+                            "cash_pct": {
+                              "format": "double",
+                              "type": "number"
+                            },
+                            "stocks_pct": {
+                              "format": "double",
+                              "type": "number"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "expected_return": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "source": {
+                          "type": "string"
+                        },
+                        "volatility": {
+                          "format": "double",
+                          "type": "number"
+                        }
+                      },
+                      "type": "object"
+                    },
                     "bands": {
                       "items": {
                         "properties": {

--- a/backend-go/internal/simulations/handler.go
+++ b/backend-go/internal/simulations/handler.go
@@ -288,15 +288,22 @@ func (h *Handler) Retirement(w http.ResponseWriter, r *http.Request) {
 
 // monteCarloInputsWire mirrors MonteCarloInputs over JSON.
 type monteCarloInputsWire struct {
-	CurrentPortfolio   pyFloat `json:"current_portfolio"`
-	AnnualContribution pyFloat `json:"annual_contribution"`
-	ExpectedReturn     pyFloat `json:"expected_return"`
-	Volatility         pyFloat `json:"volatility"`
-	CurrentAge         int     `json:"current_age"`
-	RetirementAge      int     `json:"retirement_age"`
-	LifeExpectancy     int     `json:"life_expectancy"`
-	AnnualWithdrawal   pyFloat `json:"annual_withdrawal"`
-	Paths              int     `json:"paths,omitempty"`
+	CurrentPortfolio   pyFloat                   `json:"current_portfolio"`
+	AnnualContribution pyFloat                   `json:"annual_contribution"`
+	ExpectedReturn     pyFloat                   `json:"expected_return"`
+	Volatility         pyFloat                   `json:"volatility"`
+	CurrentAge         int                       `json:"current_age"`
+	RetirementAge      int                       `json:"retirement_age"`
+	LifeExpectancy     int                       `json:"life_expectancy"`
+	AnnualWithdrawal   pyFloat                   `json:"annual_withdrawal"`
+	Paths              int                       `json:"paths,omitempty"`
+	Allocation         *monteCarloAllocationWire `json:"allocation,omitempty"`
+}
+
+type monteCarloAllocationWire struct {
+	StocksPct pyFloat `json:"stocks_pct"`
+	BondsPct  pyFloat `json:"bonds_pct"`
+	CashPct   pyFloat `json:"cash_pct"`
 }
 
 // MonteCarlo serves POST /api/simulations/monte-carlo. It runs `paths`
@@ -329,6 +336,24 @@ func (h *Handler) MonteCarlo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var allocation *MonteCarloAllocation
+	if in.Allocation != nil {
+		stocks := float64(in.Allocation.StocksPct)
+		bonds := float64(in.Allocation.BondsPct)
+		cash := float64(in.Allocation.CashPct)
+		if stocks < 0 || bonds < 0 || cash < 0 {
+			writeValidationError(w, "allocation", "allocation percentages must be non-negative", "")
+			return
+		}
+		sum := stocks + bonds + cash
+		if math.Abs(sum-100) > 0.01 {
+			writeValidationError(w, "allocation",
+				fmt.Sprintf("allocation must sum to 100 (got %.2f)", sum), "")
+			return
+		}
+		allocation = &MonteCarloAllocation{StocksPct: stocks, BondsPct: bonds, CashPct: cash}
+	}
+
 	rng := rand.New(rand.NewPCG(uint64(h.now().UnixNano()), 0xdeadbeef))
 	result := RunMonteCarlo(rng, MonteCarloInputs{
 		CurrentPortfolio:   float64(in.CurrentPortfolio),
@@ -340,6 +365,7 @@ func (h *Handler) MonteCarlo(w http.ResponseWriter, r *http.Request) {
 		LifeExpectancy:     in.LifeExpectancy,
 		AnnualWithdrawal:   float64(in.AnnualWithdrawal),
 		Paths:              in.Paths,
+		Allocation:         allocation,
 	})
 	writeJSON(w, http.StatusOK, result)
 }

--- a/backend-go/internal/simulations/handler.go
+++ b/backend-go/internal/simulations/handler.go
@@ -323,10 +323,6 @@ func (h *Handler) MonteCarlo(w http.ResponseWriter, r *http.Request) {
 		writeValidationError(w, "retirement_age", "retirement_age must be between current_age and life_expectancy", "")
 		return
 	}
-	if in.Volatility < 0 {
-		writeValidationError(w, "volatility", "volatility must be non-negative", "")
-		return
-	}
 	if in.CurrentPortfolio < 0 || in.AnnualContribution < 0 || in.AnnualWithdrawal < 0 {
 		writeValidationError(w, "amount", "monetary inputs must be non-negative", "")
 		return
@@ -352,6 +348,9 @@ func (h *Handler) MonteCarlo(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		allocation = &MonteCarloAllocation{StocksPct: stocks, BondsPct: bonds, CashPct: cash}
+	} else if in.Volatility < 0 {
+		writeValidationError(w, "volatility", "volatility must be non-negative", "")
+		return
 	}
 
 	rng := rand.New(rand.NewPCG(uint64(h.now().UnixNano()), 0xdeadbeef))

--- a/backend-go/internal/simulations/montecarlo.go
+++ b/backend-go/internal/simulations/montecarlo.go
@@ -1,12 +1,35 @@
 package simulations
 
 import (
+	"math"
 	"math/rand/v2"
 	"sort"
 )
 
+// Per-asset long-term nominal assumptions (annual, percent). These are
+// the canonical reference numbers used when the user supplies a portfolio
+// allocation instead of an explicit expected_return/volatility pair.
+const (
+	AssetReturnStocksPct = 7.0
+	AssetReturnBondsPct  = 3.5
+	AssetReturnCashPct   = 2.0
+	AssetVolStocksPct    = 18.0
+	AssetVolBondsPct     = 6.0
+	AssetVolCashPct      = 1.0
+)
+
+// MonteCarloAllocation captures the stocks/bonds/cash split (percent,
+// must sum to 100). When set on MonteCarloInputs, the simulation derives
+// ExpectedReturn and Volatility from the per-asset constants above.
+type MonteCarloAllocation struct {
+	StocksPct float64
+	BondsPct  float64
+	CashPct   float64
+}
+
 // MonteCarloInputs is the validated user payload for a retirement Monte
 // Carlo run. Volatility is the std-dev of annual returns (percent).
+// Allocation, when non-nil, overrides ExpectedReturn/Volatility.
 type MonteCarloInputs struct {
 	CurrentPortfolio   float64
 	AnnualContribution float64
@@ -17,6 +40,7 @@ type MonteCarloInputs struct {
 	LifeExpectancy     int
 	AnnualWithdrawal   float64
 	Paths              int // defaults to 1000
+	Allocation         *MonteCarloAllocation
 }
 
 // MonteCarloPercentileBand is one age slice of the fan chart: p5/p50/p95
@@ -28,12 +52,47 @@ type MonteCarloPercentileBand struct {
 	P95 float64 `json:"p95"`
 }
 
+// MonteCarloAssumptions echoes the return/volatility pair actually used
+// by the simulation. When inputs carried an Allocation, Source is
+// "allocation" and the percentages used to derive the numbers are
+// included; otherwise Source is "manual" and Allocation is nil.
+type MonteCarloAssumptions struct {
+	ExpectedReturn float64                  `json:"expected_return"`
+	Volatility     float64                  `json:"volatility"`
+	Source         string                   `json:"source"`
+	Allocation     *MonteCarloAllocationOut `json:"allocation,omitempty"`
+}
+
+// MonteCarloAllocationOut is the wire echo of the allocation split.
+type MonteCarloAllocationOut struct {
+	StocksPct float64 `json:"stocks_pct"`
+	BondsPct  float64 `json:"bonds_pct"`
+	CashPct   float64 `json:"cash_pct"`
+}
+
 // MonteCarloResult is what the handler ships back. SuccessRate is the
 // share of paths with non-negative ending balance at life_expectancy.
 type MonteCarloResult struct {
 	SuccessRate float64                    `json:"success_rate"`
 	Bands       []MonteCarloPercentileBand `json:"bands"`
 	Paths       int                        `json:"paths"`
+	Assumptions MonteCarloAssumptions      `json:"assumptions"`
+}
+
+// DeriveAssumptions returns the expected return and volatility implied by
+// an allocation: a value-weighted mean for return, and the variance of a
+// zero-correlation portfolio for volatility (a deliberate simplification
+// that captures diversification without requiring a full correlation
+// matrix).
+func DeriveAssumptions(a MonteCarloAllocation) (float64, float64) {
+	ws := a.StocksPct / 100
+	wb := a.BondsPct / 100
+	wc := a.CashPct / 100
+	expectedReturn := ws*AssetReturnStocksPct + wb*AssetReturnBondsPct + wc*AssetReturnCashPct
+	variance := ws*ws*AssetVolStocksPct*AssetVolStocksPct +
+		wb*wb*AssetVolBondsPct*AssetVolBondsPct +
+		wc*wc*AssetVolCashPct*AssetVolCashPct
+	return expectedReturn, math.Sqrt(variance)
 }
 
 // RunMonteCarlo simulates `params.Paths` retirement paths. Returns drawn
@@ -48,11 +107,24 @@ func RunMonteCarlo(rng *rand.Rand, p MonteCarloInputs) MonteCarloResult {
 	}
 	years := p.LifeExpectancy - p.CurrentAge
 	if years <= 0 {
-		return MonteCarloResult{Paths: paths}
+		return MonteCarloResult{Paths: paths, Assumptions: emptyAssumptions(p)}
 	}
 
-	mean := p.ExpectedReturn / 100.0
-	sd := p.Volatility / 100.0
+	expectedReturn := p.ExpectedReturn
+	volatility := p.Volatility
+	source := "manual"
+	var allocOut *MonteCarloAllocationOut
+	if p.Allocation != nil {
+		expectedReturn, volatility = DeriveAssumptions(*p.Allocation)
+		source = "allocation"
+		allocOut = &MonteCarloAllocationOut{
+			StocksPct: p.Allocation.StocksPct,
+			BondsPct:  p.Allocation.BondsPct,
+			CashPct:   p.Allocation.CashPct,
+		}
+	}
+	mean := expectedReturn / 100.0
+	sd := volatility / 100.0
 
 	// trajectories[pathIdx][yearIdx] = balance at end of year.
 	trajectories := make([][]float64, paths)
@@ -99,6 +171,35 @@ func RunMonteCarlo(rng *rand.Rand, p MonteCarloInputs) MonteCarloResult {
 		SuccessRate: float64(survived) / float64(paths),
 		Bands:       bands,
 		Paths:       paths,
+		Assumptions: MonteCarloAssumptions{
+			ExpectedReturn: expectedReturn,
+			Volatility:     volatility,
+			Source:         source,
+			Allocation:     allocOut,
+		},
+	}
+}
+
+// emptyAssumptions echoes the chosen ER/vol pair when years <= 0 so the
+// response shape stays consistent with the happy path.
+func emptyAssumptions(p MonteCarloInputs) MonteCarloAssumptions {
+	if p.Allocation == nil {
+		return MonteCarloAssumptions{
+			ExpectedReturn: p.ExpectedReturn,
+			Volatility:     p.Volatility,
+			Source:         "manual",
+		}
+	}
+	r, v := DeriveAssumptions(*p.Allocation)
+	return MonteCarloAssumptions{
+		ExpectedReturn: r,
+		Volatility:     v,
+		Source:         "allocation",
+		Allocation: &MonteCarloAllocationOut{
+			StocksPct: p.Allocation.StocksPct,
+			BondsPct:  p.Allocation.BondsPct,
+			CashPct:   p.Allocation.CashPct,
+		},
 	}
 }
 

--- a/backend-go/internal/simulations/montecarlo_test.go
+++ b/backend-go/internal/simulations/montecarlo_test.go
@@ -1,6 +1,7 @@
 package simulations
 
 import (
+	"math"
 	"math/rand/v2"
 	"testing"
 )
@@ -127,6 +128,90 @@ func TestPercentile_KnownValues(t *testing.T) {
 				t.Errorf("percentile(%v, %v) = %v, want %v", tc.sorted, tc.pct, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestDeriveAssumptions_AllStocksMatchesStockConstants(t *testing.T) {
+	r, v := DeriveAssumptions(MonteCarloAllocation{StocksPct: 100})
+	if r != AssetReturnStocksPct {
+		t.Errorf("100%% stocks return = %v, want %v", r, AssetReturnStocksPct)
+	}
+	if v != AssetVolStocksPct {
+		t.Errorf("100%% stocks vol = %v, want %v", v, AssetVolStocksPct)
+	}
+}
+
+func TestDeriveAssumptions_AllCashMatchesCashConstants(t *testing.T) {
+	r, v := DeriveAssumptions(MonteCarloAllocation{CashPct: 100})
+	if r != AssetReturnCashPct {
+		t.Errorf("100%% cash return = %v, want %v", r, AssetReturnCashPct)
+	}
+	if v != AssetVolCashPct {
+		t.Errorf("100%% cash vol = %v, want %v", v, AssetVolCashPct)
+	}
+}
+
+func TestDeriveAssumptions_BalancedDiversifies(t *testing.T) {
+	// 50/50 stocks/bonds: return is the simple weighted mean; volatility
+	// (zero-corr) is strictly less than the weighted mean of vols thanks
+	// to diversification.
+	r, v := DeriveAssumptions(MonteCarloAllocation{StocksPct: 50, BondsPct: 50})
+	wantR := 0.5*AssetReturnStocksPct + 0.5*AssetReturnBondsPct
+	if r != wantR {
+		t.Errorf("50/50 return = %v, want %v", r, wantR)
+	}
+	weightedVol := 0.5*AssetVolStocksPct + 0.5*AssetVolBondsPct
+	if v >= weightedVol {
+		t.Errorf("50/50 vol = %v, expected < weighted mean %v (diversification)", v, weightedVol)
+	}
+}
+
+func TestRunMonteCarlo_AllocationOverridesManualAssumptions(t *testing.T) {
+	got := RunMonteCarlo(newSeededRng(), MonteCarloInputs{
+		CurrentPortfolio: 100000,
+		ExpectedReturn:   99, // should be ignored
+		Volatility:       99, // should be ignored
+		CurrentAge:       30,
+		RetirementAge:    65,
+		LifeExpectancy:   90,
+		AnnualWithdrawal: 30000,
+		Paths:            100,
+		Allocation:       &MonteCarloAllocation{StocksPct: 60, BondsPct: 30, CashPct: 10},
+	})
+	if got.Assumptions.Source != "allocation" {
+		t.Errorf("source = %q, want %q", got.Assumptions.Source, "allocation")
+	}
+	wantR, wantV := DeriveAssumptions(MonteCarloAllocation{StocksPct: 60, BondsPct: 30, CashPct: 10})
+	if math.Abs(got.Assumptions.ExpectedReturn-wantR) > 1e-9 {
+		t.Errorf("ER = %v, want %v", got.Assumptions.ExpectedReturn, wantR)
+	}
+	if math.Abs(got.Assumptions.Volatility-wantV) > 1e-9 {
+		t.Errorf("vol = %v, want %v", got.Assumptions.Volatility, wantV)
+	}
+	if got.Assumptions.Allocation == nil || got.Assumptions.Allocation.StocksPct != 60 {
+		t.Errorf("allocation echo missing or wrong: %+v", got.Assumptions.Allocation)
+	}
+}
+
+func TestRunMonteCarlo_ManualSourceWhenNoAllocation(t *testing.T) {
+	got := RunMonteCarlo(newSeededRng(), MonteCarloInputs{
+		CurrentPortfolio: 100000,
+		ExpectedReturn:   6,
+		Volatility:       15,
+		CurrentAge:       30,
+		RetirementAge:    65,
+		LifeExpectancy:   90,
+		AnnualWithdrawal: 30000,
+		Paths:            10,
+	})
+	if got.Assumptions.Source != "manual" {
+		t.Errorf("source = %q, want %q", got.Assumptions.Source, "manual")
+	}
+	if got.Assumptions.ExpectedReturn != 6 || got.Assumptions.Volatility != 15 {
+		t.Errorf("assumptions = %+v, want ER=6 vol=15", got.Assumptions)
+	}
+	if got.Assumptions.Allocation != nil {
+		t.Errorf("allocation should be nil, got %+v", got.Assumptions.Allocation)
 	}
 }
 

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -4737,6 +4737,21 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            assumptions?: {
+                                allocation?: {
+                                    /** Format: double */
+                                    bonds_pct?: number;
+                                    /** Format: double */
+                                    cash_pct?: number;
+                                    /** Format: double */
+                                    stocks_pct?: number;
+                                } | null;
+                                /** Format: double */
+                                expected_return?: number;
+                                source?: string;
+                                /** Format: double */
+                                volatility?: number;
+                            };
                             bands?: {
                                 age?: number;
                                 /** Format: double */

--- a/src/lib/utils/charts/montecarlo.test.ts
+++ b/src/lib/utils/charts/montecarlo.test.ts
@@ -5,7 +5,8 @@ function makeResult(bands: Array<[number, number, number, number]>): MonteCarloR
 	return {
 		success_rate: 0.9,
 		paths: 1000,
-		bands: bands.map(([age, p5, p50, p95]) => ({ age, p5, p50, p95 }))
+		bands: bands.map(([age, p5, p50, p95]) => ({ age, p5, p50, p95 })),
+		assumptions: { expected_return: 6, volatility: 15, source: 'manual' }
 	};
 }
 

--- a/src/lib/utils/charts/montecarlo.ts
+++ b/src/lib/utils/charts/montecarlo.ts
@@ -8,10 +8,24 @@ export interface MonteCarloBand {
 	p95: number;
 }
 
+export interface MonteCarloAllocationOut {
+	stocks_pct: number;
+	bonds_pct: number;
+	cash_pct: number;
+}
+
+export interface MonteCarloAssumptions {
+	expected_return: number;
+	volatility: number;
+	source: 'manual' | 'allocation';
+	allocation?: MonteCarloAllocationOut;
+}
+
 export interface MonteCarloResult {
 	success_rate: number;
 	bands: MonteCarloBand[];
 	paths: number;
+	assumptions: MonteCarloAssumptions;
 }
 
 function fmtPLN(value: number): string {

--- a/src/routes/retirement/+page.svelte
+++ b/src/routes/retirement/+page.svelte
@@ -17,6 +17,12 @@
 	let lifeExpectancy = $state(90);
 	let annualWithdrawal = $state(40000);
 
+	let useAllocation = $state(false);
+	let allocStocks = $state(60);
+	let allocBonds = $state(30);
+	let allocCash = $state(10);
+	const allocSum = $derived(allocStocks + allocBonds + allocCash);
+
 	let loading = $state(false);
 	let error = $state('');
 	let result: MonteCarloResult | null = $state(null);
@@ -48,21 +54,34 @@
 				loading = false;
 				return;
 			}
+			if (useAllocation && Math.abs(allocSum - 100) > 0.01) {
+				error = `Alokacja musi sumować się do 100% (obecnie ${allocSum.toFixed(1)}%)`;
+				loading = false;
+				return;
+			}
 
 			const apiUrl = resolveApiUrl();
+			const body: Record<string, unknown> = {
+				current_portfolio: currentPortfolio,
+				annual_contribution: annualContribution,
+				expected_return: expectedReturn,
+				volatility,
+				current_age: currentAge,
+				retirement_age: retirementAge,
+				life_expectancy: lifeExpectancy,
+				annual_withdrawal: annualWithdrawal
+			};
+			if (useAllocation) {
+				body.allocation = {
+					stocks_pct: allocStocks,
+					bonds_pct: allocBonds,
+					cash_pct: allocCash
+				};
+			}
 			const response = await fetch(`${apiUrl}/api/simulations/monte-carlo`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					current_portfolio: currentPortfolio,
-					annual_contribution: annualContribution,
-					expected_return: expectedReturn,
-					volatility,
-					current_age: currentAge,
-					retirement_age: retirementAge,
-					life_expectancy: lifeExpectancy,
-					annual_withdrawal: annualWithdrawal
-				})
+				body: JSON.stringify(body)
 			});
 			if (!response.ok) throw new Error(`Symulacja nieudana: ${response.statusText}`);
 			result = await response.json();
@@ -147,11 +166,24 @@
 			</label>
 			<label class="space-y-1">
 				<span class="text-xs font-semibold">Oczekiwana stopa zwrotu (%)</span>
-				<input type="number" step="0.1" class="input w-full" bind:value={expectedReturn} />
+				<input
+					type="number"
+					step="0.1"
+					class="input w-full"
+					bind:value={expectedReturn}
+					disabled={useAllocation}
+				/>
 			</label>
 			<label class="space-y-1">
 				<span class="text-xs font-semibold">Zmienność / odchylenie std. (%)</span>
-				<input type="number" min="0" step="0.1" class="input w-full" bind:value={volatility} />
+				<input
+					type="number"
+					min="0"
+					step="0.1"
+					class="input w-full"
+					bind:value={volatility}
+					disabled={useAllocation}
+				/>
 			</label>
 			<label class="space-y-1">
 				<span class="text-xs font-semibold">Obecny wiek</span>
@@ -169,6 +201,57 @@
 				<span class="text-xs font-semibold">Roczna wypłata na emeryturze (PLN)</span>
 				<input type="number" min="0" class="input w-full" bind:value={annualWithdrawal} />
 			</label>
+		</div>
+
+		<div class="space-y-3 pt-2 border-t border-surface-300-700">
+			<label class="flex items-center gap-2 text-sm font-semibold">
+				<input type="checkbox" class="checkbox" bind:checked={useAllocation} />
+				Wyprowadź stopę zwrotu i zmienność z alokacji portfela
+			</label>
+			{#if useAllocation}
+				<div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+					<label class="space-y-1">
+						<span class="text-xs font-semibold">Akcje (%)</span>
+						<input
+							type="number"
+							min="0"
+							max="100"
+							step="1"
+							class="input w-full"
+							bind:value={allocStocks}
+						/>
+					</label>
+					<label class="space-y-1">
+						<span class="text-xs font-semibold">Obligacje (%)</span>
+						<input
+							type="number"
+							min="0"
+							max="100"
+							step="1"
+							class="input w-full"
+							bind:value={allocBonds}
+						/>
+					</label>
+					<label class="space-y-1">
+						<span class="text-xs font-semibold">Gotówka (%)</span>
+						<input
+							type="number"
+							min="0"
+							max="100"
+							step="1"
+							class="input w-full"
+							bind:value={allocCash}
+						/>
+					</label>
+				</div>
+				<div
+					class="text-xs {Math.abs(allocSum - 100) < 0.01
+						? 'text-success-600-400'
+						: 'text-error-600-400'}"
+				>
+					Suma: {allocSum.toFixed(1)}% (musi być 100%)
+				</div>
+			{/if}
 		</div>
 
 		<button
@@ -218,6 +301,28 @@
 					</p>
 				</div>
 			{/if}
+
+			<div class="card preset-tonal-surface p-3 text-sm space-y-1">
+				<div class="font-semibold text-xs uppercase text-surface-600-400">
+					Założenia symulacji
+				</div>
+				<div>
+					Stopa zwrotu: <strong>{result.assumptions.expected_return.toFixed(2)}%</strong>,
+					zmienność: <strong>{result.assumptions.volatility.toFixed(2)}%</strong>
+					<span class="text-xs text-surface-600-400">
+						({result.assumptions.source === 'allocation'
+							? 'wyprowadzone z alokacji'
+							: 'wpisane ręcznie'})
+					</span>
+				</div>
+				{#if result.assumptions.allocation}
+					<div class="text-xs text-surface-700-300">
+						Alokacja: {result.assumptions.allocation.stocks_pct}% akcje /
+						{result.assumptions.allocation.bonds_pct}% obligacje /
+						{result.assumptions.allocation.cash_pct}% gotówka
+					</div>
+				{/if}
+			</div>
 
 			<div bind:this={chartContainer} class="w-full h-[320px] sm:h-[420px]"></div>
 

--- a/src/routes/retirement/+page.svelte
+++ b/src/routes/retirement/+page.svelte
@@ -303,9 +303,7 @@
 			{/if}
 
 			<div class="card preset-tonal-surface p-3 text-sm space-y-1">
-				<div class="font-semibold text-xs uppercase text-surface-600-400">
-					Założenia symulacji
-				</div>
+				<div class="font-semibold text-xs uppercase text-surface-600-400">Założenia symulacji</div>
 				<div>
 					Stopa zwrotu: <strong>{result.assumptions.expected_return.toFixed(2)}%</strong>,
 					zmienność: <strong>{result.assumptions.volatility.toFixed(2)}%</strong>


### PR DESCRIPTION
## Motivation

Closes #559. Lets users enter a stocks / bonds / cash allocation and have the Monte Carlo simulation derive expected return and volatility from per-asset assumptions, instead of (or in addition to) the manual return/volatility pair.

## Implementation information

- Backend (`backend-go/internal/simulations/montecarlo.go`):
  - Per-asset long-term assumptions as package constants (stocks 7% / 18%, bonds 3.5% / 6%, cash 2% / 1%).
  - `MonteCarloAllocation` optional input. When set, `DeriveAssumptions` produces value-weighted return + zero-correlation portfolio volatility (deliberate simplification, captures diversification without a full correlation matrix).
  - `MonteCarloResult.Assumptions` echoes whatever the run actually used, with `source: "allocation" | "manual"` and the allocation split when relevant.
- Handler validates allocation sums to 100 ± 0.01 and rejects negatives.
- Frontend (`src/routes/retirement/+page.svelte`):
  - Checkbox toggles allocation mode. When on, the manual ER/vol inputs are disabled and three percentage inputs appear with live sum validation.
  - Result panel always renders the assumptions actually used.
- Unit tests cover single-asset edges (100% stocks / cash matches constants), diversification (50/50 stocks/bonds vol strictly less than weighted mean), override behavior (manual ER/vol ignored when allocation set), and the manual-source fallback.
- Regenerated `api/openapi-go.json` and `src/lib/types/api.generated.ts`.

## Supporting documentation

Issue #559.

> Changelog: feat(montecarlo): add allocation inputs