### PR TITLE
refactor(salaries): extract pure format helpers

### DIFF
--- a/src/lib/utils/salaries.test.ts
+++ b/src/lib/utils/salaries.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { formatPctSigned, formatPlnSigned, isNonNegative, isoDateLocal } from './salaries';
+
+describe('isNonNegative', () => {
+	it('treats null as zero', () => {
+		expect(isNonNegative(null)).toBe(true);
+	});
+	it('matches zero', () => {
+		expect(isNonNegative(0)).toBe(true);
+	});
+	it('matches positive', () => {
+		expect(isNonNegative(0.01)).toBe(true);
+	});
+	it('rejects negative', () => {
+		expect(isNonNegative(-0.01)).toBe(false);
+	});
+});
+
+describe('formatPctSigned', () => {
+	it('renders em-dash for null', () => {
+		expect(formatPctSigned(null)).toBe('—');
+	});
+	it('renders em-dash for NaN', () => {
+		expect(formatPctSigned(Number.NaN)).toBe('—');
+	});
+	it('prefixes positive with +', () => {
+		expect(formatPctSigned(5)).toBe('+5.0%');
+	});
+	it('prefixes zero with +', () => {
+		expect(formatPctSigned(0)).toBe('+0.0%');
+	});
+	it('keeps the native minus for negative — no explicit sign override', () => {
+		expect(formatPctSigned(-3.25)).toBe('-3.3%');
+	});
+	it('rounds to one decimal', () => {
+		expect(formatPctSigned(12.34)).toBe('+12.3%');
+	});
+});
+
+describe('formatPlnSigned', () => {
+	it('renders em-dash for null', () => {
+		expect(formatPlnSigned(null)).toBe('—');
+	});
+	it('renders em-dash for NaN', () => {
+		expect(formatPlnSigned(Number.NaN)).toBe('—');
+	});
+	it('prefixes positive with +', () => {
+		expect(formatPlnSigned(1500).startsWith('+')).toBe(true);
+	});
+	it('prefixes zero with + (matches legacy delta-cell look)', () => {
+		expect(formatPlnSigned(0).startsWith('+')).toBe(true);
+	});
+	it('prefixes negative with U+2212 and drops the inner minus', () => {
+		const out = formatPlnSigned(-1500);
+		expect(out.startsWith('−')).toBe(true);
+		expect(out).not.toContain('-');
+	});
+});
+
+describe('isoDateLocal', () => {
+	it('formats a normal date as YYYY-MM-DD using local components', () => {
+		// Constructed via local-time fields so the assertion holds regardless
+		// of the test runner's timezone — including TZ > UTC where
+		// toISOString() would shift the day.
+		expect(isoDateLocal(new Date(2026, 11, 31, 0, 0, 0))).toBe('2026-12-31');
+	});
+	it('pads single-digit month and day', () => {
+		expect(isoDateLocal(new Date(2025, 0, 5, 0, 0, 0))).toBe('2025-01-05');
+	});
+	it('survives end-of-month rollover', () => {
+		expect(isoDateLocal(new Date(2025, 1, 28, 23, 59, 0))).toBe('2025-02-28');
+	});
+});

--- a/src/lib/utils/salaries.ts
+++ b/src/lib/utils/salaries.ts
@@ -1,0 +1,40 @@
+// Small pure helpers used by the salaries route. Extracted from
+// src/routes/salaries/+page.svelte as step 1 of the broader refactor in
+// #614 — the file is still 1957 lines and a full split is a multi-day job.
+// These five primitives are the cleanest first slice because they are
+// stateless and were already pure functions inside the .svelte file.
+
+import { formatPLN } from './format';
+
+export function isNonNegative(value: number | null): boolean {
+	return (value ?? 0) >= 0;
+}
+
+// Differs from format.ts's formatSignedPercent: this variant relies on the
+// number's own minus glyph (regular hyphen) for negatives and only prepends
+// a `+` for non-negatives, matching the legacy salaries UI exactly.
+export function formatPctSigned(value: number | null): string {
+	if (value == null || Number.isNaN(value)) return '—';
+	const sign = value >= 0 ? '+' : '';
+	return `${sign}${value.toFixed(1)}%`;
+}
+
+// Differs from format.ts's formatSignedPLN by always prefixing a sign
+// (including `+` for 0) — preserves the salaries-row "delta" cell look.
+export function formatPlnSigned(value: number | null): string {
+	if (value == null || Number.isNaN(value)) return '—';
+	const sign = value >= 0 ? '+' : '−';
+	return `${sign}${formatPLN(Math.abs(value))}`;
+}
+
+function pad2(n: number): string {
+	return n.toString().padStart(2, '0');
+}
+
+// toISOString() converts to UTC and shifts the day for TZ > UTC (e.g. PL in
+// winter: 2026-12-31 00:00 local → 2026-12-30T23:00Z). Build YYYY-MM-DD from
+// the local components to keep comparisons consistent with date-only values
+// returned by the API.
+export function isoDateLocal(d: Date): string {
+	return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}

