### PR TITLE
refactor(validation): add raw date helper

### DIFF
--- a/backend-go/internal/debt_payments/handler.go
+++ b/backend-go/internal/debt_payments/handler.go
@@ -274,8 +274,8 @@ func requireOwnerUserID(raw map[string]json.RawMessage) (*int, *httputil.Validat
 	if validation.IsNull(v) {
 		return nil, nil
 	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
+	n, err := validation.RawInt(v)
+	if err != nil {
 		return nil, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
 	}
 	return &n, nil
@@ -287,13 +287,12 @@ func requireDateNotFuture(raw map[string]json.RawMessage) (time.Time, *httputil.
 	if !ok || validation.IsNull(v) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	t, err := time.Parse("2006-01-02", s)
+	t, err := validation.RawDate(v)
 	if err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
+		if validation.IsRawDateFormatError(err) {
+			return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
+		}
+		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
 	}
 	today := time.Now().UTC()
 	today = time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)

--- a/backend-go/internal/salaries/validation.go
+++ b/backend-go/internal/salaries/validation.go
@@ -3,7 +3,6 @@ package salaries
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -66,13 +65,12 @@ func buildCreateRequest(raw map[string]json.RawMessage, now func() time.Time) (c
 func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (UpdatePatch, *httputil.ValidationError) {
 	var p UpdatePatch
 	if v, ok := raw["date"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return p, &httputil.ValidationError{Field: "date", Msg: "must be a string"}
-		}
-		t, err := time.Parse("2006-01-02", s)
+		t, err := validation.RawDate(v)
 		if err != nil {
-			return p, &httputil.ValidationError{Field: "date", Msg: "must be YYYY-MM-DD"}
+			if validation.IsRawDateFormatError(err) {
+				return p, &httputil.ValidationError{Field: "date", Msg: "must be YYYY-MM-DD"}
+			}
+			return p, &httputil.ValidationError{Field: "date", Msg: "must be a string"}
 		}
 		if t.After(truncateDay(now().UTC())) {
 			return p, &httputil.ValidationError{Field: "date", Msg: "Date cannot be in the future"}
@@ -90,8 +88,8 @@ func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (Upd
 		p.GrossAmount = &d
 	}
 	if v, ok := raw["contract_type"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
+		s, err := validation.RawString(v)
+		if err != nil {
 			return p, &httputil.ValidationError{Field: "contract_type", Msg: "must be a string"}
 		}
 		if _, ok := validContractTypes[s]; !ok {
@@ -100,11 +98,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (Upd
 		p.ContractType = &s
 	}
 	if v, ok := raw["company"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
+		s, err := validation.RawTrimmedString(v)
+		if err != nil {
 			return p, &httputil.ValidationError{Field: "company", Msg: "must be a string"}
 		}
-		s = strings.TrimSpace(s)
 		if s == "" {
 			return p, &httputil.ValidationError{Field: "company", Msg: "Company cannot be empty"}
 		}
@@ -115,8 +112,8 @@ func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (Upd
 		if validation.IsNull(v) {
 			p.OwnerUserID = nil
 		} else {
-			var n int
-			if err := json.Unmarshal(v, &n); err != nil {
+			n, err := validation.RawInt(v)
+			if err != nil {
 				return p, &httputil.ValidationError{Field: "owner_user_id", Msg: "must be an integer"}
 			}
 			p.OwnerUserID = &n
@@ -135,8 +132,8 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 	if validation.IsNull(v) {
 		return nil, nil
 	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
+	n, err := validation.RawInt(v)
+	if err != nil {
 		return nil, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
 	}
 	return &n, nil
@@ -147,11 +144,10 @@ func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string
 	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
+	s, err := validation.RawTrimmedString(v)
+	if err != nil {
 		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
 	}
-	s = strings.TrimSpace(s)
 	if s == "" {
 		return "", &httputil.ValidationError{Field: key, Msg: emptyMsg}
 	}
@@ -163,13 +159,12 @@ func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httput
 	if !ok || validation.IsNull(v) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	t, err := time.Parse("2006-01-02", s)
+	t, err := validation.RawDate(v)
 	if err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
+		if validation.IsRawDateFormatError(err) {
+			return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
+		}
+		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
 	}
 	return t, nil
 }
@@ -194,8 +189,8 @@ func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[s
 	if !ok || validation.IsNull(v) {
 		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
+	s, err := validation.RawString(v)
+	if err != nil {
 		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
 	}
 	if _, ok := allowed[s]; !ok {

--- a/backend-go/internal/transactions/handler.go
+++ b/backend-go/internal/transactions/handler.go
@@ -298,8 +298,8 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	r.OwnerUserID = ownerID
 
 	if v, ok := raw["transaction_type"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
+		s, err := validation.RawString(v)
+		if err != nil {
 			return r, &httputil.ValidationError{Field: "transaction_type", Msg: "must be a string"}
 		}
 		if !IsValid(s) {
@@ -320,8 +320,8 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 	if validation.IsNull(v) {
 		return nil, nil
 	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
+	n, err := validation.RawInt(v)
+	if err != nil {
 		return nil, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
 	}
 	return &n, nil
@@ -332,13 +332,12 @@ func requireDateNotFuture(raw map[string]json.RawMessage, key string) (time.Time
 	if !ok || validation.IsNull(v) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	t, err := time.Parse("2006-01-02", s)
+	t, err := validation.RawDate(v)
 	if err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
+		if validation.IsRawDateFormatError(err) {
+			return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
+		}
+		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
 	}
 	today := time.Now().UTC()
 	today = time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)

--- a/backend-go/internal/validation/raw.go
+++ b/backend-go/internal/validation/raw.go
@@ -8,7 +8,9 @@ package validation
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"strings"
+	"time"
 
 	"github.com/shopspring/decimal"
 )
@@ -38,6 +40,21 @@ func RawTrimmedString(v json.RawMessage) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(s), nil
+}
+
+// RawDate decodes a json.RawMessage as a YYYY-MM-DD date.
+func RawDate(v json.RawMessage) (time.Time, error) {
+	s, err := RawString(v)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Parse("2006-01-02", s)
+}
+
+// IsRawDateFormatError reports whether err came from parsing a date string.
+func IsRawDateFormatError(err error) bool {
+	var parseErr *time.ParseError
+	return errors.As(err, &parseErr)
 }
 
 // RawInt decodes a json.RawMessage as an int.

--- a/backend-go/internal/validation/raw_test.go
+++ b/backend-go/internal/validation/raw_test.go
@@ -43,6 +43,33 @@ func TestRawTrimmedString(t *testing.T) {
 	}
 }
 
+func TestRawDate(t *testing.T) {
+	d, err := RawDate(json.RawMessage(`"2026-05-25"`))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got := d.Format("2006-01-02"); got != "2026-05-25" {
+		t.Fatalf("got %s", got)
+	}
+	if _, err := RawDate(json.RawMessage(`"25/05/2026"`)); err == nil {
+		t.Fatal("expected error for invalid date")
+	}
+	if _, err := RawDate(json.RawMessage(`20260525`)); err == nil {
+		t.Fatal("expected error for non-string date")
+	}
+}
+
+func TestIsRawDateFormatError(t *testing.T) {
+	_, err := RawDate(json.RawMessage(`"25/05/2026"`))
+	if err == nil || !IsRawDateFormatError(err) {
+		t.Fatalf("format err = %v", err)
+	}
+	_, err = RawDate(json.RawMessage(`20260525`))
+	if err == nil || IsRawDateFormatError(err) {
+		t.Fatalf("type err = %v", err)
+	}
+}
+
 func TestRawInt(t *testing.T) {
 	n, err := RawInt(json.RawMessage(`42`))
 	if err != nil || n != 42 {


### PR DESCRIPTION
## Motivation

Reduce repeated raw JSON parsing in backend validators.

> Changelog: refactor(validation): add raw date helper

## Implementation information

Added `validation.RawDate` beside existing raw primitives. Migrated transactions, debt payments, and salaries validators to use shared raw string/int/date helpers while preserving domain error messages.

## Supporting documentation

Phase 2 of backend refactor pass.