### PR TITLE
test(db): unit tests for internal/db schema utils

### DIFF
--- a/backend-go/internal/db/db_test.go
+++ b/backend-go/internal/db/db_test.go
@@ -1,15 +1,12 @@
 package db
 
 import (
-	"context"
 	"strings"
 	"testing"
-
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func TestNewRejectsMalformedDSN(t *testing.T) {
-	_, err := New(context.Background(), "postgres://bad host:5432/db")
+	_, err := New(t.Context(), "postgres://bad host:5432/db")
 	if err == nil {
 		t.Fatal("expected parse error for malformed DSN")
 	}
@@ -31,7 +28,3 @@ func TestNewAppliesPoolDefaults(t *testing.T) {
 		t.Errorf("HealthCheckPeriod: want 1m, got %s", cfg.HealthCheckPeriod)
 	}
 }
-
-// compile-time assertion that pgxpool.Pool stays the return type — guards
-// against accidental refactors that would break callers expecting a real pool.
-var _ func(context.Context, string) (*pgxpool.Pool, error) = New

--- a/backend-go/internal/db/db_test.go
+++ b/backend-go/internal/db/db_test.go
@@ -1,0 +1,37 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestNewRejectsMalformedDSN(t *testing.T) {
+	_, err := New(context.Background(), "postgres://bad host:5432/db")
+	if err == nil {
+		t.Fatal("expected parse error for malformed DSN")
+	}
+	if !strings.Contains(err.Error(), "parse db dsn") {
+		t.Errorf("expected parse error, got: %v", err)
+	}
+}
+
+func TestNewAppliesPoolDefaults(t *testing.T) {
+	pool := integrationPool(t)
+	cfg := pool.Config()
+	if cfg.MaxConns != 10 {
+		t.Errorf("MaxConns: want 10, got %d", cfg.MaxConns)
+	}
+	if cfg.MaxConnIdleTime.Minutes() != 5 {
+		t.Errorf("MaxConnIdleTime: want 5m, got %s", cfg.MaxConnIdleTime)
+	}
+	if cfg.HealthCheckPeriod.Minutes() != 1 {
+		t.Errorf("HealthCheckPeriod: want 1m, got %s", cfg.HealthCheckPeriod)
+	}
+}
+
+// compile-time assertion that pgxpool.Pool stays the return type — guards
+// against accidental refactors that would break callers expecting a real pool.
+var _ func(context.Context, string) (*pgxpool.Pool, error) = New

--- a/backend-go/internal/db/migrate_test.go
+++ b/backend-go/internal/db/migrate_test.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"context"
 	"slices"
 	"testing"
 )