--- a/src/lib/utils/salaries.ts
+++ b/src/lib/utils/salaries.ts
@@ -1,7 +1,8 @@
 // Small pure helpers used by the salaries route. Extracted from
 // src/routes/salaries/+page.svelte as step 1 of the broader refactor in
-// #614 — the file is still 1957 lines and a full split is a multi-day job.
-// These five primitives are the cleanest first slice because they are
+// #614 — the page was ~1957 lines before this extraction and a full split
+// (chart component, summary cards, grouping utilities) is a multi-day job.
+// These four primitives are the cleanest first slice because they are
 // stateless and were already pure functions inside the .svelte file.
 
 import { formatPLN } from './format';

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -8,6 +8,12 @@
 	import SalaryFormModal from '$lib/components/salaries/SalaryFormModal.svelte';
 	import ValuationFormModal from '$lib/components/salaries/ValuationFormModal.svelte';
 	import { formatPLN } from '$lib/utils/format';
+	import {
+		formatPctSigned,
+		formatPlnSigned,
+		isNonNegative,
+		isoDateLocal
+	} from '$lib/utils/salaries';
 	import { buildCpiLookup, inflationAdjust, parseIsoDate } from '$lib/utils/inflation';
 	import { grossToNet, type PlContractType } from '$lib/utils/pl_tax';
 	import { PL_RULES } from '$lib/utils/pl_rules.generated';
@@ -76,22 +82,6 @@
 		'listopad',
 		'grudzień'
 	];
-
-	function isNonNegative(value: number | null): boolean {
-		return (value ?? 0) >= 0;
-	}
-
-	function formatPctSigned(value: number | null): string {
-		if (value == null || Number.isNaN(value)) return '—';
-		const sign = value >= 0 ? '+' : '';
-		return `${sign}${value.toFixed(1)}%`;
-	}
-
-	function formatPlnSigned(value: number | null): string {
-		if (value == null || Number.isNaN(value)) return '—';
-		const sign = value >= 0 ? '+' : '−';
-		return `${sign}${formatPLN(Math.abs(value))}`;
-	}
 
 	let chartContainer: HTMLDivElement;
 	let chart: echarts.ECharts | undefined;
@@ -182,18 +172,6 @@
 	// "net" estimate only; real net depends on actual sale and tax_treatment.
 	// Sourced from the centralized rules table (#545).
 	const EQUITY_CAPITAL_GAINS_RATE = PL_RULES['capital_gains_tax_2026'].value;
-
-	function pad2(n: number): string {
-		return n.toString().padStart(2, '0');
-	}
-
-	function isoDateLocal(d: Date): string {
-		// toISOString() converts to UTC and shifts the day for TZ > UTC (e.g. PL
-		// in winter: 2026-12-31 00:00 local → 2026-12-30T23:00Z). Build YYYY-MM-DD
-		// from the local components to keep comparisons consistent with date-only
-		// values returned by the API.
-		return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
-	}
 
 	const compSummary = $derived.by<OwnerCompSummary | null>(() => {
 		if (totalCompOwner === null) return null;


### PR DESCRIPTION
## Motivation

`src/routes/salaries/+page.svelte` is 1957 lines. A full split per #614's description is a 2-4 day strategic refactor. This PR is the first slice — the safest one — so the page starts shrinking without behavioural risk. Refs #614.

## Implementation information

- New `src/lib/utils/salaries.ts` (40 lines): exports `isNonNegative`, `formatPctSigned`, `formatPlnSigned`, `isoDateLocal`. These were already pure functions inside the .svelte file; the body of each is unchanged.
- New `src/lib/utils/salaries.test.ts` (73 lines): covers null/NaN sentinel, sign-prefix behaviour for negative/zero/positive, the regular-hyphen vs U+2212 difference, the local-component date formatting that survives TZ > UTC (the bug the original comment called out).
- Updated `+page.svelte` imports + deleted the local copies. Page goes 1957 → 1935 lines and overall coverage rises by ~0.15pp across all four metrics.
- Did NOT replace these with the existing `formatSignedPLN`/`formatSignedPercent` from `format.ts` because behaviour differs in three subtle ways (zero handling, sign-glyph choice, decimal precision). Reconciling them is a separate question — flagged in the new file's header comment so the next slice can pick it up.

**Out of scope (intentionally — for future PRs in this thread):**

- Extracting `SalaryProgressChart.svelte` (the chart + `applyChart` setup)
- Splitting the current-salary / total-compensation summary cards
- Moving bonus/equity/valuation grouping into a utility module

Quality gates: `npm run check`, `npm run lint`, `npm run test`, `npm run test:coverage` all pass locally.

## Supporting documentation

Final issue in umbrella #598.

> Changelog: refactor(salaries): extract pure format helpers