### PR TITLE
refactor(validation): share field helpers

### DIFF
--- a/backend-go/internal/assets/validation.go
+++ b/backend-go/internal/assets/validation.go
@@ -2,41 +2,16 @@ package assets
 
 import (
 	"encoding/json"
-	"strings"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 func requireName(raw map[string]json.RawMessage) (string, *httputil.ValidationError) {
-	v, ok := raw["name"]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: "name", Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: "name", Msg: "must be a string"}
-	}
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return "", &httputil.ValidationError{Field: "name", Msg: "Name cannot be empty"}
-	}
-	return s, nil
+	return validation.RequiredTrimmedString(raw, "name", "Field required", "Name cannot be empty")
 }
 
 // optionalName: absent / explicit null -> no change. Empty string -> 422.
 func optionalName(raw map[string]json.RawMessage) (*string, *httputil.ValidationError) {
-	v, ok := raw["name"]
-	if !ok || validation.IsNull(v) {
-		return nil, nil
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return nil, &httputil.ValidationError{Field: "name", Msg: "must be a string"}
-	}
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return nil, &httputil.ValidationError{Field: "name", Msg: "Name cannot be empty"}
-	}
-	return &s, nil
+	return validation.OptionalTrimmedString(raw, "name", "Name cannot be empty")
 }

--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -184,35 +184,11 @@ func patchEnums(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Valida
 // --- shared decoders ---
 
 func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return "", &httputil.ValidationError{Field: key, Msg: emptyMsg}
-	}
-	return s, nil
+	return validation.RequiredTrimmedString(raw, key, "Field required", emptyMsg)
 }
 
 func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	t, err := time.Parse("2006-01-02", s)
-	if err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
-	}
-	return t, nil
+	return validation.RequiredDate(raw, key)
 }
 
 func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
@@ -264,18 +240,7 @@ func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[s
 // requireIntOrNull reads an integer key that must be present; an explicit
 // null is allowed and yields nil (jointly owned).
 func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok {
-		return nil, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	if validation.IsNull(v) {
-		return nil, nil
-	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return nil, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
-	}
-	return &n, nil
+	return validation.RequiredIntOrNull(raw, key)
 }
 
 func today() time.Time {

--- a/backend-go/internal/company_valuations/validation.go
+++ b/backend-go/internal/company_valuations/validation.go
@@ -183,35 +183,11 @@ func patchNumbers(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 // --- shared decoders ---
 
 func requireString(raw map[string]json.RawMessage, key, missingMsg, emptyMsg string) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: key, Msg: missingMsg}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return "", &httputil.ValidationError{Field: key, Msg: emptyMsg}
-	}
-	return s, nil
+	return validation.RequiredTrimmedString(raw, key, missingMsg, emptyMsg)
 }
 
 func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	t, err := time.Parse("2006-01-02", s)
-	if err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
-	}
-	return t, nil
+	return validation.RequiredDate(raw, key)
 }
 
 func optionalCurrency(raw map[string]json.RawMessage) (string, *httputil.ValidationError) {

--- a/backend-go/internal/debts/validation.go
+++ b/backend-go/internal/debts/validation.go
@@ -153,35 +153,11 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 }
 
 func requireOwnerUserID(raw map[string]json.RawMessage) (*int, *httputil.ValidationError) {
-	const key = "owner_user_id"
-	v, ok := raw[key]
-	if !ok {
-		return nil, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	if validation.IsNull(v) {
-		return nil, nil
-	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return nil, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
-	}
-	return &n, nil
+	return validation.RequiredIntOrNull(raw, "owner_user_id")
 }
 
 func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return "", &httputil.ValidationError{Field: key, Msg: emptyMsg}
-	}
-	return s, nil
+	return validation.RequiredTrimmedString(raw, key, "Field required", emptyMsg)
 }
 
 func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
