### PR TITLE
refactor(retirement): split compute, validation

### DIFF
--- a/backend-go/internal/retirement/compute.go
+++ b/backend-go/internal/retirement/compute.go
@@ -1,0 +1,133 @@
+package retirement
+
+import (
+	"math"
+
+	"github.com/shopspring/decimal"
+)
+
+// computeYearlyStat folds the contribution totals against the configured
+// limit into the wire-shape yearly stat. The IKZE PIT fields are left zero —
+// callers add them after looking up the owner's salary.
+//
+// Untyped-remainder rule: when typed buckets sum to less than the total,
+// the gap is attributed to the employee bucket (matches the legacy Python
+// behavior the bb-tests pin).
+//
+// isWarning uses the unrounded percentage on purpose: 89.95% must NOT flip
+// the badge even though it renders as 90.0 in percentage_used.
+func computeYearlyStat(year int, wrapper string, ownerUserID *int, totals ContributionTotals, limit decimal.Decimal) yearlyStat {
+	totalF, _ := totals.Total.Float64()
+	employeeF, _ := totals.Employee.Float64()
+	employerF, _ := totals.Employer.Float64()
+	if totalF > employeeF+employerF {
+		employeeF += totalF - (employeeF + employerF)
+	}
+	limitF, _ := limit.Float64()
+	remaining := limitF - totalF
+	if remaining < 0 {
+		remaining = 0
+	}
+	percentage := 0.0
+	if limitF > 0 {
+		percentage = totalF / limitF * 100
+	}
+	lAmt := pyFloat(limitF)
+	rem := pyFloat(remaining)
+	pct := pyFloat(math.Round(percentage*10) / 10)
+	return yearlyStat{
+		Year:                year,
+		AccountWrapper:      wrapper,
+		OwnerUserID:         ownerUserID,
+		LimitAmount:         &lAmt,
+		TotalContributed:    pyFloat(totalF),
+		EmployeeContributed: pyFloat(employeeF),
+		EmployerContributed: pyFloat(employerF),
+		Remaining:           &rem,
+		PercentageUsed:      &pct,
+		IsWarning:           percentage >= 90,
+	}
+}
+
+// computePPKStat collapses contribution totals + latest snapshot value into
+// the PPK wire stat. Same untyped-remainder rule as computeYearlyStat: any
+// gap between Total and Employee+Employer+Government is attributed to the
+// employee bucket.
+func computePPKStat(ownerUserID *int, totals ContributionTotals, latest decimal.Decimal) ppkStat {
+	totalF, _ := totals.Total.Float64()
+	employeeF, _ := totals.Employee.Float64()
+	employerF, _ := totals.Employer.Float64()
+	governmentF, _ := totals.Government.Float64()
+	if totalF > employeeF+employerF+governmentF {
+		employeeF += totalF - (employeeF + employerF + governmentF)
+	}
+	totalValue, _ := latest.Float64()
+	returns := totalValue - totalF
+	roi := 0.0
+	if totalF > 0 {
+		roi = returns / totalF * 100
+	}
+	roiRounded := math.Round(roi*100) / 100
+	return ppkStat{
+		OwnerUserID:           ownerUserID,
+		TotalValue:            pyFloat(totalValue),
+		EmployeeContributed:   pyFloat(employeeF),
+		EmployerContributed:   pyFloat(employerF),
+		GovernmentContributed: pyFloat(governmentF),
+		TotalContributed:      pyFloat(totalF),
+		Returns:               pyFloat(returns),
+		ROIPercentage:         pyFloat(roiRounded),
+	}
+}
+
+// computePPKContributionAmounts returns (employee, employer) PPK contribution
+// amounts: gross salary multiplied by each rate, divided by 100.
+func computePPKContributionAmounts(gross, employeeRate, employerRate decimal.Decimal) (decimal.Decimal, decimal.Decimal) {
+	hundred := decimal.NewFromInt(100)
+	return gross.Mul(employeeRate).Div(hundred), gross.Mul(employerRate).Div(hundred)
+}
+
+// computePPKGenerateResponse assembles the wire response for a generated
+// month of PPK contributions, including any welcome/annual subsidies that
+// were actually inserted by the store.
+func computePPKGenerateResponse(
+	req generateRequest,
+	gross, employeeAmt, employerAmt decimal.Decimal,
+	subsidy SubsidyConfig,
+	result PPKContributionResult,
+) ppkGenerateResponse {
+	grossF, _ := gross.Float64()
+	empF, _ := employeeAmt.Float64()
+	emprF, _ := employerAmt.Float64()
+	govF := 0.0
+	welcomeApplied := result.WelcomeID != nil
+	annualApplied := result.AnnualID != nil
+	if welcomeApplied {
+		w, _ := subsidy.WelcomeAmount.Float64()
+		govF += w
+	}
+	if annualApplied {
+		a, _ := subsidy.AnnualAmount.Float64()
+		govF += a
+	}
+	ids := []int{result.EmployeeID, result.EmployerID}
+	if result.WelcomeID != nil {
+		ids = append(ids, *result.WelcomeID)
+	}
+	if result.AnnualID != nil {
+		ids = append(ids, *result.AnnualID)
+	}
+	return ppkGenerateResponse{
+		OwnerUserID:         req.OwnerUserID,
+		Month:               req.Month,
+		Year:                req.Year,
+		GrossSalary:         pyFloat(grossF),
+		EmployeeAmount:      pyFloat(empF),
+		EmployerAmount:      pyFloat(emprF),
+		GovernmentAmount:    pyFloat(govF),
+		WelcomeApplied:      welcomeApplied,
+		AnnualApplied:       annualApplied,
+		TotalAmount:         pyFloat(empF + emprF + govF),
+		TransactionsCreated: ids,
+	}
+}

