### PR TITLE
refactor(openapi): add auth routes

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -1317,6 +1317,371 @@
         ]
       }
     },
+    "/api/auth/login": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "password": {
+                    "type": "string"
+                  },
+                  "remember_me": {
+                    "type": "boolean"
+                  },
+                  "username": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "token": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "properties": {
+                        "created_at": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "integer"
+                        },
+                        "is_admin": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "ppk_employee_rate": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "ppk_employer_rate": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "surname": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "username": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Log in",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Log out",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/me": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_admin": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "ppk_employee_rate": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "ppk_employer_rate": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "surname": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "username": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Read current user",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/users": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "created_at": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "integer"
+                      },
+                      "is_admin": {
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "ppk_employee_rate": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "ppk_employer_rate": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "surname": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "username": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List users",
+        "tags": [
+          "auth"
+        ]
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "name": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  },
+                  "ppk_employee_rate": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "ppk_employer_rate": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "surname": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "username": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_admin": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "ppk_employee_rate": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "ppk_employer_rate": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "surname": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "username": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Create a user",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/users/{id}": {
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "name": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "ppk_employee_rate": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "ppk_employer_rate": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "surname": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "is_admin": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "ppk_employee_rate": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "ppk_employer_rate": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "surname": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "username": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Update a user",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
     "/api/bonds": {
       "get": {
         "responses": {
@@ -8139,6 +8504,37 @@
         "summary": "List valid transaction_type enum values",
         "tags": [
           "transactions"
+        ]
+      }
+    },
+    "/api/users": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List owner options",
+        "tags": [
+          "auth"
         ]
       }
     },

--- a/backend-go/cmd/gen-openapi/main_test.go
+++ b/backend-go/cmd/gen-openapi/main_test.go
@@ -131,6 +131,31 @@ func TestAddRouteRejectsUnsupportedMethod(t *testing.T) {
 	}
 }
 
