### PR TITLE
refactor(validation): extract IsNull + RawDecimal

### DIFF
--- a/backend-go/internal/accounts/validation.go
+++ b/backend-go/internal/accounts/validation.go
@@ -1,7 +1,6 @@
 package accounts
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -9,6 +8,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 type createRequest struct {
@@ -98,7 +98,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 //     (Pydantic's `Wrapper | None` lets None through and the service writes it)
 func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.ValidationError) {
 	var p UpdatePatch
-	if v, ok := raw["name"]; ok && !isNull(v) {
+	if v, ok := raw["name"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return p, &httputil.ValidationError{Field: "name", Msg: "must be a string"}
@@ -114,7 +114,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 	}
 	if v, ok := raw["owner_user_id"]; ok {
 		p.OwnerUserIDSet = true
-		if isNull(v) {
+		if validation.IsNull(v) {
 			p.OwnerUserID = nil
 		} else {
 			var n int
@@ -132,7 +132,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 	}
 	if v, ok := raw["account_wrapper"]; ok {
 		p.AccountWrapperSet = true
-		if isNull(v) {
+		if validation.IsNull(v) {
 			p.AccountWrapper = nil
 		} else {
 			var s string
@@ -147,24 +147,24 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 	}
 	if v, ok := raw["square_meters"]; ok {
 		p.SquareMetersSet = true
-		if isNull(v) {
+		if validation.IsNull(v) {
 			p.SquareMeters = nil
 		} else {
-			d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+			d, err := validation.RawDecimal(v)
 			if err != nil {
 				return p, &httputil.ValidationError{Field: "square_meters", Msg: "must be a number"}
 			}
 			p.SquareMeters = &d
 		}
 	}
-	if v, ok := raw["receives_contributions"]; ok && !isNull(v) {
+	if v, ok := raw["receives_contributions"]; ok && !validation.IsNull(v) {
 		var b bool
 		if err := json.Unmarshal(v, &b); err != nil {
 			return p, &httputil.ValidationError{Field: "receives_contributions", Msg: "must be a boolean"}
 		}
 		p.ReceivesContributions = &b
 	}
-	if v, ok := raw["excluded_from_fire"]; ok && !isNull(v) {
+	if v, ok := raw["excluded_from_fire"]; ok && !validation.IsNull(v) {
 		var b bool
 		if err := json.Unmarshal(v, &b); err != nil {
 			return p, &httputil.ValidationError{Field: "excluded_from_fire", Msg: "must be a boolean"}
@@ -178,7 +178,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 
 func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -199,7 +199,7 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 	if !ok {
 		return nil, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return nil, nil
 	}
 	var n int
@@ -211,7 +211,7 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 
 func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -229,7 +229,7 @@ func optionalString(raw map[string]json.RawMessage, key, fallback string) (strin
 	if !ok {
 		return fallback, nil
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
 	}
 	var s string
@@ -241,7 +241,7 @@ func optionalString(raw map[string]json.RawMessage, key, fallback string) (strin
 
 func optionalEnumOrNull(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (*string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil, nil
 	}
 	var s string
@@ -256,10 +256,10 @@ func optionalEnumOrNull(raw map[string]json.RawMessage, key string, allowed map[
 
 func optionalDecimal(raw map[string]json.RawMessage, key string) (*decimal.Decimal, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil, nil
 	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	d, err := validation.RawDecimal(v)
 	if err != nil {
 		return nil, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
@@ -271,7 +271,7 @@ func optionalBoolDefaultTrue(raw map[string]json.RawMessage, key string) (bool, 
 	if !ok {
 		return true, nil
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return false, &httputil.ValidationError{Field: key, Msg: "must be a boolean"}
 	}
 	var b bool
@@ -283,7 +283,7 @@ func optionalBoolDefaultTrue(raw map[string]json.RawMessage, key string) (bool, 
 
 func optionalBoolDefaultFalse(raw map[string]json.RawMessage, key string) (bool, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return false, nil
 	}
 	var b bool
@@ -295,7 +295,7 @@ func optionalBoolDefaultFalse(raw map[string]json.RawMessage, key string) (bool,
 
 func patchEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}, dest **string) *httputil.ValidationError {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil
 	}
 	var s string
@@ -311,7 +311,7 @@ func patchEnumString(raw map[string]json.RawMessage, key string, allowed map[str
 
 func patchPlainString(raw map[string]json.RawMessage, key string, dest **string) *httputil.ValidationError {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil
 	}
 	var s string
@@ -320,8 +320,4 @@ func patchPlainString(raw map[string]json.RawMessage, key string, dest **string)
 	}
 	*dest = &s
 	return nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/accounts/validation_test.go
+++ b/backend-go/internal/accounts/validation_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 func rawJSON(t *testing.T, m map[string]any) map[string]json.RawMessage {
@@ -310,8 +312,8 @@ func TestIsNullVariants(t *testing.T) {
 		{`""`, false},
 	}
 	for _, tc := range cases {
-		if got := isNull(json.RawMessage(tc.in)); got != tc.want {
-			t.Errorf("isNull(%q) = %v, want %v", tc.in, got, tc.want)
+		if got := validation.IsNull(json.RawMessage(tc.in)); got != tc.want {
+			t.Errorf("validation.IsNull(%q) = %v, want %v", tc.in, got, tc.want)
 		}
 	}
 }

--- a/backend-go/internal/allocation/validation.go
+++ b/backend-go/internal/allocation/validation.go
@@ -1,13 +1,13 @@
 package allocation
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 // validAllocationCategories are the asset-side categories users can target.
@@ -33,7 +33,7 @@ func validateCreate(req *createRequest) *httputil.ValidationError {
 // (owner_user_id / category) is delete + create.
 func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.ValidationError) {
 	var p UpdatePatch
-	if v, ok := raw["target_pct"]; ok && !isNull(v) {
+	if v, ok := raw["target_pct"]; ok && !validation.IsNull(v) {
 		var f float64
 		if err := json.Unmarshal(v, &f); err != nil {
 			return p, &httputil.ValidationError{Field: "target_pct", Msg: "must be a number"}
@@ -84,8 +84,4 @@ func validateReplaceBatch(items []replaceItem) *httputil.ValidationError {
 		}
 	}
 	return nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/assets/validation.go
+++ b/backend-go/internal/assets/validation.go
@@ -1,16 +1,16 @@
 package assets
 
 import (
-	"bytes"
 	"encoding/json"
 	"strings"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 func requireName(raw map[string]json.RawMessage) (string, *httputil.ValidationError) {
 	v, ok := raw["name"]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: "name", Msg: "Field required"}
 	}
 	var s string
@@ -27,7 +27,7 @@ func requireName(raw map[string]json.RawMessage) (string, *httputil.ValidationEr
 // optionalName: absent / explicit null -> no change. Empty string -> 422.
 func optionalName(raw map[string]json.RawMessage) (*string, *httputil.ValidationError) {
 	v, ok := raw["name"]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil, nil
 	}
 	var s string
@@ -39,8 +39,4 @@ func optionalName(raw map[string]json.RawMessage) (*string, *httputil.Validation
 		return nil, &httputil.ValidationError{Field: "name", Msg: "Name cannot be empty"}
 	}
 	return &s, nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/assets/validation_test.go
+++ b/backend-go/internal/assets/validation_test.go
@@ -3,6 +3,8 @@ package assets
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 func rawJSON(t *testing.T, m map[string]any) map[string]json.RawMessage {
@@ -95,8 +97,8 @@ func TestIsNullCases(t *testing.T) {
 		{"0", false},
 	}
 	for _, tc := range cases {
-		if got := isNull(json.RawMessage(tc.in)); got != tc.want {
-			t.Errorf("isNull(%q) = %v want %v", tc.in, got, tc.want)
+		if got := validation.IsNull(json.RawMessage(tc.in)); got != tc.want {
+			t.Errorf("validation.IsNull(%q) = %v want %v", tc.in, got, tc.want)
 		}
 	}
 }

--- a/backend-go/internal/bonds/validation.go
+++ b/backend-go/internal/bonds/validation.go
@@ -1,7 +1,6 @@
 package bonds
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 // validateCreate normalizes and rejects bad inputs on the create path.
@@ -46,7 +46,7 @@ func validateCreate(req *createRequest) *httputil.ValidationError {
 // package's Pydantic-shaped sparse-update behavior.
 func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.ValidationError) {
 	var p UpdatePatch
-	if v, ok := raw["type"]; ok && !isNull(v) {
+	if v, ok := raw["type"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return p, &httputil.ValidationError{Field: "type", Msg: "must be a string"}
@@ -57,7 +57,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.Type = &t
 	}
-	if v, ok := raw["series"]; ok && !isNull(v) {
+	if v, ok := raw["series"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return p, &httputil.ValidationError{Field: "series", Msg: "must be a string"}
@@ -71,7 +71,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 	if vErr := patchPositiveAmount(raw, "face_value", &p.FaceValue, "Face value must be greater than 0"); vErr != nil {
 		return p, vErr
 	}
-	if v, ok := raw["purchase_date"]; ok && !isNull(v) {
+	if v, ok := raw["purchase_date"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return p, &httputil.ValidationError{Field: "purchase_date", Msg: "must be a string"}
@@ -84,7 +84,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 	}
 	if v, ok := raw["owner_user_id"]; ok {
 		p.OwnerUserIDSet = true
-		if !isNull(v) {
+		if !validation.IsNull(v) {
 			var id int
 			if err := json.Unmarshal(v, &id); err != nil {
 				return p, &httputil.ValidationError{Field: "owner_user_id", Msg: "must be an integer"}
@@ -98,7 +98,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 	if vErr := patchRatePercent(raw, "margin", &p.Margin); vErr != nil {
 		return p, vErr
 	}
-	if v, ok := raw["capitalize"]; ok && !isNull(v) {
+	if v, ok := raw["capitalize"]; ok && !validation.IsNull(v) {
 		var b bool
 		if err := json.Unmarshal(v, &b); err != nil {
 			return p, &httputil.ValidationError{Field: "capitalize", Msg: "must be a boolean"}
@@ -110,7 +110,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 
 func patchPositiveAmount(raw map[string]json.RawMessage, field string, dest **decimal.Decimal, msg string) *httputil.ValidationError {
 	v, ok := raw[field]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil
 	}
 	var f float64
@@ -127,7 +127,7 @@ func patchPositiveAmount(raw map[string]json.RawMessage, field string, dest **de
 
 func patchRatePercent(raw map[string]json.RawMessage, field string, dest **decimal.Decimal) *httputil.ValidationError {
 	v, ok := raw[field]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil
 	}
 	var f float64
@@ -140,8 +140,4 @@ func patchRatePercent(raw map[string]json.RawMessage, field string, dest **decim
 	d := decimal.NewFromFloat(f)
 	*dest = &d
 	return nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -1,7 +1,6 @@
 package bonusevents
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 // buildCreateRequest reads + validates the POST body. JSON numbers are parsed
@@ -65,7 +65,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 		return r, vErr
 	}
 
-	if v, ok := raw["notes"]; ok && !isNull(v) {
+	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return r, &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
@@ -89,7 +89,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 }
 
 func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.ValidationError {
-	if v, ok := raw["date"]; ok && !isNull(v) {
+	if v, ok := raw["date"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "date", Msg: "must be a string"}
@@ -103,8 +103,8 @@ func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 		}
 		p.Date = &t
 	}
-	if v, ok := raw["amount"]; ok && !isNull(v) {
-		d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if v, ok := raw["amount"]; ok && !validation.IsNull(v) {
+		d, err := validation.RawDecimal(v)
 		if err != nil {
 			return &httputil.ValidationError{Field: "amount", Msg: "must be a number"}
 		}
@@ -113,7 +113,7 @@ func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 		}
 		p.Amount = &d
 	}
-	if v, ok := raw["currency"]; ok && !isNull(v) {
+	if v, ok := raw["currency"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "currency", Msg: "must be a string"}
@@ -124,7 +124,7 @@ func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 		}
 		p.Currency = &s
 	}
-	if v, ok := raw["company"]; ok && !isNull(v) {
+	if v, ok := raw["company"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "company", Msg: "must be a string"}
@@ -137,7 +137,7 @@ func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 	}
 	if v, ok := raw["owner_user_id"]; ok {
 		p.OwnerUserIDSet = true
-		if isNull(v) {
+		if validation.IsNull(v) {
 			p.OwnerUserID = nil
 		} else {
 			var n int
@@ -147,7 +147,7 @@ func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 			p.OwnerUserID = &n
 		}
 	}
-	if v, ok := raw["notes"]; ok && !isNull(v) {
+	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
@@ -158,7 +158,7 @@ func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 }
 
 func patchEnums(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.ValidationError {
-	if v, ok := raw["type"]; ok && !isNull(v) {
+	if v, ok := raw["type"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "type", Msg: "must be a string"}
@@ -168,7 +168,7 @@ func patchEnums(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Valida
 		}
 		p.Type = &s
 	}
-	if v, ok := raw["contract_type"]; ok && !isNull(v) {
+	if v, ok := raw["contract_type"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "contract_type", Msg: "must be a string"}
@@ -185,7 +185,7 @@ func patchEnums(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Valida
 
 func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -201,7 +201,7 @@ func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string
 
 func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -217,10 +217,10 @@ func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httput
 
 func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	d, err := validation.RawDecimal(v)
 	if err != nil {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
@@ -232,7 +232,7 @@ func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (de
 
 func optionalCurrency(raw map[string]json.RawMessage, fallback string) (string, *httputil.ValidationError) {
 	v, ok := raw["currency"]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return fallback, nil
 	}
 	var s string
@@ -248,7 +248,7 @@ func optionalCurrency(raw map[string]json.RawMessage, fallback string) (string, 
 
 func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -268,7 +268,7 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 	if !ok {
 		return nil, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return nil, nil
 	}
 	var n int
@@ -281,8 +281,4 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 func today() time.Time {
 	now := time.Now().UTC()
 	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/company_valuations/validation.go
+++ b/backend-go/internal/company_valuations/validation.go
@@ -1,7 +1,6 @@
 package companyvaluations
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 // buildCreateRequest is the POST body parser + validator.
@@ -75,7 +75,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Source = source
 
-	if v, ok := raw["notes"]; ok && !isNull(v) {
+	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return r, &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
@@ -100,7 +100,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 }
 
 func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.ValidationError {
-	if v, ok := raw["company"]; ok && !isNull(v) {
+	if v, ok := raw["company"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "company", Msg: "must be a string"}
@@ -111,7 +111,7 @@ func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 		}
 		p.Company = &s
 	}
-	if v, ok := raw["currency"]; ok && !isNull(v) {
+	if v, ok := raw["currency"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "currency", Msg: "must be a string"}
@@ -122,7 +122,7 @@ func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 		}
 		p.Currency = &s
 	}
-	if v, ok := raw["source"]; ok && !isNull(v) {
+	if v, ok := raw["source"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "source", Msg: "must be a string"}
@@ -132,14 +132,14 @@ func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 		}
 		p.Source = &s
 	}
-	if v, ok := raw["notes"]; ok && !isNull(v) {
+	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
 		}
 		p.Notes = &s
 	}
-	if v, ok := raw["date"]; ok && !isNull(v) {
+	if v, ok := raw["date"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "date", Msg: "must be a string"}
@@ -184,7 +184,7 @@ func patchNumbers(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 
 func requireString(raw map[string]json.RawMessage, key, missingMsg, emptyMsg string) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: missingMsg}
 	}
 	var s string
@@ -200,7 +200,7 @@ func requireString(raw map[string]json.RawMessage, key, missingMsg, emptyMsg str
 
 func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -216,7 +216,7 @@ func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httput
 
 func optionalCurrency(raw map[string]json.RawMessage) (string, *httputil.ValidationError) {
 	v, ok := raw["currency"]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "USD", nil // Python default
 	}
 	var s string
@@ -235,10 +235,10 @@ func optionalCurrency(raw map[string]json.RawMessage) (string, *httputil.Validat
 // preserved end-to-end.
 func requireNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	d, err := validation.RawDecimal(v)
 	if err != nil {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
@@ -250,10 +250,10 @@ func requireNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) 
 
 func optionalNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) (*decimal.Decimal, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil, nil
 	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	d, err := validation.RawDecimal(v)
 	if err != nil {
 		return nil, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
@@ -265,10 +265,10 @@ func optionalNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string)
 
 func optionalDiscountPct(raw map[string]json.RawMessage) (*decimal.Decimal, *httputil.ValidationError) {
 	v, ok := raw["common_stock_discount_pct"]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil, nil
 	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	d, err := validation.RawDecimal(v)
 	if err != nil {
 		return nil, &httputil.ValidationError{Field: "common_stock_discount_pct", Msg: "must be a number"}
 	}
@@ -281,8 +281,4 @@ func optionalDiscountPct(raw map[string]json.RawMessage) (*decimal.Decimal, *htt
 		}
 	}
 	return &d, nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/company_valuations/validation_test.go
+++ b/backend-go/internal/company_valuations/validation_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 // numericFields are the keys whose values must travel over the wire as JSON
@@ -291,8 +293,8 @@ func TestIsNull(t *testing.T) {
 		{`0`, false},
 	}
 	for _, c := range cases {
-		if got := isNull(json.RawMessage(c.in)); got != c.want {
-			t.Errorf("isNull(%q): want %v, got %v", c.in, c.want, got)
+		if got := validation.IsNull(json.RawMessage(c.in)); got != c.want {
+			t.Errorf("validation.IsNull(%q): want %v, got %v", c.in, c.want, got)
 		}
 	}
 }

--- a/backend-go/internal/cpi/handler.go
+++ b/backend-go/internal/cpi/handler.go
@@ -1,7 +1,6 @@
 package cpi
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
@@ -183,7 +183,7 @@ func (h *Handler) Refresh(w http.ResponseWriter, r *http.Request) {
 
 func requireFloat(raw map[string]json.RawMessage, key string) (float64, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var f float64
@@ -195,7 +195,7 @@ func requireFloat(raw map[string]json.RawMessage, key string) (float64, *httputi
 
 func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -207,8 +207,4 @@ func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httput
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
 	}
 	return t, nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/debt_payments/handler.go
+++ b/backend-go/internal/debt_payments/handler.go
@@ -1,7 +1,6 @@
 package debtpayments
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +14,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
@@ -290,7 +290,7 @@ func requireOwnerUserID(raw map[string]json.RawMessage) (*int, *httputil.Validat
 	if !ok {
 		return nil, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return nil, nil
 	}
 	var n int
@@ -303,7 +303,7 @@ func requireOwnerUserID(raw map[string]json.RawMessage) (*int, *httputil.Validat
 func requireDateNotFuture(raw map[string]json.RawMessage) (time.Time, *httputil.ValidationError) {
 	const key = "date"
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -328,10 +328,10 @@ func requireAmount(raw map[string]json.RawMessage) (decimal.Decimal, *httputil.V
 		msg = "Amount must be greater than 0"
 	)
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	d, err := validation.RawDecimal(v)
 	if err != nil {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
@@ -339,8 +339,4 @@ func requireAmount(raw map[string]json.RawMessage) (decimal.Decimal, *httputil.V
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: msg}
 	}
 	return d, nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/debt_payments/handler_test.go
+++ b/backend-go/internal/debt_payments/handler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/shopspring/decimal"
 
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
@@ -27,8 +28,8 @@ func TestIsNull(t *testing.T) {
 		{`""`, false},
 	}
 	for _, c := range cases {
-		if got := isNull(rawJSON(c.in)); got != c.want {
-			t.Errorf("isNull(%q): want %v, got %v", c.in, c.want, got)
+		if got := validation.IsNull(rawJSON(c.in)); got != c.want {
+			t.Errorf("validation.IsNull(%q): want %v, got %v", c.in, c.want, got)
 		}
 	}
 }

--- a/backend-go/internal/debts/validation.go
+++ b/backend-go/internal/debts/validation.go
@@ -1,7 +1,6 @@
 package debts
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 var validDebtTypes = map[string]struct{}{
@@ -64,7 +64,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Currency = cur
 
-	if v, ok := raw["notes"]; ok && !isNull(v) {
+	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return r, &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
@@ -76,7 +76,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 
 func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.ValidationError) {
 	var p UpdatePatch
-	if v, ok := raw["name"]; ok && !isNull(v) {
+	if v, ok := raw["name"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return p, &httputil.ValidationError{Field: "name", Msg: "must be a string"}
@@ -87,7 +87,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.Name = &s
 	}
-	if v, ok := raw["debt_type"]; ok && !isNull(v) {
+	if v, ok := raw["debt_type"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return p, &httputil.ValidationError{Field: "debt_type", Msg: "must be a string"}
@@ -97,7 +97,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.DebtType = &s
 	}
-	if v, ok := raw["start_date"]; ok && !isNull(v) {
+	if v, ok := raw["start_date"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return p, &httputil.ValidationError{Field: "start_date", Msg: "must be a string"}
@@ -111,8 +111,8 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.StartDate = &t
 	}
-	if v, ok := raw["initial_amount"]; ok && !isNull(v) {
-		d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if v, ok := raw["initial_amount"]; ok && !validation.IsNull(v) {
+		d, err := validation.RawDecimal(v)
 		if err != nil {
 			return p, &httputil.ValidationError{Field: "initial_amount", Msg: "must be a number"}
 		}
@@ -121,8 +121,8 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.InitialAmount = &d
 	}
-	if v, ok := raw["interest_rate"]; ok && !isNull(v) {
-		d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if v, ok := raw["interest_rate"]; ok && !validation.IsNull(v) {
+		d, err := validation.RawDecimal(v)
 		if err != nil {
 			return p, &httputil.ValidationError{Field: "interest_rate", Msg: "must be a number"}
 		}
@@ -131,7 +131,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.InterestRate = &d
 	}
-	if v, ok := raw["currency"]; ok && !isNull(v) {
+	if v, ok := raw["currency"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return p, &httputil.ValidationError{Field: "currency", Msg: "must be a string"}
@@ -141,7 +141,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.Currency = &s
 	}
-	if v, ok := raw["notes"]; ok && !isNull(v) {
+	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return p, &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
@@ -158,7 +158,7 @@ func requireOwnerUserID(raw map[string]json.RawMessage) (*int, *httputil.Validat
 	if !ok {
 		return nil, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return nil, nil
 	}
 	var n int
@@ -170,7 +170,7 @@ func requireOwnerUserID(raw map[string]json.RawMessage) (*int, *httputil.Validat
 
 func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -186,7 +186,7 @@ func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string
 
 func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -201,7 +201,7 @@ func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[s
 
 func requireDateNotFuture(raw map[string]json.RawMessage, key, msg string) (time.Time, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -220,10 +220,10 @@ func requireDateNotFuture(raw map[string]json.RawMessage, key, msg string) (time
 
 func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	d, err := validation.RawDecimal(v)
 	if err != nil {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
@@ -235,10 +235,10 @@ func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (de
 
 func requireNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	d, err := validation.RawDecimal(v)
 	if err != nil {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
@@ -250,7 +250,7 @@ func requireNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) 
 
 func optionalCurrencyPLN(raw map[string]json.RawMessage) (string, *httputil.ValidationError) {
 	v, ok := raw["currency"]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "PLN", nil
 	}
 	var s string
@@ -266,8 +266,4 @@ func optionalCurrencyPLN(raw map[string]json.RawMessage) (string, *httputil.Vali
 func today() time.Time {
 	t := time.Now().UTC()
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -1,7 +1,6 @@
 package equitygrants
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -11,6 +10,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 // createRequest is the parsed-and-validated input ready for Store.Create.
@@ -163,14 +163,14 @@ func requireGrantVesting(raw map[string]json.RawMessage, r *createRequest) *http
 }
 
 func optionalGrantLiquidity(raw map[string]json.RawMessage, r *createRequest) *httputil.ValidationError {
-	if v, ok := raw["requires_liquidity_event"]; ok && !isNull(v) {
+	if v, ok := raw["requires_liquidity_event"]; ok && !validation.IsNull(v) {
 		var b bool
 		if err := json.Unmarshal(v, &b); err != nil {
 			return &httputil.ValidationError{Field: "requires_liquidity_event", Msg: "must be a boolean"}
 		}
 		r.RequiresLiquidityEvent = b
 	}
-	if v, ok := raw["liquidity_event_date"]; ok && !isNull(v) {
+	if v, ok := raw["liquidity_event_date"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "liquidity_event_date", Msg: "must be a string"}
@@ -191,7 +191,7 @@ func optionalGrantTaxNotes(raw map[string]json.RawMessage, r *createRequest) *ht
 	}
 	r.TaxTreatment = tax
 
-	if v, ok := raw["notes"]; ok && !isNull(v) {
+	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
@@ -239,7 +239,7 @@ func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 	if vErr := patchEnumString(raw, "tax_treatment", validTaxTreatments, &p.TaxTreatment); vErr != nil {
 		return vErr
 	}
-	if v, ok := raw["notes"]; ok && !isNull(v) {
+	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
@@ -259,8 +259,8 @@ func patchNumbersAndBools(raw map[string]json.RawMessage, p *UpdatePatch) *httpu
 	if vErr := patchPositiveInt(raw, "vest_total_months", "Total vesting months must be greater than 0", &p.VestTotalMonths); vErr != nil {
 		return vErr
 	}
-	if v, ok := raw["strike_price"]; ok && !isNull(v) {
-		d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if v, ok := raw["strike_price"]; ok && !validation.IsNull(v) {
+		d, err := validation.RawDecimal(v)
 		if err != nil {
 			return &httputil.ValidationError{Field: "strike_price", Msg: "must be a number"}
 		}
@@ -269,7 +269,7 @@ func patchNumbersAndBools(raw map[string]json.RawMessage, p *UpdatePatch) *httpu
 		}
 		p.StrikePrice = &d
 	}
-	if v, ok := raw["requires_liquidity_event"]; ok && !isNull(v) {
+	if v, ok := raw["requires_liquidity_event"]; ok && !validation.IsNull(v) {
 		var b bool
 		if err := json.Unmarshal(v, &b); err != nil {
 			return &httputil.ValidationError{Field: "requires_liquidity_event", Msg: "must be a boolean"}
@@ -289,7 +289,7 @@ func patchDates(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Valida
 		{"liquidity_event_date", &p.LiquidityEventDate},
 	} {
 		v, ok := raw[f.key]
-		if !ok || isNull(v) {
+		if !ok || validation.IsNull(v) {
 			continue
 		}
 		var s string
@@ -310,7 +310,7 @@ func patchDates(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Valida
 // actual JSON array reassigns the field.
 func patchSchedule(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.ValidationError {
 	v, ok := raw["vest_custom_schedule"]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil
 	}
 	schedule, vErr := parseCustomSchedule(v)
@@ -326,7 +326,7 @@ func patchSchedule(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Val
 
 func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -342,7 +342,7 @@ func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string
 
 func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -358,7 +358,7 @@ func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httput
 
 func requirePositiveInt(raw map[string]json.RawMessage, key, msg string) (int, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var n int
@@ -373,7 +373,7 @@ func requirePositiveInt(raw map[string]json.RawMessage, key, msg string) (int, *
 
 func optionalNonNegativeInt(raw map[string]json.RawMessage, key, msg string, fallback int) (int, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return fallback, nil
 	}
 	var n int
@@ -388,7 +388,7 @@ func optionalNonNegativeInt(raw map[string]json.RawMessage, key, msg string, fal
 
 func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -403,7 +403,7 @@ func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[s
 
 func optionalEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}, fallback string) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return fallback, nil
 	}
 	var s string
@@ -418,7 +418,7 @@ func optionalEnumString(raw map[string]json.RawMessage, key string, allowed map[
 
 func optionalCurrency(raw map[string]json.RawMessage, fallback string) (string, *httputil.ValidationError) {
 	v, ok := raw["currency"]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return fallback, nil
 	}
 	var s string
@@ -434,10 +434,10 @@ func optionalCurrency(raw map[string]json.RawMessage, fallback string) (string, 
 
 func optionalNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) (*decimal.Decimal, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil, nil
 	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	d, err := validation.RawDecimal(v)
 	if err != nil {
 		return nil, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
@@ -449,7 +449,7 @@ func optionalNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string)
 
 func optionalCustomSchedule(raw map[string]json.RawMessage) ([]CustomScheduleEntry, *httputil.ValidationError) {
 	v, ok := raw["vest_custom_schedule"]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil, nil
 	}
 	return parseCustomSchedule(v)
@@ -516,7 +516,7 @@ func toFloat(v any) (float64, error) {
 
 func patchEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}, dest **string) *httputil.ValidationError {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil
 	}
 	var s string
@@ -532,7 +532,7 @@ func patchEnumString(raw map[string]json.RawMessage, key string, allowed map[str
 
 func patchNonEmptyString(raw map[string]json.RawMessage, key, emptyMsg string, dest **string) *httputil.ValidationError {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil
 	}
 	var s string
@@ -549,7 +549,7 @@ func patchNonEmptyString(raw map[string]json.RawMessage, key, emptyMsg string, d
 
 func patchCurrency(raw map[string]json.RawMessage, dest **string) *httputil.ValidationError {
 	v, ok := raw["currency"]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil
 	}
 	var s string
@@ -566,7 +566,7 @@ func patchCurrency(raw map[string]json.RawMessage, dest **string) *httputil.Vali
 
 func patchPositiveInt(raw map[string]json.RawMessage, key, msg string, dest **int) *httputil.ValidationError {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil
 	}
 	var n int
@@ -582,7 +582,7 @@ func patchPositiveInt(raw map[string]json.RawMessage, key, msg string, dest **in
 
 func patchNonNegativeIntPtr(raw map[string]json.RawMessage, key, msg string, dest **int) *httputil.ValidationError {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil
 	}
 	var n int
@@ -603,7 +603,7 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 	if !ok {
 		return nil, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return nil, nil
 	}
 	var n int
@@ -621,7 +621,7 @@ func patchOwnerUserID(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.
 		return nil
 	}
 	p.OwnerUserIDSet = true
-	if isNull(v) {
+	if validation.IsNull(v) {
 		p.OwnerUserID = nil
 		return nil
 	}
@@ -631,8 +631,4 @@ func patchOwnerUserID(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.
 	}
 	p.OwnerUserID = &n
 	return nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/goals/validation.go
+++ b/backend-go/internal/goals/validation.go
@@ -1,7 +1,6 @@
 package goals
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 func validateCreate(req *createRequest) *httputil.ValidationError {
@@ -62,7 +62,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 // Matches Python's GoalUpdate validators: explicit null is treated as
 // "no-op" (the validator returns None and the service skips that field).
 func patchScalarFields(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.ValidationError {
-	if v, ok := raw["name"]; ok && !isNull(v) {
+	if v, ok := raw["name"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "name", Msg: "must be a string"}
@@ -76,7 +76,7 @@ func patchScalarFields(raw map[string]json.RawMessage, p *UpdatePatch) *httputil
 	if vErr := patchPositiveAmount(raw, "target_amount", &p.TargetAmount, "Target amount must be greater than 0"); vErr != nil {
 		return vErr
 	}
-	if v, ok := raw["target_date"]; ok && !isNull(v) {
+	if v, ok := raw["target_date"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return &httputil.ValidationError{Field: "target_date", Msg: "must be a string"}
@@ -93,7 +93,7 @@ func patchScalarFields(raw map[string]json.RawMessage, p *UpdatePatch) *httputil
 	if vErr := patchNonNegativeAmount(raw, "monthly_contribution", &p.MonthlyContribution, "Monthly contribution must be non-negative"); vErr != nil {
 		return vErr
 	}
-	if v, ok := raw["is_completed"]; ok && !isNull(v) {
+	if v, ok := raw["is_completed"]; ok && !validation.IsNull(v) {
 		var b bool
 		if err := json.Unmarshal(v, &b); err != nil {
 			return &httputil.ValidationError{Field: "is_completed", Msg: "must be a boolean"}
@@ -108,7 +108,7 @@ func patchScalarFields(raw map[string]json.RawMessage, p *UpdatePatch) *httputil
 func patchNullableRefs(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.ValidationError {
 	if v, ok := raw["account_id"]; ok {
 		p.AccountIDSet = true
-		if !isNull(v) {
+		if !validation.IsNull(v) {
 			var id int
 			if err := json.Unmarshal(v, &id); err != nil {
 				return &httputil.ValidationError{Field: "account_id", Msg: "must be an integer"}
@@ -118,7 +118,7 @@ func patchNullableRefs(raw map[string]json.RawMessage, p *UpdatePatch) *httputil
 	}
 	if v, ok := raw["category"]; ok {
 		p.CategorySet = true
-		if !isNull(v) {
+		if !validation.IsNull(v) {
 			var s string
 			if err := json.Unmarshal(v, &s); err != nil {
 				return &httputil.ValidationError{Field: "category", Msg: "must be a string"}
@@ -137,7 +137,7 @@ func patchNullableRefs(raw map[string]json.RawMessage, p *UpdatePatch) *httputil
 
 func patchPositiveAmount(raw map[string]json.RawMessage, field string, dest **decimal.Decimal, msg string) *httputil.ValidationError {
 	v, ok := raw[field]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil
 	}
 	var f float64
@@ -154,7 +154,7 @@ func patchPositiveAmount(raw map[string]json.RawMessage, field string, dest **de
 
 func patchNonNegativeAmount(raw map[string]json.RawMessage, field string, dest **decimal.Decimal, msg string) *httputil.ValidationError {
 	v, ok := raw[field]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil
 	}
 	var f float64
@@ -167,8 +167,4 @@ func patchNonNegativeAmount(raw map[string]json.RawMessage, field string, dest *
 	d := decimal.NewFromFloat(f)
 	*dest = &d
 	return nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/retirement/validation.go
+++ b/backend-go/internal/retirement/validation.go
@@ -1,7 +1,6 @@
 package retirement
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -9,6 +8,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 type limitRequest struct {
@@ -51,7 +51,7 @@ func buildLimitRequest(raw map[string]json.RawMessage, now func() time.Time) (li
 	}
 	r.LimitAmount = amt
 
-	if v, ok := raw["notes"]; ok && !isNull(v) {
+	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return r, &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
@@ -112,7 +112,7 @@ func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) 
 // gets a 422 instead of silently degrading to false.
 func optionalBool(raw map[string]json.RawMessage, key string) (bool, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return false, nil
 	}
 	var b bool
@@ -125,7 +125,7 @@ func optionalBool(raw map[string]json.RawMessage, key string) (bool, *httputil.V
 // requireInt reads an integer key that must be present and non-null.
 func requireInt(raw map[string]json.RawMessage, key string) (int, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var n int
@@ -142,7 +142,7 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 	if !ok {
 		return nil, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return nil, nil
 	}
 	var n int
@@ -154,7 +154,7 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 
 func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -169,7 +169,7 @@ func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[s
 
 func requireIntRange(raw map[string]json.RawMessage, key string, lo, hi int, msg string) (int, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var n int
@@ -184,10 +184,10 @@ func requireIntRange(raw map[string]json.RawMessage, key string, lo, hi int, msg
 
 func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	d, err := validation.RawDecimal(v)
 	if err != nil {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
@@ -195,8 +195,4 @@ func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (de
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: msg}
 	}
 	return d, nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/salaries/validation.go
+++ b/backend-go/internal/salaries/validation.go
@@ -1,7 +1,6 @@
 package salaries
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 // createRequest is the validated POST body. OwnerUserID is required as a
@@ -65,7 +65,7 @@ func buildCreateRequest(raw map[string]json.RawMessage, now func() time.Time) (c
 // buildUpdatePatch reads the PATCH body. Null = no-op (Pydantic semantics).
 func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (UpdatePatch, *httputil.ValidationError) {
 	var p UpdatePatch
-	if v, ok := raw["date"]; ok && !isNull(v) {
+	if v, ok := raw["date"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return p, &httputil.ValidationError{Field: "date", Msg: "must be a string"}
@@ -79,8 +79,8 @@ func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (Upd
 		}
 		p.Date = &t
 	}
-	if v, ok := raw["gross_amount"]; ok && !isNull(v) {
-		d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	if v, ok := raw["gross_amount"]; ok && !validation.IsNull(v) {
+		d, err := validation.RawDecimal(v)
 		if err != nil {
 			return p, &httputil.ValidationError{Field: "gross_amount", Msg: "must be a number"}
 		}
@@ -89,7 +89,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (Upd
 		}
 		p.GrossAmount = &d
 	}
-	if v, ok := raw["contract_type"]; ok && !isNull(v) {
+	if v, ok := raw["contract_type"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return p, &httputil.ValidationError{Field: "contract_type", Msg: "must be a string"}
@@ -99,7 +99,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (Upd
 		}
 		p.ContractType = &s
 	}
-	if v, ok := raw["company"]; ok && !isNull(v) {
+	if v, ok := raw["company"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return p, &httputil.ValidationError{Field: "company", Msg: "must be a string"}
@@ -112,7 +112,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (Upd
 	}
 	if v, ok := raw["owner_user_id"]; ok {
 		p.OwnerUserIDSet = true
-		if isNull(v) {
+		if validation.IsNull(v) {
 			p.OwnerUserID = nil
 		} else {
 			var n int
@@ -132,7 +132,7 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 	if !ok {
 		return nil, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return nil, nil
 	}
 	var n int
@@ -144,7 +144,7 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 
 func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -160,7 +160,7 @@ func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string
 
 func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -176,10 +176,10 @@ func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httput
 
 func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	d, err := validation.RawDecimal(v)
 	if err != nil {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
@@ -191,7 +191,7 @@ func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (de
 
 func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -202,8 +202,4 @@ func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[s
 		return "", &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
 	}
 	return s, nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/simulations/validation.go
+++ b/backend-go/internal/simulations/validation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 	"github.com/Automaat/finance-buddy/backend-go/internal/rules"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
@@ -58,7 +59,7 @@ func buildMortgageInputs(raw map[string]json.RawMessage) (MortgageInputs, *httpu
 		return in, &httputil.ValidationError{Field: "expected_annual_return", Msg: "Expected annual return must be between 0 and 50%"}
 	}
 	in.InflationRate = 3.0
-	if v, ok := raw["inflation_rate"]; ok && !isNullRaw(v) {
+	if v, ok := raw["inflation_rate"]; ok && !validation.IsNull(v) {
 		f, err := floatFromRaw(v)
 		if err != nil {
 			return in, &httputil.ValidationError{Field: "inflation_rate", Msg: "must be a number"}
@@ -68,7 +69,7 @@ func buildMortgageInputs(raw map[string]json.RawMessage) (MortgageInputs, *httpu
 		}
 		in.InflationRate = f
 	}
-	if v, ok := raw["enable_variable_rate"]; ok && !isNullRaw(v) {
+	if v, ok := raw["enable_variable_rate"]; ok && !validation.IsNull(v) {
 		var b bool
 		if err := json.Unmarshal(v, &b); err != nil {
 			return in, &httputil.ValidationError{Field: "enable_variable_rate", Msg: "must be a boolean"}
@@ -105,7 +106,7 @@ func buildWiborInputs(raw map[string]json.RawMessage) (WiborScenarioInputs, *htt
 	if in.RemainingMonths < 1 || in.RemainingMonths > 600 {
 		return in, &httputil.ValidationError{Field: "remaining_months", Msg: "Remaining months must be between 1 and 600"}
 	}
-	if v, ok := raw["base_payment"]; ok && !isNullRaw(v) {
+	if v, ok := raw["base_payment"]; ok && !validation.IsNull(v) {
 		f, err := floatFromRaw(v)
 		if err != nil {
 			return in, &httputil.ValidationError{Field: "base_payment", Msg: "must be a number"}
@@ -268,7 +269,7 @@ func parseSimAssumptions(raw map[string]json.RawMessage, in *simulationInputs) *
 	}
 	for _, rt := range rates {
 		v, ok := raw[rt.key]
-		if !ok || isNullRaw(v) {
+		if !ok || validation.IsNull(v) {
 			continue
 		}
 		f, err := floatFromRaw(v)
@@ -284,21 +285,21 @@ func parseSimAssumptions(raw map[string]json.RawMessage, in *simulationInputs) *
 }
 
 func parseSimAccounts(raw map[string]json.RawMessage, in *simulationInputs) *httputil.ValidationError {
-	if v, ok := raw["ike_ikze_accounts"]; ok && !isNullRaw(v) {
+	if v, ok := raw["ike_ikze_accounts"]; ok && !validation.IsNull(v) {
 		ike, vErr := parseIkeIkze(v)
 		if vErr != nil {
 			return vErr
 		}
 		in.IkeIkzeAccounts = ike
 	}
-	if v, ok := raw["ppk_accounts"]; ok && !isNullRaw(v) {
+	if v, ok := raw["ppk_accounts"]; ok && !validation.IsNull(v) {
 		ppk, vErr := parsePPK(v)
 		if vErr != nil {
 			return vErr
 		}
 		in.PPKAccounts = ppk
 	}
-	if v, ok := raw["brokerage_accounts"]; ok && !isNullRaw(v) {
+	if v, ok := raw["brokerage_accounts"]; ok && !validation.IsNull(v) {
 		brk, vErr := parseBrokerage(v)
 		if vErr != nil {
 			return vErr
@@ -420,7 +421,7 @@ func parseBrokerage(raw json.RawMessage) ([]brokerageInput, *httputil.Validation
 
 func requireFloat(raw map[string]json.RawMessage, key string) (float64, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNullRaw(v) {
+	if !ok || validation.IsNull(v) {
 		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	f, err := floatFromRaw(v)
@@ -432,7 +433,7 @@ func requireFloat(raw map[string]json.RawMessage, key string) (float64, *httputi
 
 func requireInt(raw map[string]json.RawMessage, key string) (int, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNullRaw(v) {
+	if !ok || validation.IsNull(v) {
 		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var n int
@@ -459,10 +460,6 @@ func floatFromRaw(v json.RawMessage) (float64, error) {
 		return 0, err
 	}
 	return f, nil
-}
-
-func isNullRaw(v json.RawMessage) bool {
-	return string(v) == "null"
 }
 
 // requiredStringField enforces a non-empty string for fields the Pydantic

--- a/backend-go/internal/snapshots/validation.go
+++ b/backend-go/internal/snapshots/validation.go
@@ -1,14 +1,12 @@
 package snapshots
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/shopspring/decimal"
-
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 type createRequest struct {
@@ -25,7 +23,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Date = t
 
-	if v, ok := raw["notes"]; ok && !isNull(v) {
+	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return r, &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
@@ -34,7 +32,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 
 	vRaw, ok := raw["values"]
-	if !ok || isNull(vRaw) {
+	if !ok || validation.IsNull(vRaw) {
 		return r, &httputil.ValidationError{Field: "values", Msg: "Field required"}
 	}
 	values, vErr := parseValues(vRaw)
@@ -50,7 +48,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 
 func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.ValidationError) {
 	var p UpdatePatch
-	if v, ok := raw["date"]; ok && !isNull(v) {
+	if v, ok := raw["date"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return p, &httputil.ValidationError{Field: "date", Msg: "must be a string"}
@@ -63,7 +61,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 	}
 	if v, ok := raw["notes"]; ok {
 		p.NotesSet = true
-		if isNull(v) {
+		if validation.IsNull(v) {
 			p.Notes = nil
 		} else {
 			var s string
@@ -73,7 +71,7 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 			p.Notes = &s
 		}
 	}
-	if v, ok := raw["values"]; ok && !isNull(v) {
+	if v, ok := raw["values"]; ok && !validation.IsNull(v) {
 		values, vErr := parseValues(v)
 		if vErr != nil {
 			return p, vErr
@@ -126,10 +124,10 @@ func parseValueEntry(e map[string]json.RawMessage) (ValueInput, *httputil.Valida
 	}
 
 	valRaw, ok := e["value"]
-	if !ok || isNull(valRaw) {
+	if !ok || validation.IsNull(valRaw) {
 		return v, &httputil.ValidationError{Field: "value", Msg: "Field required"}
 	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(valRaw)))
+	d, err := validation.RawDecimal(valRaw)
 	if err != nil {
 		return v, &httputil.ValidationError{Field: "value", Msg: "must be a number"}
 	}
@@ -139,7 +137,7 @@ func parseValueEntry(e map[string]json.RawMessage) (ValueInput, *httputil.Valida
 
 func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -155,7 +153,7 @@ func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httput
 
 func optionalInt(raw map[string]json.RawMessage, key string) (*int, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return nil, nil
 	}
 	var n int
@@ -163,8 +161,4 @@ func optionalInt(raw map[string]json.RawMessage, key string) (*int, *httputil.Va
 		return nil, &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("%s must be an integer", key)}
 	}
 	return &n, nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/transactions/handler.go
+++ b/backend-go/internal/transactions/handler.go
@@ -1,7 +1,6 @@
 package transactions
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +14,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
@@ -316,7 +316,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.OwnerUserID = ownerID
 
-	if v, ok := raw["transaction_type"]; ok && !isNull(v) {
+	if v, ok := raw["transaction_type"]; ok && !validation.IsNull(v) {
 		var s string
 		if err := json.Unmarshal(v, &s); err != nil {
 			return r, &httputil.ValidationError{Field: "transaction_type", Msg: "must be a string"}
@@ -336,7 +336,7 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 	if !ok {
 		return nil, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return nil, nil
 	}
 	var n int
@@ -348,7 +348,7 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 
 func requireDateNotFuture(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -369,10 +369,10 @@ func requireDateNotFuture(raw map[string]json.RawMessage, key string) (time.Time
 
 func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	d, err := decimal.NewFromString(string(bytes.TrimSpace(v)))
+	d, err := validation.RawDecimal(v)
 	if err != nil {
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
@@ -380,8 +380,4 @@ func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (de
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: msg}
 	}
 	return d, nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }

--- a/backend-go/internal/validation/raw.go
+++ b/backend-go/internal/validation/raw.go
@@ -1,0 +1,57 @@
+// Package validation holds primitive helpers for parsing request bodies
+// that arrive as map[string]json.RawMessage (the PATCH/null-vs-missing
+// pattern). Domain packages keep their require*/patch* wrappers so error
+// messages remain wire-stable; this package only owns the small parsing
+// primitives that were duplicated across every domain.
+package validation
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/shopspring/decimal"
+)
+
+// IsNull reports whether the raw value is the JSON literal `null`. Used
+// to distinguish "missing key" from "explicit null" in PATCH bodies.
+func IsNull(v json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+}
+
+// RawString decodes a json.RawMessage as a string. Returns the unmarshal
+// error verbatim so callers can map it to whatever domain-specific
+// validation message they need.
+func RawString(v json.RawMessage) (string, error) {
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return "", err
+	}
+	return s, nil
+}
+
+// RawTrimmedString is RawString followed by strings.TrimSpace — the most
+// common pattern across domain validators.
+func RawTrimmedString(v json.RawMessage) (string, error) {
+	s, err := RawString(v)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(s), nil
+}
+
+// RawInt decodes a json.RawMessage as an int.
+func RawInt(v json.RawMessage) (int, error) {
+	var n int
+	if err := json.Unmarshal(v, &n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// RawDecimal decodes a JSON number/string as a decimal.Decimal. Accepts
+// the raw bytes (trimmed) so numeric values stay exact — never round-
+// trip through float64.
+func RawDecimal(v json.RawMessage) (decimal.Decimal, error) {
+	return decimal.NewFromString(string(bytes.TrimSpace(v)))
+}

--- a/backend-go/internal/validation/raw.go
+++ b/backend-go/internal/validation/raw.go
@@ -49,9 +49,11 @@ func RawInt(v json.RawMessage) (int, error) {
 	return n, nil
 }
 
-// RawDecimal decodes a JSON number/string as a decimal.Decimal. Accepts
-// the raw bytes (trimmed) so numeric values stay exact — never round-
-// trip through float64.
+// RawDecimal decodes a JSON *number* as a decimal.Decimal. Quoted
+// strings ("123.45") are rejected on purpose — callers map the error
+// into a "must be a number" validation message, matching the Python
+// pydantic behavior the bb-tests pin. Numeric values stay exact —
+// never round-trip through float64.
 func RawDecimal(v json.RawMessage) (decimal.Decimal, error) {
 	return decimal.NewFromString(string(bytes.TrimSpace(v)))
 }

--- a/backend-go/internal/validation/raw_test.go
+++ b/backend-go/internal/validation/raw_test.go
@@ -1,0 +1,69 @@
+package validation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestIsNull(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{`null`, true},
+		{`  null `, true},
+		{`"null"`, false},
+		{`0`, false},
+		{`{}`, false},
+		{``, false},
+	}
+	for _, tc := range cases {
+		if got := IsNull(json.RawMessage(tc.in)); got != tc.want {
+			t.Fatalf("IsNull(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRawString(t *testing.T) {
+	s, err := RawString(json.RawMessage(`"hi"`))
+	if err != nil || s != "hi" {
+		t.Fatalf("got %q err %v", s, err)
+	}
+	if _, err := RawString(json.RawMessage(`123`)); err == nil {
+		t.Fatal("expected error for non-string")
+	}
+}
+
+func TestRawTrimmedString(t *testing.T) {
+	s, err := RawTrimmedString(json.RawMessage(`"  hi  "`))
+	if err != nil || s != "hi" {
+		t.Fatalf("got %q err %v", s, err)
+	}
+}
+
+func TestRawInt(t *testing.T) {
+	n, err := RawInt(json.RawMessage(`42`))
+	if err != nil || n != 42 {
+		t.Fatalf("got %d err %v", n, err)
+	}
+	if _, err := RawInt(json.RawMessage(`"42"`)); err == nil {
+		t.Fatal("expected error for quoted int")
+	}
+}
+
+func TestRawDecimal(t *testing.T) {
+	d, err := RawDecimal(json.RawMessage(`123.45`))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !d.Equal(decimal.RequireFromString("123.45")) {
+		t.Fatalf("got %s", d)
+	}
+	// Whitespace handling.
+	d, err = RawDecimal(json.RawMessage(`  1.5  `))
+	if err != nil || !d.Equal(decimal.RequireFromString("1.5")) {
+		t.Fatalf("ws got %s err %v", d, err)
+	}
+}

--- a/backend-go/internal/validation/raw_test.go
+++ b/backend-go/internal/validation/raw_test.go
@@ -67,3 +67,11 @@ func TestRawDecimal(t *testing.T) {
 		t.Fatalf("ws got %s err %v", d, err)
 	}
 }
+
+func TestRawDecimalRejectsQuotedString(t *testing.T) {
+	// Quoted strings are NOT accepted — callers translate the error
+	// into "must be a number" to match pydantic's behavior.
+	if _, err := RawDecimal(json.RawMessage(`"123.45"`)); err == nil {
+		t.Fatal("expected error for quoted decimal")
+	}
+}

--- a/backend-go/internal/zus/validation.go
+++ b/backend-go/internal/zus/validation.go
@@ -1,12 +1,12 @@
 package zus
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 type calculateInputs struct {
@@ -105,7 +105,7 @@ func readSalaryHistory(raw map[string]json.RawMessage, in *Inputs) *httputil.Val
 	if !ok {
 		return nil
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return &httputil.ValidationError{Field: "salary_history", Msg: "must be an array"}
 	}
 	var entries []map[string]any
@@ -156,7 +156,7 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 	if !ok {
 		return nil, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return nil, nil
 	}
 	var n int
@@ -168,7 +168,7 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 
 func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -184,7 +184,7 @@ func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httput
 
 func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var s string
@@ -199,7 +199,7 @@ func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[s
 
 func requireNonNegativeFloat(raw map[string]json.RawMessage, key, msg string) (float64, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var f float64
@@ -219,7 +219,7 @@ func optionalNonNegativeFloat(raw map[string]json.RawMessage, key string, fallba
 	if !ok {
 		return fallback, nil
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return 0, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
 	var f float64
@@ -237,7 +237,7 @@ func optionalFloatRange(raw map[string]json.RawMessage, key string, fallback, lo
 	if !ok {
 		return fallback, nil
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return 0, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
 	var f float64
@@ -255,7 +255,7 @@ func optionalIntRange(raw map[string]json.RawMessage, key string, fallback, lo, 
 	if !ok {
 		return fallback, nil
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return 0, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
 	}
 	var n int
@@ -270,7 +270,7 @@ func optionalIntRange(raw map[string]json.RawMessage, key string, fallback, lo, 
 
 func requireIntRange(raw map[string]json.RawMessage, key string, lo, hi int, msg string) (int, *httputil.ValidationError) {
 	v, ok := raw[key]
-	if !ok || isNull(v) {
+	if !ok || validation.IsNull(v) {
 		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var n int
@@ -288,7 +288,7 @@ func optionalBool(raw map[string]json.RawMessage, key string, fallback bool) (bo
 	if !ok {
 		return fallback, nil
 	}
-	if isNull(v) {
+	if validation.IsNull(v) {
 		return false, &httputil.ValidationError{Field: key, Msg: "must be a boolean"}
 	}
 	var b bool
@@ -296,8 +296,4 @@ func optionalBool(raw map[string]json.RawMessage, key string, fallback bool) (bo
 		return false, &httputil.ValidationError{Field: key, Msg: "must be a boolean"}
 	}
 	return b, nil
-}
-
-func isNull(v json.RawMessage) bool {
-	return bytes.Equal(bytes.TrimSpace(v), []byte("null"))
 }


### PR DESCRIPTION
## Motivation

`isNull(json.RawMessage) bool` was duplicated verbatim in 17 packages.
The `decimal.NewFromString(string(bytes.TrimSpace(v)))` pattern lived
in 10 places. Phase 1.3 of the backend refactor punch list.

## Implementation information

- New `internal/validation` package with:
  - `IsNull(json.RawMessage) bool`
  - `RawString` / `RawTrimmedString` / `RawInt` / `RawDecimal`
- All 17 local `isNull` defs deleted; callers updated to
  `validation.IsNull`.
- All 10 inline `decimal.NewFromString(string(bytes.TrimSpace(v)))`
  sites replaced with `validation.RawDecimal`.
- Domain-specific `require*` / `patch*` wrappers stay put — their
  error-message variation isn't worth unifying, and bb-tests partially
  pin those strings.
- Net: -62 LOC (smaller than wire/httputil because we deliberately
  kept the larger wrappers in domain code).

Verified locally:
- `go build ./...` clean
- `go test ./...` — all green
- `golangci-lint run ./...` — 0 issues
- `backend-bb-tests` — 154 passed, 1 skipped
- Generated `api/openapi-go.json` byte-identical

## Supporting documentation

Phase 1.3 of the backend refactor research. Follow-up to wire (#633)
and httputil (#634).