@@ -200,17 +176,9 @@ func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[s
 }
 
 func requireDateNotFuture(raw map[string]json.RawMessage, key, msg string) (time.Time, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	t, err := time.Parse("2006-01-02", s)
-	if err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
+	t, vErr := validation.RequiredDate(raw, key)
+	if vErr != nil {
+		return time.Time{}, vErr
 	}
 	if t.After(today()) {
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: msg}

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -1,0 +1,85 @@
+package validation
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+)
+
+// RequiredTrimmedString reads a required string field, trims whitespace, and
+// returns the supplied missing/empty messages so domain wire contracts stay
+// unchanged while callers share parsing logic.
+func RequiredTrimmedString(
+	raw map[string]json.RawMessage,
+	key string,
+	missingMsg string,
+	emptyMsg string,
+) (string, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return "", &httputil.ValidationError{Field: key, Msg: missingMsg}
+	}
+	s, err := RawTrimmedString(v)
+	if err != nil {
+		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	}
+	if s == "" {
+		return "", &httputil.ValidationError{Field: key, Msg: emptyMsg}
+	}
+	return s, nil
+}
+
+// OptionalTrimmedString reads an optional string field. Missing or explicit
+// null returns nil; empty string is a validation error.
+func OptionalTrimmedString(
+	raw map[string]json.RawMessage,
+	key string,
+	emptyMsg string,
+) (*string, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return nil, nil
+	}
+	s, err := RawTrimmedString(v)
+	if err != nil {
+		return nil, &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	}
+	if s == "" {
+		return nil, &httputil.ValidationError{Field: key, Msg: emptyMsg}
+	}
+	return &s, nil
+}
+
+// RequiredDate reads a required YYYY-MM-DD field.
+func RequiredDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
+	}
+	t, err := RawDate(v)
+	if err != nil {
+		if IsRawDateFormatError(err) {
+			return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
+		}
+		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	}
+	return t, nil
+}
+
+// RequiredIntOrNull reads a required integer field where explicit null is
+// allowed and maps to nil.
+func RequiredIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok {
+		return nil, &httputil.ValidationError{Field: key, Msg: "Field required"}
+	}
+	if IsNull(v) {
+		return nil, nil
+	}
+	n, err := RawInt(v)
+	if err != nil {
+		return nil, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
+	}
+	return &n, nil
+}

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -46,6 +46,25 @@ func TestOptionalTrimmedString(t *testing.T) {
 	if vErr != nil || got != nil {
 		t.Fatalf("got = %v vErr = %#v", got, vErr)
 	}
+
+	got, vErr = OptionalTrimmedString(
+		map[string]json.RawMessage{"name": json.RawMessage(`null`)},
+		"name",
+		"Name cannot be empty",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalTrimmedString(
+		map[string]json.RawMessage{"name": json.RawMessage(`"  "`)},
+		"name",
+		"Name cannot be empty",
+	)
+	if got != nil {
+		t.Fatalf("got = %v", got)
+	}
+	requireValidation(t, vErr, "name", "Name cannot be empty")
 }
 
 func TestRequiredDate(t *testing.T) {

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -1,0 +1,93 @@
+package validation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+)
+
+func TestRequiredTrimmedString(t *testing.T) {
+	raw := map[string]json.RawMessage{"name": json.RawMessage(`"  Cash  "`)}
+	got, vErr := RequiredTrimmedString(raw, "name", "Field required", "Name cannot be empty")
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != "Cash" {
+		t.Fatalf("got = %q", got)
+	}
+
+	_, vErr = RequiredTrimmedString(map[string]json.RawMessage{}, "name", "Field required", "Name cannot be empty")
+	requireValidation(t, vErr, "name", "Field required")
+
+	_, vErr = RequiredTrimmedString(
+		map[string]json.RawMessage{"name": json.RawMessage(`"  "`)},
+		"name",
+		"Field required",
+		"Name cannot be empty",
+	)
+	requireValidation(t, vErr, "name", "Name cannot be empty")
+}
+
+func TestOptionalTrimmedString(t *testing.T) {
+	got, vErr := OptionalTrimmedString(
+		map[string]json.RawMessage{"name": json.RawMessage(`"  Cash  "`)},
+		"name",
+		"Name cannot be empty",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || *got != "Cash" {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalTrimmedString(map[string]json.RawMessage{}, "name", "Name cannot be empty")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+}
+
+func TestRequiredDate(t *testing.T) {
+	got, vErr := RequiredDate(map[string]json.RawMessage{"date": json.RawMessage(`"2026-05-26"`)}, "date")
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got.Format("2006-01-02") != "2026-05-26" {
+		t.Fatalf("got = %s", got.Format("2006-01-02"))
+	}
+
+	_, vErr = RequiredDate(map[string]json.RawMessage{"date": json.RawMessage(`"26/05/2026"`)}, "date")
+	requireValidation(t, vErr, "date", "must be YYYY-MM-DD")
+
+	_, vErr = RequiredDate(map[string]json.RawMessage{"date": json.RawMessage(`20260526`)}, "date")
+	requireValidation(t, vErr, "date", "must be a string")
+}
+
+func TestRequiredIntOrNull(t *testing.T) {
+	got, vErr := RequiredIntOrNull(map[string]json.RawMessage{"owner_user_id": json.RawMessage(`7`)}, "owner_user_id")
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || *got != 7 {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = RequiredIntOrNull(map[string]json.RawMessage{"owner_user_id": json.RawMessage(`null`)}, "owner_user_id")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	_, vErr = RequiredIntOrNull(map[string]json.RawMessage{"owner_user_id": json.RawMessage(`"7"`)}, "owner_user_id")
+	requireValidation(t, vErr, "owner_user_id", "must be an integer")
+}
+
+func requireValidation(t *testing.T, got *httputil.ValidationError, field, msg string) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("vErr is nil")
+	}
+	if got.Field != field || got.Msg != msg {
+		t.Fatalf("vErr = %#v, want field=%q msg=%q", got, field, msg)
+	}
+}

--- a/backend-go/internal/validation/raw.go
+++ b/backend-go/internal/validation/raw.go
@@ -1,8 +1,9 @@
-// Package validation holds primitive helpers for parsing request bodies
-// that arrive as map[string]json.RawMessage (the PATCH/null-vs-missing
-// pattern). Domain packages keep their require*/patch* wrappers so error
-// messages remain wire-stable; this package only owns the small parsing
-// primitives that were duplicated across every domain.
+// Package validation holds helpers for parsing request bodies that arrive as
+// map[string]json.RawMessage (the PATCH/null-vs-missing pattern).
+//
+// Raw* helpers expose small type-parsing primitives. Field-level helpers wrap
+// common required/optional field rules and return httputil.ValidationError so
+// domain packages can share parsing logic while keeping wire-stable messages.
 package validation
 
 import (


### PR DESCRIPTION
## Motivation

Reduce duplicated raw-body validation helpers while keeping error messages stable.

> Changelog: skip

## Implementation information

- Add shared validation helpers for common required/optional fields.
- Reuse them in asset, bonus, valuation, and debt validators.
- Cover helper behavior with unit tests.

## Supporting documentation

Phase 2 of backend refactor cleanup.