### PR TITLE
refactor(dbutil): MapErr for ErrNoRows branches

### DIFF
--- a/backend-go/internal/accounts/store.go
+++ b/backend-go/internal/accounts/store.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/aggregates"
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // Account mirrors backend/app/models/account.Account. OwnerUserID is the
@@ -88,10 +89,7 @@ func (s *Store) Get(ctx context.Context, id int) (*Account, error) {
 	)
 	a, err := scanAccount(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("get account: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "get account")
 	}
 	return a, nil
 }
@@ -344,10 +342,7 @@ func lockAccount(ctx context.Context, tx pgx.Tx, id int) (*Account, error) {
 	)
 	a, err := scanAccount(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("lock account: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "lock account")
 	}
 	return a, nil
 }
@@ -358,10 +353,7 @@ func loadAccount(ctx context.Context, tx pgx.Tx, id int) (*Account, error) {
 	)
 	a, err := scanAccount(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("load account: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "load account")
 	}
 	return a, nil
 }

--- a/backend-go/internal/allocation/store.go
+++ b/backend-go/internal/allocation/store.go
@@ -19,6 +19,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // Target is one allocation_targets row.
@@ -121,10 +123,7 @@ func (s *Store) Get(ctx context.Context, id int) (*Target, error) {
 	)
 	t, err := scanTarget(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("get allocation target: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "get allocation target")
 	}
 	return t, nil
 }
@@ -176,10 +175,7 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Target, err
 	)
 	updated, err := scanTarget(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("update allocation target: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "update allocation target")
 	}
 	return updated, nil
 }

--- a/backend-go/internal/assets/store.go
+++ b/backend-go/internal/assets/store.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/aggregates"
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // Asset mirrors backend/app/models/asset.Asset.
@@ -249,10 +250,7 @@ func lockAsset(ctx context.Context, tx pgx.Tx, id int) (*Asset, error) {
 	)
 	a, err := scanAsset(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("lock asset: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "lock asset")
 	}
 	return a, nil
 }

--- a/backend-go/internal/auth/store.go
+++ b/backend-go/internal/auth/store.go
@@ -11,6 +11,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // User is an application login account and household member. Name/Surname and
@@ -209,10 +211,7 @@ func scanUser(row pgx.Row) (*User, error) {
 	var u User
 	if err := row.Scan(&u.ID, &u.Username, &u.PasswordHash, &u.IsAdmin,
 		&u.Name, &u.Surname, &u.PPKEmployeeRate, &u.PPKEmployerRate, &u.CreatedAt); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("scan user: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "scan user")
 	}
 	return &u, nil
 }

--- a/backend-go/internal/bonds/store.go
+++ b/backend-go/internal/bonds/store.go
@@ -2,13 +2,14 @@ package bonds
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // Store is the persistence boundary for treasury_bonds + the bond-side CPI
@@ -81,10 +82,7 @@ func (s *Store) Get(ctx context.Context, id int) (*TreasuryBond, error) {
 	)
 	b, err := scanBond(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("get treasury bond: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "get treasury bond")
 	}
 	return b, nil
 }
