### PR TITLE
feat(montecarlo): apply Belka tax to paths

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -7005,6 +7005,32 @@
                   "properties": {
                     "assumptions": {
                       "properties": {
+                        "account_mix": {
+                          "nullable": true,
+                          "properties": {
+                            "ike_pct": {
+                              "format": "double",
+                              "type": "number"
+                            },
+                            "ikze_pct": {
+                              "format": "double",
+                              "type": "number"
+                            },
+                            "taxable_gain_pct": {
+                              "format": "double",
+                              "type": "number"
+                            },
+                            "taxable_pct": {
+                              "format": "double",
+                              "type": "number"
+                            },
+                            "zus_pct": {
+                              "format": "double",
+                              "type": "number"
+                            }
+                          },
+                          "type": "object"
+                        },
                         "allocation": {
                           "nullable": true,
                           "properties": {
@@ -7059,7 +7085,23 @@
                             "format": "double",
                             "type": "number"
                           },
+                          "p50_net": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "p50_net_real": {
+                            "format": "double",
+                            "type": "number"
+                          },
                           "p50_real": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "p5_net": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "p5_net_real": {
                             "format": "double",
                             "type": "number"
                           },
@@ -7068,6 +7110,14 @@
                             "type": "number"
                           },
                           "p95": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "p95_net": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "p95_net_real": {
                             "format": "double",
                             "type": "number"
                           },
@@ -7094,6 +7144,24 @@
                     "success_rate": {
                       "format": "double",
                       "type": "number"
+                    },
+                    "tax": {
+                      "nullable": true,
+                      "properties": {
+                        "effective_lifetime_rate": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "gross_withdrawals_total": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "tax_total": {
+                          "format": "double",
+                          "type": "number"
+                        }
+                      },
+                      "type": "object"
                     }
                   },
                   "type": "object"

--- a/backend-go/internal/simulations/handler.go
+++ b/backend-go/internal/simulations/handler.go
@@ -300,12 +300,21 @@ type monteCarloInputsWire struct {
 	Allocation          *monteCarloAllocationWire `json:"allocation,omitempty"`
 	InflationMean       pyFloat                   `json:"inflation_mean"`
 	InflationVolatility pyFloat                   `json:"inflation_volatility"`
+	AccountMix          *monteCarloAccountMixWire `json:"account_mix,omitempty"`
 }
 
 type monteCarloAllocationWire struct {
 	StocksPct pyFloat `json:"stocks_pct"`
 	BondsPct  pyFloat `json:"bonds_pct"`
 	CashPct   pyFloat `json:"cash_pct"`
+}
+
+type monteCarloAccountMixWire struct {
+	TaxablePct     pyFloat `json:"taxable_pct"`
+	IkePct         pyFloat `json:"ike_pct"`
+	IkzePct        pyFloat `json:"ikze_pct"`
+	ZusPct         pyFloat `json:"zus_pct"`
+	TaxableGainPct pyFloat `json:"taxable_gain_pct"`
 }
 
 // MonteCarlo serves POST /api/simulations/monte-carlo. It runs `paths`
@@ -363,6 +372,34 @@ func (h *Handler) MonteCarlo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var accountMix *MonteCarloAccountMix
+	if in.AccountMix != nil {
+		taxable := float64(in.AccountMix.TaxablePct)
+		ike := float64(in.AccountMix.IkePct)
+		ikze := float64(in.AccountMix.IkzePct)
+		zus := float64(in.AccountMix.ZusPct)
+		gain := float64(in.AccountMix.TaxableGainPct)
+		if taxable < 0 || ike < 0 || ikze < 0 || zus < 0 {
+			writeValidationError(w, "account_mix", "account_mix percentages must be non-negative", "")
+			return
+		}
+		if gain < 0 || gain > 100 {
+			writeValidationError(w, "account_mix",
+				"taxable_gain_pct must be within [0, 100]", "")
+			return
+		}
+		sum := taxable + ike + ikze + zus
+		if math.Abs(sum-100) > 0.01 {
+			writeValidationError(w, "account_mix",
+				fmt.Sprintf("account_mix must sum to 100 (got %.2f)", sum), "")
+			return
+		}
+		accountMix = &MonteCarloAccountMix{
+			TaxablePct: taxable, IkePct: ike, IkzePct: ikze, ZusPct: zus,
+			TaxableGainPct: gain,
+		}
+	}
+
 	rng := rand.New(rand.NewPCG(uint64(h.now().UnixNano()), 0xdeadbeef))
 	result := RunMonteCarlo(rng, MonteCarloInputs{
 		CurrentPortfolio:    float64(in.CurrentPortfolio),
@@ -377,6 +414,7 @@ func (h *Handler) MonteCarlo(w http.ResponseWriter, r *http.Request) {
 		Allocation:          allocation,
 		InflationMean:       float64(in.InflationMean),
 		InflationVolatility: float64(in.InflationVolatility),
+		AccountMix:          accountMix,
 	})
 	writeJSON(w, http.StatusOK, result)
 }

--- a/backend-go/internal/simulations/montecarlo.go
+++ b/backend-go/internal/simulations/montecarlo.go
@@ -302,11 +302,12 @@ func simulatePaths(rng *rand.Rand, p MonteCarloInputs, paths, years int, expecte
 		balance := p.CurrentPortfolio
 		nomRow := make([]float64, years)
 		realRow := make([]float64, years)
-		var netRow, netRealRow []float64
-		if hasTax {
-			netRow = make([]float64, years)
-			netRealRow = make([]float64, years)
-		}
+		// Always allocate the row slices to keep nilaway happy; the per-year
+		// math below is still gated on hasTax so the no-tax common case
+		// avoids the EffectiveTaxRate call. Real savings come from the
+		// buildBands gate that skips the extra sorts.
+		netRow := make([]float64, years)
+		netRealRow := make([]float64, years)
 		spendRow := make([]float64, years)
 		spendRealRow := make([]float64, years)
 		cumInflation := 1.0
@@ -386,11 +387,8 @@ func buildBands(m pathMatrix, paths, years, currentAge int) []MonteCarloPercenti
 	bands := make([]MonteCarloPercentileBand, years)
 	col := make([]float64, paths)
 	colReal := make([]float64, paths)
-	var colNet, colNetReal []float64
-	if hasTax {
-		colNet = make([]float64, paths)
-		colNetReal = make([]float64, paths)
-	}
+	colNet := make([]float64, paths)
+	colNetReal := make([]float64, paths)
 	for y := range years {
 		for i := range paths {
 			col[i] = m.nominal[i][y]

--- a/backend-go/internal/simulations/montecarlo.go
+++ b/backend-go/internal/simulations/montecarlo.go
@@ -18,6 +18,14 @@ const (
 	AssetVolCashPct      = 1.0
 )
 
+// Polish withdrawal-phase tax rates (as fractions, not percent).
+const (
+	BelkaRate       = 0.19 // 19% on realized capital gains (taxable brokerage)
+	IkzePostAgeRate = 0.10 // 10% PIT on IKZE withdrawals post-65
+	IkeFreeAge      = 60   // IKE withdrawals tax-free from this age
+	IkzeFreeAge     = 65   // IKZE switches from Belka-like penalty to 10% PIT
+)
+
 // MonteCarloAllocation captures the stocks/bonds/cash split (percent,
 // must sum to 100). When set on MonteCarloInputs, the simulation derives
 // ExpectedReturn and Volatility from the per-asset constants above.
@@ -25,6 +33,43 @@ type MonteCarloAllocation struct {
 	StocksPct float64
 	BondsPct  float64
 	CashPct   float64
+}
+
+// MonteCarloAccountMix expresses what share of each PLN withdrawn comes
+// from which Polish wrapper, plus the gain fraction of the taxable
+// brokerage balance (used to apply 19% Belka only on appreciation, not
+// cost basis). Pcts must sum to 100. When set, the simulation grosses up
+// withdrawals to cover tax and reports both gross and net-of-tax bands.
+type MonteCarloAccountMix struct {
+	TaxablePct     float64
+	IkePct         float64
+	IkzePct        float64
+	ZusPct         float64
+	TaxableGainPct float64 // fraction of taxable balance that's gains
+}
+
+// EffectiveTaxRate returns the share of each gross PLN withdrawn that
+// goes to tax at the given age. Branches:
+//   - Taxable brokerage: 19% Belka on the gain portion only.
+//   - IKE: tax-free post-60, taxed like brokerage if withdrawn earlier.
+//   - IKZE: 10% PIT post-65, taxed like brokerage if withdrawn earlier.
+//   - ZUS: already taxed at source (treated as 0% here for the portfolio).
+func (m MonteCarloAccountMix) EffectiveTaxRate(age int) float64 {
+	gain := m.TaxableGainPct / 100
+	taxable := m.TaxablePct / 100
+	ike := m.IkePct / 100
+	ikze := m.IkzePct / 100
+	rate := taxable * gain * BelkaRate
+	if age < IkeFreeAge {
+		// IKE pre-60: early withdrawal taxed like brokerage gains.
+		rate += ike * gain * BelkaRate
+	}
+	if age >= IkzeFreeAge {
+		rate += ikze * IkzePostAgeRate
+	} else {
+		rate += ikze * gain * BelkaRate
+	}
+	return rate
 }
 
 // MonteCarloInputs is the validated user payload for a retirement Monte
@@ -48,6 +93,11 @@ type MonteCarloInputs struct {
 	Allocation          *MonteCarloAllocation
 	InflationMean       float64 // percent, annual
 	InflationVolatility float64 // percent, std-dev of annual inflation
+	// AccountMix, when non-nil, makes AnnualWithdrawal a net (after-tax)
+	// target and grosses up the portfolio debit by the per-age effective
+	// tax rate. Also enables the net-of-tax balance bands and the
+	// effective-lifetime-tax-rate metric.
+	AccountMix *MonteCarloAccountMix
 }
 
 // MonteCarloPercentileBand is one age slice of the fan chart: p5/p50/p95
@@ -62,12 +112,30 @@ type MonteCarloPercentileBand struct {
 	P5Real  float64 `json:"p5_real"`
 	P50Real float64 `json:"p50_real"`
 	P95Real float64 `json:"p95_real"`
-	// Spending is the average realized nominal withdrawal at this age
-	// (zero in the accumulation phase), and SpendingReal is that same
-	// value deflated by the path's cumulative inflation factor — both
-	// averaged across paths so the chart can show one curve per series.
+	// Net* are the balance bands after subtracting the estimated tax
+	// owed on a full liquidation at this age (per the AccountMix). When
+	// AccountMix is nil they mirror the gross bands.
+	P5Net      float64 `json:"p5_net"`
+	P50Net     float64 `json:"p50_net"`
+	P95Net     float64 `json:"p95_net"`
+	P5NetReal  float64 `json:"p5_net_real"`
+	P50NetReal float64 `json:"p50_net_real"`
+	P95NetReal float64 `json:"p95_net_real"`
+	// Spending is the average realized nominal withdrawal (net to the
+	// retiree) at this age (zero in the accumulation phase). SpendingReal
+	// is that same value deflated by the path's cumulative inflation
+	// factor. Both averaged across paths so the chart can show one curve.
 	Spending     float64 `json:"spending"`
 	SpendingReal float64 `json:"spending_real"`
+}
+
+// MonteCarloTaxSummary aggregates Belka / IKZE PIT across all paths and
+// all retirement years. EffectiveLifetimeRate = TaxTotal / GrossTotal,
+// i.e. the average tax wedge per gross PLN drawn from the portfolio.
+type MonteCarloTaxSummary struct {
+	GrossWithdrawalsTotal float64 `json:"gross_withdrawals_total"`
+	TaxTotal              float64 `json:"tax_total"`
+	EffectiveLifetimeRate float64 `json:"effective_lifetime_rate"`
 }
 
 // MonteCarloAssumptions echoes the return/volatility pair actually used
@@ -82,6 +150,16 @@ type MonteCarloAssumptions struct {
 	Allocation          *MonteCarloAllocationOut `json:"allocation,omitempty"`
 	InflationMean       float64                  `json:"inflation_mean"`
 	InflationVolatility float64                  `json:"inflation_volatility"`
+	AccountMix          *MonteCarloAccountMixOut `json:"account_mix,omitempty"`
+}
+
+// MonteCarloAccountMixOut echoes the account mix supplied in the request.
+type MonteCarloAccountMixOut struct {
+	TaxablePct     float64 `json:"taxable_pct"`
+	IkePct         float64 `json:"ike_pct"`
+	IkzePct        float64 `json:"ikze_pct"`
+	ZusPct         float64 `json:"zus_pct"`
+	TaxableGainPct float64 `json:"taxable_gain_pct"`
 }
 
 // MonteCarloAllocationOut is the wire echo of the allocation split.
@@ -93,11 +171,13 @@ type MonteCarloAllocationOut struct {
 
 // MonteCarloResult is what the handler ships back. SuccessRate is the
 // share of paths with non-negative ending balance at life_expectancy.
+// Tax is present only when AccountMix was supplied.
 type MonteCarloResult struct {
 	SuccessRate float64                    `json:"success_rate"`
 	Bands       []MonteCarloPercentileBand `json:"bands"`
 	Paths       int                        `json:"paths"`
 	Assumptions MonteCarloAssumptions      `json:"assumptions"`
+	Tax         *MonteCarloTaxSummary      `json:"tax,omitempty"`
 }
 
 // DeriveAssumptions returns the expected return and volatility implied by
@@ -147,6 +227,23 @@ func RunMonteCarlo(rng *rand.Rand, p MonteCarloInputs) MonteCarloResult {
 	sim := simulatePaths(rng, p, paths, years, expectedReturn, volatility)
 	bands := buildBands(sim, paths, years, p.CurrentAge)
 
+	var taxSummary *MonteCarloTaxSummary
+	var mixOut *MonteCarloAccountMixOut
+	if p.AccountMix != nil {
+		mixOut = &MonteCarloAccountMixOut{
+			TaxablePct:     p.AccountMix.TaxablePct,
+			IkePct:         p.AccountMix.IkePct,
+			IkzePct:        p.AccountMix.IkzePct,
+			ZusPct:         p.AccountMix.ZusPct,
+			TaxableGainPct: p.AccountMix.TaxableGainPct,
+		}
+		taxSummary = &MonteCarloTaxSummary{
+			GrossWithdrawalsTotal: sim.grossTotal,
+			TaxTotal:              sim.taxTotal,
+			EffectiveLifetimeRate: safeDiv(sim.taxTotal, sim.grossTotal),
+		}
+	}
+
 	return MonteCarloResult{
 		SuccessRate: float64(sim.survived) / float64(paths),
 		Bands:       bands,
@@ -158,7 +255,9 @@ func RunMonteCarlo(rng *rand.Rand, p MonteCarloInputs) MonteCarloResult {
 			Allocation:          allocOut,
 			InflationMean:       p.InflationMean,
 			InflationVolatility: p.InflationVolatility,
+			AccountMix:          mixOut,
 		},
+		Tax: taxSummary,
 	}
 }
 
@@ -167,9 +266,13 @@ func RunMonteCarlo(rng *rand.Rand, p MonteCarloInputs) MonteCarloResult {
 type pathMatrix struct {
 	nominal      [][]float64
 	realBalance  [][]float64
+	netNominal   [][]float64
+	netReal      [][]float64
 	spending     [][]float64
 	spendingReal [][]float64
 	survived     int
+	grossTotal   float64
+	taxTotal     float64
 }
 
 func simulatePaths(rng *rand.Rand, p MonteCarloInputs, paths, years int, expectedReturn, volatility float64) pathMatrix {
@@ -180,6 +283,8 @@ func simulatePaths(rng *rand.Rand, p MonteCarloInputs, paths, years int, expecte
 	m := pathMatrix{
 		nominal:      make([][]float64, paths),
 		realBalance:  make([][]float64, paths),
+		netNominal:   make([][]float64, paths),
+		netReal:      make([][]float64, paths),
 		spending:     make([][]float64, paths),
 		spendingReal: make([][]float64, paths),
 	}
@@ -187,6 +292,8 @@ func simulatePaths(rng *rand.Rand, p MonteCarloInputs, paths, years int, expecte
 		balance := p.CurrentPortfolio
 		nomRow := make([]float64, years)
 		realRow := make([]float64, years)
+		netRow := make([]float64, years)
+		netRealRow := make([]float64, years)
 		spendRow := make([]float64, years)
 		spendRealRow := make([]float64, years)
 		cumInflation := 1.0
@@ -210,24 +317,48 @@ func simulatePaths(rng *rand.Rand, p MonteCarloInputs, paths, years int, expecte
 			if age <= p.RetirementAge {
 				balance += p.AnnualContribution
 			} else {
-				desired := p.AnnualWithdrawal * cumInflation
-				if desired > balance {
+				desiredNet := p.AnnualWithdrawal * cumInflation
+				// Gross up the portfolio debit to cover the tax that this
+				// year's withdrawal mix incurs. With no AccountMix, taxRate
+				// is 0 and gross == desiredNet (back-compat).
+				taxRate := 0.0
+				if p.AccountMix != nil {
+					taxRate = p.AccountMix.EffectiveTaxRate(age)
+				}
+				gross := desiredNet
+				if taxRate > 0 && taxRate < 1 {
+					gross = desiredNet / (1 - taxRate)
+				}
+				if gross > balance {
 					// Path busts this year: retiree withdraws whatever the
-					// portfolio still holds, not the desired nominal amount.
-					withdrawal = balance
+					// portfolio still holds, pays the tax on that gross, and
+					// consumes the remainder net.
+					gross = balance
+					withdrawal = gross * (1 - taxRate)
 					balance = 0
 				} else {
-					withdrawal = desired
-					balance -= desired
+					withdrawal = desiredNet
+					balance -= gross
 				}
+				m.grossTotal += gross
+				m.taxTotal += gross - withdrawal
 			}
 			nomRow[y] = balance
 			realRow[y] = safeDiv(balance, cumInflation)
+			liquidationRate := 0.0
+			if p.AccountMix != nil {
+				liquidationRate = p.AccountMix.EffectiveTaxRate(age)
+			}
+			netBalance := balance * (1 - liquidationRate)
+			netRow[y] = netBalance
+			netRealRow[y] = safeDiv(netBalance, cumInflation)
 			spendRow[y] = withdrawal
 			spendRealRow[y] = safeDiv(withdrawal, cumInflation)
 		}
 		m.nominal[i] = nomRow
 		m.realBalance[i] = realRow
+		m.netNominal[i] = netRow
+		m.netReal[i] = netRealRow
 		m.spending[i] = spendRow
 		m.spendingReal[i] = spendRealRow
 		if balance > 0 {
@@ -241,13 +372,19 @@ func buildBands(m pathMatrix, paths, years, currentAge int) []MonteCarloPercenti
 	bands := make([]MonteCarloPercentileBand, years)
 	col := make([]float64, paths)
 	colReal := make([]float64, paths)
+	colNet := make([]float64, paths)
+	colNetReal := make([]float64, paths)
 	for y := range years {
 		for i := range paths {
 			col[i] = m.nominal[i][y]
 			colReal[i] = m.realBalance[i][y]
+			colNet[i] = m.netNominal[i][y]
+			colNetReal[i] = m.netReal[i][y]
 		}
 		sort.Float64s(col)
 		sort.Float64s(colReal)
+		sort.Float64s(colNet)
+		sort.Float64s(colNetReal)
 		bands[y] = MonteCarloPercentileBand{
 			Age:          currentAge + y + 1,
 			P5:           percentile(col, 5),
@@ -256,6 +393,12 @@ func buildBands(m pathMatrix, paths, years, currentAge int) []MonteCarloPercenti
 			P5Real:       percentile(colReal, 5),
 			P50Real:      percentile(colReal, 50),
 			P95Real:      percentile(colReal, 95),
+			P5Net:        percentile(colNet, 5),
+			P50Net:       percentile(colNet, 50),
+			P95Net:       percentile(colNet, 95),
+			P5NetReal:    percentile(colNetReal, 5),
+			P50NetReal:   percentile(colNetReal, 50),
+			P95NetReal:   percentile(colNetReal, 95),
 			Spending:     meanColumn(m.spending, y),
 			SpendingReal: meanColumn(m.spendingReal, y),
 		}
@@ -300,6 +443,15 @@ func emptyAssumptions(p MonteCarloInputs) MonteCarloAssumptions {
 			StocksPct: p.Allocation.StocksPct,
 			BondsPct:  p.Allocation.BondsPct,
 			CashPct:   p.Allocation.CashPct,
+		}
+	}
+	if p.AccountMix != nil {
+		a.AccountMix = &MonteCarloAccountMixOut{
+			TaxablePct:     p.AccountMix.TaxablePct,
+			IkePct:         p.AccountMix.IkePct,
+			IkzePct:        p.AccountMix.IkzePct,
+			ZusPct:         p.AccountMix.ZusPct,
+			TaxableGainPct: p.AccountMix.TaxableGainPct,
 		}
 	}
 	return a

--- a/backend-go/internal/simulations/montecarlo.go
+++ b/backend-go/internal/simulations/montecarlo.go
@@ -36,16 +36,21 @@ type MonteCarloAllocation struct {
 }
 
 // MonteCarloAccountMix expresses what share of each PLN withdrawn comes
-// from which Polish wrapper, plus the gain fraction of the taxable
-// brokerage balance (used to apply 19% Belka only on appreciation, not
-// cost basis). Pcts must sum to 100. When set, the simulation grosses up
-// withdrawals to cover tax and reports both gross and net-of-tax bands.
+// from which Polish wrapper, plus the gain fraction used for Belka. Pcts
+// must sum to 100. When set, the simulation grosses up withdrawals to
+// cover tax and reports both gross and net-of-tax bands.
+//
+// TaxableGainPct is the gain fraction (vs cost basis) of the taxable
+// brokerage balance. The same fraction is used as a proxy for IKE
+// withdrawals before age 60 and IKZE withdrawals before age 65 — early
+// withdrawals from those wrappers are taxed like brokerage gains in our
+// model, so they need a gain-fraction assumption too.
 type MonteCarloAccountMix struct {
 	TaxablePct     float64
 	IkePct         float64
 	IkzePct        float64
 	ZusPct         float64
-	TaxableGainPct float64 // fraction of taxable balance that's gains
+	TaxableGainPct float64
 }
 
 // EffectiveTaxRate returns the share of each gross PLN withdrawn that
@@ -262,7 +267,9 @@ func RunMonteCarlo(rng *rand.Rand, p MonteCarloInputs) MonteCarloResult {
 }
 
 // pathMatrix bundles per-path per-year trajectories so RunMonteCarlo can
-// stay short and the loop body stays linear.
+// stay short and the loop body stays linear. netNominal/netReal are nil
+// when no AccountMix was supplied; consumers must mirror gross in that
+// case (saves an allocation + per-band sort on the common no-tax path).
 type pathMatrix struct {
 	nominal      [][]float64
 	realBalance  [][]float64
@@ -280,20 +287,26 @@ func simulatePaths(rng *rand.Rand, p MonteCarloInputs, paths, years int, expecte
 	sd := volatility / 100.0
 	infMean := p.InflationMean / 100.0
 	infSd := p.InflationVolatility / 100.0
+	hasTax := p.AccountMix != nil
 	m := pathMatrix{
 		nominal:      make([][]float64, paths),
 		realBalance:  make([][]float64, paths),
-		netNominal:   make([][]float64, paths),
-		netReal:      make([][]float64, paths),
 		spending:     make([][]float64, paths),
 		spendingReal: make([][]float64, paths),
+	}
+	if hasTax {
+		m.netNominal = make([][]float64, paths)
+		m.netReal = make([][]float64, paths)
 	}
 	for i := range paths {
 		balance := p.CurrentPortfolio
 		nomRow := make([]float64, years)
 		realRow := make([]float64, years)
-		netRow := make([]float64, years)
-		netRealRow := make([]float64, years)
+		var netRow, netRealRow []float64
+		if hasTax {
+			netRow = make([]float64, years)
+			netRealRow = make([]float64, years)
+		}
 		spendRow := make([]float64, years)
 		spendRealRow := make([]float64, years)
 		cumInflation := 1.0
@@ -345,20 +358,20 @@ func simulatePaths(rng *rand.Rand, p MonteCarloInputs, paths, years int, expecte
 			}
 			nomRow[y] = balance
 			realRow[y] = safeDiv(balance, cumInflation)
-			liquidationRate := 0.0
-			if p.AccountMix != nil {
-				liquidationRate = p.AccountMix.EffectiveTaxRate(age)
+			if hasTax {
+				netBalance := balance * (1 - p.AccountMix.EffectiveTaxRate(age))
+				netRow[y] = netBalance
+				netRealRow[y] = safeDiv(netBalance, cumInflation)
 			}
-			netBalance := balance * (1 - liquidationRate)
-			netRow[y] = netBalance
-			netRealRow[y] = safeDiv(netBalance, cumInflation)
 			spendRow[y] = withdrawal
 			spendRealRow[y] = safeDiv(withdrawal, cumInflation)
 		}
 		m.nominal[i] = nomRow
 		m.realBalance[i] = realRow
-		m.netNominal[i] = netRow
-		m.netReal[i] = netRealRow
+		if hasTax {
+			m.netNominal[i] = netRow
+			m.netReal[i] = netRealRow
+		}
 		m.spending[i] = spendRow
 		m.spendingReal[i] = spendRealRow
 		if balance > 0 {
@@ -369,23 +382,27 @@ func simulatePaths(rng *rand.Rand, p MonteCarloInputs, paths, years int, expecte
 }
 
 func buildBands(m pathMatrix, paths, years, currentAge int) []MonteCarloPercentileBand {
+	hasTax := m.netNominal != nil
 	bands := make([]MonteCarloPercentileBand, years)
 	col := make([]float64, paths)
 	colReal := make([]float64, paths)
-	colNet := make([]float64, paths)
-	colNetReal := make([]float64, paths)
+	var colNet, colNetReal []float64
+	if hasTax {
+		colNet = make([]float64, paths)
+		colNetReal = make([]float64, paths)
+	}
 	for y := range years {
 		for i := range paths {
 			col[i] = m.nominal[i][y]
 			colReal[i] = m.realBalance[i][y]
-			colNet[i] = m.netNominal[i][y]
-			colNetReal[i] = m.netReal[i][y]
+			if hasTax {
+				colNet[i] = m.netNominal[i][y]
+				colNetReal[i] = m.netReal[i][y]
+			}
 		}
 		sort.Float64s(col)
 		sort.Float64s(colReal)
-		sort.Float64s(colNet)
-		sort.Float64s(colNetReal)
-		bands[y] = MonteCarloPercentileBand{
+		b := MonteCarloPercentileBand{
 			Age:          currentAge + y + 1,
 			P5:           percentile(col, 5),
 			P50:          percentile(col, 50),
@@ -393,15 +410,27 @@ func buildBands(m pathMatrix, paths, years, currentAge int) []MonteCarloPercenti
 			P5Real:       percentile(colReal, 5),
 			P50Real:      percentile(colReal, 50),
 			P95Real:      percentile(colReal, 95),
-			P5Net:        percentile(colNet, 5),
-			P50Net:       percentile(colNet, 50),
-			P95Net:       percentile(colNet, 95),
-			P5NetReal:    percentile(colNetReal, 5),
-			P50NetReal:   percentile(colNetReal, 50),
-			P95NetReal:   percentile(colNetReal, 95),
 			Spending:     meanColumn(m.spending, y),
 			SpendingReal: meanColumn(m.spendingReal, y),
 		}
+		if hasTax {
+			sort.Float64s(colNet)
+			sort.Float64s(colNetReal)
+			b.P5Net = percentile(colNet, 5)
+			b.P50Net = percentile(colNet, 50)
+			b.P95Net = percentile(colNet, 95)
+			b.P5NetReal = percentile(colNetReal, 5)
+			b.P50NetReal = percentile(colNetReal, 50)
+			b.P95NetReal = percentile(colNetReal, 95)
+		} else {
+			b.P5Net = b.P5
+			b.P50Net = b.P50
+			b.P95Net = b.P95
+			b.P5NetReal = b.P5Real
+			b.P50NetReal = b.P50Real
+			b.P95NetReal = b.P95Real
+		}
+		bands[y] = b
 	}
 	return bands
 }

--- a/backend-go/internal/simulations/montecarlo_test.go
+++ b/backend-go/internal/simulations/montecarlo_test.go
@@ -366,6 +366,138 @@ func TestRunMonteCarlo_AssumptionsEchoesInflation(t *testing.T) {
 	}
 }
 
+func TestEffectiveTaxRate_TaxableOnlyFullGain(t *testing.T) {
+	mix := MonteCarloAccountMix{TaxablePct: 100, TaxableGainPct: 100}
+	got := mix.EffectiveTaxRate(70)
+	if math.Abs(got-BelkaRate) > 1e-9 {
+		t.Errorf("100%% taxable, 100%% gain at age 70: got %v, want %v", got, BelkaRate)
+	}
+}
+
+func TestEffectiveTaxRate_TaxableHalfGainHalfBasis(t *testing.T) {
+	mix := MonteCarloAccountMix{TaxablePct: 100, TaxableGainPct: 50}
+	got := mix.EffectiveTaxRate(70)
+	want := 0.5 * BelkaRate
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("100%% taxable, 50%% gain: got %v, want %v", got, want)
+	}
+}
+
+func TestEffectiveTaxRate_IkePost60IsFree(t *testing.T) {
+	mix := MonteCarloAccountMix{IkePct: 100, TaxableGainPct: 100}
+	if r := mix.EffectiveTaxRate(60); r != 0 {
+		t.Errorf("IKE at 60: got %v, want 0", r)
+	}
+	if r := mix.EffectiveTaxRate(59); r != BelkaRate {
+		t.Errorf("IKE pre-60 should fall back to Belka: got %v, want %v", r, BelkaRate)
+	}
+}
+
+func TestEffectiveTaxRate_IkzePost65Is10Pct(t *testing.T) {
+	mix := MonteCarloAccountMix{IkzePct: 100, TaxableGainPct: 100}
+	if r := mix.EffectiveTaxRate(65); math.Abs(r-IkzePostAgeRate) > 1e-9 {
+		t.Errorf("IKZE at 65: got %v, want %v", r, IkzePostAgeRate)
+	}
+	if r := mix.EffectiveTaxRate(64); math.Abs(r-BelkaRate) > 1e-9 {
+		t.Errorf("IKZE pre-65 falls back to Belka: got %v, want %v", r, BelkaRate)
+	}
+}
+
+func TestEffectiveTaxRate_ZusIsAlwaysFree(t *testing.T) {
+	mix := MonteCarloAccountMix{ZusPct: 100, TaxableGainPct: 100}
+	if r := mix.EffectiveTaxRate(70); r != 0 {
+		t.Errorf("ZUS at 70: got %v, want 0", r)
+	}
+}
+
+func TestEffectiveTaxRate_BlendedMix(t *testing.T) {
+	// 60% taxable (100% gain), 20% IKE, 20% IKZE at age 70.
+	mix := MonteCarloAccountMix{
+		TaxablePct: 60, IkePct: 20, IkzePct: 20, TaxableGainPct: 100,
+	}
+	got := mix.EffectiveTaxRate(70)
+	want := 0.60*BelkaRate + 0.20*IkzePostAgeRate
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("blended mix: got %v, want %v", got, want)
+	}
+}
+
+func TestRunMonteCarlo_NoAccountMix_NoTaxSummary(t *testing.T) {
+	got := RunMonteCarlo(newSeededRng(), MonteCarloInputs{
+		CurrentPortfolio: 100000, CurrentAge: 30, RetirementAge: 65, LifeExpectancy: 90,
+		ExpectedReturn: 6, Volatility: 15, AnnualWithdrawal: 30000, Paths: 50,
+	})
+	if got.Tax != nil {
+		t.Errorf("tax summary should be nil without AccountMix, got %+v", got.Tax)
+	}
+	for _, b := range got.Bands {
+		if b.P50Net != b.P50 || b.P50NetReal != b.P50Real {
+			t.Errorf("age %d: net bands should mirror gross without AccountMix", b.Age)
+		}
+	}
+}
+
+func TestRunMonteCarlo_AccountMix_TaxSummaryHasExpectedLifetimeRate(t *testing.T) {
+	// Deterministic path: zero vol on returns and inflation. 100% taxable
+	// with 100% gain means every withdrawn PLN pays the full Belka rate.
+	got := RunMonteCarlo(newSeededRng(), MonteCarloInputs{
+		CurrentPortfolio:    1_000_000,
+		AnnualContribution:  0,
+		ExpectedReturn:      0,
+		Volatility:          0,
+		CurrentAge:          65,
+		RetirementAge:       65,
+		LifeExpectancy:      70,
+		AnnualWithdrawal:    40000,
+		Paths:               5,
+		InflationMean:       0,
+		InflationVolatility: 0,
+		AccountMix:          &MonteCarloAccountMix{TaxablePct: 100, TaxableGainPct: 100},
+	})
+	if got.Tax == nil {
+		t.Fatalf("expected tax summary, got nil")
+	}
+	if math.Abs(got.Tax.EffectiveLifetimeRate-BelkaRate) > 1e-9 {
+		t.Errorf("effective lifetime rate = %v, want Belka %v",
+			got.Tax.EffectiveLifetimeRate, BelkaRate)
+	}
+	wantGrossPerPath := 5 * (40000.0 / (1 - BelkaRate))
+	wantGrossTotal := wantGrossPerPath * 5
+	if math.Abs(got.Tax.GrossWithdrawalsTotal-wantGrossTotal) > 1e-6 {
+		t.Errorf("gross total = %v, want %v", got.Tax.GrossWithdrawalsTotal, wantGrossTotal)
+	}
+}
+
+func TestRunMonteCarlo_AccountMix_NetBandsDeflateGrossByTaxRate(t *testing.T) {
+	// All ZUS = 0% tax → net == gross. All taxable 100% gain → net = gross * 0.81.
+	zusGot := RunMonteCarlo(newSeededRng(), MonteCarloInputs{
+		CurrentPortfolio: 100000, AnnualContribution: 0,
+		ExpectedReturn: 0, Volatility: 0,
+		CurrentAge: 65, RetirementAge: 65, LifeExpectancy: 70,
+		AnnualWithdrawal: 0, Paths: 3,
+		AccountMix: &MonteCarloAccountMix{ZusPct: 100},
+	})
+	for _, b := range zusGot.Bands {
+		if math.Abs(b.P50Net-b.P50) > 1e-6 {
+			t.Errorf("ZUS-only: net %v should equal gross %v at age %d", b.P50Net, b.P50, b.Age)
+		}
+	}
+	taxGot := RunMonteCarlo(newSeededRng(), MonteCarloInputs{
+		CurrentPortfolio: 100000, AnnualContribution: 0,
+		ExpectedReturn: 0, Volatility: 0,
+		CurrentAge: 65, RetirementAge: 65, LifeExpectancy: 70,
+		AnnualWithdrawal: 0, Paths: 3,
+		AccountMix: &MonteCarloAccountMix{TaxablePct: 100, TaxableGainPct: 100},
+	})
+	for _, b := range taxGot.Bands {
+		want := b.P50 * (1 - BelkaRate)
+		if math.Abs(b.P50Net-want) > 1e-6 {
+			t.Errorf("age %d: net %v != gross %v × (1 - %v) = %v",
+				b.Age, b.P50Net, b.P50, BelkaRate, want)
+		}
+	}
+}
+
 func TestRunMonteCarlo_PercentilesAreSorted(t *testing.T) {
 	// Across reasonable inputs p5 <= p50 <= p95 at every age.
 	got := RunMonteCarlo(newSeededRng(), MonteCarloInputs{

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -4738,6 +4738,18 @@ export interface paths {
                     content: {
                         "application/json": {
                             assumptions?: {
+                                account_mix?: {
+                                    /** Format: double */
+                                    ike_pct?: number;
+                                    /** Format: double */
+                                    ikze_pct?: number;
+                                    /** Format: double */
+                                    taxable_gain_pct?: number;
+                                    /** Format: double */
+                                    taxable_pct?: number;
+                                    /** Format: double */
+                                    zus_pct?: number;
+                                } | null;
                                 allocation?: {
                                     /** Format: double */
                                     bonds_pct?: number;
@@ -4763,11 +4775,23 @@ export interface paths {
                                 /** Format: double */
                                 p50?: number;
                                 /** Format: double */
+                                p50_net?: number;
+                                /** Format: double */
+                                p50_net_real?: number;
+                                /** Format: double */
                                 p50_real?: number;
+                                /** Format: double */
+                                p5_net?: number;
+                                /** Format: double */
+                                p5_net_real?: number;
                                 /** Format: double */
                                 p5_real?: number;
                                 /** Format: double */
                                 p95?: number;
+                                /** Format: double */
+                                p95_net?: number;
+                                /** Format: double */
+                                p95_net_real?: number;
                                 /** Format: double */
                                 p95_real?: number;
                                 /** Format: double */
@@ -4778,6 +4802,14 @@ export interface paths {
                             paths?: number;
                             /** Format: double */
                             success_rate?: number;
+                            tax?: {
+                                /** Format: double */
+                                effective_lifetime_rate?: number;
+                                /** Format: double */
+                                gross_withdrawals_total?: number;
+                                /** Format: double */
+                                tax_total?: number;
+                            } | null;
                         };
                     };
                 };

--- a/src/lib/utils/charts/montecarlo.test.ts
+++ b/src/lib/utils/charts/montecarlo.test.ts
@@ -73,6 +73,40 @@ describe('buildMonteCarloFanOption', () => {
 		expect(series[2].data).toEqual([]);
 	});
 
+	it('uses the *_net fields when net=true', () => {
+		const result = makeResult([
+			[60, 100, 200, 300],
+			[61, 150, 280, 410]
+		]);
+		// Distinguish net from gross by mutating only the net fields.
+		result.bands[0].p5_net = 10;
+		result.bands[0].p50_net = 20;
+		result.bands[0].p95_net = 30;
+		result.bands[1].p5_net = 15;
+		result.bands[1].p50_net = 25;
+		result.bands[1].p95_net = 35;
+		const opt = buildMonteCarloFanOption(result, { net: true });
+		const series = opt.series as Array<{ data: number[] }>;
+		expect(series[0].data).toEqual([10, 15]); // P5 base = p5_net
+		expect(series[2].data).toEqual([20, 25]); // median = p50_net
+		const title = opt.title as { text: string };
+		expect(title.text).toContain('po podatku');
+	});
+
+	it('uses the *_net_real fields when both real and net are true', () => {
+		const result = makeResult([[60, 100, 200, 300]]);
+		result.bands[0].p5_net_real = 11;
+		result.bands[0].p50_net_real = 22;
+		result.bands[0].p95_net_real = 33;
+		const opt = buildMonteCarloFanOption(result, { net: true, real: true });
+		const series = opt.series as Array<{ data: number[] }>;
+		expect(series[0].data).toEqual([11]);
+		expect(series[2].data).toEqual([22]);
+		const title = opt.title as { text: string };
+		expect(title.text).toContain('realne');
+		expect(title.text).toContain('po podatku');
+	});
+
 	it('tooltip formatter renders the three percentiles', () => {
 		const opt = buildMonteCarloFanOption(
 			makeResult([

--- a/src/lib/utils/charts/montecarlo.test.ts
+++ b/src/lib/utils/charts/montecarlo.test.ts
@@ -13,6 +13,12 @@ function makeResult(bands: Array<[number, number, number, number]>): MonteCarloR
 			p5_real: p5,
 			p50_real: p50,
 			p95_real: p95,
+			p5_net: p5,
+			p50_net: p50,
+			p95_net: p95,
+			p5_net_real: p5,
+			p50_net_real: p50,
+			p95_net_real: p95,
 			spending: 0,
 			spending_real: 0
 		})),

--- a/src/lib/utils/charts/montecarlo.ts
+++ b/src/lib/utils/charts/montecarlo.ts
@@ -9,6 +9,12 @@ export interface MonteCarloBand {
 	p5_real: number;
 	p50_real: number;
 	p95_real: number;
+	p5_net: number;
+	p50_net: number;
+	p95_net: number;
+	p5_net_real: number;
+	p50_net_real: number;
+	p95_net_real: number;
 	spending: number;
 	spending_real: number;
 }
@@ -19,6 +25,14 @@ export interface MonteCarloAllocationOut {
 	cash_pct: number;
 }
 
+export interface MonteCarloAccountMixOut {
+	taxable_pct: number;
+	ike_pct: number;
+	ikze_pct: number;
+	zus_pct: number;
+	taxable_gain_pct: number;
+}
+
 export interface MonteCarloAssumptions {
 	expected_return: number;
 	volatility: number;
@@ -26,6 +40,13 @@ export interface MonteCarloAssumptions {
 	allocation?: MonteCarloAllocationOut;
 	inflation_mean: number;
 	inflation_volatility: number;
+	account_mix?: MonteCarloAccountMixOut;
+}
+
+export interface MonteCarloTaxSummary {
+	gross_withdrawals_total: number;
+	tax_total: number;
+	effective_lifetime_rate: number;
 }
 
 export interface MonteCarloResult {
@@ -33,6 +54,7 @@ export interface MonteCarloResult {
 	bands: MonteCarloBand[];
 	paths: number;
 	assumptions: MonteCarloAssumptions;
+	tax?: MonteCarloTaxSummary;
 }
 
 function fmtPLN(value: number): string {
@@ -51,19 +73,43 @@ function escapeHtml(value: string): string {
 		.replace(/'/g, '&#39;');
 }
 
+type BandKey =
+	| 'p5'
+	| 'p50'
+	| 'p95'
+	| 'p5_real'
+	| 'p50_real'
+	| 'p95_real'
+	| 'p5_net'
+	| 'p50_net'
+	| 'p95_net'
+	| 'p5_net_real'
+	| 'p50_net_real'
+	| 'p95_net_real';
+
+function pickKeys(real: boolean, net: boolean): { p5: BandKey; p50: BandKey; p95: BandKey } {
+	if (net && real) return { p5: 'p5_net_real', p50: 'p50_net_real', p95: 'p95_net_real' };
+	if (net) return { p5: 'p5_net', p50: 'p50_net', p95: 'p95_net' };
+	if (real) return { p5: 'p5_real', p50: 'p50_real', p95: 'p95_real' };
+	return { p5: 'p5', p50: 'p50', p95: 'p95' };
+}
+
 // Fan chart: shaded P5–P95 band with the P50 median overlaid. Implemented
 // as a stack — base = P5, ribbon = P95 - P5 (transparent fill on top).
-// Pass {real: true} to plot the real (inflation-adjusted) bands instead
-// of the nominal ones; tooltip labels follow the choice.
+// Pass {real: true} to plot real (inflation-adjusted) bands; pass {net:
+// true} to plot net-of-tax bands (uses the AccountMix-driven net series);
+// they compose.
 export function buildMonteCarloFanOption(
 	result: MonteCarloResult,
-	opts: { real?: boolean } = {}
+	opts: { real?: boolean; net?: boolean } = {}
 ): EChartsOption {
 	const real = opts.real === true;
+	const net = opts.net === true;
+	const keys = pickKeys(real, net);
 	const ages = result.bands.map((b) => b.age);
-	const p5 = result.bands.map((b) => (real ? b.p5_real : b.p5));
-	const p50 = result.bands.map((b) => (real ? b.p50_real : b.p50));
-	const p95 = result.bands.map((b) => (real ? b.p95_real : b.p95));
+	const p5 = result.bands.map((b) => b[keys.p5]);
+	const p50 = result.bands.map((b) => b[keys.p50]);
+	const p95 = result.bands.map((b) => b[keys.p95]);
 	const ribbon = p95.map((v, i) => v - p5[i]);
 
 	const series: LineSeriesOption[] = [
@@ -97,7 +143,10 @@ export function buildMonteCarloFanOption(
 		}
 	];
 
-	const suffix = real ? ' (realne)' : '';
+	const suffixParts: string[] = [];
+	if (real) suffixParts.push('realne');
+	if (net) suffixParts.push('po podatku');
+	const suffix = suffixParts.length > 0 ? ` (${suffixParts.join(', ')})` : '';
 	return {
 		title: { text: `Symulacja Monte Carlo — projekcja salda${suffix}` },
 		tooltip: {
@@ -108,9 +157,9 @@ export function buildMonteCarloFanOption(
 				const idx = items[0].dataIndex;
 				const band = result.bands[idx as number];
 				if (!band) return '';
-				const v5 = real ? band.p5_real : band.p5;
-				const v50 = real ? band.p50_real : band.p50;
-				const v95 = real ? band.p95_real : band.p95;
+				const v5 = band[keys.p5];
+				const v50 = band[keys.p50];
+				const v95 = band[keys.p95];
 				return (
 					`<strong>Wiek ${escapeHtml(String(age))}${suffix}</strong><br/>` +
 					`P5: ${fmtPLN(v5)} PLN<br/>` +

--- a/src/routes/retirement/+page.svelte
+++ b/src/routes/retirement/+page.svelte
@@ -27,6 +27,15 @@
 	let inflationVolatility = $state(0);
 	let showReal = $state(true);
 
+	let useAccountMix = $state(false);
+	let mixTaxable = $state(50);
+	let mixIke = $state(20);
+	let mixIkze = $state(20);
+	let mixZus = $state(10);
+	let mixTaxableGain = $state(60);
+	const mixSum = $derived(mixTaxable + mixIke + mixIkze + mixZus);
+	let showNet = $state(false);
+
 	let loading = $state(false);
 	let error = $state('');
 	let result: MonteCarloResult | null = $state(null);
@@ -68,6 +77,16 @@
 				loading = false;
 				return;
 			}
+			if (useAccountMix && Math.abs(mixSum - 100) > 0.01) {
+				error = `Konta muszą sumować się do 100% (obecnie ${mixSum.toFixed(1)}%)`;
+				loading = false;
+				return;
+			}
+			if (useAccountMix && (mixTaxableGain < 0 || mixTaxableGain > 100)) {
+				error = 'Udział zysku w koncie maklerskim musi mieścić się w 0–100%';
+				loading = false;
+				return;
+			}
 
 			const apiUrl = resolveApiUrl();
 			const body: Record<string, unknown> = {
@@ -87,6 +106,15 @@
 					stocks_pct: allocStocks,
 					bonds_pct: allocBonds,
 					cash_pct: allocCash
+				};
+			}
+			if (useAccountMix) {
+				body.account_mix = {
+					taxable_pct: mixTaxable,
+					ike_pct: mixIke,
+					ikze_pct: mixIkze,
+					zus_pct: mixZus,
+					taxable_gain_pct: mixTaxableGain
 				};
 			}
 			const response = await fetch(`${apiUrl}/api/simulations/monte-carlo`, {
@@ -118,7 +146,7 @@
 			chartHandle = createChart(chartContainer);
 			chart = chartHandle.chart;
 		}
-		chart?.setOption(buildMonteCarloFanOption(result, { real: showReal }), true);
+		chart?.setOption(buildMonteCarloFanOption(result, { real: showReal, net: showNet }), true);
 	});
 
 	const successPercent = $derived.by(() => {
@@ -236,6 +264,85 @@
 			<p class="text-xs text-surface-600-400">
 				Roczna wypłata jest interpretowana jako kwota w dzisiejszych PLN i rośnie razem z inflacją.
 			</p>
+		</div>
+
+		<div class="space-y-3 pt-2 border-t border-surface-300-700">
+			<label class="flex items-center gap-2 text-sm font-semibold">
+				<input type="checkbox" class="checkbox" bind:checked={useAccountMix} />
+				Uwzględnij podatek (Belka / IKZE 10%) wg miksu kont
+			</label>
+			{#if useAccountMix}
+				<div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+					<label class="space-y-1">
+						<span class="text-xs font-semibold">Konto maklerskie (%)</span>
+						<input
+							type="number"
+							min="0"
+							max="100"
+							step="1"
+							class="input w-full"
+							bind:value={mixTaxable}
+						/>
+					</label>
+					<label class="space-y-1">
+						<span class="text-xs font-semibold">IKE (%)</span>
+						<input
+							type="number"
+							min="0"
+							max="100"
+							step="1"
+							class="input w-full"
+							bind:value={mixIke}
+						/>
+					</label>
+					<label class="space-y-1">
+						<span class="text-xs font-semibold">IKZE (%)</span>
+						<input
+							type="number"
+							min="0"
+							max="100"
+							step="1"
+							class="input w-full"
+							bind:value={mixIkze}
+						/>
+					</label>
+					<label class="space-y-1">
+						<span class="text-xs font-semibold">ZUS (%)</span>
+						<input
+							type="number"
+							min="0"
+							max="100"
+							step="1"
+							class="input w-full"
+							bind:value={mixZus}
+						/>
+					</label>
+				</div>
+				<div
+					class="text-xs {Math.abs(mixSum - 100) < 0.01
+						? 'text-success-600-400'
+						: 'text-error-600-400'}"
+				>
+					Suma kont: {mixSum.toFixed(1)}% (musi być 100%)
+				</div>
+				<label class="space-y-1 block">
+					<span class="text-xs font-semibold">
+						Udział zysku w koncie maklerskim (%) — pozostała część to wkład własny
+					</span>
+					<input
+						type="number"
+						min="0"
+						max="100"
+						step="1"
+						class="input w-full sm:max-w-xs"
+						bind:value={mixTaxableGain}
+					/>
+				</label>
+				<p class="text-xs text-surface-600-400">
+					Roczna wypłata to kwota po podatku. Portfel jest pomniejszany o brutto, aby pokryć daniny.
+					IKE jest wolne od podatku po 60. r.ż., IKZE płaci 10% po 65.
+				</p>
+			{/if}
 		</div>
 
 		<div class="space-y-3 pt-2 border-t border-surface-300-700">
@@ -361,20 +468,61 @@
 				{/if}
 			</div>
 
-			<label class="flex items-center gap-2 text-sm">
-				<input type="checkbox" class="checkbox" bind:checked={showReal} />
-				Pokaż wartości realne (w dzisiejszych PLN)
-			</label>
+			<div class="flex flex-wrap gap-4">
+				<label class="flex items-center gap-2 text-sm">
+					<input type="checkbox" class="checkbox" bind:checked={showReal} />
+					Pokaż wartości realne (w dzisiejszych PLN)
+				</label>
+				{#if result.tax}
+					<label class="flex items-center gap-2 text-sm">
+						<input type="checkbox" class="checkbox" bind:checked={showNet} />
+						Pokaż portfel netto (po likwidacji + Belka/IKZE)
+					</label>
+				{/if}
+			</div>
+
+			{#if result.tax}
+				<div class="card preset-tonal-surface p-3 text-sm space-y-1">
+					<div class="font-semibold text-xs uppercase text-surface-600-400">
+						Podatek (efektywny wymiar życiowy)
+					</div>
+					<div>
+						Stopa efektywna:
+						<strong>{(result.tax.effective_lifetime_rate * 100).toFixed(2)}%</strong>
+						(wzięte z portfela: {formatPLN(result.tax.gross_withdrawals_total)} PLN, podatek: {formatPLN(
+							result.tax.tax_total
+						)} PLN)
+					</div>
+				</div>
+			{/if}
 
 			<div bind:this={chartContainer} class="w-full h-[320px] sm:h-[420px]"></div>
 
 			{#if result.bands.length > 0}
 				{@const last = result.bands[result.bands.length - 1]}
-				{@const lastP5 = showReal ? last.p5_real : last.p5}
-				{@const lastP50 = showReal ? last.p50_real : last.p50}
-				{@const lastP95 = showReal ? last.p95_real : last.p95}
+				{@const lastP5 = showNet
+					? showReal
+						? last.p5_net_real
+						: last.p5_net
+					: showReal
+						? last.p5_real
+						: last.p5}
+				{@const lastP50 = showNet
+					? showReal
+						? last.p50_net_real
+						: last.p50_net
+					: showReal
+						? last.p50_real
+						: last.p50}
+				{@const lastP95 = showNet
+					? showReal
+						? last.p95_net_real
+						: last.p95_net
+					: showReal
+						? last.p95_real
+						: last.p95}
 				{@const spendingBand = result.bands.find((b) => b.spending > 0)}
-				{@const valueLabel = showReal ? 'realne' : 'nominalne'}
+				{@const valueLabel = `${showReal ? 'realne' : 'nominalne'}${showNet ? ', netto' : ''}`}
 				<div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
 					<div class="card preset-tonal-surface p-4">
 						<div class="text-xs text-surface-600-400">

--- a/src/routes/retirement/+page.svelte
+++ b/src/routes/retirement/+page.svelte
@@ -77,6 +77,11 @@
 				loading = false;
 				return;
 			}
+			if (useAccountMix && (mixTaxable < 0 || mixIke < 0 || mixIkze < 0 || mixZus < 0)) {
+				error = 'Udziały kont muszą być nieujemne';
+				loading = false;
+				return;
+			}
 			if (useAccountMix && Math.abs(mixSum - 100) > 0.01) {
 				error = `Konta muszą sumować się do 100% (obecnie ${mixSum.toFixed(1)}%)`;
 				loading = false;
@@ -146,7 +151,8 @@
 			chartHandle = createChart(chartContainer);
 			chart = chartHandle.chart;
 		}
-		chart?.setOption(buildMonteCarloFanOption(result, { real: showReal, net: showNet }), true);
+		const net = showNet && !!result.tax;
+		chart?.setOption(buildMonteCarloFanOption(result, { real: showReal, net }), true);
 	});
 
 	const successPercent = $derived.by(() => {
@@ -500,21 +506,22 @@
 
 			{#if result.bands.length > 0}
 				{@const last = result.bands[result.bands.length - 1]}
-				{@const lastP5 = showNet
+				{@const netActive = showNet && !!result.tax}
+				{@const lastP5 = netActive
 					? showReal
 						? last.p5_net_real
 						: last.p5_net
 					: showReal
 						? last.p5_real
 						: last.p5}
-				{@const lastP50 = showNet
+				{@const lastP50 = netActive
 					? showReal
 						? last.p50_net_real
 						: last.p50_net
 					: showReal
 						? last.p50_real
 						: last.p50}
-				{@const lastP95 = showNet
+				{@const lastP95 = netActive
 					? showReal
 						? last.p95_net_real
 						: last.p95_net
@@ -522,7 +529,7 @@
 						? last.p95_real
 						: last.p95}
 				{@const spendingBand = result.bands.find((b) => b.spending > 0)}
-				{@const valueLabel = `${showReal ? 'realne' : 'nominalne'}${showNet ? ', netto' : ''}`}
+				{@const valueLabel = `${showReal ? 'realne' : 'nominalne'}${netActive ? ', netto' : ''}`}
 				<div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
 					<div class="card preset-tonal-surface p-4">
 						<div class="text-xs text-surface-600-400">


### PR DESCRIPTION
## Motivation

Closes #571. The Monte Carlo retirement simulation previously treated every withdrawal as tax-free. In reality a Polish retiree pays 19% Belka on taxable-brokerage realized gains, 10% PIT on IKZE from age 65, and IKE goes tax-free from 60. Net-of-tax trajectory shifts the FIRE date materially, so the simulation now grosses up withdrawals to cover the appropriate per-account tax and surfaces both gross and net portfolio bands.

## Implementation information

- Backend (`backend-go/internal/simulations/montecarlo.go`):
  - New `MonteCarloAccountMix` input — share of each withdrawn PLN coming from taxable / IKE / IKZE / ZUS (must sum to 100), plus `TaxableGainPct` (proportion of the taxable balance that is appreciation vs cost basis).
  - `EffectiveTaxRate(age)` blends per-bucket marginal rates: 19% Belka on the gain portion of taxable, IKE tax-free from age 60 (else Belka), IKZE 10% from 65 (else Belka), ZUS treated as 0% (already taxed at source).
  - Each retirement-year `AnnualWithdrawal` is treated as the desired **net** spend. The portfolio debit is grossed up to `desired / (1 - effectiveRate)`; on a busted year the retiree withdraws whatever is left and pays the year's effective rate on it.
  - New band fields `p5_net/p50_net/p95_net` plus their `_real` siblings: balance after subtracting the estimated tax that would be owed on a full liquidation at that age. With no `account_mix`, these mirror the gross bands.
  - New `tax` summary on the response: `gross_withdrawals_total`, `tax_total`, `effective_lifetime_rate`. Only emitted when `account_mix` was supplied.
- Handler validates non-negative mix percentages, that the four buckets sum to 100, and `taxable_gain_pct ∈ [0, 100]`.
- Tests:
  - Per-bucket rate cases: taxable full-gain, taxable half-gain, IKE post/pre-60, IKZE post/pre-65, ZUS-only, blended mix.
  - Integration: no-mix run produces no `tax` summary and net == gross; full-taxable run produces lifetime rate equal to Belka and gross totals match `years × paths × (desiredNet / (1 - 0.19))`; ZUS-only net == gross while taxable net = gross × (1 - 0.19).
- Frontend (`src/routes/retirement/+page.svelte`):
  - New opt-in "uwzględnij podatek" section with four bucket percentages, gain-fraction input, and live sum validation.
  - Result panel gains a "pokaż portfel netto" toggle (visible only when the run included a mix) and a tax-summary card with the effective lifetime rate, total gross drawn, and total tax paid.
  - Fan chart already takes `real`; now also accepts `net` and the two compose, with the title and tooltip labels updated.
- Regenerated `api/openapi-go.json` and `src/lib/types/api.generated.ts`.

## Supporting documentation

Issue #571. Umbrella #355. The full withdrawal-order sequencing planned in #558 is not a hard prerequisite for this slice — the mix-share model captures the per-year tax wedge without needing per-account balance tracking, and can be replaced by sequenced bucket draws once #558 lands.

> Changelog: feat(montecarlo): apply Belka tax to paths