### PR TITLE
fix(fx): set User-Agent on NBP fetch

### DIFF
--- a/backend-go/internal/fx/fx.go
+++ b/backend-go/internal/fx/fx.go
@@ -31,6 +31,8 @@ const (
 	lookbackDays      = 10
 	cacheToleranceDay = 7
 	httpTimeout       = 5 * time.Second
+	// NBP's CDN returns 403 for the default Go-http-client UA.
+	nbpUserAgent = "finance-buddy/1.0 (+https://finance.mskalski.dev)"
 )
 
 // Rate represents a cached NBP rate row.
@@ -190,6 +192,7 @@ func (s *Service) fetchRange(ctx context.Context, code string, start, end time.T
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
+	req.Header.Set("User-Agent", nbpUserAgent)
 	resp, err := s.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("nbp request: %w", err)


### PR DESCRIPTION
## Motivation

NBP's CDN (`api.nbp.pl`) returns HTTP 403 to the default Go `User-Agent: Go-http-client/*`, breaking USD→PLN conversion for equity grants. The dashboard's equity paper value renders as `0 zł · część grantów bez FX` whenever any grant uses USD/EUR/GBP/CHF — anything non-PLN.

Verified from the prod LXC:
```
$ curl -A 'Go-http-client/1.1' 'https://api.nbp.pl/api/exchangerates/rates/A/USD/?format=json'
HTTP/1.0 403 Forbidden
$ curl -A 'finance-buddy/1.0' 'https://api.nbp.pl/api/exchangerates/rates/A/USD/?format=json'
{"table":"A","currency":"dolar amerykański",...}
```

Backend logs show `level=WARN msg="nbp fetch failed" currency=USD err="nbp http 403"` repeatedly since equity grants were added.

## Implementation information

Two-line change: declare an `nbpUserAgent` const and set the `User-Agent` header on every NBP request inside `fetchRange`. The UA string is `finance-buddy/1.0 (+https://finance.mskalski.dev)` — identifies the client to NBP without impersonating a browser.

Alternative considered: extracting `nbpBaseURL` as a `Service` field so an httptest server could verify the header. Rejected as scope creep for a hotfix; left as a separate cleanup ticket-worthy item.

## Supporting documentation

> Changelog: fix(fx): set User-Agent on NBP fetch