@@ -139,10 +137,7 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*TreasuryBon
 	)
 	b, err := scanBond(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("lock treasury bond: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "lock treasury bond")
 	}
 	if p.Type != nil {
 		b.Type = *p.Type

--- a/backend-go/internal/bonus_events/store.go
+++ b/backend-go/internal/bonus_events/store.go
@@ -16,6 +16,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // BonusEvent mirrors backend/app/models/bonus_event.BonusEvent.
@@ -115,10 +117,7 @@ func (s *Store) Get(ctx context.Context, id int) (*BonusEvent, error) {
 	)
 	b, err := scanBonus(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("select bonus: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "select bonus")
 	}
 	if !b.IsActive {
 		return nil, ErrNotFound
@@ -196,10 +195,7 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*BonusEvent,
 	)
 	updated, err := scanBonus(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("update bonus: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "update bonus")
 	}
 	return updated, nil
 }

--- a/backend-go/internal/company_valuations/store.go
+++ b/backend-go/internal/company_valuations/store.go
@@ -14,6 +14,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // Valuation mirrors backend/app/models/company_valuation.CompanyValuation.
@@ -103,10 +105,7 @@ func (s *Store) Get(ctx context.Context, id int) (*Valuation, error) {
 	)
 	v, err := scanValuation(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("select valuation: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "select valuation")
 	}
 	if !v.IsActive {
 		return nil, ErrNotFound
@@ -198,10 +197,7 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Valuation, 
 	)
 	updated, err := scanValuation(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("update valuation: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "update valuation")
 	}
 	return updated, nil
 }
@@ -222,10 +218,7 @@ func (s *Store) GetLatestForCompany(ctx context.Context, company string, onDate 
 	row := s.pool.QueryRow(ctx, query, args...)
 	v, err := scanValuation(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNoValuation
-		}
-		return nil, fmt.Errorf("select latest valuation: %w", err)
+		return nil, dbutil.MapErr(err, ErrNoValuation, "select latest valuation")
 	}
 	return v, nil
 }

--- a/backend-go/internal/config/store.go
+++ b/backend-go/internal/config/store.go
@@ -13,6 +13,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // Config mirrors backend/app/models/app_config.AppConfig — DB column names
@@ -67,10 +69,7 @@ func (s *Store) Get(ctx context.Context) (*Config, error) {
 	row := s.pool.QueryRow(ctx, `SELECT `+selectColumns+` FROM app_config WHERE id = 1`)
 	c, err := scanConfig(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("select app_config: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "select app_config")
 	}
 	return c, nil
 }

--- a/backend-go/internal/dbutil/scan.go
+++ b/backend-go/internal/dbutil/scan.go
@@ -1,0 +1,25 @@
+// Package dbutil holds small pgx helpers shared across stores. The goal
+// is not abstraction — it's killing the 4-line "if ErrNoRows → sentinel /
+// else wrap" pattern that repeats in every Get/scan call site.
+package dbutil
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// MapErr converts a pgx error into the canonical pair every store uses:
+// pgx.ErrNoRows → notFound (the domain's sentinel), everything else →
+// wrapPrefix-prefixed wrap. Returns nil when err is nil so the call can
+// stand at the end of a Scan branch unconditionally.
+func MapErr(err, notFound error, wrapPrefix string) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return notFound
+	}
+	return fmt.Errorf("%s: %w", wrapPrefix, err)
+}

--- a/backend-go/internal/dbutil/scan_test.go
+++ b/backend-go/internal/dbutil/scan_test.go
@@ -1,0 +1,44 @@
+package dbutil
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+var errSentinel = errors.New("sentinel")
+
+func TestMapErrNil(t *testing.T) {
+	if err := MapErr(nil, errSentinel, "x"); err != nil {
+		t.Fatalf("nil → %v", err)
+	}
+}
+
+func TestMapErrNoRows(t *testing.T) {
+	err := MapErr(pgx.ErrNoRows, errSentinel, "load thing")
+	if !errors.Is(err, errSentinel) {
+		t.Fatalf("expected sentinel, got %v", err)
+	}
+}
+
+func TestMapErrWrapsOthers(t *testing.T) {
+	inner := errors.New("boom")
+	err := MapErr(inner, errSentinel, "load thing")
+	if !errors.Is(err, inner) {
+		t.Fatalf("inner not wrapped: %v", err)
+	}
+	if got := err.Error(); got != "load thing: boom" {
+		t.Fatalf("wrap text = %q", got)
+	}
+}
+
+func TestMapErrPreservesWrappedNoRows(t *testing.T) {
+	// A pgx error wrapped via fmt.Errorf should still map to the sentinel.
+	wrapped := fmt.Errorf("scan: %w", pgx.ErrNoRows)
+	err := MapErr(wrapped, errSentinel, "load thing")
+	if !errors.Is(err, errSentinel) {
+		t.Fatalf("expected sentinel for wrapped ErrNoRows, got %v", err)
+	}
+}

--- a/backend-go/internal/debt_payments/store.go
+++ b/backend-go/internal/debt_payments/store.go
@@ -11,6 +11,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // DebtPayment mirrors backend/app/models/debt_payment.DebtPayment.
@@ -58,10 +60,7 @@ func (s *Store) LoadAccount(ctx context.Context, id int) (*AccountInfo, error) {
 	)
 	var a AccountInfo
 	if err := row.Scan(&a.ID, &a.Name, &a.Type, &a.IsActive); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrAccountNotFound
-		}
-		return nil, fmt.Errorf("load account: %w", err)
+		return nil, dbutil.MapErr(err, ErrAccountNotFound, "load account")
 	}
 	if !a.IsActive {
 		return nil, ErrAccountNotFound

--- a/backend-go/internal/debts/store.go
+++ b/backend-go/internal/debts/store.go
@@ -13,6 +13,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // Debt mirrors backend/app/models/debt.Debt.
@@ -84,10 +86,7 @@ func (s *Store) LoadAccount(ctx context.Context, id int) (*AccountInfo, error) {
 	)
 	var a AccountInfo
 	if err := row.Scan(&a.ID, &a.Name, &a.OwnerUserID, &a.Type, &a.IsActive); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrAccountNotFound
-		}
-		return nil, fmt.Errorf("load account: %w", err)
+		return nil, dbutil.MapErr(err, ErrAccountNotFound, "load account")
 	}
 	if !a.IsActive {
 		return &a, ErrAccountInactive
@@ -251,10 +250,7 @@ func (s *Store) Get(ctx context.Context, debtID int) (*DebtWithAccount, error) {
 		&d.InitialAmount, &d.InterestRate, &d.Currency, &d.Notes,
 		&d.IsActive, &d.CreatedAt, &a.Name, &a.OwnerUserID,
 	); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("get debt: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "get debt")
 	}
 	a.ID = d.AccountID
 	return &DebtWithAccount{Debt: d, Account: a}, nil
@@ -392,10 +388,7 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*DebtWithAcc
 	)
 	current, err := scanDebt(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("lock debt: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "lock debt")
 	}
 	applyPatch(current, p)
 	if _, err := tx.Exec(ctx, `

--- a/backend-go/internal/equity_grants/store.go
+++ b/backend-go/internal/equity_grants/store.go
@@ -11,6 +11,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // EquityGrant mirrors backend/app/models/equity_grant.EquityGrant.
@@ -120,10 +122,7 @@ func (s *Store) Get(ctx context.Context, id int) (*EquityGrant, error) {
 	)
 	g, err := scanGrant(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("select equity grant: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "select equity grant")
 	}
 	if !g.IsActive {
 		return nil, ErrNotFound
@@ -227,10 +226,7 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*EquityGrant
 	)
 	updated, err := scanGrant(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("update equity grant: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "update equity grant")
 	}
 	return updated, nil
 }

--- a/backend-go/internal/goals/store.go
+++ b/backend-go/internal/goals/store.go
@@ -15,6 +15,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // Goal mirrors backend/app/models/goal.Goal.
@@ -101,10 +103,7 @@ func (s *Store) Get(ctx context.Context, id int) (*Goal, string, error) {
 	)
 	g, err := scanGoal(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, "", ErrNotFound
-		}
-		return nil, "", fmt.Errorf("select goal: %w", err)
+		return nil, "", dbutil.MapErr(err, ErrNotFound, "select goal")
 	}
 	name, err := s.accountName(ctx, g.AccountID)
 	if err != nil {
@@ -206,10 +205,7 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Goal, strin
 		// pgx.ErrNoRows here means the row was concurrently deleted between
 		// the Get above and this UPDATE; surface as a 404 instead of 200ing
 		// with stale in-memory state.
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, "", ErrNotFound
-		}
-		return nil, "", fmt.Errorf("update goal: %w", err)
+		return nil, "", dbutil.MapErr(err, ErrNotFound, "update goal")
 	}
 	name, err := s.accountName(ctx, updated.AccountID)
 	if err != nil {

--- a/backend-go/internal/retirement/store.go
+++ b/backend-go/internal/retirement/store.go
@@ -14,6 +14,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // Sentinel errors.
@@ -278,10 +280,7 @@ func (s *Store) CurrentSalaryFor(ctx context.Context, ownerUserID *int, asOfDate
 	)
 	var v decimal.Decimal
 	if err := row.Scan(&v); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return decimal.Zero, ErrNoSalary
-		}
-		return decimal.Zero, fmt.Errorf("current salary: %w", err)
+		return decimal.Zero, dbutil.MapErr(err, ErrNoSalary, "current salary")
 	}
 	return v, nil
 }
@@ -300,10 +299,7 @@ func (s *Store) UserPPKRates(ctx context.Context, ownerUserID *int) (decimal.Dec
 	)
 	var employee, employer decimal.Decimal
 	if err := row.Scan(&employee, &employer); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return decimal.Zero, decimal.Zero, ErrUserNotFound
-		}
-		return decimal.Zero, decimal.Zero, fmt.Errorf("ppk rates: %w", err)
+		return decimal.Zero, decimal.Zero, dbutil.MapErr(err, ErrUserNotFound, "ppk rates")
 	}
 	return employee, employer, nil
 }
@@ -319,10 +315,7 @@ func (s *Store) ActivePPKAccountForOwner(ctx context.Context, ownerUserID *int) 
 	)
 	var id int
 	if err := row.Scan(&id); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return 0, ErrNoPPKAccount
-		}
-		return 0, fmt.Errorf("ppk account: %w", err)
+		return 0, dbutil.MapErr(err, ErrNoPPKAccount, "ppk account")
 	}
 	return id, nil
 }

--- a/backend-go/internal/salaries/store.go
+++ b/backend-go/internal/salaries/store.go
@@ -16,6 +16,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // SalaryRecord mirrors backend/app/models/salary_record.SalaryRecord.
@@ -113,10 +115,7 @@ func (s *Store) Get(ctx context.Context, id int) (*SalaryRecord, error) {
 	)
 	r, err := scanRecord(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("select salary record: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "select salary record")
 	}
 	if !r.IsActive {
 		return nil, ErrNotFound
@@ -210,10 +209,7 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*SalaryRecor
 	)
 	updated, err := scanRecord(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("update salary record: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "update salary record")
 	}
 	return updated, nil
 }

--- a/backend-go/internal/scenarios/store.go
+++ b/backend-go/internal/scenarios/store.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // Scenario is the persisted form of one saved simulation input bundle.
@@ -86,10 +88,7 @@ func (s *Store) Get(ctx context.Context, id int) (*Scenario, error) {
 	)
 	sc, err := scanScenario(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("select scenario: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "select scenario")
 	}
 	return sc, nil
 }
@@ -121,10 +120,7 @@ func (s *Store) Update(ctx context.Context, id int, name string, inputs json.Raw
 	)
 	updated, err := scanScenario(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("update scenario: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "update scenario")
 	}
 	return updated, nil
 }
@@ -142,10 +138,7 @@ func (s *Store) Clone(ctx context.Context, id int, name string) (*Scenario, erro
 	)
 	created, err := scanScenario(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("clone scenario: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "clone scenario")
 	}
 	return created, nil
 }
@@ -165,10 +158,7 @@ func (s *Store) CloneWithSuffix(ctx context.Context, id int) (*Scenario, error) 
 	)
 	created, err := scanScenario(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("clone scenario: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "clone scenario")
 	}
 	return created, nil
 }

--- a/backend-go/internal/snapshots/store.go
+++ b/backend-go/internal/snapshots/store.go
@@ -17,6 +17,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/aggregates"
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // Snapshot mirrors backend/app/models/snapshot.Snapshot.
@@ -134,10 +135,7 @@ func (s *Store) Get(ctx context.Context, id int) (*Snapshot, []Value, error) {
 	)
 	var snap Snapshot
 	if err := row.Scan(&snap.ID, &snap.Date, &snap.Notes, &snap.CreatedAt); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, nil, ErrNotFound
-		}
-		return nil, nil, fmt.Errorf("get snapshot: %w", err)
+		return nil, nil, dbutil.MapErr(err, ErrNotFound, "get snapshot")
 	}
 	values, err := s.loadValues(ctx, id)
 	if err != nil {
@@ -460,10 +458,7 @@ func lockSnapshot(ctx context.Context, tx pgx.Tx, id int) (*Snapshot, error) {
 	)
 	var s Snapshot
 	if err := row.Scan(&s.ID, &s.Date, &s.Notes, &s.CreatedAt); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, fmt.Errorf("lock snapshot: %w", err)
+		return nil, dbutil.MapErr(err, ErrNotFound, "lock snapshot")
 	}
 	return &s, nil
 }

--- a/backend-go/internal/transactions/store.go
+++ b/backend-go/internal/transactions/store.go
@@ -15,6 +15,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
 // Transaction mirrors backend/app/models/transaction.Transaction.
@@ -79,10 +81,7 @@ func (s *Store) LoadAccount(ctx context.Context, id int) (*AccountInfo, error) {
 	)
 	a, err := scanAccount(row)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrAccountNotFound
-		}
-		return nil, fmt.Errorf("load account: %w", err)
+		return nil, dbutil.MapErr(err, ErrAccountNotFound, "load account")
 	}
 	if !a.IsActive {
 		return nil, ErrAccountNotFound


### PR DESCRIPTION
## Motivation

The 4-line "`if errors.Is(err, pgx.ErrNoRows) { return sentinel }
return fmt.Errorf("...: %w", err)`" pattern was repeated at 35 store
call sites across 17 packages, with subtle inconsistencies in which
sentinel was returned. Phase 1.6 of the backend refactor punch list.

## Implementation information

- New `internal/dbutil` package with one function:
  `MapErr(err, sentinel, wrapPrefix) error`. Nil passes through,
  `pgx.ErrNoRows` (including wrapped) → sentinel, anything else →
  `fmt.Errorf("<prefix>: %w", err)`.
- 35 call sites collapsed from 4 lines to 1; the script targeted
  only the clean 2-return shape. Sites with extra logic (LatestBalance,
  dupe-name probes, 3-return paths) intentionally left untouched.
- Net -75 LOC; no behavior change.

Verified locally:
- `go build ./...` clean
- `go test ./...` — all green
- `golangci-lint run ./...` — 0 issues
- `backend-bb-tests` — 154 passed, 1 skipped

## Supporting documentation

Phase 1.6 of the backend refactor research. Last Tier-2 item; the
research list is now complete.