### PR TITLE
refactor(wire): extract shared JSON wire types

### DIFF
--- a/backend-go/cmd/gen-openapi/main.go
+++ b/backend-go/cmd/gen-openapi/main.go
@@ -163,17 +163,17 @@ func customizeScalar(_ string, t reflect.Type, _ reflect.StructTag, schema *open
 		return nil
 	}
 	switch t.Name() {
-	case "pyFloat":
+	case "PyFloat":
 		schema.Type = &openapi3.Types{"number"}
 		schema.Properties = nil
 	case "moneyJSON", "ppkRate", "rateJSON", "dimString":
 		schema.Type = &openapi3.Types{"string"}
 		schema.Properties = nil
-	case "isoDate":
+	case "IsoDate":
 		schema.Type = &openapi3.Types{"string"}
 		schema.Format = "date"
 		schema.Properties = nil
-	case "isoNaive":
+	case "IsoNaive":
 		schema.Type = &openapi3.Types{"string"}
 		schema.Format = "date-time"
 		schema.Properties = nil

--- a/backend-go/internal/accounts/handler.go
+++ b/backend-go/internal/accounts/handler.go
@@ -8,11 +8,11 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
-	"strings"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 var (
@@ -31,20 +31,20 @@ var (
 )
 
 type response struct {
-	ID                    int      `json:"id"`
-	Name                  string   `json:"name"`
-	Type                  string   `json:"type"`
-	Category              string   `json:"category"`
-	OwnerUserID           *int     `json:"owner_user_id"`
-	Currency              string   `json:"currency"`
-	AccountWrapper        *string  `json:"account_wrapper"`
-	Purpose               string   `json:"purpose"`
-	SquareMeters          *pyFloat `json:"square_meters"`
-	IsActive              bool     `json:"is_active"`
-	ReceivesContributions bool     `json:"receives_contributions"`
-	ExcludedFromFire      bool     `json:"excluded_from_fire"`
-	CreatedAt             isoNaive `json:"created_at"`
-	CurrentValue          pyFloat  `json:"current_value"`
+	ID                    int           `json:"id"`
+	Name                  string        `json:"name"`
+	Type                  string        `json:"type"`
+	Category              string        `json:"category"`
+	OwnerUserID           *int          `json:"owner_user_id"`
+	Currency              string        `json:"currency"`
+	AccountWrapper        *string       `json:"account_wrapper"`
+	Purpose               string        `json:"purpose"`
+	SquareMeters          *wire.PyFloat `json:"square_meters"`
+	IsActive              bool          `json:"is_active"`
+	ReceivesContributions bool          `json:"receives_contributions"`
+	ExcludedFromFire      bool          `json:"excluded_from_fire"`
+	CreatedAt             wire.IsoNaive `json:"created_at"`
+	CurrentValue          wire.PyFloat  `json:"current_value"`
 }
 
 type listResponse struct {
@@ -80,12 +80,12 @@ func toResponse(a *Account, currentValue decimal.Decimal) response {
 		IsActive:              a.IsActive,
 		ReceivesContributions: a.ReceivesContributions,
 		ExcludedFromFire:      a.ExcludedFromFire,
-		CreatedAt:             isoNaive(a.CreatedAt.UTC()),
-		CurrentValue:          pyFloat(cv),
+		CreatedAt:             wire.IsoNaive(a.CreatedAt.UTC()),
+		CurrentValue:          wire.PyFloat(cv),
 	}
 	if a.SquareMeters != nil {
 		f, _ := a.SquareMeters.Float64()
-		pf := pyFloat(f)
+		pf := wire.PyFloat(f)
 		out.SquareMeters = &pf
 	}
 	return out
@@ -229,22 +229,4 @@ func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
 		return 0, false
 	}
 	return id, true
-}
-
-// --- shared wire types ---
-
-type isoNaive time.Time
-
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/accounts/handler_test.go
+++ b/backend-go/internal/accounts/handler_test.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 func TestIsoNaiveMarshalJSON(t *testing.T) {
-	tm := isoNaive(time.Date(2026, 5, 23, 10, 11, 12, 345678000, time.UTC))
+	tm := wire.IsoNaive(time.Date(2026, 5, 23, 10, 11, 12, 345678000, time.UTC))
 	got, err := tm.MarshalJSON()
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -25,7 +27,7 @@ func TestIsoNaiveMarshalJSON(t *testing.T) {
 }
 
 func TestIsoNaiveZeroValueFormatsAsZero(t *testing.T) {
-	tm := isoNaive(time.Time{})
+	tm := wire.IsoNaive(time.Time{})
 	got, err := tm.MarshalJSON()
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -36,7 +38,7 @@ func TestIsoNaiveZeroValueFormatsAsZero(t *testing.T) {
 }
 
 func TestPyFloatIntegerGetsDotZero(t *testing.T) {
-	got, err := pyFloat(5).MarshalJSON()
+	got, err := wire.PyFloat(5).MarshalJSON()
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -46,7 +48,7 @@ func TestPyFloatIntegerGetsDotZero(t *testing.T) {
 }
 
 func TestPyFloatPreservesDecimal(t *testing.T) {
-	got, err := pyFloat(5.5).MarshalJSON()
+	got, err := wire.PyFloat(5.5).MarshalJSON()
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -56,7 +58,7 @@ func TestPyFloatPreservesDecimal(t *testing.T) {
 }
 
 func TestPyFloatNegative(t *testing.T) {
-	got, err := pyFloat(-12.34).MarshalJSON()
+	got, err := wire.PyFloat(-12.34).MarshalJSON()
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}

--- a/backend-go/internal/allocation/handler.go
+++ b/backend-go/internal/allocation/handler.go
@@ -9,21 +9,22 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 // response is the wire shape for a single allocation_targets row.
 type response struct {
-	ID          int      `json:"id"`
-	Category    string   `json:"category"`
-	OwnerUserID *int     `json:"owner_user_id"`
-	TargetPct   float64  `json:"target_pct"`
-	CreatedAt   isoNaive `json:"created_at"`
+	ID          int           `json:"id"`
+	Category    string        `json:"category"`
+	OwnerUserID *int          `json:"owner_user_id"`
+	TargetPct   float64       `json:"target_pct"`
+	CreatedAt   wire.IsoNaive `json:"created_at"`
 }
 
 type listResponse struct {
@@ -103,7 +104,7 @@ func toResponse(t *Target) response {
 		Category:    t.Category,
 		OwnerUserID: t.OwnerUserID,
 		TargetPct:   pct,
-		CreatedAt:   isoNaive(t.CreatedAt),
+		CreatedAt:   wire.IsoNaive(t.CreatedAt),
 	}
 }
 
@@ -334,12 +335,4 @@ func (h *HoldingsFromSnapshots) LatestHoldings(ctx context.Context) ([]CategoryA
 		return nil, fmt.Errorf("iterate snapshot values: %w", err)
 	}
 	return out, nil
-}
-
-// isoNaive serializes a time.Time as ISO without a timezone suffix; mirrors
-// Python's datetime.isoformat() on naive datetimes.
-type isoNaive time.Time
-
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
 }

--- a/backend-go/internal/assets/handler.go
+++ b/backend-go/internal/assets/handler.go
@@ -8,19 +8,19 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
-	"strings"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 type response struct {
-	ID           int      `json:"id"`
-	Name         string   `json:"name"`
-	IsActive     bool     `json:"is_active"`
-	CreatedAt    isoNaive `json:"created_at"`
-	CurrentValue pyFloat  `json:"current_value"`
+	ID           int           `json:"id"`
+	Name         string        `json:"name"`
+	IsActive     bool          `json:"is_active"`
+	CreatedAt    wire.IsoNaive `json:"created_at"`
+	CurrentValue wire.PyFloat  `json:"current_value"`
 }
 
 type listResponse struct {
@@ -47,8 +47,8 @@ func toResponse(a *Asset, current decimal.Decimal) response {
 		ID:           a.ID,
 		Name:         a.Name,
 		IsActive:     a.IsActive,
-		CreatedAt:    isoNaive(a.CreatedAt.UTC()),
-		CurrentValue: pyFloat(cv),
+		CreatedAt:    wire.IsoNaive(a.CreatedAt.UTC()),
+		CurrentValue: wire.PyFloat(cv),
 	}
 }
 
@@ -173,22 +173,4 @@ func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
 		return 0, false
 	}
 	return id, true
-}
-
-// --- wire types (shared) ---
-
-type isoNaive time.Time
-
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/bonds/handler.go
+++ b/backend-go/internal/bonds/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 // CPILoader is the subset of cpi.Store the handler needs. Decoupling the
@@ -40,19 +41,19 @@ func NewHandler(store *Store, cpiStore CPILoader, logger *slog.Logger) *Handler 
 
 // response is the wire shape for a single bond.
 type response struct {
-	ID            int      `json:"id"`
-	Type          string   `json:"type"`
-	Series        string   `json:"series"`
-	FaceValue     float64  `json:"face_value"`
-	PurchaseDate  isoDate  `json:"purchase_date"`
-	MaturityDate  isoDate  `json:"maturity_date"`
-	OwnerUserID   *int     `json:"owner_user_id"`
-	FirstYearRate float64  `json:"first_year_rate"`
-	Margin        float64  `json:"margin"`
-	Capitalize    bool     `json:"capitalize"`
-	CurrentValue  float64  `json:"current_value"`
-	CurrentYield  float64  `json:"current_yield"`
-	CreatedAt     isoNaive `json:"created_at"`
+	ID            int           `json:"id"`
+	Type          string        `json:"type"`
+	Series        string        `json:"series"`
+	FaceValue     float64       `json:"face_value"`
+	PurchaseDate  wire.IsoDate  `json:"purchase_date"`
+	MaturityDate  wire.IsoDate  `json:"maturity_date"`
+	OwnerUserID   *int          `json:"owner_user_id"`
+	FirstYearRate float64       `json:"first_year_rate"`
+	Margin        float64       `json:"margin"`
+	Capitalize    bool          `json:"capitalize"`
+	CurrentValue  float64       `json:"current_value"`
+	CurrentYield  float64       `json:"current_yield"`
+	CreatedAt     wire.IsoNaive `json:"created_at"`
 }
 
 type listResponse struct {
@@ -62,10 +63,10 @@ type listResponse struct {
 }
 
 type ytmPointResponse struct {
-	Year     int     `json:"year"`
-	Date     isoDate `json:"date"`
-	Value    float64 `json:"value"`
-	YearRate float64 `json:"year_rate"`
+	Year     int          `json:"year"`
+	Date     wire.IsoDate `json:"date"`
+	Value    float64      `json:"value"`
+	YearRate float64      `json:"year_rate"`
 }
 
 type ytmResponse struct {
@@ -74,14 +75,14 @@ type ytmResponse struct {
 }
 
 type createRequest struct {
-	Type          string  `json:"type"`
-	Series        string  `json:"series"`
-	FaceValue     float64 `json:"face_value"`
-	PurchaseDate  isoDate `json:"purchase_date"`
-	OwnerUserID   *int    `json:"owner_user_id"`
-	FirstYearRate float64 `json:"first_year_rate"`
-	Margin        float64 `json:"margin"`
-	Capitalize    bool    `json:"capitalize"`
+	Type          string       `json:"type"`
+	Series        string       `json:"series"`
+	FaceValue     float64      `json:"face_value"`
+	PurchaseDate  wire.IsoDate `json:"purchase_date"`
+	OwnerUserID   *int         `json:"owner_user_id"`
+	FirstYearRate float64      `json:"first_year_rate"`
+	Margin        float64      `json:"margin"`
+	Capitalize    bool         `json:"capitalize"`
 }
 
 func (h *Handler) toResponse(b *TreasuryBond, yoy map[int]decimal.Decimal) response {
@@ -97,15 +98,15 @@ func (h *Handler) toResponse(b *TreasuryBond, yoy map[int]decimal.Decimal) respo
 		Type:          string(b.Type),
 		Series:        b.Series,
 		FaceValue:     face,
-		PurchaseDate:  isoDate(b.PurchaseDate),
-		MaturityDate:  isoDate(MaturityDate(b)),
+		PurchaseDate:  wire.IsoDate(b.PurchaseDate),
+		MaturityDate:  wire.IsoDate(MaturityDate(b)),
 		OwnerUserID:   b.OwnerUserID,
 		FirstYearRate: firstYear,
 		Margin:        margin,
 		Capitalize:    b.Capitalize,
 		CurrentValue:  currentFloat,
 		CurrentYield:  yieldRate,
-		CreatedAt:     isoNaive(b.CreatedAt),
+		CreatedAt:     wire.IsoNaive(b.CreatedAt),
 	}
 }
 
@@ -181,7 +182,7 @@ func (h *Handler) YTM(w http.ResponseWriter, r *http.Request) {
 		rate, _ := p.YearRate.Float64()
 		out.Points = append(out.Points, ytmPointResponse{
 			Year:     p.Year,
-			Date:     isoDate(p.Date),
+			Date:     wire.IsoDate(p.Date),
 			Value:    v,
 			YearRate: rate,
 		})
@@ -298,33 +299,3 @@ func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
 // Sanity: keep the package's cpi import alive even if the production wiring
 // uses a different interface; the cpi.Store satisfies CPILoader exactly.
 var _ CPILoader = (*cpi.Store)(nil)
-
-// isoDate is the same YYYY-MM-DD format used elsewhere in the backend.
-type isoDate time.Time
-
-const isoDateLayout = "2006-01-02"
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
-}
-
-func (d *isoDate) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	t, err := time.Parse(isoDateLayout, s)
-	if err != nil {
-		return err
-	}
-	*d = isoDate(t)
-	return nil
-}
-
-// isoNaive serializes time.Time without timezone, matching the Python-era
-// JSON shape used by other endpoints.
-type isoNaive time.Time
-
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
-}

