### PR TITLE
feat(dashboard): IKE/IKZE year-end countdown

### DIFF
--- a/src/lib/utils/yearEnd.test.ts
+++ b/src/lib/utils/yearEnd.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { countdownTier, daysLabel, daysUntilYearEnd } from './yearEnd';
+
+describe('daysUntilYearEnd', () => {
+	it('counts 365 days on Jan 1 of a non-leap year', () => {
+		expect(daysUntilYearEnd(new Date(2026, 0, 1, 0, 0, 0))).toBe(365);
+	});
+
+	it('counts 366 days on Jan 1 of a leap year', () => {
+		expect(daysUntilYearEnd(new Date(2028, 0, 1, 0, 0, 0))).toBe(366);
+	});
+
+	it('counts 2 days on Dec 30 (today + Dec 31)', () => {
+		expect(daysUntilYearEnd(new Date(2026, 11, 30, 12, 0, 0))).toBe(2);
+	});
+
+	it('counts 1 day on Dec 31 (today is the last chance)', () => {
+		expect(daysUntilYearEnd(new Date(2026, 11, 31, 23, 59, 59, 999))).toBe(1);
+	});
+
+	it('counts ~half year on Jul 1', () => {
+		expect(daysUntilYearEnd(new Date(2026, 6, 1, 0, 0, 0))).toBe(184);
+	});
+});
+
+describe('countdownTier', () => {
+	it('returns maxed when limit reached regardless of month', () => {
+		expect(countdownTier(new Date(2026, 0, 15), 100)).toBe('maxed');
+		expect(countdownTier(new Date(2026, 11, 15), 150)).toBe('maxed');
+	});
+
+	it('returns safe in Q1-Q2 (Jan-Jun)', () => {
+		expect(countdownTier(new Date(2026, 0, 1), 0)).toBe('safe');
+		expect(countdownTier(new Date(2026, 5, 30), 99)).toBe('safe');
+	});
+
+	it('returns warn in Q3 (Jul-Sep)', () => {
+		expect(countdownTier(new Date(2026, 6, 1), 0)).toBe('warn');
+		expect(countdownTier(new Date(2026, 8, 30), 50)).toBe('warn');
+	});
+
+	it('returns urgent in Q4 (Oct-Dec) when not maxed', () => {
+		expect(countdownTier(new Date(2026, 9, 1), 50)).toBe('urgent');
+		expect(countdownTier(new Date(2026, 11, 31), 99.9)).toBe('urgent');
+	});
+});
+
+describe('daysLabel', () => {
+	it('uses singular for 1', () => {
+		expect(daysLabel(1)).toBe('dzień');
+	});
+
+	it('uses plural for 0', () => {
+		expect(daysLabel(0)).toBe('dni');
+	});
+
+	it('uses plural for 2-4', () => {
+		expect(daysLabel(2)).toBe('dni');
+		expect(daysLabel(4)).toBe('dni');
+	});
+
+	it('uses plural for larger numbers', () => {
+		expect(daysLabel(5)).toBe('dni');
+		expect(daysLabel(100)).toBe('dni');
+		expect(daysLabel(365)).toBe('dni');
+	});
+});

