### PR TITLE
feat(dev): auto-seed fixture data on mise dev

### DIFF
--- a/backend-bb-tests/fixtures/Dockerfile.seed
+++ b/backend-bb-tests/fixtures/Dockerfile.seed
@@ -1,0 +1,5 @@
+FROM python:3.13-slim
+RUN pip install --no-cache-dir psycopg2-binary==2.9.10
+WORKDIR /seed
+COPY seed.py run_seed.py ./
+CMD ["python", "run_seed.py"]

--- a/backend-bb-tests/fixtures/run_seed.py
+++ b/backend-bb-tests/fixtures/run_seed.py
@@ -1,0 +1,32 @@
+"""Dev seeder entrypoint.
+
+Applies the bb-tests fixture seed against the dev database, but only when the
+accounts table is empty. Lets `mise dev` boot a populated app on a fresh
+volume without clobbering data added through the UI on subsequent restarts.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import psycopg2
+
+from seed import seed
+
+
+def main() -> int:
+    dsn = os.environ["DATABASE_URL"]
+    with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM accounts LIMIT 1")
+        if cur.fetchone() is not None:
+            print("dev seed: accounts present, skipping")
+            return 0
+    print("dev seed: applying fixture data")
+    seed(dsn)
+    print("dev seed: done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,6 +40,18 @@ services:
       retries: 5
       start_period: 10s
 
+  seed:
+    build:
+      context: ./backend-bb-tests/fixtures
+      dockerfile: Dockerfile.seed
+    container_name: finance-seed
+    environment:
+      - DATABASE_URL=postgresql://finance:${POSTGRES_PASSWORD:-password}@postgres:5432/finance
+    depends_on:
+      backend-go:
+        condition: service_healthy
+    restart: 'no'
+
   frontend:
     build:
       context: .


### PR DESCRIPTION
## Motivation

`mise dev` brought up an empty app — the dev compose only ran Postgres + backend + frontend, and the bb-tests fixture seed was reachable only from pytest. New volume → blank dashboard, no accounts, no snapshots.

## Implementation information

- New one-shot `seed` service in `docker-compose.dev.yml`, depends on `backend-go` healthy so schema is applied first.
- `backend-bb-tests/fixtures/Dockerfile.seed` — `python:3.13-slim` + `psycopg2-binary`. (3.14 has no psycopg2 wheels yet.)
- `backend-bb-tests/fixtures/run_seed.py` — guards on `SELECT 1 FROM accounts`; skips when non-empty so data added through the UI survives restarts. On fresh volume it imports `seed.seed()` and applies the fixtures.

Reuses the existing bb-tests fixture instead of forking a parallel dev dataset.

Alternatives considered:
- Init-container via `docker-entrypoint-initdb.d` — runs before backend applies `schema.sql`, tables don't exist yet.
- Rewriting seed as raw SQL — duplicates state, drifts from bb-tests source of truth.

## Supporting documentation

> Changelog: feat(dev): auto-seed fixture data on mise dev