### PR TITLE
refactor(http): add request helpers

### DIFF
--- a/backend-go/internal/debt_payments/handler.go
+++ b/backend-go/internal/debt_payments/handler.go
@@ -4,13 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
@@ -94,22 +92,16 @@ func (h *Handler) ListForAccount(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) ListAll(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	f := ListFilter{}
-	if v := q.Get("account_id"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil {
-			httputil.WriteBodyValidationError(w, "account_id", "must be an integer", v)
-			return
-		}
-		f.AccountID = &n
+	accountID, ok := httputil.OptionalQueryInt(w, q, "account_id")
+	if !ok {
+		return
 	}
-	if v := q.Get("owner_user_id"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil {
-			httputil.WriteBodyValidationError(w, "owner_user_id", "must be an integer", v)
-			return
-		}
-		f.OwnerUserID = &n
+	f.AccountID = accountID
+	ownerUserID, ok := httputil.OptionalQueryInt(w, q, "owner_user_id")
+	if !ok {
+		return
 	}
+	f.OwnerUserID = ownerUserID
 	for _, p := range []struct {
 		key  string
 		dest **time.Time
@@ -117,14 +109,11 @@ func (h *Handler) ListAll(w http.ResponseWriter, r *http.Request) {
 		{"date_from", &f.DateFrom},
 		{"date_to", &f.DateTo},
 	} {
-		if v := q.Get(p.key); v != "" {
-			t, err := time.Parse("2006-01-02", v)
-			if err != nil {
-				httputil.WriteBodyValidationError(w, p.key, "must be YYYY-MM-DD", v)
-				return
-			}
-			*p.dest = &t
+		t, ok := httputil.OptionalQueryDate(w, q, p.key)
+		if !ok {
+			return
 		}
+		*p.dest = t
 	}
 	rows, err := h.store.ListAll(r.Context(), f)
 	if err != nil {
@@ -160,8 +149,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	req, vErr := buildCreateRequest(raw)
@@ -192,9 +180,8 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	paymentID, err := strconv.Atoi(chi.URLParam(r, "payment_id"))
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "payment_id", "must be an integer", chi.URLParam(r, "payment_id"))
+	paymentID, ok := httputil.PathInt(w, r, "payment_id")
+	if !ok {
 		return
 	}
 	if err := h.store.SoftDelete(r.Context(), accountID, paymentID); err != nil {
@@ -245,13 +232,7 @@ func (h *Handler) writeAccountError(w http.ResponseWriter, err error, id int, na
 }
 
 func parseAccountID(w http.ResponseWriter, r *http.Request) (int, bool) {
-	raw := chi.URLParam(r, "account_id")
-	id, err := strconv.Atoi(raw)
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "account_id", "must be an integer", raw)
-		return 0, false
-	}
-	return id, true
+	return httputil.PathInt(w, r, "account_id")
 }
 
 type createRequest struct {

--- a/backend-go/internal/httputil/request.go
+++ b/backend-go/internal/httputil/request.go
@@ -1,0 +1,64 @@
+package httputil
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// DecodeJSON reads a size-limited JSON request body and writes the existing
+// Pydantic-shaped validation envelope on decode failure.
+func DecodeJSON(w http.ResponseWriter, r *http.Request, maxBytes int64, dst any) bool {
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxBytes)).Decode(dst); err != nil {
+		WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+		return false
+	}
+	return true
+}
+
+// PathInt parses an integer chi path parameter and writes the backend's
+// existing validation envelope on parse failure.
+func PathInt(w http.ResponseWriter, r *http.Request, param string) (int, bool) {
+	raw := chi.URLParam(r, param)
+	id, err := strconv.Atoi(raw)
+	if err != nil {
+		WriteBodyValidationError(w, param, "must be an integer", raw)
+		return 0, false
+	}
+	return id, true
+}
+
+// OptionalQueryInt parses an optional integer query parameter. It writes a body
+// validation envelope, matching the legacy handlers' wire shape.
+func OptionalQueryInt(w http.ResponseWriter, q url.Values, key string) (*int, bool) {
+	v := q.Get(key)
+	if v == "" {
+		return nil, true
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		WriteBodyValidationError(w, key, "must be an integer", v)
+		return nil, false
+	}
+	return &n, true
+}
+
+// OptionalQueryDate parses an optional YYYY-MM-DD query parameter. It writes a
+// body validation envelope, matching the legacy handlers' wire shape.
+func OptionalQueryDate(w http.ResponseWriter, q url.Values, key string) (*time.Time, bool) {
+	v := q.Get(key)
+	if v == "" {
+		return nil, true
+	}
+	t, err := time.Parse("2006-01-02", v)
+	if err != nil {
+		WriteBodyValidationError(w, key, "must be YYYY-MM-DD", v)
+		return nil, false
+	}
+	return &t, true
+}

--- a/backend-go/internal/httputil/request_test.go
+++ b/backend-go/internal/httputil/request_test.go
@@ -1,0 +1,135 @@
+package httputil
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestDecodeJSON(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(
+			context.Background(), http.MethodPost, "/", strings.NewReader(`{"name":"x"}`),
+		)
+		var got struct {
+			Name string `json:"name"`
+		}
+		if !DecodeJSON(rec, req, 1024, &got) {
+			t.Fatal("DecodeJSON returned false")
+		}
+		if got.Name != "x" {
+			t.Fatalf("Name = %q", got.Name)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", strings.NewReader(`{`))
+		var got map[string]json.RawMessage
+		if DecodeJSON(rec, req, 1024, &got) {
+			t.Fatal("DecodeJSON returned true")
+		}
+		if rec.Code != http.StatusUnprocessableEntity {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		assertValidationField(t, rec, "body")
+	})
+}
+
+func TestPathInt(t *testing.T) {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/accounts/42", http.NoBody)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("account_id", "42")
+	req = req.WithContext(contextWithRoute(req, rctx))
+
+	got, ok := PathInt(httptest.NewRecorder(), req, "account_id")
+	if !ok {
+		t.Fatal("PathInt returned false")
+	}
+	if got != 42 {
+		t.Fatalf("got = %d", got)
+	}
+}
+
+func TestPathIntInvalid(t *testing.T) {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/accounts/x", http.NoBody)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("account_id", "x")
+	req = req.WithContext(contextWithRoute(req, rctx))
+	rec := httptest.NewRecorder()
+
+	if _, ok := PathInt(rec, req, "account_id"); ok {
+		t.Fatal("PathInt returned true")
+	}
+	assertValidationField(t, rec, "account_id")
+}
+
+func TestOptionalQueryInt(t *testing.T) {
+	rec := httptest.NewRecorder()
+	got, ok := OptionalQueryInt(rec, url.Values{"owner_user_id": []string{"7"}}, "owner_user_id")
+	if !ok {
+		t.Fatal("OptionalQueryInt returned false")
+	}
+	if got == nil || *got != 7 {
+		t.Fatalf("got = %v", got)
+	}
+}
+
+func TestOptionalQueryIntInvalid(t *testing.T) {
+	rec := httptest.NewRecorder()
+	if _, ok := OptionalQueryInt(rec, url.Values{"owner_user_id": []string{"x"}}, "owner_user_id"); ok {
+		t.Fatal("OptionalQueryInt returned true")
+	}
+	assertValidationField(t, rec, "owner_user_id")
+}
+
+func TestOptionalQueryDate(t *testing.T) {
+	rec := httptest.NewRecorder()
+	got, ok := OptionalQueryDate(rec, url.Values{"date_from": []string{"2026-05-25"}}, "date_from")
+	if !ok {
+		t.Fatal("OptionalQueryDate returned false")
+	}
+	if got == nil || got.Format("2006-01-02") != "2026-05-25" {
+		t.Fatalf("got = %v", got)
+	}
+}
+
+func TestOptionalQueryDateInvalid(t *testing.T) {
+	rec := httptest.NewRecorder()
+	if _, ok := OptionalQueryDate(rec, url.Values{"date_from": []string{"25/05/2026"}}, "date_from"); ok {
+		t.Fatal("OptionalQueryDate returned true")
+	}
+	assertValidationField(t, rec, "date_from")
+}
+
+func contextWithRoute(req *http.Request, rctx *chi.Context) context.Context {
+	return context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+}
+
+func assertValidationField(t *testing.T, rec *httptest.ResponseRecorder, field string) {
+	t.Helper()
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var env struct {
+		Detail []struct {
+			Loc []string `json:"loc"`
+		} `json:"detail"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(env.Detail) != 1 {
+		t.Fatalf("detail len = %d", len(env.Detail))
+	}
+	if len(env.Detail[0].Loc) != 2 || env.Detail[0].Loc[0] != "body" || env.Detail[0].Loc[1] != field {
+		t.Fatalf("loc = %v", env.Detail[0].Loc)
+	}
+}

--- a/backend-go/internal/transactions/handler.go
+++ b/backend-go/internal/transactions/handler.go
@@ -4,13 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
@@ -94,22 +92,16 @@ func (h *Handler) ListForAccount(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) ListAll(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	f := ListFilter{}
-	if v := q.Get("account_id"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil {
-			httputil.WriteBodyValidationError(w, "account_id", "must be an integer", v)
-			return
-		}
-		f.AccountID = &n
+	accountID, ok := httputil.OptionalQueryInt(w, q, "account_id")
+	if !ok {
+		return
 	}
-	if v := q.Get("owner_user_id"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil {
-			httputil.WriteBodyValidationError(w, "owner_user_id", "must be an integer", v)
-			return
-		}
-		f.OwnerUserID = &n
+	f.AccountID = accountID
+	ownerUserID, ok := httputil.OptionalQueryInt(w, q, "owner_user_id")
+	if !ok {
+		return
 	}
+	f.OwnerUserID = ownerUserID
 	for _, p := range []struct {
 		key  string
 		dest **time.Time
@@ -117,14 +109,11 @@ func (h *Handler) ListAll(w http.ResponseWriter, r *http.Request) {
 		{"date_from", &f.DateFrom},
 		{"date_to", &f.DateTo},
 	} {
-		if v := q.Get(p.key); v != "" {
-			t, err := time.Parse("2006-01-02", v)
-			if err != nil {
-				httputil.WriteBodyValidationError(w, p.key, "must be YYYY-MM-DD", v)
-				return
-			}
-			*p.dest = &t
+		t, ok := httputil.OptionalQueryDate(w, q, p.key)
+		if !ok {
+			return
 		}
+		*p.dest = t
 	}
 	rows, err := h.store.ListAll(r.Context(), f)
 	if err != nil {
@@ -165,8 +154,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	req, vErr := buildCreateRequest(raw)
@@ -195,9 +183,8 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	transactionID, err := strconv.Atoi(chi.URLParam(r, "transaction_id"))
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "transaction_id", "must be an integer", chi.URLParam(r, "transaction_id"))
+	transactionID, ok := httputil.PathInt(w, r, "transaction_id")
+	if !ok {
 		return
 	}
 	if err := h.store.SoftDelete(r.Context(), accountID, transactionID); err != nil {
@@ -278,13 +265,7 @@ func (h *Handler) writeAccountError(w http.ResponseWriter, err error, id int, na
 }
 
 func parseAccountID(w http.ResponseWriter, r *http.Request) (int, bool) {
-	raw := chi.URLParam(r, "account_id")
-	id, err := strconv.Atoi(raw)
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "account_id", "must be an integer", raw)
-		return 0, false
-	}
-	return id, true
+	return httputil.PathInt(w, r, "account_id")
 }
 
 // --- request parsing ---


### PR DESCRIPTION
## Motivation

Reduce duplicated request parsing in backend handlers before broader backend refactors.

> Changelog: refactor(http): add request helpers

## Implementation information

Added shared httputil helpers for limited JSON decode, chi path int parsing, and optional query int/date parsing. Migrated transactions and debt payments handlers to prove the pattern with a small scope.

Local checks:
- go test ./...
- go vet ./...

## Supporting documentation

Phase 1 of backend refactor sequence.