--- a/backend-go/internal/bonus_events/handler.go
+++ b/backend-go/internal/bonus_events/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 var (
@@ -32,24 +33,24 @@ var (
 
 // response mirrors backend/app/schemas/bonus_events.BonusEventResponse.
 //
-// CreatedAt uses isoNaive — same format every Go-served endpoint emits.
+// CreatedAt uses wire.IsoNaive — same format every Go-served endpoint emits.
 // Python's bonus_events column is TIMESTAMPTZ and Pydantic appends Z; the
 // Go API deliberately diverges (no Z) so the new API stays internally
 // coherent regardless of which migration declared which column type.
 type response struct {
-	ID           int      `json:"id"`
-	Date         isoDate  `json:"date"`
-	Amount       pyFloat  `json:"amount"`
-	Currency     string   `json:"currency"`
-	Type         string   `json:"type"`
-	Company      string   `json:"company"`
-	OwnerUserID  *int     `json:"owner_user_id"`
-	ContractType string   `json:"contract_type"`
-	Notes        *string  `json:"notes"`
-	IsActive     bool     `json:"is_active"`
-	CreatedAt    isoNaive `json:"created_at"`
-	AmountPLN    *pyFloat `json:"amount_pln"`
-	FXRate       *pyFloat `json:"fx_rate"`
+	ID           int           `json:"id"`
+	Date         wire.IsoDate  `json:"date"`
+	Amount       wire.PyFloat  `json:"amount"`
+	Currency     string        `json:"currency"`
+	Type         string        `json:"type"`
+	Company      string        `json:"company"`
+	OwnerUserID  *int          `json:"owner_user_id"`
+	ContractType string        `json:"contract_type"`
+	Notes        *string       `json:"notes"`
+	IsActive     bool          `json:"is_active"`
+	CreatedAt    wire.IsoNaive `json:"created_at"`
+	AmountPLN    *wire.PyFloat `json:"amount_pln"`
+	FXRate       *wire.PyFloat `json:"fx_rate"`
 }
 
 type listResponse struct {
@@ -95,8 +96,8 @@ func (h *Handler) toResponse(ctx context.Context, b *BonusEvent) (response, erro
 	amt, _ := b.Amount.Float64()
 	out := response{
 		ID:           b.ID,
-		Date:         isoDate(b.Date),
-		Amount:       pyFloat(amt),
+		Date:         wire.IsoDate(b.Date),
+		Amount:       wire.PyFloat(amt),
 		Currency:     b.Currency,
 		Type:         b.Type,
 		Company:      b.Company,
@@ -104,16 +105,16 @@ func (h *Handler) toResponse(ctx context.Context, b *BonusEvent) (response, erro
 		ContractType: b.ContractType,
 		Notes:        b.Notes,
 		IsActive:     b.IsActive,
-		CreatedAt:    isoNaive(b.CreatedAt.UTC()),
+		CreatedAt:    wire.IsoNaive(b.CreatedAt.UTC()),
 	}
 	if hasPLN {
 		f, _ := plnAmount.Float64()
-		pf := pyFloat(f)
+		pf := wire.PyFloat(f)
 		out.AmountPLN = &pf
 	}
 	if rate.Found {
 		f, _ := rate.Rate.Float64()
-		pf := pyFloat(f)
+		pf := wire.PyFloat(f)
 		out.FXRate = &pf
 	}
 	return out, nil
@@ -298,46 +299,4 @@ func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
 		return 0, false
 	}
 	return id, true
-}
-
-// --- shared wire-format helpers (copied per package; promote when third user needs them) ---
-
-type isoDate time.Time
-
-const isoDateLayout = "2006-01-02"
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
-}
-
-func (d *isoDate) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("date must be a string: %w", err)
-	}
-	t, err := time.Parse(isoDateLayout, s)
-	if err != nil {
-		return fmt.Errorf("date must be YYYY-MM-DD: %w", err)
-	}
-	*d = isoDate(t)
-	return nil
-}
-
-// isoNaive emits a UTC-normalized ISO timestamp without a TZ suffix — the
-// unified format the Go API uses on every created_at field, regardless of
-// whether the underlying Postgres column was declared TIMESTAMPTZ or not.
-type isoNaive time.Time
-
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/company_valuations/handler.go
+++ b/backend-go/internal/company_valuations/handler.go
@@ -8,11 +8,12 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 var (
@@ -26,21 +27,21 @@ var (
 
 // response mirrors backend/app/schemas/company_valuations.CompanyValuationResponse.
 //
-// Money fields use pyFloat so JSON output preserves Python's `float(x)`
+// Money fields use wire.PyFloat so JSON output preserves Python's `float(x)`
 // formatting — `14.0` not `14`, matching Pydantic's number serialization.
 type response struct {
-	ID                     int      `json:"id"`
-	Company                string   `json:"company"`
-	Date                   isoDate  `json:"date"`
-	Currency               string   `json:"currency"`
-	FMVPerShare            pyFloat  `json:"fmv_per_share"`
-	FMVLow                 *pyFloat `json:"fmv_low"`
-	FMVHigh                *pyFloat `json:"fmv_high"`
-	Source                 string   `json:"source"`
-	CommonStockDiscountPct *pyFloat `json:"common_stock_discount_pct"`
-	Notes                  *string  `json:"notes"`
-	IsActive               bool     `json:"is_active"`
-	CreatedAt              isoNaive `json:"created_at"`
+	ID                     int           `json:"id"`
+	Company                string        `json:"company"`
+	Date                   wire.IsoDate  `json:"date"`
+	Currency               string        `json:"currency"`
+	FMVPerShare            wire.PyFloat  `json:"fmv_per_share"`
+	FMVLow                 *wire.PyFloat `json:"fmv_low"`
+	FMVHigh                *wire.PyFloat `json:"fmv_high"`
+	Source                 string        `json:"source"`
+	CommonStockDiscountPct *wire.PyFloat `json:"common_stock_discount_pct"`
+	Notes                  *string       `json:"notes"`
+	IsActive               bool          `json:"is_active"`
+	CreatedAt              wire.IsoNaive `json:"created_at"`
 }
 
 type listResponse struct {
@@ -85,27 +86,27 @@ func toResponse(v *Valuation) response {
 	out := response{
 		ID:          v.ID,
 		Company:     v.Company,
-		Date:        isoDate(v.Date),
+		Date:        wire.IsoDate(v.Date),
 		Currency:    v.Currency,
-		FMVPerShare: pyFloat(fmv),
+		FMVPerShare: wire.PyFloat(fmv),
 		Source:      v.Source,
 		Notes:       v.Notes,
 		IsActive:    v.IsActive,
-		CreatedAt:   isoNaive(v.CreatedAt),
+		CreatedAt:   wire.IsoNaive(v.CreatedAt),
 	}
 	if v.FMVLow != nil {
 		f, _ := v.FMVLow.Float64()
-		pf := pyFloat(f)
+		pf := wire.PyFloat(f)
 		out.FMVLow = &pf
 	}
 	if v.FMVHigh != nil {
 		f, _ := v.FMVHigh.Float64()
-		pf := pyFloat(f)
+		pf := wire.PyFloat(f)
 		out.FMVHigh = &pf
 	}
 	if v.CommonStockDiscountPct != nil {
 		f, _ := v.CommonStockDiscountPct.Float64()
-		pf := pyFloat(f)
+		pf := wire.PyFloat(f)
 		out.CommonStockDiscountPct = &pf
 	}
 	return out
@@ -244,45 +245,4 @@ func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
 		return 0, false
 	}
 	return id, true
-}
-
-// isoDate and isoNaive — identical formats to the other packages.
-type isoDate time.Time
-
-const isoDateLayout = "2006-01-02"
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
-}
-
-func (d *isoDate) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("date must be a string: %w", err)
-	}
-	t, err := time.Parse(isoDateLayout, s)
-	if err != nil {
-		return fmt.Errorf("date must be YYYY-MM-DD: %w", err)
-	}
-	*d = isoDate(t)
-	return nil
-}
-
-type isoNaive time.Time
-
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
-}
-
-// pyFloat marshals identically to Python's `float(x)` JSON encoding —
-// always includes at least one digit after the decimal point so 14.0
-// emits as "14.0", not "14". This matches Pydantic's number formatting.
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/config/handler.go
+++ b/backend-go/internal/config/handler.go
@@ -3,13 +3,14 @@ package config
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 // response mirrors backend/app/schemas/config.ConfigResponse byte-for-byte.
@@ -17,30 +18,30 @@ import (
 // Date is serialized as "YYYY-MM-DD". Decimal money fields are quoted JSON
 // strings with two decimals (Python Pydantic v2's default for Decimal).
 type response struct {
-	ID                      int        `json:"id"`
-	BirthDate               isoDate    `json:"birth_date"`
-	RetirementAge           int        `json:"retirement_age"`
-	RetirementMonthlySalary moneyJSON  `json:"retirement_monthly_salary"`
-	AllocationRealEstate    int        `json:"allocation_real_estate"`
-	AllocationStocks        int        `json:"allocation_stocks"`
-	AllocationBonds         int        `json:"allocation_bonds"`
-	AllocationGold          int        `json:"allocation_gold"`
-	AllocationCommodities   int        `json:"allocation_commodities"`
-	MonthlyExpenses         moneyJSON  `json:"monthly_expenses"`
-	MonthlyMortgagePayment  moneyJSON  `json:"monthly_mortgage_payment"`
-	WithdrawalRate          rateJSON   `json:"withdrawal_rate"`
-	CoastFIRETargetAge      *int       `json:"coast_fire_target_age"`
-	ExpectedReturnRate      rateJSON   `json:"expected_return_rate"`
-	BaristaMonthlyIncome    *moneyJSON `json:"barista_monthly_income"`
-	LeanMonthlyExpenses     *moneyJSON `json:"lean_monthly_expenses"`
-	FatMonthlyExpenses      *moneyJSON `json:"fat_monthly_expenses"`
-	MonthlySavings          *moneyJSON `json:"monthly_savings"`
+	ID                      int          `json:"id"`
+	BirthDate               wire.IsoDate `json:"birth_date"`
+	RetirementAge           int          `json:"retirement_age"`
+	RetirementMonthlySalary moneyJSON    `json:"retirement_monthly_salary"`
+	AllocationRealEstate    int          `json:"allocation_real_estate"`
+	AllocationStocks        int          `json:"allocation_stocks"`
+	AllocationBonds         int          `json:"allocation_bonds"`
+	AllocationGold          int          `json:"allocation_gold"`
+	AllocationCommodities   int          `json:"allocation_commodities"`
+	MonthlyExpenses         moneyJSON    `json:"monthly_expenses"`
+	MonthlyMortgagePayment  moneyJSON    `json:"monthly_mortgage_payment"`
+	WithdrawalRate          rateJSON     `json:"withdrawal_rate"`
+	CoastFIRETargetAge      *int         `json:"coast_fire_target_age"`
+	ExpectedReturnRate      rateJSON     `json:"expected_return_rate"`
+	BaristaMonthlyIncome    *moneyJSON   `json:"barista_monthly_income"`
+	LeanMonthlyExpenses     *moneyJSON   `json:"lean_monthly_expenses"`
+	FatMonthlyExpenses      *moneyJSON   `json:"fat_monthly_expenses"`
+	MonthlySavings          *moneyJSON   `json:"monthly_savings"`
 }
 
 // request is the PUT body. Date arrives as "YYYY-MM-DD" and money as either
 // a JSON number or string — pydantic on the Python side accepts both.
 type request struct {
-	BirthDate               isoDate          `json:"birth_date"`
+	BirthDate               wire.IsoDate     `json:"birth_date"`
 	RetirementAge           int              `json:"retirement_age"`
 	RetirementMonthlySalary decimal.Decimal  `json:"retirement_monthly_salary"`
 	AllocationRealEstate    int              `json:"allocation_real_estate"`
@@ -62,7 +63,7 @@ type request struct {
 func toResponse(c *Config) response {
 	return response{
 		ID:                      c.ID,
-		BirthDate:               isoDate(c.BirthDate),
+		BirthDate:               wire.IsoDate(c.BirthDate),
 		RetirementAge:           c.RetirementAge,
 		RetirementMonthlySalary: moneyJSON(c.RetirementMonthlySalary),
 		AllocationRealEstate:    c.AllocationRealEstate,
@@ -185,30 +186,6 @@ var defaultWithdrawalRate = decimal.RequireFromString("0.04")
 // elsewhere in the app (retirement projection on the settings page). Used
 // when a PUT body omits expected_return_rate.
 var defaultExpectedReturnRate = decimal.RequireFromString("0.07")
-
-// isoDate is a time.Time alias that JSON-marshals as "YYYY-MM-DD" and
-// unmarshals from the same. Matches Python's `date` field on the wire.
-type isoDate time.Time
-
-const isoDateLayout = "2006-01-02"
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	stamp := fmt.Sprintf("%q", time.Time(d).Format(isoDateLayout))
-	return []byte(stamp), nil
-}
-
-func (d *isoDate) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("birth_date must be a YYYY-MM-DD string: %w", err)
-	}
-	t, err := time.Parse(isoDateLayout, s)
-	if err != nil {
-		return fmt.Errorf("birth_date must be YYYY-MM-DD: %w", err)
-	}
-	*d = isoDate(t)
-	return nil
-}
 
 // moneyJSON is a decimal.Decimal that marshals as a JSON string with two
 // decimals — matches Pydantic v2's default Decimal serialization for

--- a/backend-go/internal/config/validation_test.go
+++ b/backend-go/internal/config/validation_test.go
@@ -5,12 +5,14 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 func validRequest() *request {
 	birth := time.Date(1990, 1, 15, 0, 0, 0, 0, time.UTC)
 	return &request{
-		BirthDate:               isoDate(birth),
+		BirthDate:               wire.IsoDate(birth),
 		RetirementAge:           65,
 		RetirementMonthlySalary: decimal.NewFromInt(5000),
 		AllocationRealEstate:    20,
@@ -32,7 +34,7 @@ func TestValidateOK(t *testing.T) {
 
 func TestValidateFutureBirthDate(t *testing.T) {
 	r := validRequest()
-	r.BirthDate = isoDate(time.Now().UTC().AddDate(1, 0, 0))
+	r.BirthDate = wire.IsoDate(time.Now().UTC().AddDate(1, 0, 0))
 	if err := r.validate(); err == nil || err.Field != "birth_date" {
 		t.Fatalf("expected birth_date error, got %+v", err)
 	}
@@ -40,7 +42,7 @@ func TestValidateFutureBirthDate(t *testing.T) {
 
 func TestValidateAgeUnder18(t *testing.T) {
 	r := validRequest()
-	r.BirthDate = isoDate(time.Now().UTC().AddDate(-10, 0, 0))
+	r.BirthDate = wire.IsoDate(time.Now().UTC().AddDate(-10, 0, 0))
 	if err := r.validate(); err == nil || err.Field != "birth_date" {
 		t.Fatalf("expected birth_date error, got %+v", err)
 	}
@@ -48,7 +50,7 @@ func TestValidateAgeUnder18(t *testing.T) {
 
 func TestValidateAgeOver100(t *testing.T) {
 	r := validRequest()
-	r.BirthDate = isoDate(time.Now().UTC().AddDate(-110, 0, 0))
+	r.BirthDate = wire.IsoDate(time.Now().UTC().AddDate(-110, 0, 0))
 	if err := r.validate(); err == nil || err.Field != "birth_date" {
 		t.Fatalf("expected birth_date error, got %+v", err)
 	}
@@ -108,7 +110,7 @@ func TestValidateMarketAllocationDoesNotSumTo100(t *testing.T) {
 func TestValidateRetirementAgeBeforeCurrent(t *testing.T) {
 	r := validRequest()
 	now := time.Now().UTC()
-	r.BirthDate = isoDate(now.AddDate(-50, 0, 0))
+	r.BirthDate = wire.IsoDate(now.AddDate(-50, 0, 0))
 	r.RetirementAge = 30
 	if err := r.validate(); err == nil || err.Field != "retirement_age" {
 		t.Fatalf("expected retirement_age (vs current age) error, got %+v", err)
@@ -177,7 +179,7 @@ func TestValidateCoastFIRETargetAgeOutOfRange(t *testing.T) {
 func TestValidateCoastFIRETargetAgeBeforeCurrent(t *testing.T) {
 	r := validRequest()
 	now := time.Now().UTC()
-	r.BirthDate = isoDate(now.AddDate(-50, 0, 0))
+	r.BirthDate = wire.IsoDate(now.AddDate(-50, 0, 0))
 	r.RetirementAge = 65
 	bad := 30
 	r.CoastFIRETargetAge = &bad

--- a/backend-go/internal/cpi/handler.go
+++ b/backend-go/internal/cpi/handler.go
@@ -7,9 +7,9 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"strconv"
-	"strings"
 	"time"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 // Handler is the HTTP boundary for /api/cpi.
@@ -31,9 +31,9 @@ func NewHandler(store *Store, fetcher *GUSFetcher, logger *slog.Logger) *Handler
 }
 
 type cpiPoint struct {
-	Year            int     `json:"year"`
-	YoYRate         pyFloat `json:"yoy_rate"`
-	CumulativeIndex pyFloat `json:"cumulative_index"`
+	Year            int          `json:"year"`
+	YoYRate         wire.PyFloat `json:"yoy_rate"`
+	CumulativeIndex wire.PyFloat `json:"cumulative_index"`
 }
 
 type seriesResponse struct {
@@ -44,12 +44,12 @@ type seriesResponse struct {
 }
 
 type adjustResponse struct {
-	OriginalAmount pyFloat `json:"original_amount"`
-	AdjustedAmount pyFloat `json:"adjusted_amount"`
-	Factor         pyFloat `json:"factor"`
-	FromDate       isoDate `json:"from_date"`
-	ToDate         isoDate `json:"to_date"`
-	AsOfYear       int     `json:"as_of_year"`
+	OriginalAmount wire.PyFloat `json:"original_amount"`
+	AdjustedAmount wire.PyFloat `json:"adjusted_amount"`
+	Factor         wire.PyFloat `json:"factor"`
+	FromDate       wire.IsoDate `json:"from_date"`
+	ToDate         wire.IsoDate `json:"to_date"`
+	AsOfYear       int          `json:"as_of_year"`
 }
 
 type refreshResponse struct {
@@ -73,8 +73,8 @@ func (h *Handler) GetSeries(w http.ResponseWriter, r *http.Request) {
 		idx, _ := indexMap[y].Float64()
 		points = append(points, cpiPoint{
 			Year:            y,
-			YoYRate:         pyFloat(yoy),
-			CumulativeIndex: pyFloat(idx),
+			YoYRate:         wire.PyFloat(yoy),
+			CumulativeIndex: wire.PyFloat(idx),
 		})
 	}
 	out := seriesResponse{Points: points, Source: GUSSourceTag}
@@ -142,11 +142,11 @@ func (h *Handler) Adjust(w http.ResponseWriter, r *http.Request) {
 		factor = adjusted / amount
 	}
 	writeJSON(w, http.StatusOK, adjustResponse{
-		OriginalAmount: pyFloat(amount),
-		AdjustedAmount: pyFloat(adjusted),
-		Factor:         pyFloat(factor),
-		FromDate:       isoDate(from),
-		ToDate:         isoDate(to),
+		OriginalAmount: wire.PyFloat(amount),
+		AdjustedAmount: wire.PyFloat(adjusted),
+		Factor:         wire.PyFloat(factor),
+		FromDate:       wire.IsoDate(from),
+		ToDate:         wire.IsoDate(to),
 		AsOfYear:       latest,
 	})
 }
@@ -210,37 +210,4 @@ func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *valida
 
 func isNull(v json.RawMessage) bool {
 	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
-}
-
-// --- wire types (copies — promote when shared helper lands) ---
-
-type isoDate time.Time
-
-const isoDateLayout = "2006-01-02"
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
-}
-
-func (d *isoDate) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	t, err := time.Parse(isoDateLayout, s)
-	if err != nil {
-		return err
-	}
-	*d = isoDate(t)
-	return nil
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/dashboard/handler.go
+++ b/backend-go/internal/dashboard/handler.go
@@ -6,9 +6,10 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 // Handler is the HTTP boundary for /api/dashboard.
@@ -126,41 +127,23 @@ func filterTimeSeries(pts []timeSeriesPoint, rng dateRange) []timeSeriesPoint {
 	return out
 }
 
-// --- wire types ---
-
-type isoDate time.Time
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format("2006-01-02") + `"`), nil
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
-}
-
 type netWorthPointWire struct {
-	Date        isoDate `json:"date"`
-	Value       pyFloat `json:"value"`
-	Assets      pyFloat `json:"assets"`
-	Liabilities pyFloat `json:"liabilities"`
-	SnapshotID  int     `json:"snapshot_id"`
+	Date        wire.IsoDate `json:"date"`
+	Value       wire.PyFloat `json:"value"`
+	Assets      wire.PyFloat `json:"assets"`
+	Liabilities wire.PyFloat `json:"liabilities"`
+	SnapshotID  int          `json:"snapshot_id"`
 }
 
 type allocationItemWire struct {
-	Category    string  `json:"category"`
-	OwnerUserID *int    `json:"owner_user_id"`
-	Value       pyFloat `json:"value"`
+	Category    string       `json:"category"`
+	OwnerUserID *int         `json:"owner_user_id"`
+	Value       wire.PyFloat `json:"value"`
 }
 
 type deltaValueWire struct {
-	Absolute   pyFloat  `json:"absolute"`
-	Percentage *pyFloat `json:"percentage"`
+	Absolute   wire.PyFloat  `json:"absolute"`
+	Percentage *wire.PyFloat `json:"percentage"`
 }
 
 type tileDeltaWire struct {
@@ -175,80 +158,80 @@ type tileDeltasWire struct {
 }
 
 type metricCardsWire struct {
-	PropertySQM             pyFloat  `json:"property_sqm"`
-	EmergencyFundMonths     pyFloat  `json:"emergency_fund_months"`
-	RetirementIncomeMonthly pyFloat  `json:"retirement_income_monthly"`
-	MortgageRemaining       pyFloat  `json:"mortgage_remaining"`
-	MortgageMonthsLeft      int      `json:"mortgage_months_left"`
-	MortgageYearsLeft       pyFloat  `json:"mortgage_years_left"`
-	RetirementTotal         pyFloat  `json:"retirement_total"`
-	InvestmentContributions pyFloat  `json:"investment_contributions"`
-	InvestmentReturns       pyFloat  `json:"investment_returns"`
-	SavingsRate             *pyFloat `json:"savings_rate"`
-	DebtToIncomeRatio       *pyFloat `json:"debt_to_income_ratio"`
-	HourOfWorkCost          *pyFloat `json:"hour_of_work_cost"`
-	HourOfLifeCost          *pyFloat `json:"hour_of_life_cost"`
-	FIRENumber              *pyFloat `json:"fire_number"`
-	FIProgress              *pyFloat `json:"fi_progress"`
-	RunwayMonths            *pyFloat `json:"runway_months"`
-	AnnualExpenses          *pyFloat `json:"annual_expenses"`
-	WithdrawalRate          *pyFloat `json:"withdrawal_rate"`
-	CoastFIRENumber         *pyFloat `json:"coast_fire_number"`
-	CoastFIREGap            *pyFloat `json:"coast_fire_gap"`
-	CoastFIRETargetAge      *int     `json:"coast_fire_target_age"`
-	ExpectedReturnRate      *pyFloat `json:"expected_return_rate"`
-	BaristaMonthlyIncome    *pyFloat `json:"barista_monthly_income"`
-	BaristaAnnualGap        *pyFloat `json:"barista_annual_gap"`
-	BaristaFIRENumber       *pyFloat `json:"barista_fire_number"`
-	BaristaFIProgress       *pyFloat `json:"barista_fi_progress"`
-	BaristaYearsToFI        *pyFloat `json:"barista_years_to_fi"`
-	BridgeYears             *int     `json:"bridge_years"`
-	BridgeCapitalNeeded     *pyFloat `json:"bridge_capital_needed"`
-	BridgeLiquidCapital     *pyFloat `json:"bridge_liquid_capital"`
-	BridgeCapitalGap        *pyFloat `json:"bridge_capital_gap"`
-	LeanFIRENumber          *pyFloat `json:"lean_fire_number"`
-	LeanFIProgress          *pyFloat `json:"lean_fi_progress"`
-	FatFIRENumber           *pyFloat `json:"fat_fire_number"`
-	FatFIProgress           *pyFloat `json:"fat_fi_progress"`
-	MonthlySavings          *pyFloat `json:"monthly_savings"`
-	FIYearsRemaining        *pyFloat `json:"fi_years_remaining"`
-	FIProjectedDate         *string  `json:"fi_projected_date"`
-	FireNetWorth            *pyFloat `json:"fire_net_worth"`
-	FireExcludedValue       *pyFloat `json:"fire_excluded_value"`
+	PropertySQM             wire.PyFloat  `json:"property_sqm"`
+	EmergencyFundMonths     wire.PyFloat  `json:"emergency_fund_months"`
+	RetirementIncomeMonthly wire.PyFloat  `json:"retirement_income_monthly"`
+	MortgageRemaining       wire.PyFloat  `json:"mortgage_remaining"`
+	MortgageMonthsLeft      int           `json:"mortgage_months_left"`
+	MortgageYearsLeft       wire.PyFloat  `json:"mortgage_years_left"`
+	RetirementTotal         wire.PyFloat  `json:"retirement_total"`
+	InvestmentContributions wire.PyFloat  `json:"investment_contributions"`
+	InvestmentReturns       wire.PyFloat  `json:"investment_returns"`
+	SavingsRate             *wire.PyFloat `json:"savings_rate"`
+	DebtToIncomeRatio       *wire.PyFloat `json:"debt_to_income_ratio"`
+	HourOfWorkCost          *wire.PyFloat `json:"hour_of_work_cost"`
+	HourOfLifeCost          *wire.PyFloat `json:"hour_of_life_cost"`
+	FIRENumber              *wire.PyFloat `json:"fire_number"`
+	FIProgress              *wire.PyFloat `json:"fi_progress"`
+	RunwayMonths            *wire.PyFloat `json:"runway_months"`
+	AnnualExpenses          *wire.PyFloat `json:"annual_expenses"`
+	WithdrawalRate          *wire.PyFloat `json:"withdrawal_rate"`
+	CoastFIRENumber         *wire.PyFloat `json:"coast_fire_number"`
+	CoastFIREGap            *wire.PyFloat `json:"coast_fire_gap"`
+	CoastFIRETargetAge      *int          `json:"coast_fire_target_age"`
+	ExpectedReturnRate      *wire.PyFloat `json:"expected_return_rate"`
+	BaristaMonthlyIncome    *wire.PyFloat `json:"barista_monthly_income"`
+	BaristaAnnualGap        *wire.PyFloat `json:"barista_annual_gap"`
+	BaristaFIRENumber       *wire.PyFloat `json:"barista_fire_number"`
+	BaristaFIProgress       *wire.PyFloat `json:"barista_fi_progress"`
+	BaristaYearsToFI        *wire.PyFloat `json:"barista_years_to_fi"`
+	BridgeYears             *int          `json:"bridge_years"`
+	BridgeCapitalNeeded     *wire.PyFloat `json:"bridge_capital_needed"`
+	BridgeLiquidCapital     *wire.PyFloat `json:"bridge_liquid_capital"`
+	BridgeCapitalGap        *wire.PyFloat `json:"bridge_capital_gap"`
+	LeanFIRENumber          *wire.PyFloat `json:"lean_fire_number"`
+	LeanFIProgress          *wire.PyFloat `json:"lean_fi_progress"`
+	FatFIRENumber           *wire.PyFloat `json:"fat_fire_number"`
+	FatFIProgress           *wire.PyFloat `json:"fat_fi_progress"`
+	MonthlySavings          *wire.PyFloat `json:"monthly_savings"`
+	FIYearsRemaining        *wire.PyFloat `json:"fi_years_remaining"`
+	FIProjectedDate         *string       `json:"fi_projected_date"`
+	FireNetWorth            *wire.PyFloat `json:"fire_net_worth"`
+	FireExcludedValue       *wire.PyFloat `json:"fire_excluded_value"`
 }
 
 type allocationBreakdownWire struct {
-	Category          string  `json:"category"`
-	CurrentValue      pyFloat `json:"current_value"`
-	CurrentPercentage pyFloat `json:"current_percentage"`
-	TargetPercentage  pyFloat `json:"target_percentage"`
-	Difference        pyFloat `json:"difference"`
+	Category          string       `json:"category"`
+	CurrentValue      wire.PyFloat `json:"current_value"`
+	CurrentPercentage wire.PyFloat `json:"current_percentage"`
+	TargetPercentage  wire.PyFloat `json:"target_percentage"`
+	Difference        wire.PyFloat `json:"difference"`
 }
 
 type wrapperBreakdownWire struct {
-	Wrapper    string  `json:"wrapper"`
-	Value      pyFloat `json:"value"`
-	Percentage pyFloat `json:"percentage"`
+	Wrapper    string       `json:"wrapper"`
+	Value      wire.PyFloat `json:"value"`
+	Percentage wire.PyFloat `json:"percentage"`
 }
 
 type rebalancingWire struct {
-	Category string  `json:"category"`
-	Action   string  `json:"action"`
-	Amount   pyFloat `json:"amount"`
+	Category string       `json:"category"`
+	Action   string       `json:"action"`
+	Amount   wire.PyFloat `json:"amount"`
 }
 
 type allocationAnalysisWire struct {
 	ByCategory           []allocationBreakdownWire `json:"by_category"`
 	ByWrapper            []wrapperBreakdownWire    `json:"by_wrapper"`
 	Rebalancing          []rebalancingWire         `json:"rebalancing"`
-	TotalInvestmentValue pyFloat                   `json:"total_investment_value"`
+	TotalInvestmentValue wire.PyFloat              `json:"total_investment_value"`
 }
 
 type timeSeriesPointWire struct {
-	Date          isoDate `json:"date"`
-	Value         pyFloat `json:"value"`
-	Contributions pyFloat `json:"contributions"`
-	Returns       pyFloat `json:"returns"`
+	Date          wire.IsoDate `json:"date"`
+	Value         wire.PyFloat `json:"value"`
+	Contributions wire.PyFloat `json:"contributions"`
+	Returns       wire.PyFloat `json:"returns"`
 }
 
 type wrapperTimeSeriesWire struct {
@@ -264,12 +247,12 @@ type categoryTimeSeriesWire struct {
 
 type dashboardWire struct {
 	NetWorthHistory        []netWorthPointWire    `json:"net_worth_history"`
-	CurrentNetWorth        pyFloat                `json:"current_net_worth"`
-	ChangeVsLastMonth      pyFloat                `json:"change_vs_last_month"`
-	TotalAssets            pyFloat                `json:"total_assets"`
-	TotalLiabilities       pyFloat                `json:"total_liabilities"`
+	CurrentNetWorth        wire.PyFloat           `json:"current_net_worth"`
+	ChangeVsLastMonth      wire.PyFloat           `json:"change_vs_last_month"`
+	TotalAssets            wire.PyFloat           `json:"total_assets"`
+	TotalLiabilities       wire.PyFloat           `json:"total_liabilities"`
 	Allocation             []allocationItemWire   `json:"allocation"`
-	RetirementAccountValue pyFloat                `json:"retirement_account_value"`
+	RetirementAccountValue wire.PyFloat           `json:"retirement_account_value"`
 	MetricCards            metricCardsWire        `json:"metric_cards"`
 	AllocationAnalysis     allocationAnalysisWire `json:"allocation_analysis"`
 	InvestmentTimeSeries   []timeSeriesPointWire  `json:"investment_time_series"`
@@ -280,11 +263,11 @@ type dashboardWire struct {
 
 func toWire(res result) dashboardWire {
 	w := dashboardWire{
-		CurrentNetWorth:        pyFloat(res.CurrentNetWorth),
-		ChangeVsLastMonth:      pyFloat(res.ChangeVsLastMonth),
-		TotalAssets:            pyFloat(res.TotalAssets),
-		TotalLiabilities:       pyFloat(res.TotalLiabilities),
-		RetirementAccountValue: pyFloat(res.RetirementAccountValue),
+		CurrentNetWorth:        wire.PyFloat(res.CurrentNetWorth),
+		ChangeVsLastMonth:      wire.PyFloat(res.ChangeVsLastMonth),
+		TotalAssets:            wire.PyFloat(res.TotalAssets),
+		TotalLiabilities:       wire.PyFloat(res.TotalLiabilities),
+		RetirementAccountValue: wire.PyFloat(res.RetirementAccountValue),
 		MetricCards:            metricCardsToWire(res.MetricCards),
 		AllocationAnalysis:     allocationAnalysisToWire(res.AllocationAnalysis),
 		TileDeltas:             tileDeltasToWire(res.TileDeltas),
@@ -292,17 +275,17 @@ func toWire(res result) dashboardWire {
 	w.NetWorthHistory = make([]netWorthPointWire, 0, len(res.NetWorthHistory))
 	for _, p := range res.NetWorthHistory {
 		w.NetWorthHistory = append(w.NetWorthHistory, netWorthPointWire{
-			Date:        isoDate(p.Date),
-			Value:       pyFloat(p.Value),
-			Assets:      pyFloat(p.Assets),
-			Liabilities: pyFloat(p.Liabilities),
+			Date:        wire.IsoDate(p.Date),
+			Value:       wire.PyFloat(p.Value),
+			Assets:      wire.PyFloat(p.Assets),
+			Liabilities: wire.PyFloat(p.Liabilities),
 			SnapshotID:  p.SnapshotID,
 		})
 	}
 	w.Allocation = make([]allocationItemWire, 0, len(res.Allocation))
 	for _, a := range res.Allocation {
 		w.Allocation = append(w.Allocation, allocationItemWire{
-			Category: a.Category, OwnerUserID: a.OwnerUserID, Value: pyFloat(a.Value),
+			Category: a.Category, OwnerUserID: a.OwnerUserID, Value: wire.PyFloat(a.Value),
 		})
 	}
 	w.InvestmentTimeSeries = seriesToWire(res.InvestmentTimeSeries)
@@ -322,10 +305,10 @@ func seriesToWire(pts []timeSeriesPoint) []timeSeriesPointWire {
 	out := make([]timeSeriesPointWire, 0, len(pts))
 	for _, p := range pts {
 		out = append(out, timeSeriesPointWire{
-			Date:          isoDate(p.Date),
-			Value:         pyFloat(p.Value),
-			Contributions: pyFloat(p.Contributions),
-			Returns:       pyFloat(p.Returns),
+			Date:          wire.IsoDate(p.Date),
+			Value:         wire.PyFloat(p.Value),
+			Contributions: wire.PyFloat(p.Contributions),
+			Returns:       wire.PyFloat(p.Returns),
 		})
 	}
 	return out
@@ -333,15 +316,15 @@ func seriesToWire(pts []timeSeriesPoint) []timeSeriesPointWire {
 
 func metricCardsToWire(m metricCards) metricCardsWire {
 	return metricCardsWire{
-		PropertySQM:             pyFloat(m.PropertySQM),
-		EmergencyFundMonths:     pyFloat(m.EmergencyFundMonths),
-		RetirementIncomeMonthly: pyFloat(m.RetirementIncomeMonthly),
-		MortgageRemaining:       pyFloat(m.MortgageRemaining),
+		PropertySQM:             wire.PyFloat(m.PropertySQM),
+		EmergencyFundMonths:     wire.PyFloat(m.EmergencyFundMonths),
+		RetirementIncomeMonthly: wire.PyFloat(m.RetirementIncomeMonthly),
+		MortgageRemaining:       wire.PyFloat(m.MortgageRemaining),
 		MortgageMonthsLeft:      m.MortgageMonthsLeft,
-		MortgageYearsLeft:       pyFloat(m.MortgageYearsLeft),
-		RetirementTotal:         pyFloat(m.RetirementTotal),
-		InvestmentContributions: pyFloat(m.InvestmentContributions),
-		InvestmentReturns:       pyFloat(m.InvestmentReturns),
+		MortgageYearsLeft:       wire.PyFloat(m.MortgageYearsLeft),
+		RetirementTotal:         wire.PyFloat(m.RetirementTotal),
+		InvestmentContributions: wire.PyFloat(m.InvestmentContributions),
+		InvestmentReturns:       wire.PyFloat(m.InvestmentReturns),
 		SavingsRate:             floatPtr(m.SavingsRate),
 		DebtToIncomeRatio:       floatPtr(m.DebtToIncomeRatio),
 		HourOfWorkCost:          floatPtr(m.HourOfWorkCost),
@@ -378,7 +361,7 @@ func metricCardsToWire(m metricCards) metricCardsWire {
 
 func allocationAnalysisToWire(a allocationAnalysis) allocationAnalysisWire {
 	w := allocationAnalysisWire{
-		TotalInvestmentValue: pyFloat(a.TotalInvestmentValue),
+		TotalInvestmentValue: wire.PyFloat(a.TotalInvestmentValue),
 		ByCategory:           make([]allocationBreakdownWire, 0, len(a.ByCategory)),
 		ByWrapper:            make([]wrapperBreakdownWire, 0, len(a.ByWrapper)),
 		Rebalancing:          make([]rebalancingWire, 0, len(a.Rebalancing)),
@@ -386,20 +369,20 @@ func allocationAnalysisToWire(a allocationAnalysis) allocationAnalysisWire {
 	for _, b := range a.ByCategory {
 		w.ByCategory = append(w.ByCategory, allocationBreakdownWire{
 			Category:          b.Category,
-			CurrentValue:      pyFloat(b.CurrentValue),
-			CurrentPercentage: pyFloat(b.CurrentPercentage),
-			TargetPercentage:  pyFloat(b.TargetPercentage),
-			Difference:        pyFloat(b.Difference),
+			CurrentValue:      wire.PyFloat(b.CurrentValue),
+			CurrentPercentage: wire.PyFloat(b.CurrentPercentage),
+			TargetPercentage:  wire.PyFloat(b.TargetPercentage),
+			Difference:        wire.PyFloat(b.Difference),
 		})
 	}
 	for _, b := range a.ByWrapper {
 		w.ByWrapper = append(w.ByWrapper, wrapperBreakdownWire{
-			Wrapper: b.Wrapper, Value: pyFloat(b.Value), Percentage: pyFloat(b.Percentage),
+			Wrapper: b.Wrapper, Value: wire.PyFloat(b.Value), Percentage: wire.PyFloat(b.Percentage),
 		})
 	}
 	for _, b := range a.Rebalancing {
 		w.Rebalancing = append(w.Rebalancing, rebalancingWire{
-			Category: b.Category, Action: b.Action, Amount: pyFloat(b.Amount),
+			Category: b.Category, Action: b.Action, Amount: wire.PyFloat(b.Amount),
 		})
 	}
 	return w
@@ -421,13 +404,13 @@ func deltaToWire(d *deltaValue) *deltaValueWire {
 	if d == nil {
 		return nil
 	}
-	return &deltaValueWire{Absolute: pyFloat(d.Absolute), Percentage: floatPtr(d.Percentage)}
+	return &deltaValueWire{Absolute: wire.PyFloat(d.Absolute), Percentage: floatPtr(d.Percentage)}
 }
 
-func floatPtr(f *float64) *pyFloat {
+func floatPtr(f *float64) *wire.PyFloat {
 	if f == nil {
 		return nil
 	}
-	pf := pyFloat(*f)
+	pf := wire.PyFloat(*f)
 	return &pf
 }

--- a/backend-go/internal/debt_payments/handler.go
+++ b/backend-go/internal/debt_payments/handler.go
@@ -9,27 +9,28 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 type response struct {
-	ID          int      `json:"id"`
-	AccountID   int      `json:"account_id"`
-	AccountName string   `json:"account_name"`
-	Amount      pyFloat  `json:"amount"`
-	Date        isoDate  `json:"date"`
-	OwnerUserID *int     `json:"owner_user_id"`
-	CreatedAt   isoNaive `json:"created_at"`
+	ID          int           `json:"id"`
+	AccountID   int           `json:"account_id"`
+	AccountName string        `json:"account_name"`
+	Amount      wire.PyFloat  `json:"amount"`
+	Date        wire.IsoDate  `json:"date"`
+	OwnerUserID *int          `json:"owner_user_id"`
+	CreatedAt   wire.IsoNaive `json:"created_at"`
 }
 
 type listResponse struct {
-	Payments     []response `json:"payments"`
-	TotalPaid    pyFloat    `json:"total_paid"`
-	PaymentCount int        `json:"payment_count"`
+	Payments     []response   `json:"payments"`
+	TotalPaid    wire.PyFloat `json:"total_paid"`
+	PaymentCount int          `json:"payment_count"`
 }
 
 // Handler is the HTTP boundary.
@@ -50,8 +51,8 @@ func toResponse(p DebtPayment, name string) response {
 	amt, _ := p.Amount.Float64()
 	return response{
 		ID: p.ID, AccountID: p.AccountID, AccountName: name,
-		Amount: pyFloat(amt), Date: isoDate(p.Date), OwnerUserID: p.OwnerUserID,
-		CreatedAt: isoNaive(p.CreatedAt.UTC()),
+		Amount: wire.PyFloat(amt), Date: wire.IsoDate(p.Date), OwnerUserID: p.OwnerUserID,
+		CreatedAt: wire.IsoNaive(p.CreatedAt.UTC()),
 	}
 }
 
@@ -84,7 +85,7 @@ func (h *Handler) ListForAccount(w http.ResponseWriter, r *http.Request) {
 	}
 	out.PaymentCount = len(out.Payments)
 	f, _ := total.Float64()
-	out.TotalPaid = pyFloat(f)
+	out.TotalPaid = wire.PyFloat(f)
 	writeJSON(w, http.StatusOK, out)
 }
 
@@ -138,7 +139,7 @@ func (h *Handler) ListAll(w http.ResponseWriter, r *http.Request) {
 	}
 	out.PaymentCount = len(out.Payments)
 	f64, _ := total.Float64()
-	out.TotalPaid = pyFloat(f64)
+	out.TotalPaid = wire.PyFloat(f64)
 	writeJSON(w, http.StatusOK, out)
 }
 
@@ -341,27 +342,4 @@ func requireAmount(raw map[string]json.RawMessage) (decimal.Decimal, *validation
 
 func isNull(v json.RawMessage) bool {
 	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
-}
-
-// wire types
-type isoDate time.Time
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format("2006-01-02") + `"`), nil
-}
-
-type isoNaive time.Time
-
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/debt_payments/handler_test.go
+++ b/backend-go/internal/debt_payments/handler_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 func dec(s string) decimal.Decimal { return decimal.RequireFromString(s) }
@@ -225,7 +227,7 @@ func TestToResponse(t *testing.T) {
 }
 
 func TestIsoDateMarshal(t *testing.T) {
-	d := isoDate(time.Date(2025, 1, 5, 14, 30, 0, 0, time.UTC))
+	d := wire.IsoDate(time.Date(2025, 1, 5, 14, 30, 0, 0, time.UTC))
 	got, err := json.Marshal(d)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -240,7 +242,7 @@ func TestIsoNaiveMarshalStripsTimezone(t *testing.T) {
 	// container's zoneinfo/tzdata availability.
 	loc := time.FixedZone("CET", 3600)
 	tz := time.Date(2025, 1, 5, 14, 30, 0, 0, loc)
-	got, err := json.Marshal(isoNaive(tz))
+	got, err := json.Marshal(wire.IsoNaive(tz))
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -258,7 +260,7 @@ func TestIsoNaiveMarshalStripsTimezone(t *testing.T) {
 
 func TestPyFloatMarshal(t *testing.T) {
 	cases := []struct {
-		in   pyFloat
+		in   wire.PyFloat
 		want string
 	}{
 		{0, "0.0"},

--- a/backend-go/internal/debts/compute.go
+++ b/backend-go/internal/debts/compute.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 // debtTypeToCategory maps a debt_type to the liability account category
@@ -57,19 +59,19 @@ func toResponse(d Debt, a AccountInfo, m debtMetrics) response {
 	ip, _ := interestPaid.Float64()
 	out := response{
 		ID: d.ID, AccountID: d.AccountID, AccountName: a.Name, AccountOwnerUserID: a.OwnerUserID,
-		Name: d.Name, DebtType: d.DebtType, StartDate: isoDate(d.StartDate),
-		InitialAmount: pyFloat(initial), InterestRate: pyFloat(rate),
+		Name: d.Name, DebtType: d.DebtType, StartDate: wire.IsoDate(d.StartDate),
+		InitialAmount: wire.PyFloat(initial), InterestRate: wire.PyFloat(rate),
 		Currency: d.Currency, Notes: d.Notes, IsActive: d.IsActive,
-		CreatedAt: isoNaive(d.CreatedAt.UTC()),
-		TotalPaid: pyFloat(totalPaid), InterestPaid: pyFloat(ip),
+		CreatedAt: wire.IsoNaive(d.CreatedAt.UTC()),
+		TotalPaid: wire.PyFloat(totalPaid), InterestPaid: wire.PyFloat(ip),
 	}
 	if m.latestBalance != nil {
 		f, _ := m.latestBalance.Float64()
-		pf := pyFloat(f)
+		pf := wire.PyFloat(f)
 		out.LatestBalance = &pf
 	}
 	if m.latestBalanceDate != nil {
-		d := isoDate(*m.latestBalanceDate)
+		d := wire.IsoDate(*m.latestBalanceDate)
 		out.LatestBalanceDate = &d
 	}
 	return out

--- a/backend-go/internal/debts/compute_test.go
+++ b/backend-go/internal/debts/compute_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 func dec(s string) decimal.Decimal { return decimal.RequireFromString(s) }
@@ -130,14 +132,14 @@ func TestToResponse_PopulatesBalancePointersAndInterest(t *testing.T) {
 }
 
 func TestPyFloatMarshalsIntegerWithTrailingZero(t *testing.T) {
-	got, _ := json.Marshal(pyFloat(100))
+	got, _ := json.Marshal(wire.PyFloat(100))
 	if string(got) != "100.0" {
 		t.Errorf("want 100.0, got %s", got)
 	}
 }
 
 func TestIsoDateMarshal(t *testing.T) {
-	got, _ := json.Marshal(isoDate(time.Date(2025, 6, 1, 14, 0, 0, 0, time.UTC)))
+	got, _ := json.Marshal(wire.IsoDate(time.Date(2025, 6, 1, 14, 0, 0, 0, time.UTC)))
 	if string(got) != `"2025-06-01"` {
 		t.Errorf("want \"2025-06-01\", got %s", got)
 	}
@@ -145,7 +147,7 @@ func TestIsoDateMarshal(t *testing.T) {
 
 func TestIsoNaiveMarshalStripsTimezone(t *testing.T) {
 	loc := time.FixedZone("CET", 3600)
-	got, _ := json.Marshal(isoNaive(time.Date(2025, 1, 5, 14, 30, 0, 0, loc)))
+	got, _ := json.Marshal(wire.IsoNaive(time.Date(2025, 1, 5, 14, 30, 0, 0, loc)))
 	body := strings.TrimSuffix(strings.TrimPrefix(string(got), `"`), `"`)
 	timePart := body[strings.Index(body, "T")+1:]
 	if strings.ContainsAny(timePart, "Z+-") {

--- a/backend-go/internal/debts/handler.go
+++ b/backend-go/internal/debts/handler.go
@@ -9,38 +9,38 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
-	"strings"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 type response struct {
-	ID                 int      `json:"id"`
-	AccountID          int      `json:"account_id"`
-	AccountName        string   `json:"account_name"`
-	AccountOwnerUserID *int     `json:"account_owner_user_id"`
-	Name               string   `json:"name"`
-	DebtType           string   `json:"debt_type"`
-	StartDate          isoDate  `json:"start_date"`
-	InitialAmount      pyFloat  `json:"initial_amount"`
-	InterestRate       pyFloat  `json:"interest_rate"`
-	Currency           string   `json:"currency"`
-	Notes              *string  `json:"notes"`
-	IsActive           bool     `json:"is_active"`
-	CreatedAt          isoNaive `json:"created_at"`
-	LatestBalance      *pyFloat `json:"latest_balance"`
-	LatestBalanceDate  *isoDate `json:"latest_balance_date"`
-	TotalPaid          pyFloat  `json:"total_paid"`
-	InterestPaid       pyFloat  `json:"interest_paid"`
+	ID                 int           `json:"id"`
+	AccountID          int           `json:"account_id"`
+	AccountName        string        `json:"account_name"`
+	AccountOwnerUserID *int          `json:"account_owner_user_id"`
+	Name               string        `json:"name"`
+	DebtType           string        `json:"debt_type"`
+	StartDate          wire.IsoDate  `json:"start_date"`
+	InitialAmount      wire.PyFloat  `json:"initial_amount"`
+	InterestRate       wire.PyFloat  `json:"interest_rate"`
+	Currency           string        `json:"currency"`
+	Notes              *string       `json:"notes"`
+	IsActive           bool          `json:"is_active"`
+	CreatedAt          wire.IsoNaive `json:"created_at"`
+	LatestBalance      *wire.PyFloat `json:"latest_balance"`
+	LatestBalanceDate  *wire.IsoDate `json:"latest_balance_date"`
+	TotalPaid          wire.PyFloat  `json:"total_paid"`
+	InterestPaid       wire.PyFloat  `json:"interest_paid"`
 }
 
 type listResponse struct {
-	Debts              []response `json:"debts"`
-	TotalCount         int        `json:"total_count"`
-	TotalInitialAmount pyFloat    `json:"total_initial_amount"`
-	ActiveDebtsCount   int        `json:"active_debts_count"`
+	Debts              []response   `json:"debts"`
+	TotalCount         int          `json:"total_count"`
+	TotalInitialAmount wire.PyFloat `json:"total_initial_amount"`
+	ActiveDebtsCount   int          `json:"active_debts_count"`
 }
 
 // Handler is the HTTP boundary.
@@ -106,7 +106,7 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 	out.TotalCount = len(out.Debts)
 	out.ActiveDebtsCount = len(out.Debts)
 	f64, _ := totalInitial.Float64()
-	out.TotalInitialAmount = pyFloat(f64)
+	out.TotalInitialAmount = wire.PyFloat(f64)
 	writeJSON(w, http.StatusOK, out)
 }
 
@@ -327,27 +327,4 @@ func parseIDParam(w http.ResponseWriter, r *http.Request, urlKey, errField strin
 		return 0, false
 	}
 	return id, true
-}
-
-// wire types
-type isoDate time.Time
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format("2006-01-02") + `"`), nil
-}
-
-type isoNaive time.Time
-
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/equity_grants/handler.go
+++ b/backend-go/internal/equity_grants/handler.go
@@ -18,6 +18,7 @@ import (
 
 	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
 	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 var (
@@ -38,38 +39,38 @@ var (
 // response mirrors backend/app/schemas/equity_grants.EquityGrantResponse.
 type response struct {
 	ID                     int                   `json:"id"`
-	GrantDate              isoDate               `json:"grant_date"`
+	GrantDate              wire.IsoDate          `json:"grant_date"`
 	Type                   string                `json:"type"`
 	Company                string                `json:"company"`
 	OwnerUserID            *int                  `json:"owner_user_id"`
 	TotalShares            int                   `json:"total_shares"`
-	StrikePrice            *pyFloat              `json:"strike_price"`
+	StrikePrice            *wire.PyFloat         `json:"strike_price"`
 	Currency               string                `json:"currency"`
-	VestStartDate          isoDate               `json:"vest_start_date"`
+	VestStartDate          wire.IsoDate          `json:"vest_start_date"`
 	VestCliffMonths        int                   `json:"vest_cliff_months"`
 	VestTotalMonths        int                   `json:"vest_total_months"`
 	VestFrequency          string                `json:"vest_frequency"`
 	VestCustomSchedule     []CustomScheduleEntry `json:"vest_custom_schedule"`
 	RequiresLiquidityEvent bool                  `json:"requires_liquidity_event"`
-	LiquidityEventDate     *isoDate              `json:"liquidity_event_date"`
+	LiquidityEventDate     *wire.IsoDate         `json:"liquidity_event_date"`
 	TaxTreatment           string                `json:"tax_treatment"`
 	Notes                  *string               `json:"notes"`
 	IsActive               bool                  `json:"is_active"`
-	CreatedAt              isoNaive              `json:"created_at"`
+	CreatedAt              wire.IsoNaive         `json:"created_at"`
 
 	// Computed
-	VestedSharesToday  int      `json:"vested_shares_today"`
-	VestingProgressPct pyFloat  `json:"vesting_progress_pct"`
-	PaperValueBase     *pyFloat `json:"paper_value_base"`
-	PaperValueLow      *pyFloat `json:"paper_value_low"`
-	PaperValueHigh     *pyFloat `json:"paper_value_high"`
-	PaperValueCurrency *string  `json:"paper_value_currency"`
-	PaperValueBasePLN  *pyFloat `json:"paper_value_base_pln"`
-	PaperValueLowPLN   *pyFloat `json:"paper_value_low_pln"`
-	PaperValueHighPLN  *pyFloat `json:"paper_value_high_pln"`
-	FXRate             *pyFloat `json:"fx_rate"`
-	ValuationDate      *isoDate `json:"valuation_date"`
-	ValuationSource    *string  `json:"valuation_source"`
+	VestedSharesToday  int           `json:"vested_shares_today"`
+	VestingProgressPct wire.PyFloat  `json:"vesting_progress_pct"`
+	PaperValueBase     *wire.PyFloat `json:"paper_value_base"`
+	PaperValueLow      *wire.PyFloat `json:"paper_value_low"`
+	PaperValueHigh     *wire.PyFloat `json:"paper_value_high"`
+	PaperValueCurrency *string       `json:"paper_value_currency"`
+	PaperValueBasePLN  *wire.PyFloat `json:"paper_value_base_pln"`
+	PaperValueLowPLN   *wire.PyFloat `json:"paper_value_low_pln"`
+	PaperValueHighPLN  *wire.PyFloat `json:"paper_value_high_pln"`
+	FXRate             *wire.PyFloat `json:"fx_rate"`
+	ValuationDate      *wire.IsoDate `json:"valuation_date"`
+	ValuationSource    *string       `json:"valuation_source"`
 }
 
 type listResponse struct {
@@ -136,13 +137,13 @@ func (h *Handler) toResponse(ctx context.Context, g *EquityGrant) (response, err
 
 	out := response{
 		ID:                     g.ID,
-		GrantDate:              isoDate(g.GrantDate),
+		GrantDate:              wire.IsoDate(g.GrantDate),
 		Type:                   g.Type,
 		Company:                g.Company,
 		OwnerUserID:            g.OwnerUserID,
 		TotalShares:            g.TotalShares,
 		Currency:               g.Currency,
-		VestStartDate:          isoDate(g.VestStartDate),
+		VestStartDate:          wire.IsoDate(g.VestStartDate),
 		VestCliffMonths:        g.VestCliffMonths,
 		VestTotalMonths:        g.VestTotalMonths,
 		VestFrequency:          g.VestFrequency,
@@ -151,17 +152,17 @@ func (h *Handler) toResponse(ctx context.Context, g *EquityGrant) (response, err
 		TaxTreatment:           g.TaxTreatment,
 		Notes:                  g.Notes,
 		IsActive:               g.IsActive,
-		CreatedAt:              isoNaive(g.CreatedAt.UTC()),
+		CreatedAt:              wire.IsoNaive(g.CreatedAt.UTC()),
 		VestedSharesToday:      vested,
-		VestingProgressPct:     pyFloat(progress),
+		VestingProgressPct:     wire.PyFloat(progress),
 	}
 	if g.StrikePrice != nil {
 		f, _ := g.StrikePrice.Float64()
-		pf := pyFloat(f)
+		pf := wire.PyFloat(f)
 		out.StrikePrice = &pf
 	}
 	if g.LiquidityEventDate != nil {
-		d := isoDate(*g.LiquidityEventDate)
+		d := wire.IsoDate(*g.LiquidityEventDate)
 		out.LiquidityEventDate = &d
 	}
 	attachPaperValues(&out, paper)
@@ -172,17 +173,17 @@ func (h *Handler) toResponse(ctx context.Context, g *EquityGrant) (response, err
 func attachPaperValues(out *response, paper paperValueResult) {
 	if paper.Base != nil {
 		f, _ := paper.Base.Float64()
-		pf := pyFloat(f)
+		pf := wire.PyFloat(f)
 		out.PaperValueBase = &pf
 	}
 	if paper.Low != nil {
 		f, _ := paper.Low.Float64()
-		pf := pyFloat(f)
+		pf := wire.PyFloat(f)
 		out.PaperValueLow = &pf
 	}
 	if paper.High != nil {
 		f, _ := paper.High.Float64()
-		pf := pyFloat(f)
+		pf := wire.PyFloat(f)
 		out.PaperValueHigh = &pf
 	}
 	if paper.Currency != "" {
@@ -190,7 +191,7 @@ func attachPaperValues(out *response, paper paperValueResult) {
 		out.PaperValueCurrency = &c
 	}
 	if paper.ValuationDate != nil {
-		d := isoDate(*paper.ValuationDate)
+		d := wire.IsoDate(*paper.ValuationDate)
 		out.ValuationDate = &d
 	}
 	if paper.ValuationSource != "" {
@@ -205,7 +206,7 @@ func attachFX(out *response, rate fx.Result, currency string, paper paperValueRe
 	}
 	if rate.Found {
 		f, _ := rate.Rate.Float64()
-		pf := pyFloat(f)
+		pf := wire.PyFloat(f)
 		out.FXRate = &pf
 	}
 	out.PaperValueBasePLN = pln(paper.Base, currency, rate)
@@ -213,13 +214,13 @@ func attachFX(out *response, rate fx.Result, currency string, paper paperValueRe
 	out.PaperValueHighPLN = pln(paper.High, currency, rate)
 }
 
-func pln(amount *decimal.Decimal, currency string, rate fx.Result) *pyFloat {
+func pln(amount *decimal.Decimal, currency string, rate fx.Result) *wire.PyFloat {
 	v, ok := fx.ToPLN(amount, currency, rate)
 	if !ok {
 		return nil
 	}
 	f, _ := v.Float64()
-	pf := pyFloat(f)
+	pf := wire.PyFloat(f)
 	return &pf
 }
 
@@ -368,43 +369,4 @@ func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
 		return 0, false
 	}
 	return id, true
-}
-
-// --- shared wire types ---
-
-type isoDate time.Time
-
-const isoDateLayout = "2006-01-02"
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
-}
-
-func (d *isoDate) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("date must be a string: %w", err)
-	}
-	t, err := time.Parse(isoDateLayout, s)
-	if err != nil {
-		return fmt.Errorf("date must be YYYY-MM-DD: %w", err)
-	}
-	*d = isoDate(t)
-	return nil
-}
-
-type isoNaive time.Time
-
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/goals/handler.go
+++ b/backend-go/internal/goals/handler.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 // validCategories mirrors backend/app/core/enums.Category. Only these strings
@@ -29,20 +31,20 @@ var validCategories = map[string]struct{}{
 // strings — different convention from app_config + personas where the column
 // type drove the Pydantic Decimal -> string default).
 type response struct {
-	ID                  int      `json:"id"`
-	Name                string   `json:"name"`
-	TargetAmount        float64  `json:"target_amount"`
-	TargetDate          isoDate  `json:"target_date"`
-	CurrentAmount       float64  `json:"current_amount"`
-	MonthlyContribution float64  `json:"monthly_contribution"`
-	IsCompleted         bool     `json:"is_completed"`
-	AccountID           *int     `json:"account_id"`
-	AccountName         *string  `json:"account_name"`
-	Category            *string  `json:"category"`
-	CreatedAt           isoNaive `json:"created_at"`
-	ProgressPercent     float64  `json:"progress_percent"`
-	RemainingAmount     float64  `json:"remaining_amount"`
-	ProjectedHitDate    *isoDate `json:"projected_hit_date"`
+	ID                  int           `json:"id"`
+	Name                string        `json:"name"`
+	TargetAmount        float64       `json:"target_amount"`
+	TargetDate          wire.IsoDate  `json:"target_date"`
+	CurrentAmount       float64       `json:"current_amount"`
+	MonthlyContribution float64       `json:"monthly_contribution"`
+	IsCompleted         bool          `json:"is_completed"`
+	AccountID           *int          `json:"account_id"`
+	AccountName         *string       `json:"account_name"`
+	Category            *string       `json:"category"`
+	CreatedAt           wire.IsoNaive `json:"created_at"`
+	ProgressPercent     float64       `json:"progress_percent"`
+	RemainingAmount     float64       `json:"remaining_amount"`
+	ProjectedHitDate    *wire.IsoDate `json:"projected_hit_date"`
 }
 
 type listResponse struct {
@@ -52,14 +54,14 @@ type listResponse struct {
 }
 
 type createRequest struct {
-	Name                string  `json:"name"`
-	TargetAmount        float64 `json:"target_amount"`
-	TargetDate          isoDate `json:"target_date"`
-	CurrentAmount       float64 `json:"current_amount"`
-	MonthlyContribution float64 `json:"monthly_contribution"`
-	IsCompleted         bool    `json:"is_completed"`
-	AccountID           *int    `json:"account_id"`
-	Category            *string `json:"category"`
+	Name                string       `json:"name"`
+	TargetAmount        float64      `json:"target_amount"`
+	TargetDate          wire.IsoDate `json:"target_date"`
+	CurrentAmount       float64      `json:"current_amount"`
+	MonthlyContribution float64      `json:"monthly_contribution"`
+	IsCompleted         bool         `json:"is_completed"`
+	AccountID           *int         `json:"account_id"`
+	Category            *string      `json:"category"`
 }
 
 // Handler is the HTTP boundary for /api/goals.
@@ -97,13 +99,13 @@ func (h *Handler) toResponse(g *Goal, accountName string) response {
 		ID:                  g.ID,
 		Name:                g.Name,
 		TargetAmount:        target,
-		TargetDate:          isoDate(g.TargetDate),
+		TargetDate:          wire.IsoDate(g.TargetDate),
 		CurrentAmount:       current,
 		MonthlyContribution: monthly,
 		IsCompleted:         g.IsCompleted,
 		AccountID:           g.AccountID,
 		Category:            g.Category,
-		CreatedAt:           isoNaive(g.CreatedAt),
+		CreatedAt:           wire.IsoNaive(g.CreatedAt),
 		ProgressPercent:     progress,
 		RemainingAmount:     remaining,
 	}
@@ -112,7 +114,7 @@ func (h *Handler) toResponse(g *Goal, accountName string) response {
 		out.AccountName = &name
 	}
 	if projected != nil {
-		d := isoDate(*projected)
+		d := wire.IsoDate(*projected)
 		out.ProjectedHitDate = &d
 	}
 	return out
@@ -260,34 +262,4 @@ func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
 		return 0, false
 	}
 	return id, true
-}
-
-// isoDate is the same YYYY-MM-DD format used by config/personas/etc.
-type isoDate time.Time
-
-const isoDateLayout = "2006-01-02"
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
-}
-
-func (d *isoDate) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("date must be YYYY-MM-DD string: %w", err)
-	}
-	t, err := time.Parse(isoDateLayout, s)
-	if err != nil {
-		return fmt.Errorf("date must be YYYY-MM-DD: %w", err)
-	}
-	*d = isoDate(t)
-	return nil
-}
-
-// isoNaive serializes a time.Time as ISO without a timezone suffix; mirrors
-// Python's datetime.isoformat() on naive datetimes.
-type isoNaive time.Time
-
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
 }

--- a/backend-go/internal/goals/validation_test.go
+++ b/backend-go/internal/goals/validation_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 func rawJSON(t *testing.T, m map[string]any) map[string]json.RawMessage {
@@ -26,7 +28,7 @@ func validReq(t *testing.T) *createRequest {
 	return &createRequest{
 		Name:                "Wakacje",
 		TargetAmount:        10000,
-		TargetDate:          isoDate(time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)),
+		TargetDate:          wire.IsoDate(time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)),
 		CurrentAmount:       1000,
 		MonthlyContribution: 500,
 	}
@@ -63,7 +65,7 @@ func TestValidateCreateBlankName(t *testing.T) {
 
 func TestValidateCreateMissingDate(t *testing.T) {
 	req := validReq(t)
-	req.TargetDate = isoDate(time.Time{})
+	req.TargetDate = wire.IsoDate(time.Time{})
 	if err := validateCreate(req); err == nil || err.Field != "target_date" {
 		t.Fatalf("expected target_date error, got %+v", err)
 	}

--- a/backend-go/internal/investment/handler.go
+++ b/backend-go/internal/investment/handler.go
@@ -6,16 +6,17 @@ import (
 	"math"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 type response struct {
-	Category         string  `json:"category"`
-	TotalValue       pyFloat `json:"total_value"`
-	TotalContributed pyFloat `json:"total_contributed"`
-	Returns          pyFloat `json:"returns"`
-	ROIPercentage    pyFloat `json:"roi_percentage"`
+	Category         string       `json:"category"`
+	TotalValue       wire.PyFloat `json:"total_value"`
+	TotalContributed wire.PyFloat `json:"total_contributed"`
+	Returns          wire.PyFloat `json:"returns"`
+	ROIPercentage    wire.PyFloat `json:"roi_percentage"`
 }
 
 // Handler is the HTTP boundary for /api/investment.
@@ -35,19 +36,19 @@ func NewHandler(store *Store, logger *slog.Logger) *Handler {
 // --- Contribution-adjusted returns (#401) ---
 
 type returnsResponse struct {
-	Scope             scopeWire `json:"scope"`
-	Period            string    `json:"period"`
-	Since             *string   `json:"since"`
-	AsOf              string    `json:"as_of"`
-	Deposits          pyFloat   `json:"deposits"`
-	Withdrawals       pyFloat   `json:"withdrawals"`
-	NetContributed    pyFloat   `json:"net_contributed"`
-	CurrentValue      pyFloat   `json:"current_value"`
-	ValuationChange   pyFloat   `json:"valuation_change"`
-	SimpleROIPct      pyFloat   `json:"simple_roi_pct"`
-	MoneyWeightedPct  *pyFloat  `json:"money_weighted_pct"`
-	HasSnapshot       bool      `json:"has_snapshot"`
-	ConvergenceFailed bool      `json:"convergence_failed"`
+	Scope             scopeWire     `json:"scope"`
+	Period            string        `json:"period"`
+	Since             *string       `json:"since"`
+	AsOf              string        `json:"as_of"`
+	Deposits          wire.PyFloat  `json:"deposits"`
+	Withdrawals       wire.PyFloat  `json:"withdrawals"`
+	NetContributed    wire.PyFloat  `json:"net_contributed"`
+	CurrentValue      wire.PyFloat  `json:"current_value"`
+	ValuationChange   wire.PyFloat  `json:"valuation_change"`
+	SimpleROIPct      wire.PyFloat  `json:"simple_roi_pct"`
+	MoneyWeightedPct  *wire.PyFloat `json:"money_weighted_pct"`
+	HasSnapshot       bool          `json:"has_snapshot"`
+	ConvergenceFailed bool          `json:"convergence_failed"`
 }
 
 type scopeWire struct {
@@ -146,12 +147,12 @@ func (h *Handler) Returns(w http.ResponseWriter, r *http.Request) {
 		Scope:           scopeWire,
 		Period:          period,
 		AsOf:            asOf.Format("2006-01-02"),
-		Deposits:        pyFloat(deposits),
-		Withdrawals:     pyFloat(withdrawals),
-		NetContributed:  pyFloat(netContrib),
-		CurrentValue:    pyFloat(currentValue),
-		ValuationChange: pyFloat(valuationChange),
-		SimpleROIPct:    pyFloat(math.Round(SimpleROI(openingValue+netContrib, currentValue)*10000) / 100),
+		Deposits:        wire.PyFloat(deposits),
+		Withdrawals:     wire.PyFloat(withdrawals),
+		NetContributed:  wire.PyFloat(netContrib),
+		CurrentValue:    wire.PyFloat(currentValue),
+		ValuationChange: wire.PyFloat(valuationChange),
+		SimpleROIPct:    wire.PyFloat(math.Round(SimpleROI(openingValue+netContrib, currentValue)*10000) / 100),
 		HasSnapshot:     hasSnap,
 	}
 	if window.Since != nil {
@@ -165,7 +166,7 @@ func (h *Handler) Returns(w http.ResponseWriter, r *http.Request) {
 		if xerr != nil {
 			resp.ConvergenceFailed = true
 		} else {
-			pct := pyFloat(math.Round(mwr*10000) / 100)
+			pct := wire.PyFloat(math.Round(mwr*10000) / 100)
 			resp.MoneyWeightedPct = &pct
 		}
 	}
@@ -260,10 +261,10 @@ func (h *Handler) categoryStats(w http.ResponseWriter, r *http.Request, category
 	}
 	writeJSON(w, http.StatusOK, response{
 		Category:         category,
-		TotalValue:       pyFloat(value),
-		TotalContributed: pyFloat(contributed),
-		Returns:          pyFloat(returns),
-		ROIPercentage:    pyFloat(math.Round(roi*100) / 100),
+		TotalValue:       wire.PyFloat(value),
+		TotalContributed: wire.PyFloat(contributed),
+		Returns:          wire.PyFloat(returns),
+		ROIPercentage:    wire.PyFloat(math.Round(roi*100) / 100),
 	})
 }
 
@@ -277,14 +278,4 @@ func writeJSON(w http.ResponseWriter, status int, payload any) {
 
 func writeDetailError(w http.ResponseWriter, status int, detail string) {
 	writeJSON(w, status, map[string]string{"detail": detail})
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/pit38/realized.go
+++ b/backend-go/internal/pit38/realized.go
@@ -14,16 +14,8 @@ import (
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
-
-// isoDate marshals as a date-only YYYY-MM-DD string, matching the wire
-// format every other endpoint uses for transaction dates.
-type isoDate time.Time
-
-// MarshalJSON renders the underlying time as YYYY-MM-DD.
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format("2006-01-02") + `"`), nil
-}
 
 // SaleRow is one realized-sale row in the report. All `_PLN` fields are
 // after NBP conversion at the per-row tax date (sale date for proceeds,
@@ -33,7 +25,7 @@ type SaleRow struct {
 	SecurityID   int             `json:"security_id"`
 	Symbol       string          `json:"symbol"`
 	Currency     string          `json:"currency"`
-	Date         isoDate         `json:"date"`
+	Date         wire.IsoDate    `json:"date"`
 	Quantity     decimal.Decimal `json:"quantity"`
 	Proceeds     decimal.Decimal `json:"proceeds"`
 	CostBasis    decimal.Decimal `json:"cost_basis"`
@@ -185,7 +177,7 @@ func realizedSalesFor(
 					SecurityID:   sec.SecurityID,
 					Symbol:       sec.Symbol,
 					Currency:     sec.Currency,
-					Date:         isoDate(l.Date),
+					Date:         wire.IsoDate(l.Date),
 					Quantity:     l.Quantity,
 					Proceeds:     proceedsCcy,
 					CostBasis:    costBasisCcy,

--- a/backend-go/internal/recurring/handler.go
+++ b/backend-go/internal/recurring/handler.go
@@ -66,8 +66,8 @@ func formatDatePtr(t *time.Time) *string {
 	return &s
 }
 
-// formatTimestamp matches the isoNaive layout used across the rest of the Go
-// API (microsecond precision, naive UTC). Cf. internal/transactions/handler.go.
+// formatTimestamp matches the wire.IsoNaive layout used across the rest of
+// the Go API (microsecond precision, naive UTC). Cf. internal/wire/types.go.
 func formatTimestamp(t time.Time) string { return t.UTC().Format("2006-01-02T15:04:05.999999") }
 
 func (h *Handler) toResponse(r Recurring) response {

--- a/backend-go/internal/retirement/compute.go
+++ b/backend-go/internal/retirement/compute.go
@@ -4,6 +4,8 @@ import (
 	"math"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 // computeYearlyStat folds the contribution totals against the configured
@@ -32,17 +34,17 @@ func computeYearlyStat(year int, wrapper string, ownerUserID *int, totals Contri
 	if limitF > 0 {
 		percentage = totalF / limitF * 100
 	}
-	lAmt := pyFloat(limitF)
-	rem := pyFloat(remaining)
-	pct := pyFloat(math.Round(percentage*10) / 10)
+	lAmt := wire.PyFloat(limitF)
+	rem := wire.PyFloat(remaining)
+	pct := wire.PyFloat(math.Round(percentage*10) / 10)
 	return yearlyStat{
 		Year:                year,
 		AccountWrapper:      wrapper,
 		OwnerUserID:         ownerUserID,
 		LimitAmount:         &lAmt,
-		TotalContributed:    pyFloat(totalF),
-		EmployeeContributed: pyFloat(employeeF),
-		EmployerContributed: pyFloat(employerF),
+		TotalContributed:    wire.PyFloat(totalF),
+		EmployeeContributed: wire.PyFloat(employeeF),
+		EmployerContributed: wire.PyFloat(employerF),
 		Remaining:           &rem,
 		PercentageUsed:      &pct,
 		IsWarning:           percentage >= 90,
@@ -70,13 +72,13 @@ func computePPKStat(ownerUserID *int, totals ContributionTotals, latest decimal.
 	roiRounded := math.Round(roi*100) / 100
 	return ppkStat{
 		OwnerUserID:           ownerUserID,
-		TotalValue:            pyFloat(totalValue),
-		EmployeeContributed:   pyFloat(employeeF),
-		EmployerContributed:   pyFloat(employerF),
-		GovernmentContributed: pyFloat(governmentF),
-		TotalContributed:      pyFloat(totalF),
-		Returns:               pyFloat(returns),
-		ROIPercentage:         pyFloat(roiRounded),
+		TotalValue:            wire.PyFloat(totalValue),
+		EmployeeContributed:   wire.PyFloat(employeeF),
+		EmployerContributed:   wire.PyFloat(employerF),
+		GovernmentContributed: wire.PyFloat(governmentF),
+		TotalContributed:      wire.PyFloat(totalF),
+		Returns:               wire.PyFloat(returns),
+		ROIPercentage:         wire.PyFloat(roiRounded),
 	}
 }
 
@@ -121,13 +123,13 @@ func computePPKGenerateResponse(
 		OwnerUserID:         req.OwnerUserID,
 		Month:               req.Month,
 		Year:                req.Year,
-		GrossSalary:         pyFloat(grossF),
-		EmployeeAmount:      pyFloat(empF),
-		EmployerAmount:      pyFloat(emprF),
-		GovernmentAmount:    pyFloat(govF),
+		GrossSalary:         wire.PyFloat(grossF),
+		EmployeeAmount:      wire.PyFloat(empF),
+		EmployerAmount:      wire.PyFloat(emprF),
+		GovernmentAmount:    wire.PyFloat(govF),
 		WelcomeApplied:      welcomeApplied,
 		AnnualApplied:       annualApplied,
-		TotalAmount:         pyFloat(empF + emprF + govF),
+		TotalAmount:         wire.PyFloat(empF + emprF + govF),
 		TransactionsCreated: ids,
 	}
 }

--- a/backend-go/internal/retirement/handler.go
+++ b/backend-go/internal/retirement/handler.go
@@ -9,62 +9,63 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 type yearlyStat struct {
-	Year                int      `json:"year"`
-	AccountWrapper      string   `json:"account_wrapper"`
-	OwnerUserID         *int     `json:"owner_user_id"`
-	LimitAmount         *pyFloat `json:"limit_amount"`
-	TotalContributed    pyFloat  `json:"total_contributed"`
-	EmployeeContributed pyFloat  `json:"employee_contributed"`
-	EmployerContributed pyFloat  `json:"employer_contributed"`
-	Remaining           *pyFloat `json:"remaining"`
-	PercentageUsed      *pyFloat `json:"percentage_used"`
-	IsWarning           bool     `json:"is_warning"`
+	Year                int           `json:"year"`
+	AccountWrapper      string        `json:"account_wrapper"`
+	OwnerUserID         *int          `json:"owner_user_id"`
+	LimitAmount         *wire.PyFloat `json:"limit_amount"`
+	TotalContributed    wire.PyFloat  `json:"total_contributed"`
+	EmployeeContributed wire.PyFloat  `json:"employee_contributed"`
+	EmployerContributed wire.PyFloat  `json:"employer_contributed"`
+	Remaining           *wire.PyFloat `json:"remaining"`
+	PercentageUsed      *wire.PyFloat `json:"percentage_used"`
+	IsWarning           bool          `json:"is_warning"`
 	// IKZE-only: marginal PIT rate at the owner's annualized salary and
 	// the estimated PIT savings from this year's contributions. Nil when
 	// the wrapper is not IKZE or the owner has no salary record.
-	MarginalTaxRate *pyFloat `json:"marginal_tax_rate"`
-	PITSavings      *pyFloat `json:"pit_savings"`
+	MarginalTaxRate *wire.PyFloat `json:"marginal_tax_rate"`
+	PITSavings      *wire.PyFloat `json:"pit_savings"`
 }
 
 type ppkStat struct {
-	OwnerUserID           *int    `json:"owner_user_id"`
-	TotalValue            pyFloat `json:"total_value"`
-	EmployeeContributed   pyFloat `json:"employee_contributed"`
-	EmployerContributed   pyFloat `json:"employer_contributed"`
-	GovernmentContributed pyFloat `json:"government_contributed"`
-	TotalContributed      pyFloat `json:"total_contributed"`
-	Returns               pyFloat `json:"returns"`
-	ROIPercentage         pyFloat `json:"roi_percentage"`
+	OwnerUserID           *int         `json:"owner_user_id"`
+	TotalValue            wire.PyFloat `json:"total_value"`
+	EmployeeContributed   wire.PyFloat `json:"employee_contributed"`
+	EmployerContributed   wire.PyFloat `json:"employer_contributed"`
+	GovernmentContributed wire.PyFloat `json:"government_contributed"`
+	TotalContributed      wire.PyFloat `json:"total_contributed"`
+	Returns               wire.PyFloat `json:"returns"`
+	ROIPercentage         wire.PyFloat `json:"roi_percentage"`
 }
 
 type limitResponse struct {
-	ID             int     `json:"id"`
-	Year           int     `json:"year"`
-	AccountWrapper string  `json:"account_wrapper"`
-	OwnerUserID    *int    `json:"owner_user_id"`
-	LimitAmount    pyFloat `json:"limit_amount"`
-	Notes          *string `json:"notes"`
+	ID             int          `json:"id"`
+	Year           int          `json:"year"`
+	AccountWrapper string       `json:"account_wrapper"`
+	OwnerUserID    *int         `json:"owner_user_id"`
+	LimitAmount    wire.PyFloat `json:"limit_amount"`
+	Notes          *string      `json:"notes"`
 }
 
 type ppkGenerateResponse struct {
-	OwnerUserID         *int    `json:"owner_user_id"`
-	Month               int     `json:"month"`
-	Year                int     `json:"year"`
-	GrossSalary         pyFloat `json:"gross_salary"`
-	EmployeeAmount      pyFloat `json:"employee_amount"`
-	EmployerAmount      pyFloat `json:"employer_amount"`
-	GovernmentAmount    pyFloat `json:"government_amount"`
-	WelcomeApplied      bool    `json:"welcome_applied"`
-	AnnualApplied       bool    `json:"annual_applied"`
-	TotalAmount         pyFloat `json:"total_amount"`
-	TransactionsCreated []int   `json:"transactions_created"`
+	OwnerUserID         *int         `json:"owner_user_id"`
+	Month               int          `json:"month"`
+	Year                int          `json:"year"`
+	GrossSalary         wire.PyFloat `json:"gross_salary"`
+	EmployeeAmount      wire.PyFloat `json:"employee_amount"`
+	EmployerAmount      wire.PyFloat `json:"employer_amount"`
+	GovernmentAmount    wire.PyFloat `json:"government_amount"`
+	WelcomeApplied      bool         `json:"welcome_applied"`
+	AnnualApplied       bool         `json:"annual_applied"`
+	TotalAmount         wire.PyFloat `json:"total_amount"`
+	TransactionsCreated []int        `json:"transactions_created"`
 }
 
 // Handler is the HTTP boundary for /api/retirement.
@@ -144,8 +145,8 @@ func (h *Handler) buildYearlyStat(ctx context.Context, year int, wrapper string,
 	totalF, _ := totals.Total.Float64()
 	if wrapper == "IKZE" && totalF > 0 {
 		if rate, savings, ok := h.estimateIKZEPITSavings(ctx, ownerUserID, year, totalF); ok {
-			r := pyFloat(rate)
-			s := pyFloat(savings)
+			r := wire.PyFloat(rate)
+			s := wire.PyFloat(savings)
 			stat.MarginalTaxRate = &r
 			stat.PITSavings = &s
 		}
@@ -241,7 +242,7 @@ func (h *Handler) LimitsForYear(w http.ResponseWriter, r *http.Request) {
 		amt, _ := l.LimitAmount.Float64()
 		out = append(out, limitResponse{
 			ID: l.ID, Year: l.Year, AccountWrapper: l.AccountWrapper,
-			OwnerUserID: l.OwnerUserID, LimitAmount: pyFloat(amt), Notes: l.Notes,
+			OwnerUserID: l.OwnerUserID, LimitAmount: wire.PyFloat(amt), Notes: l.Notes,
 		})
 	}
 	writeJSON(w, http.StatusOK, out)
@@ -285,7 +286,7 @@ func (h *Handler) UpsertLimit(w http.ResponseWriter, r *http.Request) {
 	amt, _ := l.LimitAmount.Float64()
 	writeJSON(w, http.StatusOK, limitResponse{
 		ID: l.ID, Year: l.Year, AccountWrapper: l.AccountWrapper,
-		OwnerUserID: l.OwnerUserID, LimitAmount: pyFloat(amt), Notes: l.Notes,
+		OwnerUserID: l.OwnerUserID, LimitAmount: wire.PyFloat(amt), Notes: l.Notes,
 	})
 }
 
@@ -394,15 +395,4 @@ func ownerLabel(id *int) string {
 		return "Shared"
 	}
 	return strconv.Itoa(*id)
-}
-
-// wire type
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/rules/handler.go
+++ b/backend-go/internal/rules/handler.go
@@ -6,25 +6,26 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 // ruleWire mirrors a Rule on the JSON wire. Money/% values are quoted
 // strings (matches the rest of the codebase's decimal serialization
 // convention); dates are YYYY-MM-DD without timezone suffix.
 type ruleWire struct {
-	Key             string    `json:"key"`
-	Name            string    `json:"name"`
-	Category        string    `json:"category"`
-	Value           dimString `json:"value"`
-	Unit            string    `json:"unit"`
-	Year            int       `json:"year"`
-	EffectiveDate   isoDate   `json:"effective_date"`
-	SourceURL       string    `json:"source_url"`
-	LastCheckedDate isoDate   `json:"last_checked_date"`
-	Description     string    `json:"description"`
+	Key             string       `json:"key"`
+	Name            string       `json:"name"`
+	Category        string       `json:"category"`
+	Value           dimString    `json:"value"`
+	Unit            string       `json:"unit"`
+	Year            int          `json:"year"`
+	EffectiveDate   wire.IsoDate `json:"effective_date"`
+	SourceURL       string       `json:"source_url"`
+	LastCheckedDate wire.IsoDate `json:"last_checked_date"`
+	Description     string       `json:"description"`
 }
 
 type listResponse struct {
@@ -74,9 +75,9 @@ func toWire(r *Rule) ruleWire {
 		Value:           dimString(r.Value),
 		Unit:            r.Unit,
 		Year:            r.Year,
-		EffectiveDate:   isoDate(r.EffectiveDate),
+		EffectiveDate:   wire.IsoDate(r.EffectiveDate),
 		SourceURL:       r.SourceURL,
-		LastCheckedDate: isoDate(r.LastCheckedDate),
+		LastCheckedDate: wire.IsoDate(r.LastCheckedDate),
 		Description:     r.Description,
 	}
 }
@@ -90,12 +91,4 @@ type dimString decimal.Decimal
 func (d dimString) MarshalJSON() ([]byte, error) {
 	v := decimal.Decimal(d)
 	return fmt.Appendf(nil, "%q", v.String()), nil
-}
-
-// isoDate marshals a time.Time as "YYYY-MM-DD" — naïve, no zone suffix,
-// matches the wire convention used by /api/config etc.
-type isoDate time.Time
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return fmt.Appendf(nil, "%q", time.Time(d).Format("2006-01-02")), nil
 }

--- a/backend-go/internal/rules/rules_test.go
+++ b/backend-go/internal/rules/rules_test.go
@@ -120,7 +120,7 @@ func TestByCategoryFiltersAndPreservesOrder(t *testing.T) {
 }
 
 // decodeRawList decodes the wire payload into the loose map[string]any
-// shape so the test doesn't depend on dimString/isoDate UnmarshalJSON
+// shape so the test doesn't depend on dimString/wire.IsoDate UnmarshalJSON
 // implementations (they're write-only on purpose).
 func decodeRawList(t *testing.T, payload []byte) []map[string]any {
 	t.Helper()

--- a/backend-go/internal/salaries/handler.go
+++ b/backend-go/internal/salaries/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 var validContractTypes = map[string]struct{}{
@@ -25,27 +26,27 @@ var validContractTypes = map[string]struct{}{
 // response mirrors backend/app/schemas/salary_records.SalaryRecordResponse.
 // OwnerUserID is the owning household member; nil means jointly owned.
 type response struct {
-	ID           int      `json:"id"`
-	Date         isoDate  `json:"date"`
-	GrossAmount  pyFloat  `json:"gross_amount"`
-	ContractType string   `json:"contract_type"`
-	Company      string   `json:"company"`
-	OwnerUserID  *int     `json:"owner_user_id"`
-	IsActive     bool     `json:"is_active"`
-	CreatedAt    isoNaive `json:"created_at"`
+	ID           int           `json:"id"`
+	Date         wire.IsoDate  `json:"date"`
+	GrossAmount  wire.PyFloat  `json:"gross_amount"`
+	ContractType string        `json:"contract_type"`
+	Company      string        `json:"company"`
+	OwnerUserID  *int          `json:"owner_user_id"`
+	IsActive     bool          `json:"is_active"`
+	CreatedAt    wire.IsoNaive `json:"created_at"`
 }
 
 // inflationContext mirrors backend/app/schemas/salary_records.InflationContext.
 type inflationContext struct {
-	OwnerUserID              int      `json:"owner_user_id"`
-	LastChangeDate           isoDate  `json:"last_change_date"`
-	PreviousChangeDate       *isoDate `json:"previous_change_date"`
-	PreviousSalary           *pyFloat `json:"previous_salary"`
-	PreviousSalaryInTodayPLN *pyFloat `json:"previous_salary_in_today_pln"`
-	CurrentSalary            pyFloat  `json:"current_salary"`
-	RealChangePLN            *pyFloat `json:"real_change_pln"`
-	RealChangePct            *pyFloat `json:"real_change_pct"`
-	CPIAsOfYear              int      `json:"cpi_as_of_year"`
+	OwnerUserID              int           `json:"owner_user_id"`
+	LastChangeDate           wire.IsoDate  `json:"last_change_date"`
+	PreviousChangeDate       *wire.IsoDate `json:"previous_change_date"`
+	PreviousSalary           *wire.PyFloat `json:"previous_salary"`
+	PreviousSalaryInTodayPLN *wire.PyFloat `json:"previous_salary_in_today_pln"`
+	CurrentSalary            wire.PyFloat  `json:"current_salary"`
+	RealChangePLN            *wire.PyFloat `json:"real_change_pln"`
+	RealChangePct            *wire.PyFloat `json:"real_change_pct"`
+	CPIAsOfYear              int           `json:"cpi_as_of_year"`
 }
 
 // listResponse keys current_salaries and inflation_context by owner_user_id
@@ -53,7 +54,7 @@ type inflationContext struct {
 type listResponse struct {
 	SalaryRecords      []response               `json:"salary_records"`
 	TotalCount         int                      `json:"total_count"`
-	CurrentSalaries    map[int]*pyFloat         `json:"current_salaries"`
+	CurrentSalaries    map[int]*wire.PyFloat    `json:"current_salaries"`
 	InflationContext   map[int]inflationContext `json:"inflation_context"`
 	AvailableCompanies []string                 `json:"available_companies"`
 }
@@ -79,13 +80,13 @@ func toResponse(r *SalaryRecord) response {
 	gross, _ := r.GrossAmount.Float64()
 	return response{
 		ID:           r.ID,
-		Date:         isoDate(r.Date),
-		GrossAmount:  pyFloat(gross),
+		Date:         wire.IsoDate(r.Date),
+		GrossAmount:  wire.PyFloat(gross),
 		ContractType: r.ContractType,
 		Company:      r.Company,
 		OwnerUserID:  r.OwnerUserID,
 		IsActive:     r.IsActive,
-		CreatedAt:    isoNaive(r.CreatedAt.UTC()),
+		CreatedAt:    wire.IsoNaive(r.CreatedAt.UTC()),
 	}
 }
 
@@ -283,22 +284,22 @@ func (h *Handler) buildInflationContext(
 		}
 		curAmount, _ := current.GrossAmount.Float64()
 		realChangePLN := curAmount - prevInToday
-		var realChangePct *pyFloat
+		var realChangePct *wire.PyFloat
 		if prevInToday != 0 {
-			pct := pyFloat(realChangePLN / prevInToday * 100)
+			pct := wire.PyFloat(realChangePLN / prevInToday * 100)
 			realChangePct = &pct
 		}
-		prevDate := isoDate(previous.Date)
-		prevSalary := pyFloat(prevAmount)
-		prevTodayPLN := pyFloat(prevInToday)
-		realChange := pyFloat(realChangePLN)
+		prevDate := wire.IsoDate(previous.Date)
+		prevSalary := wire.PyFloat(prevAmount)
+		prevTodayPLN := wire.PyFloat(prevInToday)
+		realChange := wire.PyFloat(realChangePLN)
 		out[ownerID] = inflationContext{
 			OwnerUserID:              ownerID,
-			LastChangeDate:           isoDate(current.Date),
+			LastChangeDate:           wire.IsoDate(current.Date),
 			PreviousChangeDate:       &prevDate,
 			PreviousSalary:           &prevSalary,
 			PreviousSalaryInTodayPLN: &prevTodayPLN,
-			CurrentSalary:            pyFloat(curAmount),
+			CurrentSalary:            wire.PyFloat(curAmount),
 			RealChangePLN:            &realChange,
 			RealChangePct:            realChangePct,
 			CPIAsOfYear:              asOfYear,
@@ -309,8 +310,8 @@ func (h *Handler) buildInflationContext(
 
 func salariesToFloatMap(
 	userIDs []int, values map[int]decimal.Decimal,
-) map[int]*pyFloat {
-	out := map[int]*pyFloat{}
+) map[int]*wire.PyFloat {
+	out := map[int]*wire.PyFloat{}
 	for _, id := range userIDs {
 		v, ok := values[id]
 		if !ok {
@@ -318,7 +319,7 @@ func salariesToFloatMap(
 			continue
 		}
 		f, _ := v.Float64()
-		pf := pyFloat(f)
+		pf := wire.PyFloat(f)
 		out[id] = &pf
 	}
 	return out
@@ -373,43 +374,4 @@ func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
 
 func truncateDay(t time.Time) time.Time {
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
-}
-
-// --- shared wire types ---
-
-type isoDate time.Time
-
-const isoDateLayout = "2006-01-02"
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
-}
-
-func (d *isoDate) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	t, err := time.Parse(isoDateLayout, s)
-	if err != nil {
-		return err
-	}
-	*d = isoDate(t)
-	return nil
-}
-
-type isoNaive time.Time
-
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/scenarios/handler.go
+++ b/backend-go/internal/scenarios/handler.go
@@ -224,7 +224,7 @@ func toResponse(sc *Scenario) response {
 		Name:       sc.Name,
 		Kind:       sc.Kind,
 		InputsJSON: sc.InputsJSON,
-		CreatedAt:  wire.IsoNaive(sc.CreatedAt),
-		UpdatedAt:  wire.IsoNaive(sc.UpdatedAt),
+		CreatedAt:  wire.IsoNaive(sc.CreatedAt.UTC()),
+		UpdatedAt:  wire.IsoNaive(sc.UpdatedAt.UTC()),
 	}
 }

--- a/backend-go/internal/scenarios/handler.go
+++ b/backend-go/internal/scenarios/handler.go
@@ -3,15 +3,15 @@ package scenarios
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 // response mirrors the wire shape returned to the frontend. CreatedAt /
@@ -22,8 +22,8 @@ type response struct {
 	Name       string          `json:"name"`
 	Kind       string          `json:"kind"`
 	InputsJSON json.RawMessage `json:"inputs_json"`
-	CreatedAt  isoNaive        `json:"created_at"`
-	UpdatedAt  isoNaive        `json:"updated_at"`
+	CreatedAt  wire.IsoNaive   `json:"created_at"`
+	UpdatedAt  wire.IsoNaive   `json:"updated_at"`
 }
 
 type listResponse struct {
@@ -224,15 +224,7 @@ func toResponse(sc *Scenario) response {
 		Name:       sc.Name,
 		Kind:       sc.Kind,
 		InputsJSON: sc.InputsJSON,
-		CreatedAt:  isoNaive(sc.CreatedAt),
-		UpdatedAt:  isoNaive(sc.UpdatedAt),
+		CreatedAt:  wire.IsoNaive(sc.CreatedAt),
+		UpdatedAt:  wire.IsoNaive(sc.UpdatedAt),
 	}
-}
-
-// isoNaive marshals a time.Time as a naive ISO-8601 timestamp (no zone)
-// matching the rest of the codebase's `timestamp without time zone` columns.
-type isoNaive time.Time
-
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return fmt.Appendf(nil, "%q", time.Time(t).UTC().Format("2006-01-02T15:04:05.999999")), nil
 }

--- a/backend-go/internal/simulations/compute.go
+++ b/backend-go/internal/simulations/compute.go
@@ -2,8 +2,8 @@ package simulations
 
 import (
 	"math"
-	"strconv"
-	"strings"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 // ownerLabel resolves an owner_user_id to a display name for AccountName.
@@ -44,13 +44,13 @@ func buildSimulationResponse(in simulationInputs, sims []AccountSimulation) map[
 		"inputs":      in.echo(),
 		"simulations": simWire,
 		"summary": map[string]any{
-			"total_final_balance":            pyFloat(totalFinal),
-			"total_contributions":            pyFloat(totalContrib),
-			"total_returns":                  pyFloat(totalReturns),
-			"total_tax_savings":              pyFloat(totalTaxSavings),
-			"total_subsidies":                pyFloat(totalSubsidies),
-			"estimated_monthly_income":       pyFloat(monthlyIncome),
-			"estimated_monthly_income_today": pyFloat(monthlyIncomeToday),
+			"total_final_balance":            wire.PyFloat(totalFinal),
+			"total_contributions":            wire.PyFloat(totalContrib),
+			"total_returns":                  wire.PyFloat(totalReturns),
+			"total_tax_savings":              wire.PyFloat(totalTaxSavings),
+			"total_subsidies":                wire.PyFloat(totalSubsidies),
+			"estimated_monthly_income":       wire.PyFloat(monthlyIncome),
+			"estimated_monthly_income_today": wire.PyFloat(monthlyIncomeToday),
 			"years_until_retirement":         years,
 		},
 	}
@@ -63,43 +63,33 @@ func accountSimToWire(s *AccountSimulation) map[string]any {
 		row := map[string]any{
 			"year":                     p.Year,
 			"age":                      p.Age,
-			"annual_contribution":      pyFloat(p.AnnualContribution),
-			"balance_end_of_year":      pyFloat(p.BalanceEndOfYear),
-			"cumulative_contributions": pyFloat(p.CumulativeContributions),
-			"cumulative_returns":       pyFloat(p.CumulativeReturns),
-			"annual_limit":             pyFloat(p.AnnualLimit),
-			"limit_utilized_pct":       pyFloat(p.LimitUtilizedPct),
-			"tax_savings":              pyFloat(p.TaxSavings),
-			"government_subsidies":     pyFloat(p.GovernmentSubsidies),
+			"annual_contribution":      wire.PyFloat(p.AnnualContribution),
+			"balance_end_of_year":      wire.PyFloat(p.BalanceEndOfYear),
+			"cumulative_contributions": wire.PyFloat(p.CumulativeContributions),
+			"cumulative_returns":       wire.PyFloat(p.CumulativeReturns),
+			"annual_limit":             wire.PyFloat(p.AnnualLimit),
+			"limit_utilized_pct":       wire.PyFloat(p.LimitUtilizedPct),
+			"tax_savings":              wire.PyFloat(p.TaxSavings),
+			"government_subsidies":     wire.PyFloat(p.GovernmentSubsidies),
 			"monthly_salary":           nil,
 			"return_rate":              nil,
 		}
 		if p.MonthlySalary != nil {
-			row["monthly_salary"] = pyFloat(*p.MonthlySalary)
+			row["monthly_salary"] = wire.PyFloat(*p.MonthlySalary)
 		}
 		if p.ReturnRate != nil {
-			row["return_rate"] = pyFloat(*p.ReturnRate)
+			row["return_rate"] = wire.PyFloat(*p.ReturnRate)
 		}
 		projections = append(projections, row)
 	}
 	return map[string]any{
 		"account_name":        s.AccountName,
-		"starting_balance":    pyFloat(s.StartingBalance),
-		"total_contributions": pyFloat(s.TotalContributions),
-		"total_returns":       pyFloat(s.TotalReturns),
-		"total_tax_savings":   pyFloat(s.TotalTaxSavings),
-		"total_subsidies":     pyFloat(s.TotalSubsidies),
-		"final_balance":       pyFloat(s.FinalBalance),
+		"starting_balance":    wire.PyFloat(s.StartingBalance),
+		"total_contributions": wire.PyFloat(s.TotalContributions),
+		"total_returns":       wire.PyFloat(s.TotalReturns),
+		"total_tax_savings":   wire.PyFloat(s.TotalTaxSavings),
+		"total_subsidies":     wire.PyFloat(s.TotalSubsidies),
+		"final_balance":       wire.PyFloat(s.FinalBalance),
 		"yearly_projections":  projections,
 	}
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/simulations/compute_test.go
+++ b/backend-go/internal/simulations/compute_test.go
@@ -3,6 +3,8 @@ package simulations
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 func TestOwnerLabel_NilIsWspolne(t *testing.T) {
@@ -28,7 +30,7 @@ func TestOwnerLabel_UnknownReturnsDash(t *testing.T) {
 
 func TestPyFloatMarshal(t *testing.T) {
 	cases := []struct {
-		in   pyFloat
+		in   wire.PyFloat
 		want string
 	}{
 		{0, "0.0"},

--- a/backend-go/internal/simulations/handler.go
+++ b/backend-go/internal/simulations/handler.go
@@ -11,6 +11,8 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"time"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 const safeWithdrawalRate = 0.04
@@ -33,48 +35,48 @@ func NewHandler(store *Store, logger *slog.Logger) *Handler {
 // --- mortgage wire types ---
 
 type mortgageInputsWire struct {
-	RemainingPrincipal   pyFloat `json:"remaining_principal"`
-	AnnualInterestRate   pyFloat `json:"annual_interest_rate"`
-	RemainingMonths      int     `json:"remaining_months"`
-	TotalMonthlyBudget   pyFloat `json:"total_monthly_budget"`
-	ExpectedAnnualReturn pyFloat `json:"expected_annual_return"`
-	InflationRate        pyFloat `json:"inflation_rate"`
-	EnableVariableRate   bool    `json:"enable_variable_rate"`
+	RemainingPrincipal   wire.PyFloat `json:"remaining_principal"`
+	AnnualInterestRate   wire.PyFloat `json:"annual_interest_rate"`
+	RemainingMonths      int          `json:"remaining_months"`
+	TotalMonthlyBudget   wire.PyFloat `json:"total_monthly_budget"`
+	ExpectedAnnualReturn wire.PyFloat `json:"expected_annual_return"`
+	InflationRate        wire.PyFloat `json:"inflation_rate"`
+	EnableVariableRate   bool         `json:"enable_variable_rate"`
 }
 
 type mortgageYearlyWire struct {
-	Year                         int     `json:"year"`
-	AnnualRate                   pyFloat `json:"annual_rate"`
-	ScenarioAMortgageBalance     pyFloat `json:"scenario_a_mortgage_balance"`
-	ScenarioARealMortgageBalance pyFloat `json:"scenario_a_real_mortgage_balance"`
-	ScenarioACumulativeInterest  pyFloat `json:"scenario_a_cumulative_interest"`
-	ScenarioAInvestmentBalance   pyFloat `json:"scenario_a_investment_balance"`
-	ScenarioAAfterTaxPortfolio   pyFloat `json:"scenario_a_after_tax_portfolio"`
-	ScenarioARealPortfolio       pyFloat `json:"scenario_a_real_portfolio"`
-	ScenarioAPaidOff             bool    `json:"scenario_a_paid_off"`
-	ScenarioBMortgageBalance     pyFloat `json:"scenario_b_mortgage_balance"`
-	ScenarioBRealMortgageBalance pyFloat `json:"scenario_b_real_mortgage_balance"`
-	ScenarioBInvestmentBalance   pyFloat `json:"scenario_b_investment_balance"`
-	ScenarioBAfterTaxPortfolio   pyFloat `json:"scenario_b_after_tax_portfolio"`
-	ScenarioBRealPortfolio       pyFloat `json:"scenario_b_real_portfolio"`
-	ScenarioBCumulativeInterest  pyFloat `json:"scenario_b_cumulative_interest"`
-	NetAdvantageInvest           pyFloat `json:"net_advantage_invest"`
+	Year                         int          `json:"year"`
+	AnnualRate                   wire.PyFloat `json:"annual_rate"`
+	ScenarioAMortgageBalance     wire.PyFloat `json:"scenario_a_mortgage_balance"`
+	ScenarioARealMortgageBalance wire.PyFloat `json:"scenario_a_real_mortgage_balance"`
+	ScenarioACumulativeInterest  wire.PyFloat `json:"scenario_a_cumulative_interest"`
+	ScenarioAInvestmentBalance   wire.PyFloat `json:"scenario_a_investment_balance"`
+	ScenarioAAfterTaxPortfolio   wire.PyFloat `json:"scenario_a_after_tax_portfolio"`
+	ScenarioARealPortfolio       wire.PyFloat `json:"scenario_a_real_portfolio"`
+	ScenarioAPaidOff             bool         `json:"scenario_a_paid_off"`
+	ScenarioBMortgageBalance     wire.PyFloat `json:"scenario_b_mortgage_balance"`
+	ScenarioBRealMortgageBalance wire.PyFloat `json:"scenario_b_real_mortgage_balance"`
+	ScenarioBInvestmentBalance   wire.PyFloat `json:"scenario_b_investment_balance"`
+	ScenarioBAfterTaxPortfolio   wire.PyFloat `json:"scenario_b_after_tax_portfolio"`
+	ScenarioBRealPortfolio       wire.PyFloat `json:"scenario_b_real_portfolio"`
+	ScenarioBCumulativeInterest  wire.PyFloat `json:"scenario_b_cumulative_interest"`
+	NetAdvantageInvest           wire.PyFloat `json:"net_advantage_invest"`
 }
 
 type mortgageSummaryWire struct {
-	RegularMonthlyPayment    pyFloat `json:"regular_monthly_payment"`
-	TotalInterestA           pyFloat `json:"total_interest_a"`
-	TotalInterestB           pyFloat `json:"total_interest_b"`
-	InterestSaved            pyFloat `json:"interest_saved"`
-	FinalInvestmentPortfolio pyFloat `json:"final_investment_portfolio"`
-	BelkaTaxA                pyFloat `json:"belka_tax_a"`
-	BelkaTaxB                pyFloat `json:"belka_tax_b"`
-	FinalPortfolioAReal      pyFloat `json:"final_portfolio_a_real"`
-	FinalPortfolioBReal      pyFloat `json:"final_portfolio_b_real"`
-	MonthsSaved              int     `json:"months_saved"`
-	WinningStrategy          string  `json:"winning_strategy"`
-	NetAdvantage             pyFloat `json:"net_advantage"`
-	BreakEvenGrossReturn     pyFloat `json:"break_even_gross_return"`
+	RegularMonthlyPayment    wire.PyFloat `json:"regular_monthly_payment"`
+	TotalInterestA           wire.PyFloat `json:"total_interest_a"`
+	TotalInterestB           wire.PyFloat `json:"total_interest_b"`
+	InterestSaved            wire.PyFloat `json:"interest_saved"`
+	FinalInvestmentPortfolio wire.PyFloat `json:"final_investment_portfolio"`
+	BelkaTaxA                wire.PyFloat `json:"belka_tax_a"`
+	BelkaTaxB                wire.PyFloat `json:"belka_tax_b"`
+	FinalPortfolioAReal      wire.PyFloat `json:"final_portfolio_a_real"`
+	FinalPortfolioBReal      wire.PyFloat `json:"final_portfolio_b_real"`
+	MonthsSaved              int          `json:"months_saved"`
+	WinningStrategy          string       `json:"winning_strategy"`
+	NetAdvantage             wire.PyFloat `json:"net_advantage"`
+	BreakEvenGrossReturn     wire.PyFloat `json:"break_even_gross_return"`
 }
 
 type mortgageResponse struct {
@@ -111,47 +113,47 @@ func (h *Handler) MortgageVsInvest(w http.ResponseWriter, r *http.Request) {
 	}
 	resp := mortgageResponse{
 		Inputs: mortgageInputsWire{
-			RemainingPrincipal:   pyFloat(in.RemainingPrincipal),
-			AnnualInterestRate:   pyFloat(in.AnnualInterestRate),
+			RemainingPrincipal:   wire.PyFloat(in.RemainingPrincipal),
+			AnnualInterestRate:   wire.PyFloat(in.AnnualInterestRate),
 			RemainingMonths:      in.RemainingMonths,
-			TotalMonthlyBudget:   pyFloat(in.TotalMonthlyBudget),
-			ExpectedAnnualReturn: pyFloat(in.ExpectedAnnualReturn),
-			InflationRate:        pyFloat(in.InflationRate),
+			TotalMonthlyBudget:   wire.PyFloat(in.TotalMonthlyBudget),
+			ExpectedAnnualReturn: wire.PyFloat(in.ExpectedAnnualReturn),
+			InflationRate:        wire.PyFloat(in.InflationRate),
 			EnableVariableRate:   in.EnableVariableRate,
 		},
 		Summary: mortgageSummaryWire{
-			RegularMonthlyPayment:    pyFloat(result.Summary.RegularMonthlyPayment),
-			TotalInterestA:           pyFloat(result.Summary.TotalInterestA),
-			TotalInterestB:           pyFloat(result.Summary.TotalInterestB),
-			InterestSaved:            pyFloat(result.Summary.InterestSaved),
-			FinalInvestmentPortfolio: pyFloat(result.Summary.FinalInvestmentPortfolio),
-			FinalPortfolioAReal:      pyFloat(result.Summary.FinalPortfolioAReal),
-			FinalPortfolioBReal:      pyFloat(result.Summary.FinalPortfolioBReal),
+			RegularMonthlyPayment:    wire.PyFloat(result.Summary.RegularMonthlyPayment),
+			TotalInterestA:           wire.PyFloat(result.Summary.TotalInterestA),
+			TotalInterestB:           wire.PyFloat(result.Summary.TotalInterestB),
+			InterestSaved:            wire.PyFloat(result.Summary.InterestSaved),
+			FinalInvestmentPortfolio: wire.PyFloat(result.Summary.FinalInvestmentPortfolio),
+			FinalPortfolioAReal:      wire.PyFloat(result.Summary.FinalPortfolioAReal),
+			FinalPortfolioBReal:      wire.PyFloat(result.Summary.FinalPortfolioBReal),
 			MonthsSaved:              result.Summary.MonthsSaved,
 			WinningStrategy:          result.Summary.WinningStrategy,
-			NetAdvantage:             pyFloat(result.Summary.NetAdvantage),
-			BreakEvenGrossReturn:     pyFloat(result.Summary.BreakEvenGrossReturn),
+			NetAdvantage:             wire.PyFloat(result.Summary.NetAdvantage),
+			BreakEvenGrossReturn:     wire.PyFloat(result.Summary.BreakEvenGrossReturn),
 		},
 	}
 	resp.YearlyProjections = make([]mortgageYearlyWire, 0, len(result.Yearly))
 	for i := range result.Yearly {
 		y := &result.Yearly[i]
 		resp.YearlyProjections = append(resp.YearlyProjections, mortgageYearlyWire{
-			Year: y.Year, AnnualRate: pyFloat(y.AnnualRate),
-			ScenarioAMortgageBalance:     pyFloat(y.ScenarioAMortgageBalance),
-			ScenarioARealMortgageBalance: pyFloat(y.ScenarioARealMortgageBalance),
-			ScenarioACumulativeInterest:  pyFloat(y.ScenarioACumulativeInterest),
-			ScenarioAInvestmentBalance:   pyFloat(y.ScenarioAInvestmentBalance),
-			ScenarioAAfterTaxPortfolio:   pyFloat(y.ScenarioAAfterTaxPortfolio),
-			ScenarioARealPortfolio:       pyFloat(y.ScenarioARealPortfolio),
+			Year: y.Year, AnnualRate: wire.PyFloat(y.AnnualRate),
+			ScenarioAMortgageBalance:     wire.PyFloat(y.ScenarioAMortgageBalance),
+			ScenarioARealMortgageBalance: wire.PyFloat(y.ScenarioARealMortgageBalance),
+			ScenarioACumulativeInterest:  wire.PyFloat(y.ScenarioACumulativeInterest),
+			ScenarioAInvestmentBalance:   wire.PyFloat(y.ScenarioAInvestmentBalance),
+			ScenarioAAfterTaxPortfolio:   wire.PyFloat(y.ScenarioAAfterTaxPortfolio),
+			ScenarioARealPortfolio:       wire.PyFloat(y.ScenarioARealPortfolio),
 			ScenarioAPaidOff:             y.ScenarioAPaidOff,
-			ScenarioBMortgageBalance:     pyFloat(y.ScenarioBMortgageBalance),
-			ScenarioBRealMortgageBalance: pyFloat(y.ScenarioBRealMortgageBalance),
-			ScenarioBInvestmentBalance:   pyFloat(y.ScenarioBInvestmentBalance),
-			ScenarioBAfterTaxPortfolio:   pyFloat(y.ScenarioBAfterTaxPortfolio),
-			ScenarioBRealPortfolio:       pyFloat(y.ScenarioBRealPortfolio),
-			ScenarioBCumulativeInterest:  pyFloat(y.ScenarioBCumulativeInterest),
-			NetAdvantageInvest:           pyFloat(y.NetAdvantageInvest),
+			ScenarioBMortgageBalance:     wire.PyFloat(y.ScenarioBMortgageBalance),
+			ScenarioBRealMortgageBalance: wire.PyFloat(y.ScenarioBRealMortgageBalance),
+			ScenarioBInvestmentBalance:   wire.PyFloat(y.ScenarioBInvestmentBalance),
+			ScenarioBAfterTaxPortfolio:   wire.PyFloat(y.ScenarioBAfterTaxPortfolio),
+			ScenarioBRealPortfolio:       wire.PyFloat(y.ScenarioBRealPortfolio),
+			ScenarioBCumulativeInterest:  wire.PyFloat(y.ScenarioBCumulativeInterest),
+			NetAdvantageInvest:           wire.PyFloat(y.NetAdvantageInvest),
 		})
 	}
 	writeJSON(w, http.StatusOK, resp)
@@ -160,20 +162,20 @@ func (h *Handler) MortgageVsInvest(w http.ResponseWriter, r *http.Request) {
 // --- WIBOR scenarios wire types ---
 
 type wiborInputsWire struct {
-	RemainingPrincipal pyFloat `json:"remaining_principal"`
-	BaseAnnualRate     pyFloat `json:"base_annual_rate"`
-	RemainingMonths    int     `json:"remaining_months"`
-	BasePayment        pyFloat `json:"base_payment"`
+	RemainingPrincipal wire.PyFloat `json:"remaining_principal"`
+	BaseAnnualRate     wire.PyFloat `json:"base_annual_rate"`
+	RemainingMonths    int          `json:"remaining_months"`
+	BasePayment        wire.PyFloat `json:"base_payment"`
 }
 
 type wiborScenarioWire struct {
-	DeltaPP        pyFloat   `json:"delta_pp"`
-	AnnualRate     pyFloat   `json:"annual_rate"`
-	MonthlyPayment pyFloat   `json:"monthly_payment"`
-	TotalInterest  pyFloat   `json:"total_interest"`
-	TermMonths     int       `json:"term_months"`
-	RateFloored    bool      `json:"rate_floored"`
-	YearlyBalances []pyFloat `json:"yearly_balances"`
+	DeltaPP        wire.PyFloat   `json:"delta_pp"`
+	AnnualRate     wire.PyFloat   `json:"annual_rate"`
+	MonthlyPayment wire.PyFloat   `json:"monthly_payment"`
+	TotalInterest  wire.PyFloat   `json:"total_interest"`
+	TermMonths     int            `json:"term_months"`
+	RateFloored    bool           `json:"rate_floored"`
+	YearlyBalances []wire.PyFloat `json:"yearly_balances"`
 }
 
 type wiborResponse struct {
@@ -196,23 +198,23 @@ func (h *Handler) WiborScenarios(w http.ResponseWriter, r *http.Request) {
 	result := SimulateWiborScenarios(in, DefaultWiborDeltas)
 	resp := wiborResponse{
 		Inputs: wiborInputsWire{
-			RemainingPrincipal: pyFloat(in.RemainingPrincipal),
-			BaseAnnualRate:     pyFloat(in.BaseAnnualRate),
+			RemainingPrincipal: wire.PyFloat(in.RemainingPrincipal),
+			BaseAnnualRate:     wire.PyFloat(in.BaseAnnualRate),
 			RemainingMonths:    in.RemainingMonths,
-			BasePayment:        pyFloat(result.BasePayment),
+			BasePayment:        wire.PyFloat(result.BasePayment),
 		},
 	}
 	resp.Scenarios = make([]wiborScenarioWire, 0, len(result.Scenarios))
 	for _, s := range result.Scenarios {
-		balances := make([]pyFloat, 0, len(s.YearlyBalances))
+		balances := make([]wire.PyFloat, 0, len(s.YearlyBalances))
 		for _, b := range s.YearlyBalances {
-			balances = append(balances, pyFloat(b))
+			balances = append(balances, wire.PyFloat(b))
 		}
 		resp.Scenarios = append(resp.Scenarios, wiborScenarioWire{
-			DeltaPP:        pyFloat(s.DeltaPP),
-			AnnualRate:     pyFloat(s.AnnualRate),
-			MonthlyPayment: pyFloat(s.MonthlyPayment),
-			TotalInterest:  pyFloat(s.TotalInterest),
+			DeltaPP:        wire.PyFloat(s.DeltaPP),
+			AnnualRate:     wire.PyFloat(s.AnnualRate),
+			MonthlyPayment: wire.PyFloat(s.MonthlyPayment),
+			TotalInterest:  wire.PyFloat(s.TotalInterest),
 			TermMonths:     s.TermMonths,
 			RateFloored:    s.RateFloored,
 			YearlyBalances: balances,
@@ -229,28 +231,28 @@ func (h *Handler) Prefill(w http.ResponseWriter, r *http.Request) {
 		writeDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	balances := map[string]pyFloat{}
+	balances := map[string]wire.PyFloat{}
 	for k, v := range data.Balances {
-		balances[k] = pyFloat(v)
+		balances[k] = wire.PyFloat(v)
 	}
-	ppkBalances := map[string]pyFloat{}
+	ppkBalances := map[string]wire.PyFloat{}
 	for k, v := range data.PPKBalances {
-		ppkBalances[k] = pyFloat(v)
+		ppkBalances[k] = wire.PyFloat(v)
 	}
-	ppkRates := map[string]map[string]pyFloat{}
+	ppkRates := map[string]map[string]wire.PyFloat{}
 	for owner, rates := range data.PPKRates {
-		ppkRates[owner] = map[string]pyFloat{
-			"employee": pyFloat(rates["employee"]),
-			"employer": pyFloat(rates["employer"]),
+		ppkRates[owner] = map[string]wire.PyFloat{
+			"employee": wire.PyFloat(rates["employee"]),
+			"employer": wire.PyFloat(rates["employer"]),
 		}
 	}
-	salaries := map[string]*pyFloat{}
+	salaries := map[string]*wire.PyFloat{}
 	for k, v := range data.MonthlySalaries {
 		if v == nil {
 			salaries[k] = nil
 			continue
 		}
-		pf := pyFloat(*v)
+		pf := wire.PyFloat(*v)
 		salaries[k] = &pf
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -286,33 +288,33 @@ func (h *Handler) Retirement(w http.ResponseWriter, r *http.Request) {
 
 // monteCarloInputsWire mirrors MonteCarloInputs over JSON.
 type monteCarloInputsWire struct {
-	CurrentPortfolio    pyFloat                   `json:"current_portfolio"`
-	AnnualContribution  pyFloat                   `json:"annual_contribution"`
-	ExpectedReturn      pyFloat                   `json:"expected_return"`
-	Volatility          pyFloat                   `json:"volatility"`
+	CurrentPortfolio    wire.PyFloat              `json:"current_portfolio"`
+	AnnualContribution  wire.PyFloat              `json:"annual_contribution"`
+	ExpectedReturn      wire.PyFloat              `json:"expected_return"`
+	Volatility          wire.PyFloat              `json:"volatility"`
 	CurrentAge          int                       `json:"current_age"`
 	RetirementAge       int                       `json:"retirement_age"`
 	LifeExpectancy      int                       `json:"life_expectancy"`
-	AnnualWithdrawal    pyFloat                   `json:"annual_withdrawal"`
+	AnnualWithdrawal    wire.PyFloat              `json:"annual_withdrawal"`
 	Paths               int                       `json:"paths,omitempty"`
 	Allocation          *monteCarloAllocationWire `json:"allocation,omitempty"`
-	InflationMean       pyFloat                   `json:"inflation_mean"`
-	InflationVolatility pyFloat                   `json:"inflation_volatility"`
+	InflationMean       wire.PyFloat              `json:"inflation_mean"`
+	InflationVolatility wire.PyFloat              `json:"inflation_volatility"`
 	AccountMix          *monteCarloAccountMixWire `json:"account_mix,omitempty"`
 }
 
 type monteCarloAllocationWire struct {
-	StocksPct pyFloat `json:"stocks_pct"`
-	BondsPct  pyFloat `json:"bonds_pct"`
-	CashPct   pyFloat `json:"cash_pct"`
+	StocksPct wire.PyFloat `json:"stocks_pct"`
+	BondsPct  wire.PyFloat `json:"bonds_pct"`
+	CashPct   wire.PyFloat `json:"cash_pct"`
 }
 
 type monteCarloAccountMixWire struct {
-	TaxablePct     pyFloat `json:"taxable_pct"`
-	IkePct         pyFloat `json:"ike_pct"`
-	IkzePct        pyFloat `json:"ikze_pct"`
-	ZusPct         pyFloat `json:"zus_pct"`
-	TaxableGainPct pyFloat `json:"taxable_gain_pct"`
+	TaxablePct     wire.PyFloat `json:"taxable_pct"`
+	IkePct         wire.PyFloat `json:"ike_pct"`
+	IkzePct        wire.PyFloat `json:"ikze_pct"`
+	ZusPct         wire.PyFloat `json:"zus_pct"`
+	TaxableGainPct wire.PyFloat `json:"taxable_gain_pct"`
 }
 
 // MonteCarlo serves POST /api/simulations/monte-carlo. It runs `paths`

--- a/backend-go/internal/simulations/validation.go
+++ b/backend-go/internal/simulations/validation.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/rules"
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 type validationError struct {
@@ -165,7 +166,7 @@ type simulationInputs struct {
 }
 
 // echo reproduces the inputs block of the response from the typed values —
-// money fields go out as pyFloat so a whole-number input like 46100 still
+// money fields go out as wire.PyFloat so a whole-number input like 46100 still
 // serializes as 46100.0 (Pydantic float semantics).
 func (s simulationInputs) echo() map[string]any {
 	ike := make([]map[string]any, 0, len(s.IkeIkzeAccounts))
@@ -174,10 +175,10 @@ func (s simulationInputs) echo() map[string]any {
 			"enabled":              a.Enabled,
 			"wrapper":              a.Wrapper,
 			"owner_user_id":        a.OwnerUserID,
-			"balance":              pyFloat(a.Balance),
+			"balance":              wire.PyFloat(a.Balance),
 			"auto_fill_limit":      a.AutoFillLimit,
-			"monthly_contribution": pyFloat(a.MonthlyContribution),
-			"tax_rate":             pyFloat(a.TaxRate),
+			"monthly_contribution": wire.PyFloat(a.MonthlyContribution),
+			"tax_rate":             wire.PyFloat(a.TaxRate),
 		})
 	}
 	ppk := make([]map[string]any, 0, len(s.PPKAccounts))
@@ -185,10 +186,10 @@ func (s simulationInputs) echo() map[string]any {
 		ppk = append(ppk, map[string]any{
 			"owner_user_id":          a.OwnerUserID,
 			"enabled":                a.Enabled,
-			"starting_balance":       pyFloat(a.StartingBalance),
-			"monthly_gross_salary":   pyFloat(a.MonthlyGrossSalary),
-			"employee_rate":          pyFloat(a.EmployeeRate),
-			"employer_rate":          pyFloat(a.EmployerRate),
+			"starting_balance":       wire.PyFloat(a.StartingBalance),
+			"monthly_gross_salary":   wire.PyFloat(a.MonthlyGrossSalary),
+			"employee_rate":          wire.PyFloat(a.EmployeeRate),
+			"employer_rate":          wire.PyFloat(a.EmployerRate),
 			"salary_below_threshold": a.SalaryBelowThreshold,
 			"include_welcome_bonus":  a.IncludeWelcomeBonus,
 			"include_annual_subsidy": a.IncludeAnnualSubsidy,
@@ -199,8 +200,8 @@ func (s simulationInputs) echo() map[string]any {
 		brk = append(brk, map[string]any{
 			"enabled":              a.Enabled,
 			"owner_user_id":        a.OwnerUserID,
-			"balance":              pyFloat(a.Balance),
-			"monthly_contribution": pyFloat(a.MonthlyContribution),
+			"balance":              wire.PyFloat(a.Balance),
+			"monthly_contribution": wire.PyFloat(a.MonthlyContribution),
 		})
 	}
 	return map[string]any{
@@ -209,10 +210,10 @@ func (s simulationInputs) echo() map[string]any {
 		"ike_ikze_accounts":      ike,
 		"ppk_accounts":           ppk,
 		"brokerage_accounts":     brk,
-		"annual_return_rate":     pyFloat(s.AnnualReturnRate),
-		"limit_growth_rate":      pyFloat(s.LimitGrowthRate),
-		"expected_salary_growth": pyFloat(s.ExpectedSalaryGrowth),
-		"inflation_rate":         pyFloat(s.InflationRate),
+		"annual_return_rate":     wire.PyFloat(s.AnnualReturnRate),
+		"limit_growth_rate":      wire.PyFloat(s.LimitGrowthRate),
+		"expected_salary_growth": wire.PyFloat(s.ExpectedSalaryGrowth),
+		"inflation_rate":         wire.PyFloat(s.InflationRate),
 	}
 }
 

--- a/backend-go/internal/snapshots/handler.go
+++ b/backend-go/internal/snapshots/handler.go
@@ -12,29 +12,31 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 type valueResponse struct {
-	ID          int     `json:"id"`
-	AssetID     *int    `json:"asset_id"`
-	AssetName   *string `json:"asset_name"`
-	AccountID   *int    `json:"account_id"`
-	AccountName *string `json:"account_name"`
-	Value       pyFloat `json:"value"`
+	ID          int          `json:"id"`
+	AssetID     *int         `json:"asset_id"`
+	AssetName   *string      `json:"asset_name"`
+	AccountID   *int         `json:"account_id"`
+	AccountName *string      `json:"account_name"`
+	Value       wire.PyFloat `json:"value"`
 }
 
 type response struct {
 	ID     int             `json:"id"`
-	Date   isoDate         `json:"date"`
+	Date   wire.IsoDate    `json:"date"`
 	Notes  *string         `json:"notes"`
 	Values []valueResponse `json:"values"`
 }
 
 type listItem struct {
-	ID            int     `json:"id"`
-	Date          isoDate `json:"date"`
-	Notes         *string `json:"notes"`
-	TotalNetWorth pyFloat `json:"total_net_worth"`
+	ID            int          `json:"id"`
+	Date          wire.IsoDate `json:"date"`
+	Notes         *string      `json:"notes"`
+	TotalNetWorth wire.PyFloat `json:"total_net_worth"`
 }
 
 // Handler is the HTTP boundary for /api/snapshots.
@@ -54,7 +56,7 @@ func NewHandler(store *Store, logger *slog.Logger) *Handler {
 func buildResponse(snap *Snapshot, values []Value) response {
 	out := response{
 		ID:    snap.ID,
-		Date:  isoDate(snap.Date),
+		Date:  wire.IsoDate(snap.Date),
 		Notes: snap.Notes,
 	}
 	out.Values = make([]valueResponse, 0, len(values))
@@ -63,7 +65,7 @@ func buildResponse(snap *Snapshot, values []Value) response {
 		out.Values = append(out.Values, valueResponse{
 			ID: v.ID, AssetID: v.AssetID, AssetName: v.AssetName,
 			AccountID: v.AccountID, AccountName: v.AccountName,
-			Value: pyFloat(f),
+			Value: wire.PyFloat(f),
 		})
 	}
 	return out
@@ -80,8 +82,8 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 	out := make([]listItem, 0, len(rows))
 	for _, row := range rows {
 		out = append(out, listItem{
-			ID: row.ID, Date: isoDate(row.Date), Notes: row.Notes,
-			TotalNetWorth: pyFloat(row.TotalNetWorth),
+			ID: row.ID, Date: wire.IsoDate(row.Date), Notes: row.Notes,
+			TotalNetWorth: wire.PyFloat(row.TotalNetWorth),
 		})
 	}
 	writeJSON(w, http.StatusOK, out)
@@ -201,24 +203,4 @@ func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
 		return 0, false
 	}
 	return id, true
-}
-
-// --- wire types ---
-
-type isoDate time.Time
-
-const isoDateLayout = "2006-01-02"
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/transactions/handler.go
+++ b/backend-go/internal/transactions/handler.go
@@ -9,31 +9,32 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 // The canonical set of transaction_type values lives in types.go.
 // IsValid + ValidTypes are the only authority.
 
 type response struct {
-	ID              int      `json:"id"`
-	AccountID       int      `json:"account_id"`
-	AccountName     string   `json:"account_name"`
-	Amount          pyFloat  `json:"amount"`
-	Date            isoDate  `json:"date"`
-	OwnerUserID     *int     `json:"owner_user_id"`
-	TransactionType *string  `json:"transaction_type"`
-	CreatedAt       isoNaive `json:"created_at"`
+	ID              int           `json:"id"`
+	AccountID       int           `json:"account_id"`
+	AccountName     string        `json:"account_name"`
+	Amount          wire.PyFloat  `json:"amount"`
+	Date            wire.IsoDate  `json:"date"`
+	OwnerUserID     *int          `json:"owner_user_id"`
+	TransactionType *string       `json:"transaction_type"`
+	CreatedAt       wire.IsoNaive `json:"created_at"`
 }
 
 type listResponse struct {
-	Transactions     []response `json:"transactions"`
-	TotalInvested    pyFloat    `json:"total_invested"`
-	TransactionCount int        `json:"transaction_count"`
+	Transactions     []response   `json:"transactions"`
+	TotalInvested    wire.PyFloat `json:"total_invested"`
+	TransactionCount int          `json:"transaction_count"`
 }
 
 // Handler is the HTTP boundary.
@@ -56,11 +57,11 @@ func toResponse(t Transaction, accountName string) response {
 		ID:              t.ID,
 		AccountID:       t.AccountID,
 		AccountName:     accountName,
-		Amount:          pyFloat(amt),
-		Date:            isoDate(t.Date),
+		Amount:          wire.PyFloat(amt),
+		Date:            wire.IsoDate(t.Date),
 		OwnerUserID:     t.OwnerUserID,
 		TransactionType: t.TransactionType,
-		CreatedAt:       isoNaive(t.CreatedAt.UTC()),
+		CreatedAt:       wire.IsoNaive(t.CreatedAt.UTC()),
 	}
 }
 
@@ -143,7 +144,7 @@ func (h *Handler) ListAll(w http.ResponseWriter, r *http.Request) {
 	}
 	out.TransactionCount = len(out.Transactions)
 	total, _ := totalCents.Float64()
-	out.TotalInvested = pyFloat(total)
+	out.TotalInvested = wire.PyFloat(total)
 	writeJSON(w, http.StatusOK, out)
 }
 
@@ -256,7 +257,7 @@ func (h *Handler) writeList(w http.ResponseWriter, rows []Transaction, name func
 	}
 	out.TransactionCount = len(out.Transactions)
 	f, _ := total.Float64()
-	out.TotalInvested = pyFloat(f)
+	out.TotalInvested = wire.PyFloat(f)
 	writeJSON(w, http.StatusOK, out)
 }
 
@@ -382,30 +383,4 @@ func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (de
 
 func isNull(v json.RawMessage) bool {
 	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
-}
-
-// --- wire types ---
-
-type isoDate time.Time
-
-const isoDateLayout = "2006-01-02"
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
-}
-
-type isoNaive time.Time
-
-func (t isoNaive) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.999999") + `"`), nil
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }

--- a/backend-go/internal/wire/types.go
+++ b/backend-go/internal/wire/types.go
@@ -1,0 +1,58 @@
+// Package wire holds JSON wire types shared across HTTP handlers. They
+// preserve the JSON shapes produced by the Python-era backend: ISO date,
+// timezone-less ISO timestamp, and Python-style float (always renders a
+// decimal point).
+package wire
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	isoDateLayout  = "2006-01-02"
+	isoNaiveLayout = "2006-01-02T15:04:05.999999"
+)
+
+// IsoDate marshals a time.Time as a date-only YYYY-MM-DD string.
+type IsoDate time.Time
+
+func (d IsoDate) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
+}
+
+func (d *IsoDate) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	t, err := time.Parse(isoDateLayout, s)
+	if err != nil {
+		return err
+	}
+	*d = IsoDate(t)
+	return nil
+}
+
+// IsoNaive marshals a time.Time as an ISO-8601 timestamp without a zone
+// suffix, matching the Python datetime.isoformat() shape used by the
+// legacy API.
+type IsoNaive time.Time
+
+func (t IsoNaive) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format(isoNaiveLayout) + `"`), nil
+}
+
+// PyFloat marshals as a JSON number that always carries a decimal point,
+// mirroring Python's json.dumps behavior for floats (1 → 1.0).
+type PyFloat float64
+
+func (f PyFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}

--- a/backend-go/internal/wire/types.go
+++ b/backend-go/internal/wire/types.go
@@ -6,6 +6,7 @@ package wire
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -26,11 +27,11 @@ func (d IsoDate) MarshalJSON() ([]byte, error) {
 func (d *IsoDate) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		return err
+		return fmt.Errorf("expected YYYY-MM-DD string: %w", err)
 	}
 	t, err := time.Parse(isoDateLayout, s)
 	if err != nil {
-		return err
+		return fmt.Errorf("expected YYYY-MM-DD: %w", err)
 	}
 	*d = IsoDate(t)
 	return nil

--- a/backend-go/internal/wire/types_test.go
+++ b/backend-go/internal/wire/types_test.go
@@ -1,0 +1,81 @@
+package wire
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestIsoDateMarshal(t *testing.T) {
+	d := IsoDate(time.Date(2025, 3, 14, 9, 30, 0, 0, time.UTC))
+	out, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(out) != `"2025-03-14"` {
+		t.Fatalf("got %s", out)
+	}
+}
+
+func TestIsoDateUnmarshal(t *testing.T) {
+	var d IsoDate
+	if err := json.Unmarshal([]byte(`"2025-03-14"`), &d); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := time.Date(2025, 3, 14, 0, 0, 0, 0, time.UTC)
+	if !time.Time(d).Equal(want) {
+		t.Fatalf("got %v, want %v", time.Time(d), want)
+	}
+}
+
+func TestIsoDateUnmarshalReject(t *testing.T) {
+	var d IsoDate
+	if err := json.Unmarshal([]byte(`"2025/03/14"`), &d); err == nil {
+		t.Fatalf("expected error for bad format")
+	}
+}
+
+func TestIsoNaiveMarshal(t *testing.T) {
+	cases := []struct {
+		name string
+		in   time.Time
+		want string
+	}{
+		{"whole second", time.Date(2025, 3, 14, 9, 30, 15, 0, time.UTC), `"2025-03-14T09:30:15"`},
+		{"micros", time.Date(2025, 3, 14, 9, 30, 15, 123456000, time.UTC), `"2025-03-14T09:30:15.123456"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := json.Marshal(IsoNaive(tc.in))
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(out) != tc.want {
+				t.Fatalf("got %s, want %s", out, tc.want)
+			}
+		})
+	}
+}
+
+func TestPyFloatMarshal(t *testing.T) {
+	cases := []struct {
+		in   PyFloat
+		want string
+	}{
+		{0, "0.0"},
+		{1, "1.0"},
+		{-3, "-3.0"},
+		{1.5, "1.5"},
+		{1234.5678, "1234.5678"},
+		{0.1, "0.1"},
+	}
+	for _, tc := range cases {
+		out, err := json.Marshal(tc.in)
+		if err != nil {
+			t.Fatalf("marshal %v: %v", tc.in, err)
+		}
+		if string(out) != tc.want {
+			t.Fatalf("PyFloat(%v) -> %s, want %s", float64(tc.in), out, tc.want)
+		}
+	}
+}

--- a/backend-go/internal/zus/handler.go
+++ b/backend-go/internal/zus/handler.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
 // Handler is the HTTP boundary for /api/zus.
@@ -29,67 +30,67 @@ func NewHandler(store *Store, logger *slog.Logger) *Handler {
 // --- wire types ---
 
 type salaryHistoryEntry struct {
-	Year        int     `json:"year"`
-	AnnualGross pyFloat `json:"annual_gross"`
+	Year        int          `json:"year"`
+	AnnualGross wire.PyFloat `json:"annual_gross"`
 }
 
 type inputsResponse struct {
 	OwnerUserID               *int                 `json:"owner_user_id"`
-	BirthDate                 isoDate              `json:"birth_date"`
+	BirthDate                 wire.IsoDate         `json:"birth_date"`
 	Gender                    string               `json:"gender"`
 	RetirementAge             int                  `json:"retirement_age"`
-	CurrentGrossMonthlySalary pyFloat              `json:"current_gross_monthly_salary"`
-	SalaryGrowthRate          pyFloat              `json:"salary_growth_rate"`
-	InflationRate             pyFloat              `json:"inflation_rate"`
-	ValorizationRateKonto     pyFloat              `json:"valorization_rate_konto"`
-	ValorizationRateSubkonto  pyFloat              `json:"valorization_rate_subkonto"`
+	CurrentGrossMonthlySalary wire.PyFloat         `json:"current_gross_monthly_salary"`
+	SalaryGrowthRate          wire.PyFloat         `json:"salary_growth_rate"`
+	InflationRate             wire.PyFloat         `json:"inflation_rate"`
+	ValorizationRateKonto     wire.PyFloat         `json:"valorization_rate_konto"`
+	ValorizationRateSubkonto  wire.PyFloat         `json:"valorization_rate_subkonto"`
 	HasOFE                    bool                 `json:"has_ofe"`
-	KapitalPoczatkowy         pyFloat              `json:"kapital_poczatkowy"`
+	KapitalPoczatkowy         wire.PyFloat         `json:"kapital_poczatkowy"`
 	WorkStartYear             int                  `json:"work_start_year"`
 	SalaryHistory             []salaryHistoryEntry `json:"salary_history"`
 }
 
 type projectionResponse struct {
-	Year                 int     `json:"year"`
-	Age                  int     `json:"age"`
-	AnnualGrossSalary    pyFloat `json:"annual_gross_salary"`
-	SalaryCapped         bool    `json:"salary_capped"`
-	ContributionKonto    pyFloat `json:"contribution_konto"`
-	ContributionSubkonto pyFloat `json:"contribution_subkonto"`
-	KontoBalance         pyFloat `json:"konto_balance"`
-	SubkontoBalance      pyFloat `json:"subkonto_balance"`
-	TotalBalance         pyFloat `json:"total_balance"`
+	Year                 int          `json:"year"`
+	Age                  int          `json:"age"`
+	AnnualGrossSalary    wire.PyFloat `json:"annual_gross_salary"`
+	SalaryCapped         bool         `json:"salary_capped"`
+	ContributionKonto    wire.PyFloat `json:"contribution_konto"`
+	ContributionSubkonto wire.PyFloat `json:"contribution_subkonto"`
+	KontoBalance         wire.PyFloat `json:"konto_balance"`
+	SubkontoBalance      wire.PyFloat `json:"subkonto_balance"`
+	TotalBalance         wire.PyFloat `json:"total_balance"`
 }
 
 type sensitivityResponse struct {
-	Label                string  `json:"label"`
-	ValorizationKonto    pyFloat `json:"valorization_konto"`
-	ValorizationSubkonto pyFloat `json:"valorization_subkonto"`
-	MonthlyPensionGross  pyFloat `json:"monthly_pension_gross"`
-	MonthlyPensionNet    pyFloat `json:"monthly_pension_net"`
-	ReplacementRate      pyFloat `json:"replacement_rate"`
+	Label                string       `json:"label"`
+	ValorizationKonto    wire.PyFloat `json:"valorization_konto"`
+	ValorizationSubkonto wire.PyFloat `json:"valorization_subkonto"`
+	MonthlyPensionGross  wire.PyFloat `json:"monthly_pension_gross"`
+	MonthlyPensionNet    wire.PyFloat `json:"monthly_pension_net"`
+	ReplacementRate      wire.PyFloat `json:"replacement_rate"`
 }
 
 type calculateResponse struct {
 	Inputs                     inputsResponse        `json:"inputs"`
 	YearlyProjections          []projectionResponse  `json:"yearly_projections"`
-	LifeExpectancyMonths       pyFloat               `json:"life_expectancy_months"`
-	KontoAtRetirement          pyFloat               `json:"konto_at_retirement"`
-	SubkontoAtRetirement       pyFloat               `json:"subkonto_at_retirement"`
-	KapitalPoczatkowyValorized pyFloat               `json:"kapital_poczatkowy_valorized"`
-	TotalCapital               pyFloat               `json:"total_capital"`
-	MonthlyPensionGross        pyFloat               `json:"monthly_pension_gross"`
-	MonthlyPensionNet          pyFloat               `json:"monthly_pension_net"`
-	ReplacementRate            pyFloat               `json:"replacement_rate"`
-	LastGrossSalary            pyFloat               `json:"last_gross_salary"`
+	LifeExpectancyMonths       wire.PyFloat          `json:"life_expectancy_months"`
+	KontoAtRetirement          wire.PyFloat          `json:"konto_at_retirement"`
+	SubkontoAtRetirement       wire.PyFloat          `json:"subkonto_at_retirement"`
+	KapitalPoczatkowyValorized wire.PyFloat          `json:"kapital_poczatkowy_valorized"`
+	TotalCapital               wire.PyFloat          `json:"total_capital"`
+	MonthlyPensionGross        wire.PyFloat          `json:"monthly_pension_gross"`
+	MonthlyPensionNet          wire.PyFloat          `json:"monthly_pension_net"`
+	ReplacementRate            wire.PyFloat          `json:"replacement_rate"`
+	LastGrossSalary            wire.PyFloat          `json:"last_gross_salary"`
 	Sensitivity                []sensitivityResponse `json:"sensitivity"`
 }
 
 type prefillResponse struct {
-	BirthDate                 *isoDate             `json:"birth_date"`
+	BirthDate                 *wire.IsoDate        `json:"birth_date"`
 	RetirementAge             int                  `json:"retirement_age"`
 	Gender                    string               `json:"gender"`
-	CurrentGrossMonthlySalary *pyFloat             `json:"current_gross_monthly_salary"`
+	CurrentGrossMonthlySalary *wire.PyFloat        `json:"current_gross_monthly_salary"`
 	OwnerUserID               *int                 `json:"owner_user_id"`
 	SalaryHistory             []salaryHistoryEntry `json:"salary_history"`
 	WorkStartYear             *int                 `json:"work_start_year"`
@@ -114,51 +115,51 @@ func (h *Handler) Calculate(w http.ResponseWriter, r *http.Request) {
 	resp := calculateResponse{
 		Inputs: inputsResponse{
 			OwnerUserID:               req.Inputs.OwnerUserID,
-			BirthDate:                 isoDate(req.BirthDate),
+			BirthDate:                 wire.IsoDate(req.BirthDate),
 			Gender:                    req.Inputs.Gender,
 			RetirementAge:             req.Inputs.RetirementAge,
-			CurrentGrossMonthlySalary: pyFloat(req.Inputs.CurrentGrossMonthlySalary),
-			SalaryGrowthRate:          pyFloat(req.Inputs.SalaryGrowthRate),
-			InflationRate:             pyFloat(req.Inputs.InflationRate),
-			ValorizationRateKonto:     pyFloat(req.Inputs.ValorizationRateKonto),
-			ValorizationRateSubkonto:  pyFloat(req.Inputs.ValorizationRateSubkonto),
+			CurrentGrossMonthlySalary: wire.PyFloat(req.Inputs.CurrentGrossMonthlySalary),
+			SalaryGrowthRate:          wire.PyFloat(req.Inputs.SalaryGrowthRate),
+			InflationRate:             wire.PyFloat(req.Inputs.InflationRate),
+			ValorizationRateKonto:     wire.PyFloat(req.Inputs.ValorizationRateKonto),
+			ValorizationRateSubkonto:  wire.PyFloat(req.Inputs.ValorizationRateSubkonto),
 			HasOFE:                    req.Inputs.HasOFE,
-			KapitalPoczatkowy:         pyFloat(req.Inputs.KapitalPoczatkowy),
+			KapitalPoczatkowy:         wire.PyFloat(req.Inputs.KapitalPoczatkowy),
 			WorkStartYear:             req.Inputs.WorkStartYear,
 			SalaryHistory:             hist,
 		},
-		LifeExpectancyMonths:       pyFloat(result.LifeExpectancyMonths),
-		KontoAtRetirement:          pyFloat(result.KontoAtRetirement),
-		SubkontoAtRetirement:       pyFloat(result.SubkontoAtRetirement),
-		KapitalPoczatkowyValorized: pyFloat(result.KapitalPoczatkowyValorized),
-		TotalCapital:               pyFloat(result.TotalCapital),
-		MonthlyPensionGross:        pyFloat(result.MonthlyPensionGross),
-		MonthlyPensionNet:          pyFloat(result.MonthlyPensionNet),
-		ReplacementRate:            pyFloat(result.ReplacementRate),
-		LastGrossSalary:            pyFloat(result.LastGrossSalary),
+		LifeExpectancyMonths:       wire.PyFloat(result.LifeExpectancyMonths),
+		KontoAtRetirement:          wire.PyFloat(result.KontoAtRetirement),
+		SubkontoAtRetirement:       wire.PyFloat(result.SubkontoAtRetirement),
+		KapitalPoczatkowyValorized: wire.PyFloat(result.KapitalPoczatkowyValorized),
+		TotalCapital:               wire.PyFloat(result.TotalCapital),
+		MonthlyPensionGross:        wire.PyFloat(result.MonthlyPensionGross),
+		MonthlyPensionNet:          wire.PyFloat(result.MonthlyPensionNet),
+		ReplacementRate:            wire.PyFloat(result.ReplacementRate),
+		LastGrossSalary:            wire.PyFloat(result.LastGrossSalary),
 	}
 	resp.YearlyProjections = make([]projectionResponse, 0, len(result.YearlyProjections))
 	for _, p := range result.YearlyProjections {
 		resp.YearlyProjections = append(resp.YearlyProjections, projectionResponse{
 			Year: p.Year, Age: p.Age,
-			AnnualGrossSalary:    pyFloat(p.AnnualGrossSalary),
+			AnnualGrossSalary:    wire.PyFloat(p.AnnualGrossSalary),
 			SalaryCapped:         p.SalaryCapped,
-			ContributionKonto:    pyFloat(p.ContributionKonto),
-			ContributionSubkonto: pyFloat(p.ContributionSubkonto),
-			KontoBalance:         pyFloat(p.KontoBalance),
-			SubkontoBalance:      pyFloat(p.SubkontoBalance),
-			TotalBalance:         pyFloat(p.TotalBalance),
+			ContributionKonto:    wire.PyFloat(p.ContributionKonto),
+			ContributionSubkonto: wire.PyFloat(p.ContributionSubkonto),
+			KontoBalance:         wire.PyFloat(p.KontoBalance),
+			SubkontoBalance:      wire.PyFloat(p.SubkontoBalance),
+			TotalBalance:         wire.PyFloat(p.TotalBalance),
 		})
 	}
 	resp.Sensitivity = make([]sensitivityResponse, 0, len(result.Sensitivity))
 	for _, s := range result.Sensitivity {
 		resp.Sensitivity = append(resp.Sensitivity, sensitivityResponse{
 			Label:                s.Label,
-			ValorizationKonto:    pyFloat(s.ValorizationKonto),
-			ValorizationSubkonto: pyFloat(s.ValorizationSubkonto),
-			MonthlyPensionGross:  pyFloat(s.MonthlyPensionGross),
-			MonthlyPensionNet:    pyFloat(s.MonthlyPensionNet),
-			ReplacementRate:      pyFloat(s.ReplacementRate),
+			ValorizationKonto:    wire.PyFloat(s.ValorizationKonto),
+			ValorizationSubkonto: wire.PyFloat(s.ValorizationSubkonto),
+			MonthlyPensionGross:  wire.PyFloat(s.MonthlyPensionGross),
+			MonthlyPensionNet:    wire.PyFloat(s.MonthlyPensionNet),
+			ReplacementRate:      wire.PyFloat(s.ReplacementRate),
 		})
 	}
 	writeJSON(w, http.StatusOK, resp)
@@ -188,12 +189,12 @@ func (h *Handler) Prefill(w http.ResponseWriter, r *http.Request) {
 		Gender:        "M",
 	}
 	if data.BirthDate != nil {
-		d := isoDate(*data.BirthDate)
+		d := wire.IsoDate(*data.BirthDate)
 		resp.BirthDate = &d
 	}
 	resp.OwnerUserID = data.OwnerUserID
 	if data.CurrentGrossMonthlySalary != nil {
-		v := pyFloat(*data.CurrentGrossMonthlySalary)
+		v := wire.PyFloat(*data.CurrentGrossMonthlySalary)
 		resp.CurrentGrossMonthlySalary = &v
 	}
 	if data.WorkStartYear != nil {
@@ -212,40 +213,7 @@ func historyAsList(yearly map[int]float64) []salaryHistoryEntry {
 	sort.Ints(years)
 	out := make([]salaryHistoryEntry, 0, len(years))
 	for _, y := range years {
-		out = append(out, salaryHistoryEntry{Year: y, AnnualGross: pyFloat(yearly[y])})
+		out = append(out, salaryHistoryEntry{Year: y, AnnualGross: wire.PyFloat(yearly[y])})
 	}
 	return out
-}
-
-// --- wire types (shared) ---
-
-type isoDate time.Time
-
-const isoDateLayout = "2006-01-02"
-
-func (d isoDate) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(d).Format(isoDateLayout) + `"`), nil
-}
-
-func (d *isoDate) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	t, err := time.Parse(isoDateLayout, s)
-	if err != nil {
-		return err
-	}
-	*d = isoDate(t)
-	return nil
-}
-
-type pyFloat float64
-
-func (f pyFloat) MarshalJSON() ([]byte, error) {
-	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
-	if !strings.ContainsRune(s, '.') {
-		s += ".0"
-	}
-	return []byte(s), nil
 }


### PR DESCRIPTION
## Motivation

Per-domain handler.go files were each carrying their own copy of
`isoDate`, `isoNaive`, and `pyFloat` type definitions — identical
implementations of the legacy Python wire format duplicated across
22 packages. Phase 1 of the backend refactor punch list.

## Implementation information

- New `internal/wire/` package owns `IsoDate`, `IsoNaive`, `PyFloat`
  (capitalized, exported) plus a `UnmarshalJSON` for `IsoDate` that
  matches the existing parse behavior.
- All 22 handler files now import and use `wire.*`; per-package
  copies + their `isoDateLayout` constants are deleted.
- `cmd/gen-openapi` switch updated to match the exported names —
  the generated `api/openapi-go.json` is byte-identical.
- Net: -344 LOC.

Behavior parity verified:
- `go test ./...` — all green
- `golangci-lint run ./...` — 0 issues
- `backend-bb-tests` — 154 passed, 1 skipped (snapshot/golden suite)

## Supporting documentation

Phase 1.1 of the backend refactor research (Tier 1 cross-cutting win
from the punch list).