### PR TITLE
refactor(db): add row collector

### DIFF
--- a/backend-go/internal/dbutil/scan.go
+++ b/backend-go/internal/dbutil/scan.go
@@ -23,3 +23,21 @@ func MapErr(err, notFound error, wrapPrefix string) error {
 	}
 	return fmt.Errorf("%s: %w", wrapPrefix, err)
 }
+
+// CollectRows scans every row and preserves the store-specific scan/iterate
+// error prefixes used by existing handlers.
+func CollectRows[T any](rows pgx.Rows, scan func(pgx.Row) (T, error), scanPrefix, iterPrefix string) ([]T, error) {
+	defer rows.Close()
+	out := []T{}
+	for rows.Next() {
+		item, err := scan(rows)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", scanPrefix, err)
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("%s: %w", iterPrefix, err)
+	}
+	return out, nil
+}

--- a/backend-go/internal/dbutil/scan_test.go
+++ b/backend-go/internal/dbutil/scan_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 var errSentinel = errors.New("sentinel")
@@ -41,4 +42,116 @@ func TestMapErrPreservesWrappedNoRows(t *testing.T) {
 	if !errors.Is(err, errSentinel) {
 		t.Fatalf("expected sentinel for wrapped ErrNoRows, got %v", err)
 	}
+}
+
+func TestCollectRows(t *testing.T) {
+	rows := &fakeRows{values: []int{1, 2}}
+	got, err := CollectRows(rows, func(row pgx.Row) (int, error) {
+		var n int
+		return n, row.Scan(&n)
+	}, "scan thing", "iterate things")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !rows.closed {
+		t.Fatal("rows not closed")
+	}
+	if len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestCollectRowsScanError(t *testing.T) {
+	inner := errors.New("bad scan")
+	rows := &fakeRows{values: []int{1}, scanErr: inner}
+	_, err := CollectRows(rows, func(row pgx.Row) (int, error) {
+		var n int
+		return n, row.Scan(&n)
+	}, "scan thing", "iterate things")
+	if !rows.closed {
+		t.Fatal("rows not closed")
+	}
+	if !errors.Is(err, inner) {
+		t.Fatalf("inner not wrapped: %v", err)
+	}
+	if got := err.Error(); got != "scan thing: bad scan" {
+		t.Fatalf("err = %q", got)
+	}
+}
+
+func TestCollectRowsIterError(t *testing.T) {
+	inner := errors.New("bad iter")
+	rows := &fakeRows{iterErr: inner}
+	_, err := CollectRows(rows, func(row pgx.Row) (int, error) {
+		var n int
+		return n, row.Scan(&n)
+	}, "scan thing", "iterate things")
+	if !rows.closed {
+		t.Fatal("rows not closed")
+	}
+	if !errors.Is(err, inner) {
+		t.Fatalf("inner not wrapped: %v", err)
+	}
+	if got := err.Error(); got != "iterate things: bad iter" {
+		t.Fatalf("err = %q", got)
+	}
+}
+
+type fakeRows struct {
+	values  []int
+	index   int
+	closed  bool
+	scanErr error
+	iterErr error
+}
+
+func (r *fakeRows) Close() {
+	r.closed = true
+}
+
+func (r *fakeRows) Err() error {
+	return r.iterErr
+}
+
+func (r *fakeRows) CommandTag() pgconn.CommandTag {
+	return pgconn.CommandTag{}
+}
+
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription {
+	return nil
+}
+
+func (r *fakeRows) Next() bool {
+	if r.index >= len(r.values) {
+		return false
+	}
+	r.index++
+	return true
+}
+
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.scanErr != nil {
+		return r.scanErr
+	}
+	if len(dest) != 1 {
+		return fmt.Errorf("dest len = %d", len(dest))
+	}
+	p, ok := dest[0].(*int)
+	if !ok {
+		return fmt.Errorf("dest type %T", dest[0])
+	}
+	*p = r.values[r.index-1]
+	return nil
+}
+
+func (r *fakeRows) Values() ([]any, error) {
+	return []any{r.values[r.index-1]}, nil
+}
+
+func (r *fakeRows) RawValues() [][]byte {
+	return nil
+}
+
+func (r *fakeRows) Conn() *pgx.Conn {
+	return nil
 }

--- a/backend-go/internal/debt_payments/store.go
+++ b/backend-go/internal/debt_payments/store.go
@@ -82,19 +82,7 @@ func (s *Store) ListForAccount(ctx context.Context, accountID int) ([]DebtPaymen
 	if err != nil {
 		return nil, fmt.Errorf("query payments: %w", err)
 	}
-	defer rows.Close()
-	out := []DebtPayment{}
-	for rows.Next() {
-		p, err := scanPayment(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scan payment: %w", err)
-		}
-		out = append(out, *p)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate payments: %w", err)
-	}
-	return out, nil
+	return dbutil.CollectRows(rows, scanPaymentValue, "scan payment", "iterate payments")
 }
 
 // ListFilter narrows the all-payments view.
