### PR TITLE
test(frontend): ratchet coverage thresholds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,11 +15,14 @@ export default defineConfig({
 			provider: 'v8',
 			reporter: ['text', 'json', 'html', 'lcov'],
 			exclude: ['node_modules/**', '.svelte-kit/**', 'build/**', '**/*.config.*', '**/.*rc.*'],
+			// Thresholds are a ratchet against the current baseline, not a
+			// target — raise them as coverage improves so regressions can't
+			// slip past CI while the codebase already covers more.
 			thresholds: {
-				statements: 62,
-				branches: 43,
-				functions: 60,
-				lines: 64
+				statements: 78,
+				branches: 57,
+				functions: 81,
+				lines: 79
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation

Measured frontend coverage was 78.35 / 57.34 / 81.55 / 79.96 (statements / branches / functions / lines), but `vite.config.ts` thresholds allowed regressions all the way down to 62 / 43 / 60 / 64. A large coverage drop could land with CI staying green. Closes #609.

## Implementation information

- Raised the four thresholds to one decimal point below the current baseline (78 / 57 / 81 / 79).
- Added a short comment that they are a baseline ratchet, not a coverage target — future PRs that genuinely move coverage up are expected to raise them too.
- `npm run test:coverage` passes locally at exactly the baseline.

## Supporting documentation

Part of umbrella #598.

> Changelog: test(frontend): ratchet coverage thresholds