--- a/backend-go/internal/retirement/compute_test.go
+++ b/backend-go/internal/retirement/compute_test.go
@@ -1,0 +1,141 @@
+package retirement
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func dec(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+func TestComputeYearlyStat_AttributesUntypedRemainderToEmployee(t *testing.T) {
+	totals := ContributionTotals{
+		Total:    dec("10000"),
+		Employee: dec("3000"),
+		Employer: dec("2000"),
+	}
+	got := computeYearlyStat(2025, "IKE", nil, totals, dec("20000"))
+	if got.EmployeeContributed != 8000 {
+		t.Errorf("EmployeeContributed: want 8000, got %v", got.EmployeeContributed)
+	}
+	if got.EmployerContributed != 2000 {
+		t.Errorf("EmployerContributed: want 2000, got %v", got.EmployerContributed)
+	}
+}
+
+func TestComputeYearlyStat_CapsRemainingAtZero(t *testing.T) {
+	totals := ContributionTotals{Total: dec("25000"), Employee: dec("25000")}
+	got := computeYearlyStat(2025, "IKE", nil, totals, dec("20000"))
+	if *got.Remaining != 0 {
+		t.Errorf("Remaining: want 0 (over-limit), got %v", *got.Remaining)
+	}
+}
+
+func TestComputeYearlyStat_IsWarningUsesUnroundedPercentage(t *testing.T) {
+	// 8995 / 10000 = 89.95% — rounds to 90.0 but must NOT trigger warning.
+	totals := ContributionTotals{Total: dec("8995"), Employee: dec("8995")}
+	got := computeYearlyStat(2025, "IKE", nil, totals, dec("10000"))
+	if got.IsWarning {
+		t.Errorf("IsWarning: want false at 89.95%%, got true (rounded pct=%v)", *got.PercentageUsed)
+	}
+	if *got.PercentageUsed != 90.0 {
+		t.Errorf("PercentageUsed: want 90.0 (rounded), got %v", *got.PercentageUsed)
+	}
+}
+
+func TestComputeYearlyStat_WarningAtNinety(t *testing.T) {
+	totals := ContributionTotals{Total: dec("9000"), Employee: dec("9000")}
+	got := computeYearlyStat(2025, "IKE", nil, totals, dec("10000"))
+	if !got.IsWarning {
+		t.Errorf("IsWarning: want true at 90%%, got false")
+	}
+}
+
+func TestComputeYearlyStat_ZeroLimitGivesZeroPercentage(t *testing.T) {
+	got := computeYearlyStat(2025, "IKE", nil, ContributionTotals{}, decimal.Zero)
+	if *got.PercentageUsed != 0 {
+		t.Errorf("PercentageUsed: want 0 with zero limit, got %v", *got.PercentageUsed)
+	}
+	if got.IsWarning {
+		t.Errorf("IsWarning: want false with zero limit, got true")
+	}
+}
+
+func TestComputePPKStat_AttributesUntypedRemainderToEmployee(t *testing.T) {
+	totals := ContributionTotals{
+		Total: dec("1000"), Employee: dec("400"), Employer: dec("300"), Government: dec("100"),
+	}
+	got := computePPKStat(nil, totals, dec("1100"))
+	if got.EmployeeContributed != 600 {
+		t.Errorf("EmployeeContributed: want 600 (400 + 200 untyped), got %v", got.EmployeeContributed)
+	}
+}
+
+func TestComputePPKStat_ROIPositive(t *testing.T) {
+	totals := ContributionTotals{Total: dec("1000"), Employee: dec("1000")}
+	got := computePPKStat(nil, totals, dec("1100"))
+	if got.Returns != 100 {
+		t.Errorf("Returns: want 100, got %v", got.Returns)
+	}
+	if got.ROIPercentage != 10.0 {
+		t.Errorf("ROIPercentage: want 10.0, got %v", got.ROIPercentage)
+	}
+}
+
+func TestComputePPKStat_ZeroContributedAvoidsDivByZero(t *testing.T) {
+	got := computePPKStat(nil, ContributionTotals{}, dec("500"))
+	if got.ROIPercentage != 0 {
+		t.Errorf("ROIPercentage: want 0 with zero contributed, got %v", got.ROIPercentage)
+	}
+	if got.Returns != 500 {
+		t.Errorf("Returns: want 500 (latest - 0), got %v", got.Returns)
+	}
+}
+
+func TestComputePPKContributionAmounts(t *testing.T) {
+	emp, empr := computePPKContributionAmounts(dec("10000"), dec("2"), dec("1.5"))
+	if !emp.Equal(dec("200")) {
+		t.Errorf("employeeAmt: want 200, got %s", emp)
+	}
+	if !empr.Equal(dec("150")) {
+		t.Errorf("employerAmt: want 150, got %s", empr)
+	}
+}
+
+func TestComputePPKGenerateResponse_WelcomeAndAnnual(t *testing.T) {
+	welcomeID, annualID := 11, 12
+	req := generateRequest{OwnerUserID: new(1), Month: 6, Year: 2025}
+	subsidy := SubsidyConfig{WelcomeAmount: dec("250"), AnnualAmount: dec("240")}
+	result := PPKContributionResult{
+		EmployeeID: 1, EmployerID: 2, WelcomeID: &welcomeID, AnnualID: &annualID,
+	}
+	got := computePPKGenerateResponse(req, dec("5000"), dec("100"), dec("75"), subsidy, result)
+	if !got.WelcomeApplied || !got.AnnualApplied {
+		t.Errorf("flags: want both true, got welcome=%v annual=%v", got.WelcomeApplied, got.AnnualApplied)
+	}
+	if got.GovernmentAmount != 490 {
+		t.Errorf("GovernmentAmount: want 490 (250+240), got %v", got.GovernmentAmount)
+	}
+	if got.TotalAmount != 100+75+490 {
+		t.Errorf("TotalAmount: want 665, got %v", got.TotalAmount)
+	}
+	if len(got.TransactionsCreated) != 4 {
+		t.Errorf("TransactionsCreated: want 4 ids (emp/empr/welcome/annual), got %v", got.TransactionsCreated)
+	}
+}
+
+func TestComputePPKGenerateResponse_NoSubsidies(t *testing.T) {
+	req := generateRequest{OwnerUserID: new(1), Month: 6, Year: 2025}
+	subsidy := SubsidyConfig{WelcomeAmount: dec("250"), AnnualAmount: dec("240")}
+	result := PPKContributionResult{EmployeeID: 1, EmployerID: 2}
+	got := computePPKGenerateResponse(req, dec("5000"), dec("100"), dec("75"), subsidy, result)
+	if got.WelcomeApplied || got.AnnualApplied {
+		t.Errorf("flags: want both false, got welcome=%v annual=%v", got.WelcomeApplied, got.AnnualApplied)
+	}
+	if got.GovernmentAmount != 0 {
+		t.Errorf("GovernmentAmount: want 0 (no subsidies), got %v", got.GovernmentAmount)
+	}
+	if len(got.TransactionsCreated) != 2 {
+		t.Errorf("TransactionsCreated: want 2 ids, got %v", got.TransactionsCreated)
+	}
+}

--- a/backend-go/internal/retirement/handler.go
+++ b/backend-go/internal/retirement/handler.go
@@ -1,21 +1,18 @@
 package retirement
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/shopspring/decimal"
 )
 
 type yearlyStat struct {
@@ -143,37 +140,8 @@ func (h *Handler) buildYearlyStat(ctx context.Context, year int, wrapper string,
 	if !configured {
 		return yearlyStat{}, false, nil
 	}
+	stat := computeYearlyStat(year, wrapper, ownerUserID, totals, limit.LimitAmount)
 	totalF, _ := totals.Total.Float64()
-	employeeF, _ := totals.Employee.Float64()
-	employerF, _ := totals.Employer.Float64()
-	if totalF > employeeF+employerF {
-		employeeF += totalF - (employeeF + employerF)
-	}
-	limitF, _ := limit.LimitAmount.Float64()
-	remaining := limitF - totalF
-	if remaining < 0 {
-		remaining = 0
-	}
-	percentage := 0.0
-	if limitF > 0 {
-		percentage = totalF / limitF * 100
-	}
-	lAmt := pyFloat(limitF)
-	rem := pyFloat(remaining)
-	pct := pyFloat(math.Round(percentage*10) / 10)
-	stat := yearlyStat{
-		Year: year, AccountWrapper: wrapper, OwnerUserID: ownerUserID,
-		LimitAmount:         &lAmt,
-		TotalContributed:    pyFloat(totalF),
-		EmployeeContributed: pyFloat(employeeF),
-		EmployerContributed: pyFloat(employerF),
-		Remaining:           &rem,
-		PercentageUsed:      &pct,
-		// is_warning uses the unrounded percentage — Python computes it from
-		// the raw value, so 89.95% must NOT flip the flag even though it
-		// rounds to 90.0 in percentage_used.
-		IsWarning: percentage >= 90,
-	}
 	if wrapper == "IKZE" && totalF > 0 {
 		if rate, savings, ok := h.estimateIKZEPITSavings(ctx, ownerUserID, year, totalF); ok {
 			r := pyFloat(rate)
@@ -248,34 +216,11 @@ func (h *Handler) buildPPKStat(ctx context.Context, ownerUserID *int) (ppkStat, 
 	if err != nil {
 		return ppkStat{}, false, err
 	}
-	totalF, _ := totals.Total.Float64()
-	employeeF, _ := totals.Employee.Float64()
-	employerF, _ := totals.Employer.Float64()
-	governmentF, _ := totals.Government.Float64()
-	if totalF > employeeF+employerF+governmentF {
-		employeeF += totalF - (employeeF + employerF + governmentF)
-	}
 	latest, err := h.store.LatestSnapshotValueSum(ctx, accountIDs)
 	if err != nil {
 		return ppkStat{}, false, err
 	}
-	totalValue, _ := latest.Float64()
-	returns := totalValue - totalF
-	roi := 0.0
-	if totalF > 0 {
-		roi = returns / totalF * 100
-	}
-	roiRounded := math.Round(roi*100) / 100
-	return ppkStat{
-		OwnerUserID:           ownerUserID,
-		TotalValue:            pyFloat(totalValue),
-		EmployeeContributed:   pyFloat(employeeF),
-		EmployerContributed:   pyFloat(employerF),
-		GovernmentContributed: pyFloat(governmentF),
-		TotalContributed:      pyFloat(totalF),
-		Returns:               pyFloat(returns),
-		ROIPercentage:         pyFloat(roiRounded),
-	}, true, nil
+	return computePPKStat(ownerUserID, totals, latest), true, nil
 }
 
 // LimitsForYear serves GET /api/retirement/limits/{year}.
@@ -380,9 +325,7 @@ func (h *Handler) GeneratePPKContributions(w http.ResponseWriter, r *http.Reques
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	hundred := decimal.NewFromInt(100)
-	employeeAmt := gross.Mul(employeeRate).Div(hundred)
-	employerAmt := gross.Mul(employerRate).Div(hundred)
+	employeeAmt, employerAmt := computePPKContributionAmounts(gross, employeeRate, employerRate)
 	accountID, err := h.store.ActivePPKAccountForOwner(r.Context(), req.OwnerUserID)
 	if err != nil {
 		if errors.Is(err, ErrNoPPKAccount) {
@@ -419,49 +362,7 @@ func (h *Handler) GeneratePPKContributions(w http.ResponseWriter, r *http.Reques
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	writeJSON(w, http.StatusOK, buildPPKGenerateResponse(req, gross, employeeAmt, employerAmt, subsidy, result))
-}
-
-func buildPPKGenerateResponse(
-	req generateRequest,
-	gross, employeeAmt, employerAmt decimal.Decimal,
-	subsidy SubsidyConfig,
-	result PPKContributionResult,
-) ppkGenerateResponse {
-	grossF, _ := gross.Float64()
-	empF, _ := employeeAmt.Float64()
-	emprF, _ := employerAmt.Float64()
-	govF := 0.0
-	welcomeApplied := result.WelcomeID != nil
-	annualApplied := result.AnnualID != nil
-	if welcomeApplied {
-		w, _ := subsidy.WelcomeAmount.Float64()
-		govF += w
-	}
-	if annualApplied {
-		a, _ := subsidy.AnnualAmount.Float64()
-		govF += a
-	}
-	ids := []int{result.EmployeeID, result.EmployerID}
-	if result.WelcomeID != nil {
-		ids = append(ids, *result.WelcomeID)
-	}
-	if result.AnnualID != nil {
-		ids = append(ids, *result.AnnualID)
-	}
-	return ppkGenerateResponse{
-		OwnerUserID:         req.OwnerUserID,
-		Month:               req.Month,
-		Year:                req.Year,
-		GrossSalary:         pyFloat(grossF),
-		EmployeeAmount:      pyFloat(empF),
-		EmployerAmount:      pyFloat(emprF),
-		GovernmentAmount:    pyFloat(govF),
-		WelcomeApplied:      welcomeApplied,
-		AnnualApplied:       annualApplied,
-		TotalAmount:         pyFloat(empF + emprF + govF),
-		TransactionsCreated: ids,
-	}
+	writeJSON(w, http.StatusOK, computePPKGenerateResponse(req, gross, employeeAmt, employerAmt, subsidy, result))
 }
 
 // errBadOwnerParam marks a non-integer owner_user_id query value.
@@ -493,200 +394,6 @@ func ownerLabel(id *int) string {
 		return "Shared"
 	}
 	return strconv.Itoa(*id)
-}
-
-// --- request parsing ---
-
-type limitRequest struct {
-	Year           int
-	AccountWrapper string
-	OwnerUserID    *int
-	LimitAmount    decimal.Decimal
-	Notes          *string
-}
-
-var validWrappers = map[string]struct{}{
-	"IKE": {}, "IKZE": {}, "PPK": {},
-}
-
-func buildLimitRequest(raw map[string]json.RawMessage, now func() time.Time) (limitRequest, *validationError) {
-	var r limitRequest
-	currentYear := now().UTC().Year()
-	year, vErr := requireIntRange(raw, "year", 2000, currentYear+10,
-		fmt.Sprintf("Year must be between 2000 and %d", currentYear+10))
-	if vErr != nil {
-		return r, vErr
-	}
-	r.Year = year
-
-	wrap, vErr := requireEnumString(raw, "account_wrapper", validWrappers)
-	if vErr != nil {
-		return r, vErr
-	}
-	r.AccountWrapper = wrap
-
-	owner, vErr := requireIntOrNull(raw, "owner_user_id")
-	if vErr != nil {
-		return r, vErr
-	}
-	r.OwnerUserID = owner
-
-	amt, vErr := requirePositiveDecimal(raw, "limit_amount", "Limit amount must be greater than 0")
-	if vErr != nil {
-		return r, vErr
-	}
-	r.LimitAmount = amt
-
-	if v, ok := raw["notes"]; ok && !isNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return r, &validationError{Field: "notes", Msg: "must be a string"}
-		}
-		r.Notes = &s
-	}
-	return r, nil
-}
-
-type generateRequest struct {
-	OwnerUserID    *int
-	Month          int
-	Year           int
-	IncludeWelcome bool
-	IncludeAnnual  bool
-}
-
-func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) (generateRequest, *validationError) {
-	var r generateRequest
-	// PPK contributions are always generated for a specific person — a null
-	// (jointly owned) owner is rejected up front rather than failing later
-	// with a confusing 404.
-	owner, vErr := requireInt(raw, "owner_user_id")
-	if vErr != nil {
-		return r, vErr
-	}
-	r.OwnerUserID = &owner
-
-	month, vErr := requireIntRange(raw, "month", 1, 12, "Month must be between 1 and 12")
-	if vErr != nil {
-		return r, vErr
-	}
-	r.Month = month
-
-	currentYear := now().UTC().Year()
-	year, vErr := requireIntRange(raw, "year", 2019, currentYear+1,
-		fmt.Sprintf("Year must be between 2019 and %d", currentYear+1))
-	if vErr != nil {
-		return r, vErr
-	}
-	r.Year = year
-
-	welcome, vErr := optionalBool(raw, "include_welcome_subsidy")
-	if vErr != nil {
-		return r, vErr
-	}
-	r.IncludeWelcome = welcome
-	annual, vErr := optionalBool(raw, "include_annual_subsidy")
-	if vErr != nil {
-		return r, vErr
-	}
-	r.IncludeAnnual = annual
-	return r, nil
-}
-
-// optionalBool reads a boolean key. Missing/null returns false; a present
-// non-bool value (e.g. "true" sent as a string) is rejected so the client
-// gets a 422 instead of silently degrading to false.
-func optionalBool(raw map[string]json.RawMessage, key string) (bool, *validationError) {
-	v, ok := raw[key]
-	if !ok || isNull(v) {
-		return false, nil
-	}
-	var b bool
-	if err := json.Unmarshal(v, &b); err != nil {
-		return false, &validationError{Field: key, Msg: "must be a boolean"}
-	}
-	return b, nil
-}
-
-// --- helpers ---
-
-// requireInt reads an integer key that must be present and non-null.
-func requireInt(raw map[string]json.RawMessage, key string) (int, *validationError) {
-	v, ok := raw[key]
-	if !ok || isNull(v) {
-		return 0, &validationError{Field: key, Msg: "Field required"}
-	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return 0, &validationError{Field: key, Msg: "must be an integer"}
-	}
-	return n, nil
-}
-
-// requireIntOrNull reads an integer key that must be present; an explicit
-// null is allowed and yields nil (jointly owned).
-func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *validationError) {
-	v, ok := raw[key]
-	if !ok {
-		return nil, &validationError{Field: key, Msg: "Field required"}
-	}
-	if isNull(v) {
-		return nil, nil
-	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return nil, &validationError{Field: key, Msg: "must be an integer"}
-	}
-	return &n, nil
-}
-
-func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *validationError) {
-	v, ok := raw[key]
-	if !ok || isNull(v) {
-		return "", &validationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &validationError{Field: key, Msg: "must be a string"}
-	}
-	if _, ok := allowed[s]; !ok {
-		return "", &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
-	}
-	return s, nil
-}
-
-func requireIntRange(raw map[string]json.RawMessage, key string, lo, hi int, msg string) (int, *validationError) {
-	v, ok := raw[key]
-	if !ok || isNull(v) {
-		return 0, &validationError{Field: key, Msg: "Field required"}
-	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return 0, &validationError{Field: key, Msg: "must be an integer"}
-	}
-	if n < lo || n > hi {
-		return 0, &validationError{Field: key, Msg: msg}
-	}
-	return n, nil
-}
-
-func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *validationError) {
-	v, ok := raw[key]
-	if !ok || isNull(v) {
-		return decimal.Decimal{}, &validationError{Field: key, Msg: "Field required"}
-	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
-	if err != nil {
-		return decimal.Decimal{}, &validationError{Field: key, Msg: "must be a number"}
-	}
-	if !d.IsPositive() {
-		return decimal.Decimal{}, &validationError{Field: key, Msg: msg}
-	}
-	return d, nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }
 
 // wire type

--- a/backend-go/internal/retirement/validation.go
+++ b/backend-go/internal/retirement/validation.go
@@ -1,0 +1,200 @@
+package retirement
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+type limitRequest struct {
+	Year           int
+	AccountWrapper string
+	OwnerUserID    *int
+	LimitAmount    decimal.Decimal
+	Notes          *string
+}
+
+var validWrappers = map[string]struct{}{
+	"IKE": {}, "IKZE": {}, "PPK": {},
+}
+
+func buildLimitRequest(raw map[string]json.RawMessage, now func() time.Time) (limitRequest, *validationError) {
+	var r limitRequest
+	currentYear := now().UTC().Year()
+	year, vErr := requireIntRange(raw, "year", 2000, currentYear+10,
+		fmt.Sprintf("Year must be between 2000 and %d", currentYear+10))
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Year = year
+
+	wrap, vErr := requireEnumString(raw, "account_wrapper", validWrappers)
+	if vErr != nil {
+		return r, vErr
+	}
+	r.AccountWrapper = wrap
+
+	owner, vErr := requireIntOrNull(raw, "owner_user_id")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.OwnerUserID = owner
+
+	amt, vErr := requirePositiveDecimal(raw, "limit_amount", "Limit amount must be greater than 0")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.LimitAmount = amt
+
+	if v, ok := raw["notes"]; ok && !isNull(v) {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return r, &validationError{Field: "notes", Msg: "must be a string"}
+		}
+		r.Notes = &s
+	}
+	return r, nil
+}
+
+type generateRequest struct {
+	OwnerUserID    *int
+	Month          int
+	Year           int
+	IncludeWelcome bool
+	IncludeAnnual  bool
+}
+
+func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) (generateRequest, *validationError) {
+	var r generateRequest
+	// PPK contributions are always generated for a specific person — a null
+	// (jointly owned) owner is rejected up front rather than failing later
+	// with a confusing 404.
+	owner, vErr := requireInt(raw, "owner_user_id")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.OwnerUserID = &owner
+
+	month, vErr := requireIntRange(raw, "month", 1, 12, "Month must be between 1 and 12")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Month = month
+
+	currentYear := now().UTC().Year()
+	year, vErr := requireIntRange(raw, "year", 2019, currentYear+1,
+		fmt.Sprintf("Year must be between 2019 and %d", currentYear+1))
+	if vErr != nil {
+		return r, vErr
+	}
+	r.Year = year
+
+	welcome, vErr := optionalBool(raw, "include_welcome_subsidy")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.IncludeWelcome = welcome
+	annual, vErr := optionalBool(raw, "include_annual_subsidy")
+	if vErr != nil {
+		return r, vErr
+	}
+	r.IncludeAnnual = annual
+	return r, nil
+}
+
+// optionalBool reads a boolean key. Missing/null returns false; a present
+// non-bool value (e.g. "true" sent as a string) is rejected so the client
+// gets a 422 instead of silently degrading to false.
+func optionalBool(raw map[string]json.RawMessage, key string) (bool, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return false, nil
+	}
+	var b bool
+	if err := json.Unmarshal(v, &b); err != nil {
+		return false, &validationError{Field: key, Msg: "must be a boolean"}
+	}
+	return b, nil
+}
+
+// requireInt reads an integer key that must be present and non-null.
+func requireInt(raw map[string]json.RawMessage, key string) (int, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return 0, &validationError{Field: key, Msg: "Field required"}
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return 0, &validationError{Field: key, Msg: "must be an integer"}
+	}
+	return n, nil
+}
+
+// requireIntOrNull reads an integer key that must be present; an explicit
+// null is allowed and yields nil (jointly owned).
+func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *validationError) {
+	v, ok := raw[key]
+	if !ok {
+		return nil, &validationError{Field: key, Msg: "Field required"}
+	}
+	if isNull(v) {
+		return nil, nil
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return nil, &validationError{Field: key, Msg: "must be an integer"}
+	}
+	return &n, nil
+}
+
+func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return "", &validationError{Field: key, Msg: "Field required"}
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", &validationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return "", &validationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	return s, nil
+}
+
+func requireIntRange(raw map[string]json.RawMessage, key string, lo, hi int, msg string) (int, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return 0, &validationError{Field: key, Msg: "Field required"}
+	}
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return 0, &validationError{Field: key, Msg: "must be an integer"}
+	}
+	if n < lo || n > hi {
+		return 0, &validationError{Field: key, Msg: msg}
+	}
+	return n, nil
+}
+
+func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *validationError) {
+	v, ok := raw[key]
+	if !ok || isNull(v) {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "Field required"}
+	}
+	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if err != nil {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: "must be a number"}
+	}
+	if !d.IsPositive() {
+		return decimal.Decimal{}, &validationError{Field: key, Msg: msg}
+	}
+	return d, nil
+}
+
+func isNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}


