### PR TITLE
docs(api): sync route specs

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -4336,6 +4336,105 @@
         ]
       }
     },
+    "/api/exposure/currency": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Optional PLN target percentage; enables drift reporting when present.",
+            "in": "query",
+            "name": "target_pln_pct",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Optional non-negative drift tolerance percentage; defaults to 5.",
+            "in": "query",
+            "name": "tolerance",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "currencies": {
+                      "items": {
+                        "properties": {
+                          "currency": {
+                            "type": "string"
+                          },
+                          "percent": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "value_pln": {
+                            "format": "double",
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "drift": {
+                      "nullable": true,
+                      "properties": {
+                        "actual_pln_pct": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "drift_pln_pct": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "target_pln_pct": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "tolerance_pct": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "within_tolerance": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "foreign_pct": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "pln_pct": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "snapshot_date": {
+                      "type": "string"
+                    },
+                    "total_pln": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Currency exposure for the latest snapshot",
+        "tags": [
+          "exposure"
+        ]
+      }
+    },
     "/api/goals": {
       "get": {
         "responses": {
@@ -5412,6 +5511,123 @@
         "summary": "Debt-payment counts per account",
         "tags": [
           "debt-payments"
+        ]
+      }
+    },
+    "/api/pit38/realized": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Optional report year; defaults from PIT filing window.",
+            "in": "query",
+            "name": "year",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Optional csv value returns a downloadable text/csv report.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "csv"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "rows": {
+                      "items": {
+                        "properties": {
+                          "cost_basis": {
+                            "type": "string"
+                          },
+                          "cost_basis_pln": {
+                            "type": "string"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "date": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "fees": {
+                            "type": "string"
+                          },
+                          "fees_pln": {
+                            "type": "string"
+                          },
+                          "fx_rate": {
+                            "type": "string"
+                          },
+                          "has_fx": {
+                            "type": "boolean"
+                          },
+                          "proceeds": {
+                            "type": "string"
+                          },
+                          "proceeds_pln": {
+                            "type": "string"
+                          },
+                          "quantity": {
+                            "type": "string"
+                          },
+                          "realized_gain": {
+                            "type": "string"
+                          },
+                          "realized_pln": {
+                            "type": "string"
+                          },
+                          "security_id": {
+                            "type": "integer"
+                          },
+                          "symbol": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "totals": {
+                      "properties": {
+                        "cost_basis_pln": {
+                          "type": "string"
+                        },
+                        "fees_pln": {
+                          "type": "string"
+                        },
+                        "proceeds_pln": {
+                          "type": "string"
+                        },
+                        "realized_pln": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "year": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "PIT-38 realized gains worksheet",
+        "tags": [
+          "pit38"
         ]
       }
     },

--- a/backend-go/cmd/gen-openapi/main.go
+++ b/backend-go/cmd/gen-openapi/main.go
@@ -101,6 +101,17 @@ func addRoute(doc *openapi3.T, gen *openapi3gen.Generator, rt *apispec.Route) er
 			},
 		})
 	}
+	for _, q := range rt.Query {
+		op.Parameters = append(op.Parameters, &openapi3.ParameterRef{
+			Value: &openapi3.Parameter{
+				Name:        q.Name,
+				In:          "query",
+				Required:    q.Required,
+				Description: q.Description,
+				Schema:      queryParamSchema(q),
+			},
+		})
+	}
 	if rt.Request != nil {
 		schema, err := gen.NewSchemaRefForValue(rt.Request, nil)
 		if err != nil {
@@ -190,6 +201,25 @@ func pathParamSchema(name string) *openapi3.SchemaRef {
 	default:
 		return openapi3.NewStringSchema().NewRef()
 	}
+}
+
+func queryParamSchema(p apispec.QueryParam) *openapi3.SchemaRef {
+	schema := openapi3.NewStringSchema()
+	switch p.Type {
+	case "integer":
+		schema = openapi3.NewIntegerSchema()
+	case "number":
+		schema = openapi3.NewFloat64Schema()
+	case "boolean":
+		schema = openapi3.NewBoolSchema()
+	}
+	if p.Format != "" {
+		schema.Format = p.Format
+	}
+	for _, v := range p.Enum {
+		schema = schema.WithEnum(v)
+	}
+	return schema.NewRef()
 }
 
 func pathParams(path string) []string {

--- a/backend-go/cmd/gen-openapi/routes.go
+++ b/backend-go/cmd/gen-openapi/routes.go
@@ -14,9 +14,11 @@ import (
 	debtpayments "github.com/Automaat/finance-buddy/backend-go/internal/debt_payments"
 	"github.com/Automaat/finance-buddy/backend-go/internal/debts"
 	equitygrants "github.com/Automaat/finance-buddy/backend-go/internal/equity_grants"
+	"github.com/Automaat/finance-buddy/backend-go/internal/exposure"
 	"github.com/Automaat/finance-buddy/backend-go/internal/goals"
 	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
 	"github.com/Automaat/finance-buddy/backend-go/internal/investment"
+	"github.com/Automaat/finance-buddy/backend-go/internal/pit38"
 	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
 	"github.com/Automaat/finance-buddy/backend-go/internal/rules"
@@ -64,6 +66,8 @@ func allRoutes() []apispec.Route {
 		simulations.APISpec,
 		scenarios.APISpec,
 		rules.APISpec,
+		exposure.APISpec,
+		pit38.APISpec,
 		transactions.APISpec,
 		recurring.APISpec,
 		debtpayments.APISpec,

--- a/backend-go/internal/apispec/apispec.go
+++ b/backend-go/internal/apispec/apispec.go
@@ -16,6 +16,8 @@ type Route struct {
 	// Path is the full route path with chi placeholders, e.g.
 	// "/api/accounts/{id}".
 	Path string
+	// Query lists query parameters accepted by the endpoint.
+	Query []QueryParam
 	// Tag groups the endpoint in the spec (usually the domain name).
 	Tag string
 	// Summary is a one-line human description.
@@ -28,4 +30,14 @@ type Route struct {
 	Response any
 	// Status is the success status code (defaults to 200 when zero).
 	Status int
+}
+
+// QueryParam describes one query parameter for OpenAPI generation.
+type QueryParam struct {
+	Name        string
+	Type        string
+	Format      string
+	Description string
+	Enum        []string
+	Required    bool
 }

--- a/backend-go/internal/exposure/openapi.go
+++ b/backend-go/internal/exposure/openapi.go
@@ -1,0 +1,24 @@
+package exposure
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{
+		Method: "GET", Path: "/api/exposure/currency", Tag: "exposure",
+		Summary: "Currency exposure for the latest snapshot",
+		Query: []apispec.QueryParam{
+			{
+				Name:        "target_pln_pct",
+				Type:        "number",
+				Description: "Optional PLN target percentage; enables drift reporting when present.",
+			},
+			{
+				Name:        "tolerance",
+				Type:        "number",
+				Description: "Optional non-negative drift tolerance percentage; defaults to 5.",
+			},
+		},
+		Response: Report{},
+	},
+}

--- a/backend-go/internal/pit38/openapi.go
+++ b/backend-go/internal/pit38/openapi.go
@@ -1,0 +1,25 @@
+package pit38
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{
+		Method: "GET", Path: "/api/pit38/realized", Tag: "pit38",
+		Summary: "PIT-38 realized gains worksheet",
+		Query: []apispec.QueryParam{
+			{
+				Name:        "year",
+				Type:        "integer",
+				Description: "Optional report year; defaults from PIT filing window.",
+			},
+			{
+				Name:        "format",
+				Type:        "string",
+				Enum:        []string{"csv"},
+				Description: "Optional csv value returns a downloadable text/csv report.",
+			},
+		},
+		Response: Report{},
+	},
+}

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -2747,6 +2747,73 @@ export interface paths {
         };
         trace?: never;
     };
+    "/api/exposure/currency": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Currency exposure for the latest snapshot */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Optional PLN target percentage; enables drift reporting when present. */
+                    target_pln_pct?: number;
+                    /** @description Optional non-negative drift tolerance percentage; defaults to 5. */
+                    tolerance?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            currencies?: {
+                                currency?: string;
+                                /** Format: double */
+                                percent?: number;
+                                /** Format: double */
+                                value_pln?: number;
+                            }[];
+                            drift?: {
+                                /** Format: double */
+                                actual_pln_pct?: number;
+                                /** Format: double */
+                                drift_pln_pct?: number;
+                                /** Format: double */
+                                target_pln_pct?: number;
+                                /** Format: double */
+                                tolerance_pct?: number;
+                                within_tolerance?: boolean;
+                            } | null;
+                            /** Format: double */
+                            foreign_pct?: number;
+                            /** Format: double */
+                            pln_pct?: number;
+                            snapshot_date?: string;
+                            /** Format: double */
+                            total_pln?: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/goals": {
         parameters: {
             query?: never;
@@ -3582,6 +3649,73 @@ export interface paths {
                     content: {
                         "application/json": {
                             [key: string]: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/pit38/realized": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** PIT-38 realized gains worksheet */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Optional report year; defaults from PIT filing window. */
+                    year?: number;
+                    /** @description Optional csv value returns a downloadable text/csv report. */
+                    format?: "csv";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rows?: {
+                                cost_basis?: string;
+                                cost_basis_pln?: string;
+                                currency?: string;
+                                /** Format: date */
+                                date?: string;
+                                fees?: string;
+                                fees_pln?: string;
+                                fx_rate?: string;
+                                has_fx?: boolean;
+                                proceeds?: string;
+                                proceeds_pln?: string;
+                                quantity?: string;
+                                realized_gain?: string;
+                                realized_pln?: string;
+                                security_id?: number;
+                                symbol?: string;
+                            }[];
+                            totals?: {
+                                cost_basis_pln?: string;
+                                fees_pln?: string;
+                                proceeds_pln?: string;
+                                realized_pln?: string;
+                            };
+                            year?: number;
                         };
                     };
                 };


### PR DESCRIPTION
## Motivation

Keep generated OpenAPI coverage aligned with registered backend routes.

> Changelog: docs(api): sync route specs

## Implementation information

Added APISpec entries for exposure currency and PIT-38 realized routes, registered them in the generator, regenerated OpenAPI JSON, and regenerated frontend API types.

## Supporting documentation

Phase 4 of backend refactor pass.