### PR TITLE
feat(montecarlo): add inflation paths

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -7027,6 +7027,14 @@
                           "format": "double",
                           "type": "number"
                         },
+                        "inflation_mean": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "inflation_volatility": {
+                          "format": "double",
+                          "type": "number"
+                        },
                         "source": {
                           "type": "string"
                         },
@@ -7051,7 +7059,27 @@
                             "format": "double",
                             "type": "number"
                           },
+                          "p50_real": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "p5_real": {
+                            "format": "double",
+                            "type": "number"
+                          },
                           "p95": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "p95_real": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "spending": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "spending_real": {
                             "format": "double",
                             "type": "number"
                           }

--- a/backend-go/internal/simulations/handler.go
+++ b/backend-go/internal/simulations/handler.go
@@ -288,16 +288,18 @@ func (h *Handler) Retirement(w http.ResponseWriter, r *http.Request) {
 
 // monteCarloInputsWire mirrors MonteCarloInputs over JSON.
 type monteCarloInputsWire struct {
-	CurrentPortfolio   pyFloat                   `json:"current_portfolio"`
-	AnnualContribution pyFloat                   `json:"annual_contribution"`
-	ExpectedReturn     pyFloat                   `json:"expected_return"`
-	Volatility         pyFloat                   `json:"volatility"`
-	CurrentAge         int                       `json:"current_age"`
-	RetirementAge      int                       `json:"retirement_age"`
-	LifeExpectancy     int                       `json:"life_expectancy"`
-	AnnualWithdrawal   pyFloat                   `json:"annual_withdrawal"`
-	Paths              int                       `json:"paths,omitempty"`
-	Allocation         *monteCarloAllocationWire `json:"allocation,omitempty"`
+	CurrentPortfolio    pyFloat                   `json:"current_portfolio"`
+	AnnualContribution  pyFloat                   `json:"annual_contribution"`
+	ExpectedReturn      pyFloat                   `json:"expected_return"`
+	Volatility          pyFloat                   `json:"volatility"`
+	CurrentAge          int                       `json:"current_age"`
+	RetirementAge       int                       `json:"retirement_age"`
+	LifeExpectancy      int                       `json:"life_expectancy"`
+	AnnualWithdrawal    pyFloat                   `json:"annual_withdrawal"`
+	Paths               int                       `json:"paths,omitempty"`
+	Allocation          *monteCarloAllocationWire `json:"allocation,omitempty"`
+	InflationMean       pyFloat                   `json:"inflation_mean"`
+	InflationVolatility pyFloat                   `json:"inflation_volatility"`
 }
 
 type monteCarloAllocationWire struct {
@@ -352,19 +354,29 @@ func (h *Handler) MonteCarlo(w http.ResponseWriter, r *http.Request) {
 		writeValidationError(w, "volatility", "volatility must be non-negative", "")
 		return
 	}
+	if in.InflationVolatility < 0 {
+		writeValidationError(w, "inflation_volatility", "inflation_volatility must be non-negative", "")
+		return
+	}
+	if in.InflationMean < -50 || in.InflationMean > 50 {
+		writeValidationError(w, "inflation_mean", "inflation_mean must be within [-50, 50]", "")
+		return
+	}
 
 	rng := rand.New(rand.NewPCG(uint64(h.now().UnixNano()), 0xdeadbeef))
 	result := RunMonteCarlo(rng, MonteCarloInputs{
-		CurrentPortfolio:   float64(in.CurrentPortfolio),
-		AnnualContribution: float64(in.AnnualContribution),
-		ExpectedReturn:     float64(in.ExpectedReturn),
-		Volatility:         float64(in.Volatility),
-		CurrentAge:         in.CurrentAge,
-		RetirementAge:      in.RetirementAge,
-		LifeExpectancy:     in.LifeExpectancy,
-		AnnualWithdrawal:   float64(in.AnnualWithdrawal),
-		Paths:              in.Paths,
-		Allocation:         allocation,
+		CurrentPortfolio:    float64(in.CurrentPortfolio),
+		AnnualContribution:  float64(in.AnnualContribution),
+		ExpectedReturn:      float64(in.ExpectedReturn),
+		Volatility:          float64(in.Volatility),
+		CurrentAge:          in.CurrentAge,
+		RetirementAge:       in.RetirementAge,
+		LifeExpectancy:      in.LifeExpectancy,
+		AnnualWithdrawal:    float64(in.AnnualWithdrawal),
+		Paths:               in.Paths,
+		Allocation:          allocation,
+		InflationMean:       float64(in.InflationMean),
+		InflationVolatility: float64(in.InflationVolatility),
 	})
 	writeJSON(w, http.StatusOK, result)
 }

--- a/backend-go/internal/simulations/montecarlo.go
+++ b/backend-go/internal/simulations/montecarlo.go
@@ -30,37 +30,58 @@ type MonteCarloAllocation struct {
 // MonteCarloInputs is the validated user payload for a retirement Monte
 // Carlo run. Volatility is the std-dev of annual returns (percent).
 // Allocation, when non-nil, overrides ExpectedReturn/Volatility.
+//
+// AnnualWithdrawal is the user's spending in today's PLN; the simulation
+// inflates it by the realized inflation path each year so the user keeps
+// the same real lifestyle. With InflationMean=0 and InflationVolatility=0
+// this collapses to a constant nominal withdrawal and real == nominal.
 type MonteCarloInputs struct {
-	CurrentPortfolio   float64
-	AnnualContribution float64
-	ExpectedReturn     float64 // percent
-	Volatility         float64 // percent (standard deviation)
-	CurrentAge         int
-	RetirementAge      int
-	LifeExpectancy     int
-	AnnualWithdrawal   float64
-	Paths              int // defaults to 1000
-	Allocation         *MonteCarloAllocation
+	CurrentPortfolio    float64
+	AnnualContribution  float64
+	ExpectedReturn      float64 // percent
+	Volatility          float64 // percent (standard deviation)
+	CurrentAge          int
+	RetirementAge       int
+	LifeExpectancy      int
+	AnnualWithdrawal    float64 // today's PLN; inflated each year
+	Paths               int     // defaults to 1000
+	Allocation          *MonteCarloAllocation
+	InflationMean       float64 // percent, annual
+	InflationVolatility float64 // percent, std-dev of annual inflation
 }
 
 // MonteCarloPercentileBand is one age slice of the fan chart: p5/p50/p95
-// of end-of-year balance across all paths.
+// of end-of-year balance across all paths, both in nominal PLN and in
+// real (today's PLN) terms after dividing by the realized cumulative
+// inflation factor on each path.
 type MonteCarloPercentileBand struct {
-	Age int     `json:"age"`
-	P5  float64 `json:"p5"`
-	P50 float64 `json:"p50"`
-	P95 float64 `json:"p95"`
+	Age     int     `json:"age"`
+	P5      float64 `json:"p5"`
+	P50     float64 `json:"p50"`
+	P95     float64 `json:"p95"`
+	P5Real  float64 `json:"p5_real"`
+	P50Real float64 `json:"p50_real"`
+	P95Real float64 `json:"p95_real"`
+	// Spending is the average realized nominal withdrawal at this age
+	// (zero in the accumulation phase), and SpendingReal is that same
+	// value deflated by the path's cumulative inflation factor — both
+	// averaged across paths so the chart can show one curve per series.
+	Spending     float64 `json:"spending"`
+	SpendingReal float64 `json:"spending_real"`
 }
 
 // MonteCarloAssumptions echoes the return/volatility pair actually used
 // by the simulation. When inputs carried an Allocation, Source is
 // "allocation" and the percentages used to derive the numbers are
 // included; otherwise Source is "manual" and Allocation is nil.
+// InflationMean / InflationVolatility echo the inflation path parameters.
 type MonteCarloAssumptions struct {
-	ExpectedReturn float64                  `json:"expected_return"`
-	Volatility     float64                  `json:"volatility"`
-	Source         string                   `json:"source"`
-	Allocation     *MonteCarloAllocationOut `json:"allocation,omitempty"`
+	ExpectedReturn      float64                  `json:"expected_return"`
+	Volatility          float64                  `json:"volatility"`
+	Source              string                   `json:"source"`
+	Allocation          *MonteCarloAllocationOut `json:"allocation,omitempty"`
+	InflationMean       float64                  `json:"inflation_mean"`
+	InflationVolatility float64                  `json:"inflation_volatility"`
 }
 
 // MonteCarloAllocationOut is the wire echo of the allocation split.
@@ -123,84 +144,165 @@ func RunMonteCarlo(rng *rand.Rand, p MonteCarloInputs) MonteCarloResult {
 			CashPct:   p.Allocation.CashPct,
 		}
 	}
-	mean := expectedReturn / 100.0
-	sd := volatility / 100.0
-
-	// trajectories[pathIdx][yearIdx] = balance at end of year.
-	trajectories := make([][]float64, paths)
-	survived := 0
-	for i := range paths {
-		balance := p.CurrentPortfolio
-		path := make([]float64, years)
-		for y := range years {
-			r := rng.NormFloat64()*sd + mean
-			age := p.CurrentAge + y + 1
-			balance *= 1 + r
-			if age <= p.RetirementAge {
-				balance += p.AnnualContribution
-			} else {
-				balance -= p.AnnualWithdrawal
-			}
-			if balance < 0 {
-				balance = 0
-			}
-			path[y] = balance
-		}
-		trajectories[i] = path
-		if balance > 0 {
-			survived++
-		}
-	}
-
-	bands := make([]MonteCarloPercentileBand, years)
-	col := make([]float64, paths)
-	for y := range years {
-		for i := range paths {
-			col[i] = trajectories[i][y]
-		}
-		sort.Float64s(col)
-		bands[y] = MonteCarloPercentileBand{
-			Age: p.CurrentAge + y + 1,
-			P5:  percentile(col, 5),
-			P50: percentile(col, 50),
-			P95: percentile(col, 95),
-		}
-	}
+	sim := simulatePaths(rng, p, paths, years, expectedReturn, volatility)
+	bands := buildBands(sim, paths, years, p.CurrentAge)
 
 	return MonteCarloResult{
-		SuccessRate: float64(survived) / float64(paths),
+		SuccessRate: float64(sim.survived) / float64(paths),
 		Bands:       bands,
 		Paths:       paths,
 		Assumptions: MonteCarloAssumptions{
-			ExpectedReturn: expectedReturn,
-			Volatility:     volatility,
-			Source:         source,
-			Allocation:     allocOut,
+			ExpectedReturn:      expectedReturn,
+			Volatility:          volatility,
+			Source:              source,
+			Allocation:          allocOut,
+			InflationMean:       p.InflationMean,
+			InflationVolatility: p.InflationVolatility,
 		},
 	}
+}
+
+// pathMatrix bundles per-path per-year trajectories so RunMonteCarlo can
+// stay short and the loop body stays linear.
+type pathMatrix struct {
+	nominal      [][]float64
+	realBalance  [][]float64
+	spending     [][]float64
+	spendingReal [][]float64
+	survived     int
+}
+
+func simulatePaths(rng *rand.Rand, p MonteCarloInputs, paths, years int, expectedReturn, volatility float64) pathMatrix {
+	mean := expectedReturn / 100.0
+	sd := volatility / 100.0
+	infMean := p.InflationMean / 100.0
+	infSd := p.InflationVolatility / 100.0
+	m := pathMatrix{
+		nominal:      make([][]float64, paths),
+		realBalance:  make([][]float64, paths),
+		spending:     make([][]float64, paths),
+		spendingReal: make([][]float64, paths),
+	}
+	for i := range paths {
+		balance := p.CurrentPortfolio
+		nomRow := make([]float64, years)
+		realRow := make([]float64, years)
+		spendRow := make([]float64, years)
+		spendRealRow := make([]float64, years)
+		cumInflation := 1.0
+		for y := range years {
+			r := rng.NormFloat64()*sd + mean
+			inf := rng.NormFloat64()*infSd + infMean
+			// Clamp the annual factor so a sampled deflation tail can't flip
+			// cumInflation negative — that would invert real balances and let
+			// retirees "spend" negative withdrawals (i.e. receive money).
+			factor := 1 + inf
+			if factor < 0.01 {
+				factor = 0.01
+			}
+			cumInflation *= factor
+			age := p.CurrentAge + y + 1
+			balance *= 1 + r
+			if balance < 0 {
+				balance = 0
+			}
+			withdrawal := 0.0
+			if age <= p.RetirementAge {
+				balance += p.AnnualContribution
+			} else {
+				desired := p.AnnualWithdrawal * cumInflation
+				if desired > balance {
+					// Path busts this year: retiree withdraws whatever the
+					// portfolio still holds, not the desired nominal amount.
+					withdrawal = balance
+					balance = 0
+				} else {
+					withdrawal = desired
+					balance -= desired
+				}
+			}
+			nomRow[y] = balance
+			realRow[y] = safeDiv(balance, cumInflation)
+			spendRow[y] = withdrawal
+			spendRealRow[y] = safeDiv(withdrawal, cumInflation)
+		}
+		m.nominal[i] = nomRow
+		m.realBalance[i] = realRow
+		m.spending[i] = spendRow
+		m.spendingReal[i] = spendRealRow
+		if balance > 0 {
+			m.survived++
+		}
+	}
+	return m
+}
+
+func buildBands(m pathMatrix, paths, years, currentAge int) []MonteCarloPercentileBand {
+	bands := make([]MonteCarloPercentileBand, years)
+	col := make([]float64, paths)
+	colReal := make([]float64, paths)
+	for y := range years {
+		for i := range paths {
+			col[i] = m.nominal[i][y]
+			colReal[i] = m.realBalance[i][y]
+		}
+		sort.Float64s(col)
+		sort.Float64s(colReal)
+		bands[y] = MonteCarloPercentileBand{
+			Age:          currentAge + y + 1,
+			P5:           percentile(col, 5),
+			P50:          percentile(col, 50),
+			P95:          percentile(col, 95),
+			P5Real:       percentile(colReal, 5),
+			P50Real:      percentile(colReal, 50),
+			P95Real:      percentile(colReal, 95),
+			Spending:     meanColumn(m.spending, y),
+			SpendingReal: meanColumn(m.spendingReal, y),
+		}
+	}
+	return bands
+}
+
+func safeDiv(a, b float64) float64 {
+	if b == 0 {
+		return 0
+	}
+	return a / b
+}
+
+func meanColumn(m [][]float64, y int) float64 {
+	if len(m) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for i := range m {
+		sum += m[i][y]
+	}
+	return sum / float64(len(m))
 }
 
 // emptyAssumptions echoes the chosen ER/vol pair when years <= 0 so the
 // response shape stays consistent with the happy path.
 func emptyAssumptions(p MonteCarloInputs) MonteCarloAssumptions {
-	if p.Allocation == nil {
-		return MonteCarloAssumptions{
-			ExpectedReturn: p.ExpectedReturn,
-			Volatility:     p.Volatility,
-			Source:         "manual",
-		}
+	a := MonteCarloAssumptions{
+		ExpectedReturn:      p.ExpectedReturn,
+		Volatility:          p.Volatility,
+		Source:              "manual",
+		InflationMean:       p.InflationMean,
+		InflationVolatility: p.InflationVolatility,
 	}
-	r, v := DeriveAssumptions(*p.Allocation)
-	return MonteCarloAssumptions{
-		ExpectedReturn: r,
-		Volatility:     v,
-		Source:         "allocation",
-		Allocation: &MonteCarloAllocationOut{
+	if p.Allocation != nil {
+		r, v := DeriveAssumptions(*p.Allocation)
+		a.ExpectedReturn = r
+		a.Volatility = v
+		a.Source = "allocation"
+		a.Allocation = &MonteCarloAllocationOut{
 			StocksPct: p.Allocation.StocksPct,
 			BondsPct:  p.Allocation.BondsPct,
 			CashPct:   p.Allocation.CashPct,
-		},
+		}
 	}
+	return a
 }
 
 // percentile picks pct (0..100) using linear interpolation, matching

--- a/backend-go/internal/simulations/montecarlo_test.go
+++ b/backend-go/internal/simulations/montecarlo_test.go
@@ -215,6 +215,157 @@ func TestRunMonteCarlo_ManualSourceWhenNoAllocation(t *testing.T) {
 	}
 }
 
+func TestRunMonteCarlo_ZeroInflation_RealEqualsNominal(t *testing.T) {
+	got := RunMonteCarlo(newSeededRng(), MonteCarloInputs{
+		CurrentPortfolio:    100000,
+		AnnualContribution:  10000,
+		ExpectedReturn:      5,
+		Volatility:          10,
+		CurrentAge:          30,
+		RetirementAge:       60,
+		LifeExpectancy:      40,
+		AnnualWithdrawal:    20000,
+		Paths:               50,
+		InflationMean:       0,
+		InflationVolatility: 0,
+	})
+	for _, b := range got.Bands {
+		if math.Abs(b.P5-b.P5Real) > 1e-9 || math.Abs(b.P50-b.P50Real) > 1e-9 || math.Abs(b.P95-b.P95Real) > 1e-9 {
+			t.Errorf("age %d: zero-inflation should make real == nominal (got p5=%v vs %v, p50=%v vs %v, p95=%v vs %v)",
+				b.Age, b.P5, b.P5Real, b.P50, b.P50Real, b.P95, b.P95Real)
+		}
+		if math.Abs(b.Spending-b.SpendingReal) > 1e-9 {
+			t.Errorf("age %d: zero-inflation spending real (%v) should equal nominal (%v)", b.Age, b.SpendingReal, b.Spending)
+		}
+	}
+}
+
+func TestRunMonteCarlo_FixedInflation_DeflatesGeometrically(t *testing.T) {
+	// Zero return volatility AND zero inflation volatility => deterministic
+	// path. Real balance at year Y should equal nominal / (1+inf)^Y exactly.
+	infMean := 3.0
+	got := RunMonteCarlo(newSeededRng(), MonteCarloInputs{
+		CurrentPortfolio:    100000,
+		AnnualContribution:  0,
+		ExpectedReturn:      5,
+		Volatility:          0,
+		CurrentAge:          60,
+		RetirementAge:       60,
+		LifeExpectancy:      65,
+		AnnualWithdrawal:    0,
+		Paths:               10,
+		InflationMean:       infMean,
+		InflationVolatility: 0,
+	})
+	for y, b := range got.Bands {
+		factor := math.Pow(1+infMean/100, float64(y+1))
+		wantReal := b.P50 / factor
+		if math.Abs(b.P50Real-wantReal) > 1e-6 {
+			t.Errorf("age %d: real = %v, want %v (nominal %v / %v)", b.Age, b.P50Real, wantReal, b.P50, factor)
+		}
+	}
+}
+
+func TestRunMonteCarlo_FixedInflation_InflatesNominalWithdrawals(t *testing.T) {
+	// Zero return vol + zero inflation vol => every path is identical. The
+	// retiree's real spending stays at the supplied AnnualWithdrawal; the
+	// nominal spending grows by (1+inf)^yearsSinceRetirement.
+	infMean := 3.0
+	withdrawal := 40000.0
+	got := RunMonteCarlo(newSeededRng(), MonteCarloInputs{
+		CurrentPortfolio:    10_000_000,
+		AnnualContribution:  0,
+		ExpectedReturn:      0,
+		Volatility:          0,
+		CurrentAge:          60,
+		RetirementAge:       60,
+		LifeExpectancy:      65,
+		AnnualWithdrawal:    withdrawal,
+		Paths:               5,
+		InflationMean:       infMean,
+		InflationVolatility: 0,
+	})
+	for y, b := range got.Bands {
+		wantNominal := withdrawal * math.Pow(1+infMean/100, float64(y+1))
+		if math.Abs(b.Spending-wantNominal) > 1e-6 {
+			t.Errorf("age %d: nominal spend = %v, want %v", b.Age, b.Spending, wantNominal)
+		}
+		if math.Abs(b.SpendingReal-withdrawal) > 1e-6 {
+			t.Errorf("age %d: real spend = %v, want constant %v", b.Age, b.SpendingReal, withdrawal)
+		}
+	}
+}
+
+func TestRunMonteCarlo_NegativeInflation_RealOutpacesNominal(t *testing.T) {
+	// Deterministic deflation of 2% per year: nominal balance is unchanged
+	// (zero return), but real balance grows because each PLN is worth more.
+	got := RunMonteCarlo(newSeededRng(), MonteCarloInputs{
+		CurrentPortfolio:    100000,
+		AnnualContribution:  0,
+		ExpectedReturn:      0,
+		Volatility:          0,
+		CurrentAge:          60,
+		RetirementAge:       60,
+		LifeExpectancy:      65,
+		AnnualWithdrawal:    0,
+		Paths:               5,
+		InflationMean:       -2,
+		InflationVolatility: 0,
+	})
+	last := got.Bands[len(got.Bands)-1]
+	if last.P50Real <= last.P50 {
+		t.Errorf("deflation should make real (%v) > nominal (%v)", last.P50Real, last.P50)
+	}
+}
+
+func TestRunMonteCarlo_BustedPath_SpendingCapped(t *testing.T) {
+	// Tiny portfolio + giant withdrawal forces every path to bust quickly.
+	// After bust, recorded spending must never exceed the portfolio's
+	// pre-bust real balance — i.e. SpendingReal cannot exceed AnnualWithdrawal
+	// (which is the real per-year ask).
+	withdrawal := 50000.0
+	got := RunMonteCarlo(newSeededRng(), MonteCarloInputs{
+		CurrentPortfolio:    1000,
+		AnnualContribution:  0,
+		ExpectedReturn:      0,
+		Volatility:          0,
+		CurrentAge:          65,
+		RetirementAge:       65,
+		LifeExpectancy:      75,
+		AnnualWithdrawal:    withdrawal,
+		Paths:               5,
+		InflationMean:       3,
+		InflationVolatility: 0,
+	})
+	for _, b := range got.Bands {
+		if b.SpendingReal > withdrawal+1e-6 {
+			t.Errorf("age %d: real spending %v exceeds the requested %v on a busted path",
+				b.Age, b.SpendingReal, withdrawal)
+		}
+		if b.P50 < 0 || b.P50Real < 0 {
+			t.Errorf("age %d: negative balance band p50=%v p50_real=%v", b.Age, b.P50, b.P50Real)
+		}
+	}
+}
+
+func TestRunMonteCarlo_AssumptionsEchoesInflation(t *testing.T) {
+	got := RunMonteCarlo(newSeededRng(), MonteCarloInputs{
+		CurrentPortfolio:    100000,
+		CurrentAge:          30,
+		RetirementAge:       65,
+		LifeExpectancy:      90,
+		ExpectedReturn:      6,
+		Volatility:          15,
+		AnnualWithdrawal:    30000,
+		Paths:               10,
+		InflationMean:       3.2,
+		InflationVolatility: 1.5,
+	})
+	if got.Assumptions.InflationMean != 3.2 || got.Assumptions.InflationVolatility != 1.5 {
+		t.Errorf("inflation assumptions echo = %+v, want mean=3.2 vol=1.5", got.Assumptions)
+	}
+}
+
 func TestRunMonteCarlo_PercentilesAreSorted(t *testing.T) {
 	// Across reasonable inputs p5 <= p50 <= p95 at every age.
 	got := RunMonteCarlo(newSeededRng(), MonteCarloInputs{

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -4748,6 +4748,10 @@ export interface paths {
                                 } | null;
                                 /** Format: double */
                                 expected_return?: number;
+                                /** Format: double */
+                                inflation_mean?: number;
+                                /** Format: double */
+                                inflation_volatility?: number;
                                 source?: string;
                                 /** Format: double */
                                 volatility?: number;
@@ -4759,7 +4763,17 @@ export interface paths {
                                 /** Format: double */
                                 p50?: number;
                                 /** Format: double */
+                                p50_real?: number;
+                                /** Format: double */
+                                p5_real?: number;
+                                /** Format: double */
                                 p95?: number;
+                                /** Format: double */
+                                p95_real?: number;
+                                /** Format: double */
+                                spending?: number;
+                                /** Format: double */
+                                spending_real?: number;
                             }[];
                             paths?: number;
                             /** Format: double */

--- a/src/lib/utils/charts/montecarlo.test.ts
+++ b/src/lib/utils/charts/montecarlo.test.ts
@@ -5,8 +5,24 @@ function makeResult(bands: Array<[number, number, number, number]>): MonteCarloR
 	return {
 		success_rate: 0.9,
 		paths: 1000,
-		bands: bands.map(([age, p5, p50, p95]) => ({ age, p5, p50, p95 })),
-		assumptions: { expected_return: 6, volatility: 15, source: 'manual' }
+		bands: bands.map(([age, p5, p50, p95]) => ({
+			age,
+			p5,
+			p50,
+			p95,
+			p5_real: p5,
+			p50_real: p50,
+			p95_real: p95,
+			spending: 0,
+			spending_real: 0
+		})),
+		assumptions: {
+			expected_return: 6,
+			volatility: 15,
+			source: 'manual',
+			inflation_mean: 0,
+			inflation_volatility: 0
+		}
 	};
 }
 

--- a/src/lib/utils/charts/montecarlo.ts
+++ b/src/lib/utils/charts/montecarlo.ts
@@ -6,6 +6,11 @@ export interface MonteCarloBand {
 	p5: number;
 	p50: number;
 	p95: number;
+	p5_real: number;
+	p50_real: number;
+	p95_real: number;
+	spending: number;
+	spending_real: number;
 }
 
 export interface MonteCarloAllocationOut {
@@ -19,6 +24,8 @@ export interface MonteCarloAssumptions {
 	volatility: number;
 	source: 'manual' | 'allocation';
 	allocation?: MonteCarloAllocationOut;
+	inflation_mean: number;
+	inflation_volatility: number;
 }
 
 export interface MonteCarloResult {
@@ -46,11 +53,18 @@ function escapeHtml(value: string): string {
 
 // Fan chart: shaded P5–P95 band with the P50 median overlaid. Implemented
 // as a stack — base = P5, ribbon = P95 - P5 (transparent fill on top).
-export function buildMonteCarloFanOption(result: MonteCarloResult): EChartsOption {
+// Pass {real: true} to plot the real (inflation-adjusted) bands instead
+// of the nominal ones; tooltip labels follow the choice.
+export function buildMonteCarloFanOption(
+	result: MonteCarloResult,
+	opts: { real?: boolean } = {}
+): EChartsOption {
+	const real = opts.real === true;
 	const ages = result.bands.map((b) => b.age);
-	const p5 = result.bands.map((b) => b.p5);
-	const p50 = result.bands.map((b) => b.p50);
-	const ribbon = result.bands.map((b) => b.p95 - b.p5);
+	const p5 = result.bands.map((b) => (real ? b.p5_real : b.p5));
+	const p50 = result.bands.map((b) => (real ? b.p50_real : b.p50));
+	const p95 = result.bands.map((b) => (real ? b.p95_real : b.p95));
+	const ribbon = p95.map((v, i) => v - p5[i]);
 
 	const series: LineSeriesOption[] = [
 		{
@@ -83,8 +97,9 @@ export function buildMonteCarloFanOption(result: MonteCarloResult): EChartsOptio
 		}
 	];
 
+	const suffix = real ? ' (realne)' : '';
 	return {
-		title: { text: 'Symulacja Monte Carlo — projekcja salda' },
+		title: { text: `Symulacja Monte Carlo — projekcja salda${suffix}` },
 		tooltip: {
 			trigger: 'axis',
 			formatter: (params: TopLevelFormatterParams) => {
@@ -93,11 +108,14 @@ export function buildMonteCarloFanOption(result: MonteCarloResult): EChartsOptio
 				const idx = items[0].dataIndex;
 				const band = result.bands[idx as number];
 				if (!band) return '';
+				const v5 = real ? band.p5_real : band.p5;
+				const v50 = real ? band.p50_real : band.p50;
+				const v95 = real ? band.p95_real : band.p95;
 				return (
-					`<strong>Wiek ${escapeHtml(String(age))}</strong><br/>` +
-					`P5: ${fmtPLN(band.p5)} PLN<br/>` +
-					`P50 (mediana): ${fmtPLN(band.p50)} PLN<br/>` +
-					`P95: ${fmtPLN(band.p95)} PLN`
+					`<strong>Wiek ${escapeHtml(String(age))}${suffix}</strong><br/>` +
+					`P5: ${fmtPLN(v5)} PLN<br/>` +
+					`P50 (mediana): ${fmtPLN(v50)} PLN<br/>` +
+					`P95: ${fmtPLN(v95)} PLN`
 				);
 			}
 		},

--- a/src/routes/retirement/+page.svelte
+++ b/src/routes/retirement/+page.svelte
@@ -23,8 +23,8 @@
 	let allocCash = $state(10);
 	const allocSum = $derived(allocStocks + allocBonds + allocCash);
 
-	let inflationMean = $state(3);
-	let inflationVolatility = $state(1);
+	let inflationMean = $state(0);
+	let inflationVolatility = $state(0);
 	let showReal = $state(true);
 
 	let loading = $state(false);
@@ -373,7 +373,7 @@
 				{@const lastP5 = showReal ? last.p5_real : last.p5}
 				{@const lastP50 = showReal ? last.p50_real : last.p50}
 				{@const lastP95 = showReal ? last.p95_real : last.p95}
-				{@const lastSpending = showReal ? last.spending_real : last.spending}
+				{@const spendingBand = result.bands.find((b) => b.spending > 0)}
 				{@const valueLabel = showReal ? 'realne' : 'nominalne'}
 				<div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
 					<div class="card preset-tonal-surface p-4">
@@ -395,12 +395,14 @@
 						<div class="text-xl font-bold">{formatPLN(lastP95)} PLN</div>
 					</div>
 				</div>
-				{#if lastSpending > 0}
+				{#if spendingBand}
 					<div class="card preset-tonal-surface p-4">
 						<div class="text-xs text-surface-600-400">
-							Średnia wypłata w wieku {last.age} ({valueLabel})
+							Średnia wypłata na początku emerytury (wiek {spendingBand.age}, {valueLabel})
 						</div>
-						<div class="text-xl font-bold">{formatPLN(lastSpending)} PLN</div>
+						<div class="text-xl font-bold">
+							{formatPLN(showReal ? spendingBand.spending_real : spendingBand.spending)} PLN
+						</div>
 					</div>
 				{/if}
 			{/if}

--- a/src/routes/retirement/+page.svelte
+++ b/src/routes/retirement/+page.svelte
@@ -23,6 +23,10 @@
 	let allocCash = $state(10);
 	const allocSum = $derived(allocStocks + allocBonds + allocCash);
 
+	let inflationMean = $state(3);
+	let inflationVolatility = $state(1);
+	let showReal = $state(true);
+
 	let loading = $state(false);
 	let error = $state('');
 	let result: MonteCarloResult | null = $state(null);
@@ -59,6 +63,11 @@
 				loading = false;
 				return;
 			}
+			if (inflationVolatility < 0) {
+				error = 'Zmienność inflacji nie może być ujemna';
+				loading = false;
+				return;
+			}
 
 			const apiUrl = resolveApiUrl();
 			const body: Record<string, unknown> = {
@@ -69,7 +78,9 @@
 				current_age: currentAge,
 				retirement_age: retirementAge,
 				life_expectancy: lifeExpectancy,
-				annual_withdrawal: annualWithdrawal
+				annual_withdrawal: annualWithdrawal,
+				inflation_mean: inflationMean,
+				inflation_volatility: inflationVolatility
 			};
 			if (useAllocation) {
 				body.allocation = {
@@ -92,7 +103,8 @@
 		}
 	}
 
-	// Render the fan chart whenever results land and the container is bound.
+	// Render the fan chart whenever results land and the container is bound,
+	// or the real/nominal toggle flips.
 	$effect(() => {
 		if (!chartContainer) {
 			chartHandle?.dispose();
@@ -106,7 +118,7 @@
 			chartHandle = createChart(chartContainer);
 			chart = chartHandle.chart;
 		}
-		chart?.setOption(buildMonteCarloFanOption(result));
+		chart?.setOption(buildMonteCarloFanOption(result, { real: showReal }), true);
 	});
 
 	const successPercent = $derived.by(() => {
@@ -201,6 +213,29 @@
 				<span class="text-xs font-semibold">Roczna wypłata na emeryturze (PLN)</span>
 				<input type="number" min="0" class="input w-full" bind:value={annualWithdrawal} />
 			</label>
+		</div>
+
+		<div class="space-y-3 pt-2 border-t border-surface-300-700">
+			<div class="text-sm font-semibold">Inflacja</div>
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+				<label class="space-y-1">
+					<span class="text-xs font-semibold">Średnia roczna inflacja (%)</span>
+					<input type="number" step="0.1" class="input w-full" bind:value={inflationMean} />
+				</label>
+				<label class="space-y-1">
+					<span class="text-xs font-semibold">Zmienność inflacji / odch. std. (%)</span>
+					<input
+						type="number"
+						min="0"
+						step="0.1"
+						class="input w-full"
+						bind:value={inflationVolatility}
+					/>
+				</label>
+			</div>
+			<p class="text-xs text-surface-600-400">
+				Roczna wypłata jest interpretowana jako kwota w dzisiejszych PLN i rośnie razem z inflacją.
+			</p>
 		</div>
 
 		<div class="space-y-3 pt-2 border-t border-surface-300-700">
@@ -313,6 +348,10 @@
 							: 'wpisane ręcznie'})
 					</span>
 				</div>
+				<div class="text-xs text-surface-700-300">
+					Inflacja: średnia <strong>{result.assumptions.inflation_mean.toFixed(2)}%</strong>,
+					zmienność <strong>{result.assumptions.inflation_volatility.toFixed(2)}%</strong>
+				</div>
 				{#if result.assumptions.allocation}
 					<div class="text-xs text-surface-700-300">
 						Alokacja: {result.assumptions.allocation.stocks_pct}% akcje /
@@ -322,24 +361,48 @@
 				{/if}
 			</div>
 
+			<label class="flex items-center gap-2 text-sm">
+				<input type="checkbox" class="checkbox" bind:checked={showReal} />
+				Pokaż wartości realne (w dzisiejszych PLN)
+			</label>
+
 			<div bind:this={chartContainer} class="w-full h-[320px] sm:h-[420px]"></div>
 
 			{#if result.bands.length > 0}
 				{@const last = result.bands[result.bands.length - 1]}
+				{@const lastP5 = showReal ? last.p5_real : last.p5}
+				{@const lastP50 = showReal ? last.p50_real : last.p50}
+				{@const lastP95 = showReal ? last.p95_real : last.p95}
+				{@const lastSpending = showReal ? last.spending_real : last.spending}
+				{@const valueLabel = showReal ? 'realne' : 'nominalne'}
 				<div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
 					<div class="card preset-tonal-surface p-4">
-						<div class="text-xs text-surface-600-400">Pesymistyczne (P5) w wieku {last.age}</div>
-						<div class="text-xl font-bold">{formatPLN(last.p5)} PLN</div>
+						<div class="text-xs text-surface-600-400">
+							Pesymistyczne (P5) w wieku {last.age} ({valueLabel})
+						</div>
+						<div class="text-xl font-bold">{formatPLN(lastP5)} PLN</div>
 					</div>
 					<div class="card preset-tonal-surface p-4">
-						<div class="text-xs text-surface-600-400">Mediana (P50) w wieku {last.age}</div>
-						<div class="text-xl font-bold">{formatPLN(last.p50)} PLN</div>
+						<div class="text-xs text-surface-600-400">
+							Mediana (P50) w wieku {last.age} ({valueLabel})
+						</div>
+						<div class="text-xl font-bold">{formatPLN(lastP50)} PLN</div>
 					</div>
 					<div class="card preset-tonal-surface p-4">
-						<div class="text-xs text-surface-600-400">Optymistyczne (P95) w wieku {last.age}</div>
-						<div class="text-xl font-bold">{formatPLN(last.p95)} PLN</div>
+						<div class="text-xs text-surface-600-400">
+							Optymistyczne (P95) w wieku {last.age} ({valueLabel})
+						</div>
+						<div class="text-xl font-bold">{formatPLN(lastP95)} PLN</div>
 					</div>
 				</div>
+				{#if lastSpending > 0}
+					<div class="card preset-tonal-surface p-4">
+						<div class="text-xs text-surface-600-400">
+							Średnia wypłata w wieku {last.age} ({valueLabel})
+						</div>
+						<div class="text-xl font-bold">{formatPLN(lastSpending)} PLN</div>
+					</div>
+				{/if}
 			{/if}
 		</section>
 	{/if}


### PR DESCRIPTION
## Motivation

Closes #561. Adds an independent inflation path to the Monte Carlo retirement simulation so we can report real (today's PLN) balance and real spending alongside the existing nominal bands, and so the user's "annual withdrawal in today's PLN" actually keeps the same real lifestyle across the simulation horizon.

## Implementation information

- Backend (`backend-go/internal/simulations/montecarlo.go`):
  - `MonteCarloInputs` gains `InflationMean` and `InflationVolatility` (percent, std-dev) — defaults 0/0 collapse to a constant nominal withdrawal (back-compat).
  - Each year, after the return draw, sample inflation from a separate normal. Maintain a per-path cumulative inflation factor; the per-year factor is floored at 0.01 so a deflation tail can't flip the factor negative.
  - `AnnualWithdrawal` is treated as today's PLN and inflated to nominal by `cumInflation` before debiting the portfolio. If the desired nominal withdrawal exceeds the balance, the path withdraws only what is left (realized spending, not desired).
  - `MonteCarloPercentileBand` now also carries `p5_real/p50_real/p95_real` (real bands) plus `spending` and `spending_real` (per-path averages).
  - `MonteCarloAssumptions` echoes `inflation_mean` and `inflation_volatility`.
  - `RunMonteCarlo` split into `simulatePaths` + `buildBands` to stay under the funlen ceiling.
- Handler rejects (HTTP 422) negative `inflation_volatility` and any `inflation_mean` outside `[-50, 50]` — same validation style as the existing inputs.
- Deterministic tests:
  - `ZeroInflation_RealEqualsNominal` — zero inflation collapses real and nominal series.
  - `FixedInflation_DeflatesGeometrically` — at fixed 3% inflation, real = nominal / 1.03^year exactly.
  - `FixedInflation_InflatesNominalWithdrawals` — real spending stays at the user-supplied amount, nominal grows by (1+inf)^year.
  - `NegativeInflation_RealOutpacesNominal` — deflation drives real balance above nominal.
  - `BustedPath_SpendingCapped` — when the portfolio runs out, recorded real spending never exceeds the requested real amount.
  - `AssumptionsEchoesInflation` — inflation parameters round-trip through the response.
- Frontend (`src/routes/retirement/+page.svelte`):
  - Two new inputs (mean / volatility) default to 0/0 for back-compat — users opt into a non-zero inflation path explicitly. Help text clarifies that the withdrawal is in today's PLN.
  - A "show real values" toggle (default on) switches the fan chart and the summary cards between real and nominal.
  - An average-withdrawal card is rendered from the first retirement-year band (where spending > 0) so it stays visible even when later paths bust.
- Regenerated `api/openapi-go.json` and `src/lib/types/api.generated.ts`.

## Supporting documentation

Issue #561.

> Changelog: feat(montecarlo): add inflation paths