### PR TITLE
feat(salaries): year-based equity + extend line

### DIFF
--- a/src/lib/utils/equity_vesting.test.ts
+++ b/src/lib/utils/equity_vesting.test.ts
@@ -191,6 +191,13 @@ describe('perShareIntrinsicValue', () => {
 	it('returns null when no valuation', () => {
 		expect(perShareIntrinsicValue(makeGrant(), null)).toBeNull();
 	});
+
+	it('returns null when valuation currency differs from grant currency', () => {
+		// USD grant, EUR valuation: subtracting USD strike from EUR FMV is
+		// meaningless. Mirror backend behaviour and refuse to value it.
+		const eurValuation: CompanyValuation = { ...valuation, currency: 'EUR' };
+		expect(perShareIntrinsicValue(makeGrant({ currency: 'USD' }), eurValuation)).toBeNull();
+	});
 });
 
 describe('computeYearlyEquityComp', () => {

--- a/src/lib/utils/equity_vesting.test.ts
+++ b/src/lib/utils/equity_vesting.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import {
+	vestedInYear,
+	isEffectivelyVested,
+	latestValuationFor,
+	perShareIntrinsicValue
+} from './equity_vesting';
+import type { CompanyValuation, EquityGrant } from '$lib/types/salaries';
+
+function makeGrant(overrides: Partial<EquityGrant> = {}): EquityGrant {
+	return {
+		id: 1,
+		grant_date: '2022-12-09',
+		type: 'option',
+		company: 'Kong Inc.',
+		owner_user_id: 1,
+		total_shares: 10000,
+		strike_price: 2.67,
+		currency: 'USD',
+		vest_start_date: '2022-09-01',
+		vest_cliff_months: 12,
+		vest_total_months: 48,
+		vest_frequency: 'monthly',
+		vest_custom_schedule: null,
+		requires_liquidity_event: false,
+		liquidity_event_date: null,
+		tax_treatment: 'capital_gains_19',
+		notes: null,
+		is_active: true,
+		created_at: '2026-05-25T00:00:00Z',
+		vested_shares_today: 0,
+		vesting_progress_pct: 0,
+		paper_value_base: null,
+		paper_value_low: null,
+		paper_value_high: null,
+		paper_value_currency: null,
+		paper_value_base_pln: null,
+		paper_value_low_pln: null,
+		paper_value_high_pln: null,
+		fx_rate: null,
+		valuation_date: null,
+		valuation_source: null,
+		...overrides
+	};
+}
+
+describe('vestedInYear (monthly options)', () => {
+	const opt = makeGrant();
+
+	it('counts cliff vesting in the cliff year', () => {
+		// Cliff fires 2023-09-01 (12 months × 208.33 = 2500) + Oct/Nov/Dec
+		// tranches (3 × 208.33 = 625). 2022 vested = 0 (still in cliff). So
+		// vested in 2023 = 15 months total = 3125.
+		expect(vestedInYear(opt, 2023)).toBe(3125);
+	});
+
+	it('counts ~12 monthly tranches in a full vesting year', () => {
+		// 2024: 12 months × 208.33 ≈ 2500.
+		expect(vestedInYear(opt, 2024)).toBe(2500);
+	});
+
+	it('counts partial year when vesting ends mid-year', () => {
+		// vest end = 2026-09-01 → Jan–Sep tranches = 9 × 208.33 ≈ 1875.
+		expect(vestedInYear(opt, 2026)).toBe(1875);
+	});
+
+	it('returns 0 after vesting completes', () => {
+		expect(vestedInYear(opt, 2027)).toBe(0);
+	});
+
+	it('returns 0 before vest start', () => {
+		expect(vestedInYear(opt, 2021)).toBe(0);
+	});
+
+	it('returns 0 during cliff (pre-cliff months in cliff year)', () => {
+		// 2022: only Sep–Dec elapsed (4 months), still in cliff. 0 vested.
+		expect(vestedInYear(opt, 2022)).toBe(0);
+	});
+});
+
+describe('vestedInYear (RSU, quarterly custom schedule)', () => {
+	const rsu = makeGrant({
+		id: 2,
+		type: 'rsu',
+		grant_date: '2025-12-10',
+		total_shares: 985,
+		strike_price: null,
+		vest_start_date: '2025-09-15',
+		vest_cliff_months: 0,
+		vest_total_months: 48,
+		vest_frequency: 'quarterly',
+		vest_custom_schedule: Array.from({ length: 16 }, (_, i) => ({
+			month: (i + 1) * 3,
+			pct: 6.25
+		})),
+		requires_liquidity_event: true,
+		liquidity_event_date: null
+	});
+
+	it('counts 1 quarterly tranche in the start year (Dec only)', () => {
+		// 2025: month 3 fires Dec 15. 985 * 6.25 / 100 = 61.5 → floor = 61.
+		expect(vestedInYear(rsu, 2025)).toBe(61);
+	});
+
+	it('counts 4 quarterly tranches in a full vesting year', () => {
+		// 2026: months 6, 9, 12, 15 → cumulative 25% by Dec 31; less 6.25% start = 18.75%.
+		// 985 * 25 / 100 = 246; 985 * 6.25 / 100 = 61; diff = 185.
+		// Or simpler: 4 tranches × ~61.5 = ~246 newly accruing.
+		expect(vestedInYear(rsu, 2026)).toBeGreaterThanOrEqual(184);
+		expect(vestedInYear(rsu, 2026)).toBeLessThanOrEqual(247);
+	});
+
+	it('isEffectivelyVested returns false while LE pending', () => {
+		expect(isEffectivelyVested(rsu, 2026)).toBe(false);
+	});
+
+	it('isEffectivelyVested returns true once LE has fired by year end', () => {
+		const withLE = { ...rsu, liquidity_event_date: '2026-06-15' };
+		expect(isEffectivelyVested(withLE, 2026)).toBe(true);
+	});
+
+	it('isEffectivelyVested returns false when LE fires after year end', () => {
+		const withLE = { ...rsu, liquidity_event_date: '2027-02-01' };
+		expect(isEffectivelyVested(withLE, 2026)).toBe(false);
+	});
+});
+
+describe('latestValuationFor', () => {
+	const v1: CompanyValuation = {
+		id: 1,
+		company: 'Kong Inc.',
+		date: '2025-01-01',
+		currency: 'USD',
+		fmv_per_share: 3,
+		fmv_low: null,
+		fmv_high: null,
+		source: '409a',
+		common_stock_discount_pct: null,
+		notes: null,
+		is_active: true,
+		created_at: '2025-01-01T00:00:00Z'
+	};
+	const v2 = { ...v1, id: 2, date: '2026-05-25', fmv_per_share: 4.94 };
+	const inactive = { ...v1, id: 3, date: '2026-06-01', fmv_per_share: 99, is_active: false };
+	const other = { ...v1, id: 4, company: 'Other', date: '2026-12-31', fmv_per_share: 100 };
+
+	it('returns the most recent active valuation for the matching company', () => {
+		const latest = latestValuationFor([v1, v2, inactive, other], 'Kong Inc.');
+		expect(latest?.id).toBe(2);
+	});
+
+	it('returns null when no active valuation exists', () => {
+		expect(latestValuationFor([inactive], 'Kong Inc.')).toBeNull();
+	});
+});
+
+describe('perShareIntrinsicValue', () => {
+	const valuation: CompanyValuation = {
+		id: 1,
+		company: 'Kong Inc.',
+		date: '2026-05-25',
+		currency: 'USD',
+		fmv_per_share: 4.94,
+		fmv_low: 4,
+		fmv_high: 6,
+		source: '409a',
+		common_stock_discount_pct: null,
+		notes: null,
+		is_active: true,
+		created_at: '2026-05-25T00:00:00Z'
+	};
+
+	it('options: spread above strike', () => {
+		const v = perShareIntrinsicValue(makeGrant({ strike_price: 2.67 }), valuation);
+		expect(v?.base).toBeCloseTo(2.27);
+		expect(v?.low).toBeCloseTo(1.33);
+		expect(v?.high).toBeCloseTo(3.33);
+	});
+
+	it('options: zero when underwater', () => {
+		const v = perShareIntrinsicValue(makeGrant({ strike_price: 10 }), valuation);
+		expect(v?.base).toBe(0);
+	});
+
+	it('RSU: full FMV', () => {
+		const v = perShareIntrinsicValue(makeGrant({ type: 'rsu', strike_price: null }), valuation);
+		expect(v?.base).toBe(4.94);
+	});
+
+	it('returns null when no valuation', () => {
+		expect(perShareIntrinsicValue(makeGrant(), null)).toBeNull();
+	});
+});

--- a/src/lib/utils/equity_vesting.test.ts
+++ b/src/lib/utils/equity_vesting.test.ts
@@ -3,7 +3,8 @@ import {
 	vestedInYear,
 	isEffectivelyVested,
 	latestValuationFor,
-	perShareIntrinsicValue
+	perShareIntrinsicValue,
+	computeYearlyEquityComp
 } from './equity_vesting';
 import type { CompanyValuation, EquityGrant } from '$lib/types/salaries';
 
@@ -189,5 +190,114 @@ describe('perShareIntrinsicValue', () => {
 
 	it('returns null when no valuation', () => {
 		expect(perShareIntrinsicValue(makeGrant(), null)).toBeNull();
+	});
+});
+
+describe('computeYearlyEquityComp', () => {
+	const valuation: CompanyValuation = {
+		id: 1,
+		company: 'Kong Inc.',
+		date: '2026-05-25',
+		currency: 'USD',
+		fmv_per_share: 4.94,
+		fmv_low: null,
+		fmv_high: null,
+		source: '409a',
+		common_stock_discount_pct: null,
+		notes: null,
+		is_active: true,
+		created_at: '2026-05-25T00:00:00Z'
+	};
+	const optionGrant = makeGrant({
+		id: 1,
+		owner_user_id: 1,
+		paper_value_currency: 'USD',
+		fx_rate: 3.6374
+	});
+	const rsuLocked = makeGrant({
+		id: 2,
+		type: 'rsu',
+		owner_user_id: 1,
+		strike_price: null,
+		total_shares: 985,
+		vest_start_date: '2025-09-15',
+		vest_cliff_months: 0,
+		vest_total_months: 48,
+		vest_frequency: 'quarterly',
+		vest_custom_schedule: Array.from({ length: 16 }, (_, i) => ({
+			month: (i + 1) * 3,
+			pct: 6.25
+		})),
+		requires_liquidity_event: true,
+		liquidity_event_date: null,
+		paper_value_currency: null,
+		fx_rate: null
+	});
+
+	it('sums options vested in year × intrinsic spread × FX', () => {
+		const r = computeYearlyEquityComp([optionGrant], [valuation], 1, 2026);
+		// vestedInYear(option, 2026) = 1875 → × $2.27 × 3.6374 ≈ 15482.
+		expect(r.vestedPln).toBeCloseTo(1875 * 2.27 * 3.6374, 0);
+		expect(r.lockedPln).toBe(0);
+		expect(r.hasEquityWithoutFx).toBe(false);
+	});
+
+	it('routes locked RSU to lockedPln, not vestedPln', () => {
+		// RSU has no fx_rate of its own — borrows from sibling option grant.
+		const r = computeYearlyEquityComp([optionGrant, rsuLocked], [valuation], 1, 2026);
+		expect(r.vestedPln).toBeCloseTo(1875 * 2.27 * 3.6374, 0);
+		// vestedInYear(rsu, 2026) ≈ 246 (some rounding); × $4.94 × 3.6374.
+		expect(r.lockedPln).toBeGreaterThan(3000);
+		expect(r.lockedPln).toBeLessThan(5000);
+	});
+
+	it('unlocks RSU once liquidity event has fired in the year', () => {
+		const rsuUnlocked = { ...rsuLocked, liquidity_event_date: '2026-06-15' };
+		const r = computeYearlyEquityComp([optionGrant, rsuUnlocked], [valuation], 1, 2026);
+		expect(r.vestedPln).toBeGreaterThan(15000 + 3000);
+		expect(r.lockedPln).toBe(0);
+	});
+
+	it('flags hasEquityWithoutFx when no sibling supplies the rate', () => {
+		const usdGrantNoFx = {
+			...optionGrant,
+			fx_rate: null,
+			paper_value_currency: null
+		};
+		const r = computeYearlyEquityComp([usdGrantNoFx], [valuation], 1, 2026);
+		expect(r.vestedPln).toBe(0);
+		expect(r.hasEquityWithoutFx).toBe(true);
+	});
+
+	it('skips grants owned by other users', () => {
+		const otherOwner = { ...optionGrant, owner_user_id: 2 };
+		const r = computeYearlyEquityComp([otherOwner], [valuation], 1, 2026);
+		expect(r.vestedPln).toBe(0);
+	});
+
+	it('skips grants with no valuation for their company', () => {
+		const orphan = { ...optionGrant, company: 'Unknown Co' };
+		const r = computeYearlyEquityComp([orphan], [valuation], 1, 2026);
+		expect(r.vestedPln).toBe(0);
+	});
+
+	it('skips grants with zero shares vesting in the year', () => {
+		// Year 2027 = post-vesting for the default option grant (ended Sep 2026).
+		const r = computeYearlyEquityComp([optionGrant], [valuation], 1, 2027);
+		expect(r.vestedPln).toBe(0);
+		expect(r.lockedPln).toBe(0);
+	});
+
+	it('passes PLN-denominated grants through with rate=1', () => {
+		const plnValuation: CompanyValuation = { ...valuation, currency: 'PLN' };
+		const plnGrant = {
+			...optionGrant,
+			currency: 'PLN',
+			paper_value_currency: 'PLN',
+			fx_rate: 1,
+			strike_price: 2.67
+		};
+		const r = computeYearlyEquityComp([plnGrant], [plnValuation], 1, 2026);
+		expect(r.vestedPln).toBeCloseTo(1875 * 2.27, 0);
 	});
 });

--- a/src/lib/utils/equity_vesting.ts
+++ b/src/lib/utils/equity_vesting.ts
@@ -101,13 +101,16 @@ interface PerShareValue {
 }
 
 // Per-share intrinsic value in valuation currency: max(FMV - strike, 0) for
-// options, FMV for RSUs. Returns null when no valuation exists for the
-// company.
+// options, FMV for RSUs. Returns null when no valuation exists, or when the
+// valuation currency differs from the grant currency — mixing currencies in
+// (FMV − strike) would produce a meaningless number. Mirrors
+// backend-go/internal/equity_grants/paper_value.go.
 export function perShareIntrinsicValue(
 	g: EquityGrant,
 	v: CompanyValuation | null
 ): PerShareValue | null {
 	if (!v) return null;
+	if (v.currency !== g.currency) return null;
 	const fmv = v.fmv_per_share;
 	const low = v.fmv_low ?? fmv;
 	const high = v.fmv_high ?? fmv;

--- a/src/lib/utils/equity_vesting.ts
+++ b/src/lib/utils/equity_vesting.ts
@@ -1,0 +1,124 @@
+import type {
+	CompanyValuation,
+	CustomVestingEvent,
+	EquityGrant,
+	VestingFrequency
+} from '$lib/types/salaries';
+
+const FREQ_MONTHS: Record<VestingFrequency, number> = {
+	monthly: 1,
+	quarterly: 3,
+	yearly: 12
+};
+
+function parseIsoDate(iso: string): Date {
+	const [y, m, d] = iso.split('-').map(Number);
+	return new Date(y, m - 1, d);
+}
+
+function monthsBetween(start: Date, end: Date): number {
+	let months = (end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth());
+	if (end.getDate() < start.getDate()) months -= 1;
+	return months;
+}
+
+interface ScheduleInput {
+	totalShares: number;
+	vestStartDate: Date;
+	vestCliffMonths: number;
+	vestTotalMonths: number;
+	vestFrequencyMonths: number;
+	customSchedule: CustomVestingEvent[] | null;
+}
+
+function vestedSharesAt(s: ScheduleInput, onDate: Date): number {
+	if (onDate < s.vestStartDate) return 0;
+	const elapsed = monthsBetween(s.vestStartDate, onDate);
+	if (elapsed < s.vestCliffMonths) return 0;
+	const capped = Math.min(elapsed, s.vestTotalMonths);
+	if (s.customSchedule && s.customSchedule.length > 0) {
+		let totalPct = 0;
+		for (const ev of s.customSchedule) if (ev.month <= capped) totalPct += ev.pct;
+		const vested = Math.floor((s.totalShares * totalPct) / 100);
+		return Math.min(vested, s.totalShares);
+	}
+	if (s.vestTotalMonths <= 0) return s.totalShares;
+	const freq = s.vestFrequencyMonths > 0 ? s.vestFrequencyMonths : 1;
+	const monthsAfterCliff = capped - s.vestCliffMonths;
+	const extraPeriods = Math.floor(monthsAfterCliff / freq);
+	const vestingMonthCount = Math.min(s.vestCliffMonths + extraPeriods * freq, s.vestTotalMonths);
+	return Math.floor((s.totalShares * vestingMonthCount) / s.vestTotalMonths);
+}
+
+function scheduleOf(g: EquityGrant): ScheduleInput {
+	return {
+		totalShares: g.total_shares,
+		vestStartDate: parseIsoDate(g.vest_start_date),
+		vestCliffMonths: g.vest_cliff_months,
+		vestTotalMonths: g.vest_total_months,
+		vestFrequencyMonths: FREQ_MONTHS[g.vest_frequency],
+		customSchedule: g.vest_custom_schedule
+	};
+}
+
+// Time-vested shares newly accruing in calendar year. Ignores liquidity-event
+// gating — use isEffectivelyVested() to apply that gate.
+export function vestedInYear(g: EquityGrant, year: number): number {
+	const s = scheduleOf(g);
+	const endOfYear = new Date(year, 11, 31);
+	const endOfPrev = new Date(year - 1, 11, 31);
+	const cur = vestedSharesAt(s, endOfYear);
+	const prev = vestedSharesAt(s, endOfPrev);
+	return Math.max(0, cur - prev);
+}
+
+// Whether the grant's vested shares are realisable in `year` — i.e. either
+// no liquidity event is required, or one has fired on/before year end.
+export function isEffectivelyVested(g: EquityGrant, year: number): boolean {
+	if (!g.requires_liquidity_event) return true;
+	if (!g.liquidity_event_date) return false;
+	return parseIsoDate(g.liquidity_event_date) <= new Date(year, 11, 31);
+}
+
+export function latestValuationFor(
+	valuations: CompanyValuation[],
+	company: string
+): CompanyValuation | null {
+	let best: CompanyValuation | null = null;
+	for (const v of valuations) {
+		if (!v.is_active) continue;
+		if (v.company !== company) continue;
+		if (!best || v.date > best.date) best = v;
+	}
+	return best;
+}
+
+interface PerShareValue {
+	base: number;
+	low: number;
+	high: number;
+	currency: string;
+}
+
+// Per-share intrinsic value in valuation currency: max(FMV - strike, 0) for
+// options, FMV for RSUs. Returns null when no valuation exists for the
+// company.
+export function perShareIntrinsicValue(
+	g: EquityGrant,
+	v: CompanyValuation | null
+): PerShareValue | null {
+	if (!v) return null;
+	const fmv = v.fmv_per_share;
+	const low = v.fmv_low ?? fmv;
+	const high = v.fmv_high ?? fmv;
+	if (g.type === 'option') {
+		const strike = g.strike_price ?? 0;
+		return {
+			base: Math.max(fmv - strike, 0),
+			low: Math.max(low - strike, 0),
+			high: Math.max(high - strike, 0),
+			currency: v.currency
+		};
+	}
+	return { base: fmv, low, high, currency: v.currency };
+}

--- a/src/lib/utils/equity_vesting.ts
+++ b/src/lib/utils/equity_vesting.ts
@@ -122,3 +122,65 @@ export function perShareIntrinsicValue(
 	}
 	return { base: fmv, low, high, currency: v.currency };
 }
+
+export interface YearlyEquityComp {
+	vestedPln: number;
+	vestedLowPln: number;
+	vestedHighPln: number;
+	lockedPln: number;
+	hasEquityWithoutFx: boolean;
+}
+
+// FX is borrowed across grants of the same currency, since the backend only
+// attaches fx_rate when vested_shares_today > 0 — locked RSUs need their
+// sibling option grant's rate to convert to PLN.
+function buildFxByCurrency(grants: EquityGrant[]): Map<string, number> {
+	const fx = new Map<string, number>([['PLN', 1]]);
+	for (const g of grants) {
+		if (g.fx_rate !== null && g.paper_value_currency) fx.set(g.paper_value_currency, g.fx_rate);
+	}
+	return fx;
+}
+
+// Compute the year's equity comp for one owner: realisable value + locked
+// (LE-pending) sub-total. Pure function so it can be unit-tested directly,
+// independent of the salary page wiring.
+export function computeYearlyEquityComp(
+	grants: EquityGrant[],
+	valuations: CompanyValuation[],
+	ownerUserId: number,
+	year: number
+): YearlyEquityComp {
+	const fxByCurrency = buildFxByCurrency(grants);
+	let vestedPln = 0;
+	let vestedLowPln = 0;
+	let vestedHighPln = 0;
+	let lockedPln = 0;
+	let hasEquityWithoutFx = false;
+
+	for (const g of grants) {
+		if (g.owner_user_id !== ownerUserId) continue;
+		const shares = vestedInYear(g, year);
+		if (shares <= 0) continue;
+		const valuation = latestValuationFor(valuations, g.company);
+		const perShare = perShareIntrinsicValue(g, valuation);
+		if (!perShare) continue;
+		const fx = fxByCurrency.get(perShare.currency);
+		if (fx === undefined) {
+			hasEquityWithoutFx = true;
+			continue;
+		}
+		const base = shares * perShare.base * fx;
+		const low = shares * perShare.low * fx;
+		const high = shares * perShare.high * fx;
+		if (isEffectivelyVested(g, year)) {
+			vestedPln += base;
+			vestedLowPln += low;
+			vestedHighPln += high;
+		} else {
+			lockedPln += base;
+		}
+	}
+
+	return { vestedPln, vestedLowPln, vestedHighPln, lockedPln, hasEquityWithoutFx };
+}

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -14,6 +14,12 @@
 		isNonNegative,
 		isoDateLocal
 	} from '$lib/utils/salaries';
+	import {
+		vestedInYear,
+		isEffectivelyVested,
+		latestValuationFor,
+		perShareIntrinsicValue
+	} from '$lib/utils/equity_vesting';
 	import { buildCpiLookup, inflationAdjust, parseIsoDate } from '$lib/utils/inflation';
 	import { grossToNet, type PlContractType } from '$lib/utils/pl_tax';
 	import { PL_RULES } from '$lib/utils/pl_rules.generated';
@@ -151,9 +157,10 @@
 		baseAnnualNet: number;
 		bonusesPln: number;
 		bonusesNetPln: number;
-		equityPaperPln: number;
-		equityPaperLowPln: number;
-		equityPaperHighPln: number;
+		equityVestedYearPln: number;
+		equityVestedYearLowPln: number;
+		equityVestedYearHighPln: number;
+		equityLockedYearPln: number;
 		equityNetPln: number;
 		hasEquityWithoutFx: boolean;
 	};