@@ -30,7 +29,7 @@ func TestOwnerTablesHaveForeignKeyNames(t *testing.T) {
 
 func TestMigrateIsIdempotent(t *testing.T) {
 	pool := integrationPool(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	if err := ApplySchema(ctx, pool); err != nil {
 		t.Fatalf("apply schema: %v", err)
 	}

--- a/backend-go/internal/db/migrate_test.go
+++ b/backend-go/internal/db/migrate_test.go
@@ -1,0 +1,43 @@
+package db
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestOwnerTablesHaveForeignKeyNames(t *testing.T) {
+	for _, table := range ownerTables {
+		name, ok := ownerFK[table]
+		if !ok {
+			t.Errorf("ownerFK missing entry for table %q", table)
+			continue
+		}
+		if name == "" {
+			t.Errorf("ownerFK[%q] is empty", table)
+		}
+	}
+	if len(ownerTables) != len(ownerFK) {
+		t.Errorf("ownerTables (%d) and ownerFK (%d) length mismatch",
+			len(ownerTables), len(ownerFK))
+	}
+	for tbl := range ownerFK {
+		if !slices.Contains(ownerTables, tbl) {
+			t.Errorf("ownerFK has %q but ownerTables does not", tbl)
+		}
+	}
+}
+
+func TestMigrateIsIdempotent(t *testing.T) {
+	pool := integrationPool(t)
+	ctx := context.Background()
+	if err := ApplySchema(ctx, pool); err != nil {
+		t.Fatalf("apply schema: %v", err)
+	}
+	if err := Migrate(ctx, pool); err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+	if err := Migrate(ctx, pool); err != nil {
+		t.Fatalf("second migrate (should no-op): %v", err)
+	}
+}

--- a/backend-go/internal/db/schema_test.go
+++ b/backend-go/internal/db/schema_test.go
@@ -33,7 +33,9 @@ func TestSchemaSQLContainsCoreTables(t *testing.T) {
 }
 
 // integrationPool returns a real pool when TEST_DATABASE_URL is set,
-// otherwise the calling test is skipped. The bb-tests-go CI job is the
+// otherwise the calling test is skipped. Each call wipes the `public`
+// schema, so callers MUST NOT run in parallel with each other or with
+// any other test that shares the DSN. The bb-tests-go CI job is the
 // authoritative integration oracle for schema bootstrap; this hook lets
 // developers exercise the same code path with `go test` against a local
 // throwaway Postgres.
@@ -43,7 +45,7 @@ func integrationPool(t *testing.T) *pgxpool.Pool {
 	if dsn == "" {
 		t.Skip("TEST_DATABASE_URL not set — skipping integration test")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 	pool, err := New(ctx, dsn)
 	if err != nil {
@@ -58,7 +60,7 @@ func integrationPool(t *testing.T) *pgxpool.Pool {
 
 func TestApplySchemaCreatesAccountsTable(t *testing.T) {
 	pool := integrationPool(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	if err := ApplySchema(ctx, pool); err != nil {
 		t.Fatalf("ApplySchema on empty db: %v", err)
 	}
@@ -72,13 +74,29 @@ func TestApplySchemaCreatesAccountsTable(t *testing.T) {
 	}
 }
 
+// TestApplySchemaIsIdempotent proves the presence-check short-circuit by
+// seeding a sentinel row after the first apply: if the second apply re-ran
+// schema.sql (which begins with DROP TABLE statements via pg_dump), the
+// sentinel would be wiped. Surviving = the no-op branch fired.
 func TestApplySchemaIsIdempotent(t *testing.T) {
 	pool := integrationPool(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	if err := ApplySchema(ctx, pool); err != nil {
 		t.Fatalf("first apply: %v", err)
 	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO users (username, password_hash) VALUES ('sentinel', 'x')`); err != nil {
+		t.Fatalf("seed sentinel: %v", err)
+	}
 	if err := ApplySchema(ctx, pool); err != nil {
 		t.Fatalf("second apply (should no-op): %v", err)
+	}
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM users WHERE username = 'sentinel'`).Scan(&count); err != nil {
+		t.Fatalf("sentinel lookup: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("sentinel row wiped — second ApplySchema did not no-op (count=%d)", count)
 	}
 }

--- a/backend-go/internal/db/schema_test.go
+++ b/backend-go/internal/db/schema_test.go
@@ -52,8 +52,13 @@ func integrationPool(t *testing.T) *pgxpool.Pool {
 		t.Fatalf("connect to TEST_DATABASE_URL: %v", err)
 	}
 	t.Cleanup(pool.Close)
-	if _, err := pool.Exec(ctx, "DROP SCHEMA public CASCADE; CREATE SCHEMA public"); err != nil {
-		t.Fatalf("reset test schema: %v", err)
+	for _, stmt := range []string{
+		"DROP SCHEMA public CASCADE",
+		"CREATE SCHEMA public",
+	} {
+		if _, err := pool.Exec(ctx, stmt); err != nil {
+			t.Fatalf("reset test schema (%s): %v", stmt, err)
+		}
 	}
 	return pool
 }
@@ -75,9 +80,11 @@ func TestApplySchemaCreatesAccountsTable(t *testing.T) {
 }
 
 // TestApplySchemaIsIdempotent proves the presence-check short-circuit by
-// seeding a sentinel row after the first apply: if the second apply re-ran
-// schema.sql (which begins with DROP TABLE statements via pg_dump), the
-// sentinel would be wiped. Surviving = the no-op branch fired.
+// seeding a sentinel row after the first apply: schema.sql starts with
+// `CREATE TABLE`, so a non-short-circuited second apply would error out on
+// the already-present `accounts` table. Reaching the sentinel lookup proves
+// the no-op branch fired; the row check guards against future schema.sql
+// rewrites that prepend DROPs or otherwise survive a re-run.
 func TestApplySchemaIsIdempotent(t *testing.T) {
 	pool := integrationPool(t)
 	ctx := t.Context()

--- a/backend-go/internal/db/schema_test.go
+++ b/backend-go/internal/db/schema_test.go
@@ -1,0 +1,84 @@
+package db
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestSchemaSQLEmbedded(t *testing.T) {
+	if len(schemaSQL) == 0 {
+		t.Fatal("schemaSQL is empty — embed directive broken")
+	}
+}
+
+func TestSchemaSQLContainsCoreTables(t *testing.T) {
+	required := []string{
+		"CREATE TABLE",
+		"accounts",
+		"users",
+		"snapshots",
+		"transactions",
+		"snapshot_aggregates",
+	}
+	for _, frag := range required {
+		if !strings.Contains(schemaSQL, frag) {
+			t.Errorf("schema.sql missing fragment %q", frag)
+		}
+	}
+}
+
+// integrationPool returns a real pool when TEST_DATABASE_URL is set,
+// otherwise the calling test is skipped. The bb-tests-go CI job is the
+// authoritative integration oracle for schema bootstrap; this hook lets
+// developers exercise the same code path with `go test` against a local
+// throwaway Postgres.
+func integrationPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set — skipping integration test")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool, err := New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect to TEST_DATABASE_URL: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if _, err := pool.Exec(ctx, "DROP SCHEMA public CASCADE; CREATE SCHEMA public"); err != nil {
+		t.Fatalf("reset test schema: %v", err)
+	}
+	return pool
+}
+
+func TestApplySchemaCreatesAccountsTable(t *testing.T) {
+	pool := integrationPool(t)
+	ctx := context.Background()
+	if err := ApplySchema(ctx, pool); err != nil {
+		t.Fatalf("ApplySchema on empty db: %v", err)
+	}
+	var exists bool
+	if err := pool.QueryRow(ctx,
+		`SELECT to_regclass('public.accounts') IS NOT NULL`).Scan(&exists); err != nil {
+		t.Fatalf("regclass check: %v", err)
+	}
+	if !exists {
+		t.Fatal("accounts table not created")
+	}
+}
+
+func TestApplySchemaIsIdempotent(t *testing.T) {
+	pool := integrationPool(t)
+	ctx := context.Background()
+	if err := ApplySchema(ctx, pool); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if err := ApplySchema(ctx, pool); err != nil {
+		t.Fatalf("second apply (should no-op): %v", err)
+	}
+}


### PR DESCRIPTION
## Motivation

`internal/db` had zero test files but underpins every data mutation: pool wiring, schema bootstrap, and the personas->users migration. Closes #599.

## Implementation information

Three new `_test.go` files in `backend-go/internal/db`:

- **Pure unit tests** (run in every `go test ./...`):
  - `schemaSQL` is embedded and non-empty
  - `schemaSQL` contains the core table DDL strings
  - `ownerTables` and `ownerFK` are 1:1 consistent
  - `New` returns a `parse db dsn` error on a malformed DSN
- **Integration tests** gated on `TEST_DATABASE_URL` (skip when unset):
  - `ApplySchema` on a fresh DB creates `accounts`
  - `ApplySchema` is idempotent — seeds a sentinel row between calls and asserts it survives, proving the no-op short-circuit fired
  - `Migrate` is idempotent (two consecutive runs both succeed)
  - `New` applies the documented pool defaults (`MaxConns=10`, `MaxConnIdleTime=5m`, `HealthCheckPeriod=1m`)

### Alternatives considered

The issue suggested `testcontainers-go`. Rejected because:

- Pulls 30+ transitive deps (moby, opentelemetry, gopsutil, ...) into the backend module
- The `bb-tests-go` CI job already exercises `ApplySchema`/`Migrate` end-to-end against a real Postgres — that job is the authoritative integration oracle
- A `TEST_DATABASE_URL` skip-when-unset hook mirrors the bb-tests pattern (`BB_DATABASE_URL`) without the dep weight

Locally: `docker run --rm -p 15432:5432 -e POSTGRES_PASSWORD=test -e POSTGRES_USER=test -e POSTGRES_DB=test postgres:18-alpine` then `TEST_DATABASE_URL=postgres://test:test@localhost:15432/test go test ./internal/db/...`.

## Supporting documentation

Part of umbrella #598.

> Changelog: test(db): unit tests for internal/db schema utils