### PR DESCRIPTION
## Motivation

`internal/retirement/handler.go` was 701 lines, mixing HTTP wiring with IKE/IKZE/PPK math. Closes #600.

## Implementation information

- New `compute.go` with pure functions: `computeYearlyStat`, `computePPKStat`, `computePPKContributionAmounts`, `computePPKGenerateResponse`. Math is a lift-and-shift — the untyped-remainder rule and unrounded-percentage `is_warning` gotcha are preserved (and now documented).
- New `validation.go` with the request-parsing helpers (`buildLimitRequest`, `buildGenerateRequest`, `requireInt`/`requireIntOrNull`/`requireIntRange`/`requireEnumString`/`requirePositiveDecimal`, `optionalBool`, `isNull`). Pattern matches sibling domains.
- `handler.go` shrinks from 701 to 408 lines (target was <400; 8 over but stopping short of churn for diminishing returns).
- New `compute_test.go` pins the edges: untyped-remainder attribution, remaining cap at 0, the 89.95% / 90.0 rounding trap for `is_warning`, the 90% boundary, zero-limit divide guard, PPK ROI div-by-zero, welcome/annual subsidy on/off.

No behavioural change — bb-tests-go is the integration oracle.

## Supporting documentation

Part of umbrella #598.

> Changelog: refactor(retirement): split compute, validation