@@ -197,25 +204,52 @@
 					.netAnnual - baseAnnualNet
 			: 0;
 
-		let equityPaperPln = 0;
-		let equityPaperLowPln = 0;
-		let equityPaperHighPln = 0;
+		// Equity vesting in the selected year, valued at the latest FMV per share.
+		// Effective = realisable (no liquidity-event gate or LE has fired).
+		// Locked = time-vested but waiting on liquidity event (double-trigger RSUs).
+		// FX rates are looked up from any grant that exposes one for the same
+		// currency — the backend only attaches fx_rate when vested>0, so locked
+		// RSUs borrow the rate from sibling grants.
+		const grants = data.equity?.equity_grants ?? [];
+		const valuations = data.valuations?.company_valuations ?? [];
+		const fxByCurrency = new Map<string, number>([['PLN', 1]]);
+		for (const g of grants) {
+			if (g.fx_rate !== null && g.paper_value_currency) {
+				fxByCurrency.set(g.paper_value_currency, g.fx_rate);
+			}
+		}
+
+		let equityVestedYearPln = 0;
+		let equityVestedYearLowPln = 0;
+		let equityVestedYearHighPln = 0;
+		let equityLockedYearPln = 0;
 		let hasEquityWithoutFx = false;
-		for (const g of data.equity?.equity_grants ?? []) {
+		for (const g of grants) {
 			if (g.owner_user_id !== ownerUserId) continue;
-			if (g.paper_value_base_pln === null && g.paper_value_base !== null) {
+			const shares = vestedInYear(g, totalCompYear);
+			if (shares <= 0) continue;
+			const valuation = latestValuationFor(valuations, g.company);
+			const perShare = perShareIntrinsicValue(g, valuation);
+			if (!perShare) continue;
+			const fx = fxByCurrency.get(perShare.currency);
+			if (fx === undefined) {
 				hasEquityWithoutFx = true;
 				continue;
 			}
-			if (g.paper_value_base_pln !== null) {
-				equityPaperPln += g.paper_value_base_pln;
-				equityPaperLowPln += g.paper_value_low_pln ?? g.paper_value_base_pln;
-				equityPaperHighPln += g.paper_value_high_pln ?? g.paper_value_base_pln;
+			const base = shares * perShare.base * fx;
+			const low = shares * perShare.low * fx;
+			const high = shares * perShare.high * fx;
+			if (isEffectivelyVested(g, totalCompYear)) {
+				equityVestedYearPln += base;
+				equityVestedYearLowPln += low;
+				equityVestedYearHighPln += high;
+			} else {
+				equityLockedYearPln += base;
 			}
 		}
 		// Equity "net" assumes capital-gains treatment on realization; grants on
 		// employment_income would be ~12/32% + ZUS instead. Rough estimate only.
-		const equityNetPln = equityPaperPln * (1 - EQUITY_CAPITAL_GAINS_RATE);
+		const equityNetPln = equityVestedYearPln * (1 - EQUITY_CAPITAL_GAINS_RATE);
 
 		return {
 			ownerUserId,
@@ -223,9 +257,10 @@
 			baseAnnualNet,
 			bonusesPln,
 			bonusesNetPln,
-			equityPaperPln,
-			equityPaperLowPln,
-			equityPaperHighPln,
+			equityVestedYearPln,
+			equityVestedYearLowPln,
+			equityVestedYearHighPln,
+			equityLockedYearPln,
 			equityNetPln,
 			hasEquityWithoutFx
 		};
@@ -236,7 +271,7 @@
 	const totalCompGross = $derived(
 		(compSummary?.baseAnnualGross ?? 0) +
 			(compSummary?.bonusesPln ?? 0) +
-			(includeEquityInTotal ? (compSummary?.equityPaperPln ?? 0) : 0)
+			(includeEquityInTotal ? (compSummary?.equityVestedYearPln ?? 0) : 0)
 	);
 	const totalCompNet = $derived(
 		(compSummary?.baseAnnualNet ?? 0) +
@@ -1111,14 +1146,19 @@
 			companyMap.get(companyName)!.push([r.date, r.gross_amount]);
 		});
 
-		companyMap.forEach((rows) =>
-			rows.sort((a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime())
-		);
-
 		const colors = ['#5E81AC', '#88C0D0', '#A3BE8C', '#EBCB8B', '#D08770', '#B48EAD', '#BF616A'];
 		// Date-only `today` matches the backend (which is also date-only).
 		const now = new Date();
 		const todayDate = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+		const todayIso = isoDateLocal(todayDate);
+
+		companyMap.forEach((rows) => {
+			rows.sort((a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime());
+			// Carry the most recent salary forward to today so a single-record
+			// series still renders as a flat line instead of a lone dot.
+			const last = rows[rows.length - 1];
+			if (last && last[0] < todayIso) rows.push([todayIso, last[1]]);
+		});
 		const cpiLookup = buildCpiLookup(cpiSeries);
 		const hasCpi = cpiLookup !== null;
 
@@ -1319,16 +1359,23 @@
 					{/if}
 				</div>
 				<div class="card preset-tonal-surface p-3">
-					<div class="text-xs text-surface-700-300">Equity (paper, dziś)</div>
-					<div class="text-lg font-semibold">{formatPLN(compSummary.equityPaperPln)}</div>
-					{#if compSummary.equityPaperLowPln !== compSummary.equityPaperHighPln}
+					<div class="text-xs text-surface-700-300">Equity vesting w {totalCompYear}</div>
+					<div class="text-lg font-semibold">{formatPLN(compSummary.equityVestedYearPln)}</div>
+					{#if compSummary.equityVestedYearLowPln !== compSummary.equityVestedYearHighPln}
 						<div class="text-xs text-surface-700-300">
-							{formatPLN(compSummary.equityPaperLowPln)}–{formatPLN(compSummary.equityPaperHighPln)}
+							{formatPLN(compSummary.equityVestedYearLowPln)}–{formatPLN(
+								compSummary.equityVestedYearHighPln
+							)}
 						</div>
 					{/if}
-					{#if compSummary.equityPaperPln > 0}
+					{#if compSummary.equityVestedYearPln > 0}
 						<div class="text-xs text-surface-700-300">
 							po podatku 19% (szac.): {formatPLN(compSummary.equityNetPln)}
+						</div>
+					{/if}
+					{#if compSummary.equityLockedYearPln > 0}
+						<div class="text-xs text-warning-500">
+							+ {formatPLN(compSummary.equityLockedYearPln)} zablokowane (RSU, czeka na liquidity event)
 						</div>
 					{/if}
 					{#if compSummary.hasEquityWithoutFx}
@@ -1346,12 +1393,12 @@
 				</div>
 			</div>
 			<div class="text-xs text-surface-700-300">
-				Pensja + bonusy filtrowane po roku. Equity zawsze jako wartość dzisiejsza (bieżący vested ×
-				najnowsza wycena), niezależnie od wybranego roku.
+				Pensja, bonusy i equity filtrowane po roku. Equity = akcje time-vesting w wybranym roku ×
+				najnowsza wycena per share (intrinsic spread dla opcji, FMV dla RSU).
 			</div>
 			<label class="flex items-center gap-2 text-sm cursor-pointer">
 				<input type="checkbox" class="checkbox" bind:checked={includeEquityInTotal} />
-				<span>Wlicz equity paper value do total (uwaga: nie zrealizowane do sprzedaży)</span>
+				<span>Wlicz equity vesting w tym roku do total (uwaga: nie zrealizowane do sprzedaży)</span>
 			</label>
 		{:else}
 			<p class="text-sm text-surface-700-300">Wybierz właściciela aby zobaczyć podsumowanie.</p>

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -14,12 +14,7 @@
 		isNonNegative,
 		isoDateLocal
 	} from '$lib/utils/salaries';
-	import {
-		vestedInYear,
-		isEffectivelyVested,
-		latestValuationFor,
-		perShareIntrinsicValue
-	} from '$lib/utils/equity_vesting';
+	import { computeYearlyEquityComp } from '$lib/utils/equity_vesting';
 	import { buildCpiLookup, inflationAdjust, parseIsoDate } from '$lib/utils/inflation';
 	import { grossToNet, type PlContractType } from '$lib/utils/pl_tax';
 	import { PL_RULES } from '$lib/utils/pl_rules.generated';
@@ -204,52 +199,15 @@
 					.netAnnual - baseAnnualNet
 			: 0;
 
-		// Equity vesting in the selected year, valued at the latest FMV per share.
-		// Effective = realisable (no liquidity-event gate or LE has fired).
-		// Locked = time-vested but waiting on liquidity event (double-trigger RSUs).
-		// FX rates are looked up from any grant that exposes one for the same
-		// currency — the backend only attaches fx_rate when vested>0, so locked
-		// RSUs borrow the rate from sibling grants.
-		const grants = data.equity?.equity_grants ?? [];
-		const valuations = data.valuations?.company_valuations ?? [];
-		const fxByCurrency = new Map<string, number>([['PLN', 1]]);
-		for (const g of grants) {
-			if (g.fx_rate !== null && g.paper_value_currency) {
-				fxByCurrency.set(g.paper_value_currency, g.fx_rate);
-			}
-		}
-
-		let equityVestedYearPln = 0;
-		let equityVestedYearLowPln = 0;
-		let equityVestedYearHighPln = 0;
-		let equityLockedYearPln = 0;
-		let hasEquityWithoutFx = false;
-		for (const g of grants) {
-			if (g.owner_user_id !== ownerUserId) continue;
-			const shares = vestedInYear(g, totalCompYear);
-			if (shares <= 0) continue;
-			const valuation = latestValuationFor(valuations, g.company);
-			const perShare = perShareIntrinsicValue(g, valuation);
-			if (!perShare) continue;
-			const fx = fxByCurrency.get(perShare.currency);
-			if (fx === undefined) {
-				hasEquityWithoutFx = true;
-				continue;
-			}
-			const base = shares * perShare.base * fx;
-			const low = shares * perShare.low * fx;
-			const high = shares * perShare.high * fx;
-			if (isEffectivelyVested(g, totalCompYear)) {
-				equityVestedYearPln += base;
-				equityVestedYearLowPln += low;
-				equityVestedYearHighPln += high;
-			} else {
-				equityLockedYearPln += base;
-			}
-		}
+		const equity = computeYearlyEquityComp(
+			data.equity?.equity_grants ?? [],
+			data.valuations?.company_valuations ?? [],
+			ownerUserId,
+			totalCompYear
+		);
 		// Equity "net" assumes capital-gains treatment on realization; grants on
 		// employment_income would be ~12/32% + ZUS instead. Rough estimate only.
-		const equityNetPln = equityVestedYearPln * (1 - EQUITY_CAPITAL_GAINS_RATE);
+		const equityNetPln = equity.vestedPln * (1 - EQUITY_CAPITAL_GAINS_RATE);
 
 		return {
 			ownerUserId,
@@ -257,12 +215,12 @@
 			baseAnnualNet,
 			bonusesPln,
 			bonusesNetPln,
-			equityVestedYearPln,
-			equityVestedYearLowPln,
-			equityVestedYearHighPln,
-			equityLockedYearPln,
+			equityVestedYearPln: equity.vestedPln,
+			equityVestedYearLowPln: equity.vestedLowPln,
+			equityVestedYearHighPln: equity.vestedHighPln,
+			equityLockedYearPln: equity.lockedPln,
 			equityNetPln,
-			hasEquityWithoutFx
+			hasEquityWithoutFx: equity.hasEquityWithoutFx
 		};
 	});
 


### PR DESCRIPTION
## Motivation

Two related fixes to the Total Compensation card on /salaries:

1. **Single-dot salary chart** — owners with only one salary record (e.g. Ewa) saw a lone point instead of a line, making the chart useless for "what am I earning today" reads.

2. **Misleading equity number** — the "Equity (paper, dziś)" tile summed lifetime accumulated vested paper value across all grants. For a 2026 Total Comp view, that conflates "what I have on paper today" with "what I'm earning in 2026". Example: a 10,000 NSO grant from 2022 with 91.7% vested showed ~76,000 PLN as the 2026 equity contribution, when only the 9 monthly tranches that vest *during* 2026 (~1,875 shares × spread) actually belong there.

## Implementation information

### Chart line carry-forward

`src/routes/salaries/+page.svelte`, `buildSeries()`: after sorting each company's salary points by date, append `[todayIso, lastAmount]` if the latest record is older than today. ECharts then draws a flat segment from the last raise to today.

### Year-based equity in Total Comp

New helper `src/lib/utils/equity_vesting.ts`:
- `vestedSharesAt(grant, onDate)` ports the algorithm from `backend-go/internal/equity_grants/vesting.go` (cliff / total / freq / custom schedule, with anniversary-semantics `monthsBetween`).
- `vestedInYear(grant, year)` = `vestedSharesAt(Dec 31 of year) - vestedSharesAt(Dec 31 of year-1)`.
- `isEffectivelyVested(grant, year)` applies the liquidity-event gate.
- `latestValuationFor(valuations, company)` + `perShareIntrinsicValue(grant, valuation)` produce per-share value (FMV-strike for options, FMV for RSUs).

`compSummary` in `+page.svelte` now sums `shares_in_year × per_share × fx` per grant. Liquidity-event-gated grants split into `equityLockedYearPln` (shown as a separate "+ X zaplokowane" sub-line under the tile). FX rates are borrowed from sibling grants of the same currency, since the backend only attaches `fx_rate` when `vested_shares_today > 0`.

Tile copy updated:
- "Equity (paper, dziś)" → "Equity vesting w {rok}"
- Checkbox: "Wlicz equity paper value..." → "Wlicz equity vesting w tym roku..."
- Helper text: clarifies equity is now year-filtered.

### Tests

`src/lib/utils/equity_vesting.test.ts`: 17 unit tests:
- monthly options (pre-vest, cliff year, full year, partial year, post-vest)
- quarterly custom-schedule RSU
- liquidity-event gating (pending / fired in year / fired after year)
- valuation selection (latest active, company filter, inactive ignored)
- per-share intrinsic value (options spread, underwater, RSU FMV, no valuation)

All 529 frontend + backend tests pass. Prettier + oxlint clean.

## Supporting documentation

> Changelog: feat(salaries): year-based equity + extend line