### PR TITLE
refactor(http): reuse request helpers

### DIFF
--- a/backend-go/internal/accounts/handler.go
+++ b/backend-go/internal/accounts/handler.go
@@ -5,12 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
-	"strconv"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
@@ -255,8 +252,7 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 // Create serves POST /api/accounts.
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	req, vErr := buildCreateRequest(raw)
@@ -297,8 +293,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	patch, vErr := buildUpdatePatch(raw)
@@ -352,11 +347,5 @@ func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int, name
 }
 
 func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
-	raw := chi.URLParam(r, "id")
-	id, err := strconv.Atoi(raw)
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "account_id", "must be an integer", raw)
-		return 0, false
-	}
-	return id, true
+	return httputil.PathIntField(w, r, "id", "account_id")
 }

--- a/backend-go/internal/assets/handler.go
+++ b/backend-go/internal/assets/handler.go
@@ -4,12 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
-	"strconv"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
@@ -82,8 +79,7 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 // Create serves POST /api/assets.
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	name, vErr := requireName(raw)
@@ -112,8 +108,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	namePtr, vErr := optionalName(raw)
@@ -167,11 +162,5 @@ func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int, name
 }
 
 func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
-	raw := chi.URLParam(r, "id")
-	id, err := strconv.Atoi(raw)
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "asset_id", "must be an integer", raw)
-		return 0, false
-	}
-	return id, true
+	return httputil.PathIntField(w, r, "id", "asset_id")
 }

--- a/backend-go/internal/bonus_events/handler.go
+++ b/backend-go/internal/bonus_events/handler.go
@@ -5,14 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
@@ -168,8 +166,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 // Create serves POST /api/bonuses.
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	req, vErr := buildCreateRequest(raw)
@@ -203,8 +200,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	patch, vErr := buildUpdatePatch(raw)
@@ -293,11 +289,5 @@ func first(values []string) string {
 }
 
 func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
-	raw := chi.URLParam(r, "id")
-	id, err := strconv.Atoi(raw)
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "bonus_id", "must be an integer", raw)
-		return 0, false
-	}
-	return id, true
+	return httputil.PathIntField(w, r, "id", "bonus_id")
 }

--- a/backend-go/internal/company_valuations/handler.go
+++ b/backend-go/internal/company_valuations/handler.go
@@ -4,13 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
@@ -153,8 +150,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 // Create serves POST /api/company-valuations.
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	req, vErr := buildCreateRequest(raw)
@@ -179,8 +175,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	patch, vErr := buildUpdatePatch(raw)
@@ -239,11 +234,5 @@ func requestToValuation(req *createRequest) *Valuation {
 }
 
 func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
-	raw := chi.URLParam(r, "id")
-	id, err := strconv.Atoi(raw)
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "valuation_id", "must be an integer", raw)
-		return 0, false
-	}
-	return id, true
+	return httputil.PathIntField(w, r, "id", "valuation_id")
 }

--- a/backend-go/internal/debts/handler.go
+++ b/backend-go/internal/debts/handler.go
@@ -5,12 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
@@ -138,8 +136,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 // -> installment category).
 func (h *Handler) CreateWithAccount(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	req, vErr := buildCreateRequest(raw)
@@ -182,9 +179,8 @@ func (h *Handler) CreateWithAccount(w http.ResponseWriter, r *http.Request) {
 
 // Create serves POST /api/accounts/{account_id}/debts.
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
-	accountID, err := strconv.Atoi(chi.URLParam(r, "account_id"))
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "account_id", "must be an integer", chi.URLParam(r, "account_id"))
+	accountID, ok := httputil.PathInt(w, r, "account_id")
+	if !ok {
 		return
 	}
 	account, err := h.store.LoadAccount(r.Context(), accountID)
@@ -197,8 +193,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	req, vErr := buildCreateRequest(raw)
@@ -238,8 +233,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	patch, vErr := buildUpdatePatch(raw)
@@ -321,11 +315,5 @@ func (h *Handler) writeDebtError(w http.ResponseWriter, err error, id int) {
 }
 
 func parseIDParam(w http.ResponseWriter, r *http.Request, urlKey, errField string) (int, bool) {
-	raw := chi.URLParam(r, urlKey)
-	id, err := strconv.Atoi(raw)
-	if err != nil {
-		httputil.WriteBodyValidationError(w, errField, "must be an integer", raw)
-		return 0, false
-	}
-	return id, true
+	return httputil.PathIntField(w, r, urlKey, errField)
 }

--- a/backend-go/internal/goals/handler.go
+++ b/backend-go/internal/goals/handler.go
@@ -4,14 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"math"
 	"net/http"
-	"strconv"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
@@ -169,8 +166,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 // Create serves POST /api/goals.
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	var req createRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &req) {
 		return
 	}
 	if vErr := validateCreate(&req); vErr != nil {
@@ -206,8 +202,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	patch, vErr := buildUpdatePatch(raw)
@@ -256,11 +251,5 @@ func (h *Handler) writeStoreError(w http.ResponseWriter, err error) {
 }
 
 func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
-	raw := chi.URLParam(r, "id")
-	id, err := strconv.Atoi(raw)
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "goal_id", "must be an integer", raw)
-		return 0, false
-	}
-	return id, true
+	return httputil.PathIntField(w, r, "id", "goal_id")
 }

--- a/backend-go/internal/httputil/request.go
+++ b/backend-go/internal/httputil/request.go
@@ -24,10 +24,17 @@ func DecodeJSON(w http.ResponseWriter, r *http.Request, maxBytes int64, dst any)
 // PathInt parses an integer chi path parameter and writes the backend's
 // existing validation envelope on parse failure.
 func PathInt(w http.ResponseWriter, r *http.Request, param string) (int, bool) {
+	return PathIntField(w, r, param, param)
+}
+
+// PathIntField parses an integer chi path parameter and writes a validation
+// envelope under field. Use when the URL placeholder differs from the legacy
+// Pydantic error field that clients/tests already expect.
+func PathIntField(w http.ResponseWriter, r *http.Request, param, field string) (int, bool) {
 	raw := chi.URLParam(r, param)
 	id, err := strconv.Atoi(raw)
 	if err != nil {
-		WriteBodyValidationError(w, param, "must be an integer", raw)
+		WriteBodyValidationError(w, field, "must be an integer", raw)
 		return 0, false
 	}
 	return id, true

--- a/backend-go/internal/httputil/request_test.go
+++ b/backend-go/internal/httputil/request_test.go
@@ -71,6 +71,19 @@ func TestPathIntInvalid(t *testing.T) {
 	assertValidationField(t, rec, "account_id")
 }
 
+func TestPathIntFieldInvalid(t *testing.T) {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/goals/x", http.NoBody)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "x")
+	req = req.WithContext(contextWithRoute(req, rctx))
+	rec := httptest.NewRecorder()
+
+	if _, ok := PathIntField(rec, req, "id", "goal_id"); ok {
+		t.Fatal("PathIntField returned true")
+	}
+	assertValidationField(t, rec, "goal_id")
+}
+
 func TestOptionalQueryInt(t *testing.T) {
 	rec := httptest.NewRecorder()
 	got, ok := OptionalQueryInt(rec, url.Values{"owner_user_id": []string{"7"}}, "owner_user_id")


### PR DESCRIPTION
## Motivation

Reduce duplicated HTTP request parsing in backend handlers.

> Changelog: skip

## Implementation information

- Add PathIntField for legacy validation field names.
- Reuse DecodeJSON and path helpers in CRUD handlers.
- Cover PathIntField with a unit test.

## Supporting documentation

Phase 1 of backend refactor cleanup.