@@ -140,20 +128,7 @@ func (s *Store) ListAll(ctx context.Context, f ListFilter) ([]PaymentWithAccount
 	if err != nil {
 		return nil, fmt.Errorf("list payments: %w", err)
 	}
-	defer rows.Close()
-	out := []PaymentWithAccount{}
-	for rows.Next() {
-		var p DebtPayment
-		var name string
-		if err := rows.Scan(&p.ID, &p.AccountID, &p.Amount, &p.Date, &p.OwnerUserID, &p.IsActive, &p.CreatedAt, &name); err != nil {
-			return nil, fmt.Errorf("scan payment join: %w", err)
-		}
-		out = append(out, PaymentWithAccount{Payment: p, AccountName: name})
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate payments: %w", err)
-	}
-	return out, nil
+	return dbutil.CollectRows(rows, scanPaymentWithAccount, "scan payment join", "iterate payments")
 }
 
 // Create inserts a payment. ErrDuplicate on same (account_id, date) for an
@@ -235,9 +210,26 @@ func (s *Store) CountsByAccount(ctx context.Context) (map[int]int, error) {
 }
 
 func scanPayment(row pgx.Row) (*DebtPayment, error) {
-	var p DebtPayment
-	if err := row.Scan(&p.ID, &p.AccountID, &p.Amount, &p.Date, &p.OwnerUserID, &p.IsActive, &p.CreatedAt); err != nil {
+	p, err := scanPaymentValue(row)
+	if err != nil {
 		return nil, err
 	}
 	return &p, nil
+}
+
+func scanPaymentValue(row pgx.Row) (DebtPayment, error) {
+	var p DebtPayment
+	if err := row.Scan(&p.ID, &p.AccountID, &p.Amount, &p.Date, &p.OwnerUserID, &p.IsActive, &p.CreatedAt); err != nil {
+		return DebtPayment{}, err
+	}
+	return p, nil
+}
+
+func scanPaymentWithAccount(row pgx.Row) (PaymentWithAccount, error) {
+	var p DebtPayment
+	var name string
+	if err := row.Scan(&p.ID, &p.AccountID, &p.Amount, &p.Date, &p.OwnerUserID, &p.IsActive, &p.CreatedAt, &name); err != nil {
+		return PaymentWithAccount{}, err
+	}
+	return PaymentWithAccount{Payment: p, AccountName: name}, nil
 }

--- a/backend-go/internal/transactions/store.go
+++ b/backend-go/internal/transactions/store.go
@@ -104,19 +104,7 @@ func (s *Store) ListForAccount(ctx context.Context, accountID int) ([]Transactio
 	if err != nil {
 		return nil, fmt.Errorf("list transactions: %w", err)
 	}
-	defer rows.Close()
-	out := []Transaction{}
-	for rows.Next() {
-		t, err := scanTransaction(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scan transaction: %w", err)
-		}
-		out = append(out, *t)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate transactions: %w", err)
-	}
-	return out, nil
+	return dbutil.CollectRows(rows, scanTransactionValue, "scan transaction", "iterate transactions")
 }
 
 // ListFilter narrows the all-transactions view.
@@ -163,23 +151,7 @@ func (s *Store) ListAll(ctx context.Context, f ListFilter) ([]TxnWithAccount, er
 	if err != nil {
 		return nil, fmt.Errorf("list transactions: %w", err)
 	}
-	defer rows.Close()
-	out := []TxnWithAccount{}
-	for rows.Next() {
-		var t Transaction
-		var name string
-		if err := rows.Scan(
-			&t.ID, &t.AccountID, &t.Amount, &t.Date, &t.OwnerUserID,
-			&t.TransactionType, &t.IsActive, &t.CreatedAt, &name,
-		); err != nil {
-			return nil, fmt.Errorf("scan transaction join: %w", err)
-		}
-		out = append(out, TxnWithAccount{Transaction: t, AccountName: name})
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate transactions: %w", err)
-	}
-	return out, nil
+	return dbutil.CollectRows(rows, scanTxnWithAccount, "scan transaction join", "iterate transactions")
 }
 
 // Create inserts a transaction. Multiple active transactions may share
@@ -247,14 +219,34 @@ func (s *Store) CountsByAccount(ctx context.Context) (map[int]int, error) {
 }
 
 func scanTransaction(row pgx.Row) (*Transaction, error) {
+	t, err := scanTransactionValue(row)
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func scanTransactionValue(row pgx.Row) (Transaction, error) {
 	var t Transaction
 	if err := row.Scan(
 		&t.ID, &t.AccountID, &t.Amount, &t.Date, &t.OwnerUserID,
 		&t.TransactionType, &t.IsActive, &t.CreatedAt,
 	); err != nil {
-		return nil, err
+		return Transaction{}, err
 	}
-	return &t, nil
+	return t, nil
+}
+
+func scanTxnWithAccount(row pgx.Row) (TxnWithAccount, error) {
+	var t Transaction
+	var name string
+	if err := row.Scan(
+		&t.ID, &t.AccountID, &t.Amount, &t.Date, &t.OwnerUserID,
+		&t.TransactionType, &t.IsActive, &t.CreatedAt, &name,
+	); err != nil {
+		return TxnWithAccount{}, err
+	}
+	return TxnWithAccount{Transaction: t, AccountName: name}, nil
 }
 
 func scanAccount(row pgx.Row) (*AccountInfo, error) {


### PR DESCRIPTION
## Motivation

Reduce repeated pgx row iteration code in backend stores.

> Changelog: refactor(db): add row collector

## Implementation information

Added `dbutil.CollectRows` to own row closing, scanning, and iteration error wrapping. Migrated transaction and debt payment list queries to the helper, keeping existing error prefixes.

## Supporting documentation

Phase 3 of backend refactor pass.