### PR TITLE
ci(actions): repair deps audit for go + bb-tests

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -19,6 +19,11 @@ jobs:
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: backend-go/go.mod
+          cache-dependency-path: backend-go/go.sum
+
       - name: Install frontend dependencies
         run: npm ci
 
@@ -29,10 +34,31 @@ jobs:
           npm outdated >> "$GITHUB_STEP_SUMMARY" || true
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Report outdated Python packages
-        working-directory: backend
+      # backend-bb-tests is the only remaining Python workspace; the Python
+      # backend was decommissioned in the Go migration.
+      - name: Report outdated Python packages (backend-bb-tests)
+        working-directory: backend-bb-tests
         run: |
-          echo '## Outdated Python packages' >> "$GITHUB_STEP_SUMMARY"
+          echo '## Outdated Python packages (backend-bb-tests)' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           uv tree --outdated --depth 1 >> "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report outdated Go modules (backend-go)
+        working-directory: backend-go
+        run: |
+          echo '## Outdated Go modules (backend-go)' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          go list -m -u all >> "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Scan Go modules for known vulnerabilities
+        working-directory: backend-go
+        run: |
+          echo '## Go vulnerabilities (govulncheck)' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          govulncheck ./... >> "$GITHUB_STEP_SUMMARY" || true
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -53,12 +53,18 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install govulncheck
+        continue-on-error: true
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
       - name: Scan Go modules for known vulnerabilities
+        continue-on-error: true
         working-directory: backend-go
         run: |
           echo '## Go vulnerabilities (govulncheck)' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          govulncheck ./... >> "$GITHUB_STEP_SUMMARY" || true
+          if command -v govulncheck >/dev/null 2>&1; then
+            govulncheck ./... >> "$GITHUB_STEP_SUMMARY" || true
+          else
+            echo 'govulncheck install failed; skipping scan' >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Motivation

`.github/workflows/dependency-audit.yml` was still pointing the Python step at the decommissioned `backend/` directory and silently skipped both `backend-bb-tests` and the entire `backend-go` Go module. The weekly audit produced npm output only. Closes #610.

## Implementation information

- Moved the Python audit to `backend-bb-tests` (the only remaining Python workspace).
- Added `setup-go` and a `go list -m -u all` step in `backend-go` so the run summary lists outdated Go modules alongside npm + Python.
- Added a `govulncheck ./...` step so known Go-side vulnerabilities are surfaced in the summary instead of relying on Dependabot alone.
- Each new section runs with `|| true` so a transient outdated/vuln report doesn't fail the whole run.

Test plan: after merge, dispatch the workflow with `gh workflow run dependency-audit.yml` and confirm the run summary contains npm, Python, Go-outdated, and govulncheck sections.

## Supporting documentation

Part of umbrella #598.

> Changelog: ci(actions): repair deps audit for go + bb-tests