--- a/src/lib/utils/yearEnd.ts
+++ b/src/lib/utils/yearEnd.ts
@@ -1,0 +1,34 @@
+// Year-end contribution countdown helpers for IKE/IKZE caps.
+// Caps don't roll over — Dec 31 is the deadline. The dashboard nudge
+// escalates in Q3 (amber) and Q4 (red) when the limit is still not maxed.
+
+export type CountdownTier = 'maxed' | 'safe' | 'warn' | 'urgent';
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+// daysUntilYearEnd returns the number of calendar days the user still has
+// to contribute, inclusive of Dec 31. On Dec 31 it returns 1 (today is the
+// last chance); on Jan 1 it returns 365 (or 366 in a leap year).
+export function daysUntilYearEnd(now: Date): number {
+	const year = now.getFullYear();
+	const today = new Date(year, now.getMonth(), now.getDate());
+	const yearEnd = new Date(year, 11, 31);
+	const diffDays = Math.round((yearEnd.getTime() - today.getTime()) / MS_PER_DAY);
+	return diffDays < 0 ? 0 : diffDays + 1;
+}
+
+// countdownTier picks the urgency level for the IKE/IKZE limit card.
+// Maxed wraps any quarter; otherwise the month bucket drives the color.
+export function countdownTier(now: Date, percentageUsed: number): CountdownTier {
+	if (percentageUsed >= 100) return 'maxed';
+	const month = now.getMonth() + 1;
+	if (month <= 6) return 'safe';
+	if (month <= 9) return 'warn';
+	return 'urgent';
+}
+
+// daysLabel returns the Polish plural for "day" (dzień/dni).
+// Polish: 1 → dzień, otherwise → dni.
+export function daysLabel(days: number): string {
+	return days === 1 ? 'dzień' : 'dni';
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,6 +22,12 @@
 	import { invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
+	import {
+		countdownTier,
+		daysLabel,
+		daysUntilYearEnd,
+		type CountdownTier
+	} from '$lib/utils/yearEnd';
 	import type { PageData } from './$types';
 
 	interface Props {
@@ -115,6 +121,23 @@
 		if (last >= 2 && last <= 4 && (lastTwo < 12 || lastTwo > 14)) return 'lata';
 		return 'lat';
 	}
+
+	const now = new Date();
+	const daysLeft = daysUntilYearEnd(now);
+
+	const tierBar: Record<CountdownTier, string> = {
+		maxed: 'bg-success-500',
+		safe: 'bg-success-500',
+		warn: 'bg-warning-500',
+		urgent: 'bg-error-500'
+	};
+
+	const tierText: Record<CountdownTier, string> = {
+		maxed: 'text-success-600-400',
+		safe: 'text-success-600-400',
+		warn: 'text-warning-600-400',
+		urgent: 'text-error-600-400'
+	};
 </script>
 
 <svelte:head>
@@ -495,22 +518,29 @@
 
 		{#if dashboard.retirementStats && dashboard.retirementStats.length > 0}
 			<div class="card preset-filled-surface-100-900 p-4 space-y-4">
-				<header class="flex items-center justify-between gap-2">
+				<header class="flex items-center justify-between gap-2 flex-wrap">
 					<h3 class="h3 flex items-center gap-2">
 						<PiggyBank size={20} /> Limity Emerytalne {data.currentYear}
 					</h3>
-					<button
-						type="button"
-						class="btn-icon btn-icon-sm"
-						aria-label="Konfiguruj limity"
-						onclick={() => openLimitsModal(dashboard.retirementStats)}
-					>
-						<Settings size={18} />
-					</button>
+					<div class="flex items-center gap-2">
+						<span class="text-xs text-surface-700-300 whitespace-nowrap">
+							{daysLeft}
+							{daysLabel(daysLeft)} do 31 grudnia
+						</span>
+						<button
+							type="button"
+							class="btn-icon btn-icon-sm"
+							aria-label="Konfiguruj limity"
+							onclick={() => openLimitsModal(dashboard.retirementStats)}
+						>
+							<Settings size={18} />
+						</button>
+					</div>
 				</header>
 
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 					{#each dashboard.retirementStats as stat}
+						{@const tier = countdownTier(now, stat.percentage_used)}
 						<div class="card preset-tonal-surface p-4 space-y-2">
 							<div class="flex items-start justify-between gap-2">
 								<h4 class="font-bold">
@@ -523,39 +553,35 @@
 
 							<div class="h-2 rounded-full bg-surface-200-800 overflow-hidden">
 								<div
-									class="h-full transition-all {stat.percentage_used >= 100
-										? 'bg-success-500'
-										: stat.percentage_used >= 50
-											? 'bg-warning-500'
-											: 'bg-error-500'}"
+									class="h-full transition-all {tierBar[tier]}"
 									style="width: {Math.min(stat.percentage_used, 100)}%"
 								></div>
 							</div>
 
 							<div class="flex items-center justify-between text-sm">
 								<span class="text-surface-700-300">Pozostało: {formatPLN(stat.remaining)}</span>
-								<span
-									class="font-semibold {stat.percentage_used >= 100
-										? 'text-success-600-400'
-										: stat.percentage_used >= 50
-											? 'text-warning-600-400'
-											: 'text-error-600-400'}"
-								>
+								<span class="font-semibold {tierText[tier]}">
 									{stat.percentage_used}%
 								</span>
 							</div>
 
-							{#if stat.percentage_used >= 100}
+							{#if tier === 'maxed'}
 								<div
 									class="card preset-filled-success-500 p-2 text-xs text-center flex items-center justify-center gap-1"
 								>
 									<CheckCircle2 size={14} /> Limit osiągnięty
 								</div>
-							{:else if stat.percentage_used >= 50}
+							{:else if tier === 'urgent'}
+								<div
+									class="card preset-filled-error-500 p-2 text-xs text-center flex items-center justify-center gap-1"
+								>
+									<AlertTriangle size={14} /> Końcówka roku — limit przepadnie 31.12
+								</div>
+							{:else if tier === 'warn'}
 								<div
 									class="card preset-filled-warning-500 p-2 text-xs text-center flex items-center justify-center gap-1"
 								>
-									<AlertTriangle size={14} /> Zbliżasz się do limitu
+									<AlertTriangle size={14} /> Coraz mniej czasu na wykorzystanie limitu
 								</div>
 							{/if}
 						</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import Skeleton from '$lib/components/Skeleton.svelte';
 	import DashboardCharts from '$lib/components/DashboardCharts.svelte';
@@ -122,8 +122,22 @@
 		return 'lat';
 	}
 
-	const now = new Date();
-	const daysLeft = daysUntilYearEnd(now);
+	// Date-driven UI. SSR seeds with a server-side `now`; onMount resets to the
+	// client clock to avoid timezone drift, and a daily tick keeps the counter
+	// honest across midnight in long-lived sessions.
+	let now = $state(new Date());
+	const daysLeft = $derived(daysUntilYearEnd(now));
+
+	onMount(() => {
+		now = new Date();
+		const id = setInterval(
+			() => {
+				now = new Date();
+			},
+			60 * 60 * 1000
+		);
+		return () => clearInterval(id);
+	});
 
 	const tierBar: Record<CountdownTier, string> = {
 		maxed: 'bg-success-500',

--- a/src/routes/page.test.ts
+++ b/src/routes/page.test.ts
@@ -393,3 +393,82 @@ describe('Dashboard — FIRE / runway / bonds cards', () => {
 		await waitFor(() => expect(screen.getByText('1 obligacja (auto-wycena wg CPI)')).toBeTruthy());
 	});
 });
+
+describe('Dashboard — IKE/IKZE year-end countdown', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	function statAt(percentage_used: number) {
+		return {
+			account_wrapper: 'IKE',
+			owner_user_id: 1,
+			total_contributed: 1000,
+			limit_amount: 28260,
+			remaining: 27260,
+			percentage_used
+		};
+	}
+
+	function dataAt(percentage_used: number) {
+		return buildData({
+			dashboardData: {
+				net_worth_history: [{ date: '2024-01-01', value: 5000 }],
+				current_net_worth: 6000,
+				change_vs_last_month: 0,
+				total_assets: 10000,
+				total_liabilities: 4000,
+				allocation: [],
+				retirementStats: [statAt(percentage_used)],
+				tile_deltas: baseTileDeltas
+			},
+			owners: [{ id: 1, name: 'Marcin' }]
+		});
+	}
+
+	it('shows the days-to-Dec-31 countdown in the header', async () => {
+		vi.setSystemTime(new Date(2026, 5, 1, 12, 0, 0));
+		render(Page, { props: { data: dataAt(20) } });
+		await waitFor(() =>
+			expect(screen.getByRole('heading', { name: /Limity Emerytalne/ })).toBeTruthy()
+		);
+		expect(screen.getByText(/214 dni do 31 grudnia/)).toBeTruthy();
+	});
+
+	it('renders maxed badge when limit reached (any month)', async () => {
+		vi.setSystemTime(new Date(2026, 0, 15, 12, 0, 0));
+		render(Page, { props: { data: dataAt(100) } });
+		await waitFor(() => expect(screen.getByText('Limit osiągnięty')).toBeTruthy());
+	});
+
+	it('renders no urgency badge in Q1-Q2 when not maxed', async () => {
+		vi.setSystemTime(new Date(2026, 3, 15, 12, 0, 0));
+		render(Page, { props: { data: dataAt(10) } });
+		await waitFor(() =>
+			expect(screen.getByRole('heading', { name: /Limity Emerytalne/ })).toBeTruthy()
+		);
+		expect(screen.queryByText(/Końcówka roku/)).toBeNull();
+		expect(screen.queryByText(/Coraz mniej czasu/)).toBeNull();
+		expect(screen.queryByText('Limit osiągnięty')).toBeNull();
+	});
+
+	it('renders warn badge in Q3 when not maxed', async () => {
+		vi.setSystemTime(new Date(2026, 7, 15, 12, 0, 0));
+		render(Page, { props: { data: dataAt(40) } });
+		await waitFor(() =>
+			expect(screen.getByText(/Coraz mniej czasu na wykorzystanie limitu/)).toBeTruthy()
+		);
+	});
+
+	it('renders urgent badge in Q4 when not maxed', async () => {
+		vi.setSystemTime(new Date(2026, 10, 15, 12, 0, 0));
+		render(Page, { props: { data: dataAt(70) } });
+		await waitFor(() =>
+			expect(screen.getByText(/Końcówka roku — limit przepadnie 31\.12/)).toBeTruthy()
+		);
+	});
+});


### PR DESCRIPTION
## Motivation

IKE/IKZE annual contribution caps don't roll over — missing Dec 31 burns the
allowance forever. The existing dashboard card showed limits but had no
deadline cue, and its color logic was backwards (red on low usage).

## Implementation information

- New helpers in `src/lib/utils/yearEnd.ts`: `daysUntilYearEnd`,
  `countdownTier` (maxed/safe/warn/urgent based on month + percent_used),
  `daysLabel` (PL plural).
- Header now shows `X dni do 31 grudnia` alongside the existing config button.
- Progress bar + percentage color follow the tier: green Q1-Q2, amber Q3,
  red Q4 — maxed always green.
- Replaced the always-on "Zbliżasz się do limitu" badge with tier-specific
  text: "Końcówka roku — limit przepadnie 31.12" (urgent) and "Coraz mniej
  czasu na wykorzystanie limitu" (warn).
- Backend already exposes `limit_amount`, `remaining`, `percentage_used` via
  `/api/retirement/stats` — no backend changes needed.

Tests: 13 new unit tests for the helpers (leap year, year-end boundary,
tier transitions). Existing dashboard page tests still green.

Closes #570

> Changelog: feat(dashboard): IKE/IKZE year-end countdown