+func TestAllRoutesIncludesAuthRoutes(t *testing.T) {
+	got := routeSet(allRoutes())
+	for _, key := range []string{
+		"POST /api/auth/login",
+		"POST /api/auth/logout",
+		"GET /api/auth/me",
+		"GET /api/users",
+		"GET /api/auth/users",
+		"POST /api/auth/users",
+		"PUT /api/auth/users/{id}",
+	} {
+		if !got[key] {
+			t.Fatalf("%s missing from allRoutes", key)
+		}
+	}
+}
+
+func routeSet(routes []apispec.Route) map[string]bool {
+	out := make(map[string]bool, len(routes))
+	for _, route := range routes {
+		out[route.Method+" "+route.Path] = true
+	}
+	return out
+}
+
 func findParam(
 	t *testing.T,
 	params openapi3.Parameters,

--- a/backend-go/cmd/gen-openapi/main_test.go
+++ b/backend-go/cmd/gen-openapi/main_test.go
@@ -150,8 +150,8 @@ func TestAllRoutesIncludesAuthRoutes(t *testing.T) {
 
 func routeSet(routes []apispec.Route) map[string]bool {
 	out := make(map[string]bool, len(routes))
-	for _, route := range routes {
-		out[route.Method+" "+route.Path] = true
+	for i := range routes {
+		out[routes[i].Method+" "+routes[i].Path] = true
 	}
 	return out
 }

--- a/backend-go/cmd/gen-openapi/routes.go
+++ b/backend-go/cmd/gen-openapi/routes.go
@@ -5,6 +5,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/allocation"
 	"github.com/Automaat/finance-buddy/backend-go/internal/apispec"
 	"github.com/Automaat/finance-buddy/backend-go/internal/assets"
+	"github.com/Automaat/finance-buddy/backend-go/internal/auth"
 	"github.com/Automaat/finance-buddy/backend-go/internal/bonds"
 	bonusevents "github.com/Automaat/finance-buddy/backend-go/internal/bonus_events"
 	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
@@ -47,6 +48,7 @@ func allRoutes() []apispec.Route {
 		},
 	}
 	specs := [][]apispec.Route{
+		auth.APISpec,
 		config.APISpec,
 		goals.APISpec,
 		accounts.APISpec,

--- a/backend-go/internal/auth/handler.go
+++ b/backend-go/internal/auth/handler.go
@@ -44,6 +44,11 @@ type loginRequest struct {
 	RememberMe bool   `json:"remember_me"`
 }
 
+type loginResponse struct {
+	Token string       `json:"token"`
+	User  userResponse `json:"user"`
+}
+
 type createUserRequest struct {
 	Username        string           `json:"username"`
 	Password        string           `json:"password"`
@@ -127,7 +132,7 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	h.setSessionCookie(w, token, req.RememberMe, ttl)
-	httputil.WriteJSON(w, http.StatusOK, map[string]any{"token": token, "user": toUserResponse(user)})
+	httputil.WriteJSON(w, http.StatusOK, loginResponse{Token: token, User: toUserResponse(user)})
 }
 
 // Logout serves POST /api/auth/logout (public). It clears the session cookie;

--- a/backend-go/internal/auth/openapi.go
+++ b/backend-go/internal/auth/openapi.go
@@ -1,0 +1,46 @@
+package auth
+
+import "github.com/Automaat/finance-buddy/backend-go/internal/apispec"
+
+// APISpec registers this package's routes for OpenAPI generation.
+var APISpec = []apispec.Route{
+	{
+		Method: "POST", Path: "/api/auth/login", Tag: "auth",
+		Summary:  "Log in",
+		Request:  loginRequest{},
+		Response: loginResponse{},
+	},
+	{
+		Method: "POST", Path: "/api/auth/logout", Tag: "auth",
+		Summary: "Log out",
+		Status:  204,
+	},
+	{
+		Method: "GET", Path: "/api/auth/me", Tag: "auth",
+		Summary:  "Read current user",
+		Response: userResponse{},
+	},
+	{
+		Method: "GET", Path: "/api/users", Tag: "auth",
+		Summary:  "List owner options",
+		Response: []ownerOption{},
+	},
+	{
+		Method: "GET", Path: "/api/auth/users", Tag: "auth",
+		Summary:  "List users",
+		Response: []userResponse{},
+	},
+	{
+		Method: "POST", Path: "/api/auth/users", Tag: "auth",
+		Summary:  "Create a user",
+		Request:  createUserRequest{},
+		Response: userResponse{},
+		Status:   201,
+	},
+	{
+		Method: "PUT", Path: "/api/auth/users/{id}", Tag: "auth",
+		Summary:  "Update a user",
+		Request:  updateUserRequest{},
+		Response: userResponse{},
+	},
+}

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -948,6 +948,282 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Log in */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        password?: string;
+                        remember_me?: boolean;
+                        username?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            token?: string;
+                            user?: {
+                                created_at?: string;
+                                id?: number;
+                                is_admin?: boolean;
+                                name?: string | null;
+                                ppk_employee_rate?: string | null;
+                                ppk_employer_rate?: string | null;
+                                surname?: string | null;
+                                username?: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Log out */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read current user */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            created_at?: string;
+                            id?: number;
+                            is_admin?: boolean;
+                            name?: string | null;
+                            ppk_employee_rate?: string | null;
+                            ppk_employer_rate?: string | null;
+                            surname?: string | null;
+                            username?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List users */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            created_at?: string;
+                            id?: number;
+                            is_admin?: boolean;
+                            name?: string | null;
+                            ppk_employee_rate?: string | null;
+                            ppk_employer_rate?: string | null;
+                            surname?: string | null;
+                            username?: string;
+                        }[];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create a user */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        name?: string | null;
+                        password?: string;
+                        ppk_employee_rate?: string | null;
+                        ppk_employer_rate?: string | null;
+                        surname?: string | null;
+                        username?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            created_at?: string;
+                            id?: number;
+                            is_admin?: boolean;
+                            name?: string | null;
+                            ppk_employee_rate?: string | null;
+                            ppk_employer_rate?: string | null;
+                            surname?: string | null;
+                            username?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/users/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update a user */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        name?: string | null;
+                        ppk_employee_rate?: string | null;
+                        ppk_employer_rate?: string | null;
+                        surname?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            created_at?: string;
+                            id?: number;
+                            is_admin?: boolean;
+                            name?: string | null;
+                            ppk_employee_rate?: string | null;
+                            ppk_employer_rate?: string | null;
+                            surname?: string | null;
+                            username?: string;
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/bonds": {
         parameters: {
             query?: never;
@@ -5509,6 +5785,45 @@ export interface paths {
                         "application/json": {
                             label?: string;
                             value?: string;
+                        }[];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List owner options */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id?: number;
+                            name?: string;
                         }[];
                     };
                 };


### PR DESCRIPTION
## Motivation

Expose existing auth/user backend routes in generated OpenAPI spec.

> Changelog: skip

## Implementation information

- Add auth APISpec entries for login/logout/me/users routes.
- Use a named login response type instead of an inline map.
- Add generator coverage so auth routes stay registered.
- Regenerate api/openapi-go.json.

## Supporting documentation

Phase 3 of backend refactor cleanup.