### PR TITLE
refactor(dbutil): share store tx helpers

### DIFF
--- a/backend-go/internal/accounts/store.go
+++ b/backend-go/internal/accounts/store.go
@@ -185,7 +185,7 @@ type UpdatePatch struct {
 // snapshot_aggregates recompute for every snapshot referencing the account.
 // The whole op runs in one transaction.
 func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Account, error) {
-	var updated *Account
+	var updated Account
 	err := dbutil.WithTx(ctx, s.pool, "begin update tx", "commit update tx", func(tx pgx.Tx) error {
 		current, err := lockAccount(ctx, tx, id)
 		if err != nil {
@@ -215,13 +215,17 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Account, er
 				return err
 			}
 		}
-		updated, err = loadAccount(ctx, tx, id)
-		return err
+		loaded, err := loadAccount(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		updated = *loaded
+		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return updated, nil
+	return &updated, nil
 }
 
 // Delete soft-deletes + cascades into aggregate recompute.

--- a/backend-go/internal/accounts/store.go
+++ b/backend-go/internal/accounts/store.go
@@ -70,19 +70,7 @@ func (s *Store) List(ctx context.Context) ([]Account, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list accounts: %w", err)
 	}
-	defer rows.Close()
-	out := []Account{}
-	for rows.Next() {
-		a, err := scanAccount(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scan account: %w", err)
-		}
-		out = append(out, *a)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate accounts: %w", err)
-	}
-	return out, nil
+	return dbutil.CollectRows(rows, scanAccountValue, "scan account", "iterate accounts")
 }
 
 // Get returns the account regardless of is_active, mirroring Python's
@@ -197,52 +185,42 @@ type UpdatePatch struct {
 // snapshot_aggregates recompute for every snapshot referencing the account.
 // The whole op runs in one transaction.
 func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*Account, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("begin update tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback(ctx)
-		}
-	}()
-	current, err := lockAccount(ctx, tx, id)
-	if err != nil {
-		return nil, err
-	}
-	if p.Name != nil && *p.Name != current.Name {
-		if err := s.checkDuplicateNameTx(ctx, tx, *p.Name, id); err != nil {
-			return nil, err
-		}
-	}
-	// Capture pre-patch values to decide whether the request meaningfully
-	// changed owner or category — matches Python's old_owner/old_category.
-	oldOwnerUserID := current.OwnerUserID
-	oldCategory := current.Category
-	applyPatch(current, p)
-	needsRecompute := (p.OwnerUserIDSet && !intPtrEqual(p.OwnerUserID, oldOwnerUserID)) ||
-		(p.Category != nil && *p.Category != oldCategory)
-	if err := s.updateRow(ctx, tx, id, current); err != nil {
-		return nil, err
-	}
-	if needsRecompute {
-		ids, err := s.aggregates.AffectedSnapshotIDsForAccount(ctx, tx, id)
+	var updated *Account
+	err := dbutil.WithTx(ctx, s.pool, "begin update tx", "commit update tx", func(tx pgx.Tx) error {
+		current, err := lockAccount(ctx, tx, id)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		if err := s.aggregates.RecomputeForSnapshots(ctx, tx, ids); err != nil {
-			return nil, err
+		if p.Name != nil && *p.Name != current.Name {
+			if err := s.checkDuplicateNameTx(ctx, tx, *p.Name, id); err != nil {
+				return err
+			}
 		}
-	}
-	updated, err := loadAccount(ctx, tx, id)
+		// Capture pre-patch values to decide whether the request meaningfully
+		// changed owner or category — matches Python's old_owner/old_category.
+		oldOwnerUserID := current.OwnerUserID
+		oldCategory := current.Category
+		applyPatch(current, p)
+		needsRecompute := (p.OwnerUserIDSet && !intPtrEqual(p.OwnerUserID, oldOwnerUserID)) ||
+			(p.Category != nil && *p.Category != oldCategory)
+		if err := s.updateRow(ctx, tx, id, current); err != nil {
+			return err
+		}
+		if needsRecompute {
+			ids, err := s.aggregates.AffectedSnapshotIDsForAccount(ctx, tx, id)
+			if err != nil {
+				return err
+			}
+			if err := s.aggregates.RecomputeForSnapshots(ctx, tx, ids); err != nil {
+				return err
+			}
+		}
+		updated, err = loadAccount(ctx, tx, id)
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
-	if err := tx.Commit(ctx); err != nil {
-		return nil, fmt.Errorf("commit update tx: %w", err)
-	}
-	committed = true
 	return updated, nil
 }
 
@@ -411,6 +389,14 @@ func scanAccount(row pgx.Row) (*Account, error) {
 		return nil, err
 	}
 	return &a, nil
+}
+
+func scanAccountValue(row pgx.Row) (Account, error) {
+	a, err := scanAccount(row)
+	if err != nil {
+		return Account{}, err
+	}
+	return *a, nil
 }
 
 // intPtrEqual reports whether two optional ints are equal (both nil counts).

--- a/backend-go/internal/assets/store.go
+++ b/backend-go/internal/assets/store.go
@@ -52,19 +52,7 @@ func (s *Store) List(ctx context.Context) ([]Asset, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list assets: %w", err)
 	}
-	defer rows.Close()
-	out := []Asset{}
-	for rows.Next() {
-		a, err := scanAsset(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scan asset: %w", err)
-		}
-		out = append(out, *a)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate assets: %w", err)
-	}
-	return out, nil
+	return dbutil.CollectRows(rows, scanAssetValue, "scan asset", "iterate assets")
 }
 
 // LatestValuesByAsset returns the most recent snapshot value per asset.
@@ -139,34 +127,28 @@ func (s *Store) Create(ctx context.Context, name string) (*Asset, error) {
 // Update applies the (only) field: name. No cascade — assets don't carry
 // owner/category, so aggregates are unaffected by a rename.
 func (s *Store) Update(ctx context.Context, id int, name *string) (*Asset, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("begin update tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback(ctx)
+	var updated *Asset
+	err := dbutil.WithTx(ctx, s.pool, "begin update tx", "commit update tx", func(tx pgx.Tx) error {
+		current, err := lockAsset(ctx, tx, id)
+		if err != nil {
+			return err
 		}
-	}()
-	current, err := lockAsset(ctx, tx, id)
+		if name != nil && *name != current.Name {
+			if err := s.checkDuplicateNameTx(ctx, tx, *name, id); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(ctx, `UPDATE assets SET name = $1 WHERE id = $2`, *name, id); err != nil {
+				return fmt.Errorf("update asset: %w", err)
+			}
+			current.Name = *name
+		}
+		updated = current
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	if name != nil && *name != current.Name {
-		if err := s.checkDuplicateNameTx(ctx, tx, *name, id); err != nil {
-			return nil, err
-		}
-		if _, err := tx.Exec(ctx, `UPDATE assets SET name = $1 WHERE id = $2`, *name, id); err != nil {
-			return nil, fmt.Errorf("update asset: %w", err)
-		}
-		current.Name = *name
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return nil, fmt.Errorf("commit update tx: %w", err)
-	}
-	committed = true
-	return current, nil
+	return updated, nil
 }
 
 // Delete soft-deletes and cascades into aggregate recompute.
@@ -261,4 +243,12 @@ func scanAsset(row pgx.Row) (*Asset, error) {
 		return nil, err
 	}
 	return &a, nil
+}
+
+func scanAssetValue(row pgx.Row) (Asset, error) {
+	a, err := scanAsset(row)
+	if err != nil {
+		return Asset{}, err
+	}
+	return *a, nil
 }

--- a/backend-go/internal/assets/store.go
+++ b/backend-go/internal/assets/store.go
@@ -127,7 +127,7 @@ func (s *Store) Create(ctx context.Context, name string) (*Asset, error) {
 // Update applies the (only) field: name. No cascade — assets don't carry
 // owner/category, so aggregates are unaffected by a rename.
 func (s *Store) Update(ctx context.Context, id int, name *string) (*Asset, error) {
-	var updated *Asset
+	var updated Asset
 	err := dbutil.WithTx(ctx, s.pool, "begin update tx", "commit update tx", func(tx pgx.Tx) error {
 		current, err := lockAsset(ctx, tx, id)
 		if err != nil {
@@ -142,13 +142,13 @@ func (s *Store) Update(ctx context.Context, id int, name *string) (*Asset, error
 			}
 			current.Name = *name
 		}
-		updated = current
+		updated = *current
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return updated, nil
+	return &updated, nil
 }
 
 // Delete soft-deletes and cascades into aggregate recompute.

--- a/backend-go/internal/bonds/store.go
+++ b/backend-go/internal/bonds/store.go
@@ -60,19 +60,7 @@ func (s *Store) List(ctx context.Context) ([]TreasuryBond, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list treasury bonds: %w", err)
 	}
-	defer rows.Close()
-	out := []TreasuryBond{}
-	for rows.Next() {
-		b, err := scanBond(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scan treasury bond: %w", err)
-		}
-		out = append(out, *b)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate treasury bonds: %w", err)
-	}
-	return out, nil
+	return dbutil.CollectRows(rows, scanBondValue, "scan treasury bond", "iterate treasury bonds")
 }
 
 // Get returns one bond by id; ErrNotFound when missing or soft-deleted.
@@ -122,64 +110,57 @@ type UpdatePatch struct {
 
 // Update applies the patch and returns the refreshed bond.
 func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*TreasuryBond, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("begin update tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback(ctx)
+	var updated *TreasuryBond
+	err := dbutil.WithTx(ctx, s.pool, "begin update tx", "commit update tx", func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx,
+			`SELECT `+selectColumns+` FROM treasury_bonds WHERE id = $1 AND is_active = true FOR UPDATE`, id,
+		)
+		b, err := scanBond(row)
+		if err != nil {
+			return dbutil.MapErr(err, ErrNotFound, "lock treasury bond")
 		}
-	}()
-	row := tx.QueryRow(ctx,
-		`SELECT `+selectColumns+` FROM treasury_bonds WHERE id = $1 AND is_active = true FOR UPDATE`, id,
-	)
-	b, err := scanBond(row)
+		if p.Type != nil {
+			b.Type = *p.Type
+		}
+		if p.Series != nil {
+			b.Series = *p.Series
+		}
+		if p.FaceValue != nil {
+			b.FaceValue = *p.FaceValue
+		}
+		if p.PurchaseDate != nil {
+			b.PurchaseDate = *p.PurchaseDate
+		}
+		if p.OwnerUserIDSet {
+			b.OwnerUserID = p.OwnerUserID
+		}
+		if p.FirstYearRate != nil {
+			b.FirstYearRate = *p.FirstYearRate
+		}
+		if p.Margin != nil {
+			b.Margin = *p.Margin
+		}
+		if p.Capitalize != nil {
+			b.Capitalize = *p.Capitalize
+		}
+		row = tx.QueryRow(ctx, `
+			UPDATE treasury_bonds SET
+				type = $1, series = $2, face_value = $3, purchase_date = $4,
+				owner_user_id = $5, first_year_rate = $6, margin = $7, capitalize = $8
+			WHERE id = $9
+			RETURNING `+selectColumns,
+			string(b.Type), b.Series, b.FaceValue, b.PurchaseDate, b.OwnerUserID,
+			b.FirstYearRate, b.Margin, b.Capitalize, id,
+		)
+		updated, err = scanBond(row)
+		if err != nil {
+			return fmt.Errorf("update treasury bond: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, dbutil.MapErr(err, ErrNotFound, "lock treasury bond")
+		return nil, err
 	}
-	if p.Type != nil {
-		b.Type = *p.Type
-	}
-	if p.Series != nil {
-		b.Series = *p.Series
-	}
-	if p.FaceValue != nil {
-		b.FaceValue = *p.FaceValue
-	}
-	if p.PurchaseDate != nil {
-		b.PurchaseDate = *p.PurchaseDate
-	}
-	if p.OwnerUserIDSet {
-		b.OwnerUserID = p.OwnerUserID
-	}
-	if p.FirstYearRate != nil {
-		b.FirstYearRate = *p.FirstYearRate
-	}
-	if p.Margin != nil {
-		b.Margin = *p.Margin
-	}
-	if p.Capitalize != nil {
-		b.Capitalize = *p.Capitalize
-	}
-	row = tx.QueryRow(ctx, `
-		UPDATE treasury_bonds SET
-			type = $1, series = $2, face_value = $3, purchase_date = $4,
-			owner_user_id = $5, first_year_rate = $6, margin = $7, capitalize = $8
-		WHERE id = $9
-		RETURNING `+selectColumns,
-		string(b.Type), b.Series, b.FaceValue, b.PurchaseDate, b.OwnerUserID,
-		b.FirstYearRate, b.Margin, b.Capitalize, id,
-	)
-	updated, err := scanBond(row)
-	if err != nil {
-		return nil, fmt.Errorf("update treasury bond: %w", err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return nil, fmt.Errorf("commit update tx: %w", err)
-	}
-	committed = true
 	return updated, nil
 }
 
@@ -219,4 +200,12 @@ func scanBond(row pgx.Row) (*TreasuryBond, error) {
 	}
 	b.Type = BondType(typ)
 	return &b, nil
+}
+
+func scanBondValue(row pgx.Row) (TreasuryBond, error) {
+	b, err := scanBond(row)
+	if err != nil {
+		return TreasuryBond{}, err
+	}
+	return *b, nil
 }

--- a/backend-go/internal/bonds/store.go
+++ b/backend-go/internal/bonds/store.go
@@ -110,7 +110,7 @@ type UpdatePatch struct {
 
 // Update applies the patch and returns the refreshed bond.
 func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*TreasuryBond, error) {
-	var updated *TreasuryBond
+	var updated TreasuryBond
 	err := dbutil.WithTx(ctx, s.pool, "begin update tx", "commit update tx", func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx,
 			`SELECT `+selectColumns+` FROM treasury_bonds WHERE id = $1 AND is_active = true FOR UPDATE`, id,
@@ -152,16 +152,17 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*TreasuryBon
 			string(b.Type), b.Series, b.FaceValue, b.PurchaseDate, b.OwnerUserID,
 			b.FirstYearRate, b.Margin, b.Capitalize, id,
 		)
-		updated, err = scanBond(row)
+		loaded, err := scanBond(row)
 		if err != nil {
 			return fmt.Errorf("update treasury bond: %w", err)
 		}
+		updated = *loaded
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return updated, nil
+	return &updated, nil
 }
 
 // Delete soft-deletes the bond by toggling is_active. Hard delete would

--- a/backend-go/internal/dbutil/scan.go
+++ b/backend-go/internal/dbutil/scan.go
@@ -1,6 +1,6 @@
-// Package dbutil holds small pgx helpers shared across stores. The goal
-// is not abstraction — it's killing the 4-line "if ErrNoRows → sentinel /
-// else wrap" pattern that repeats in every Get/scan call site.
+// Package dbutil holds small pgx helpers shared across stores. Keep helpers
+// mechanical: map scan errors, collect row scans, and wrap transaction
+// commit/rollback boilerplate.
 package dbutil
 
 import (

--- a/backend-go/internal/dbutil/tx.go
+++ b/backend-go/internal/dbutil/tx.go
@@ -1,0 +1,35 @@
+package dbutil
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type txBeginner interface {
+	BeginTx(context.Context, pgx.TxOptions) (pgx.Tx, error)
+}
+
+// WithTx runs fn inside a pgx transaction, rolling back on every non-commit
+// path and preserving caller-provided begin/commit error prefixes.
+func WithTx(ctx context.Context, db txBeginner, beginPrefix, commitPrefix string, fn func(pgx.Tx) error) error {
+	tx, err := db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("%s: %w", beginPrefix, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	if err := fn(tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("%s: %w", commitPrefix, err)
+	}
+	committed = true
+	return nil
+}

--- a/backend-go/internal/dbutil/tx.go
+++ b/backend-go/internal/dbutil/tx.go
@@ -19,9 +19,10 @@ func WithTx(ctx context.Context, db txBeginner, beginPrefix, commitPrefix string
 		return fmt.Errorf("%s: %w", beginPrefix, err)
 	}
 	committed := false
+	rollbackCtx := context.WithoutCancel(ctx)
 	defer func() {
 		if !committed {
-			_ = tx.Rollback(ctx)
+			_ = tx.Rollback(rollbackCtx)
 		}
 	}()
 	if err := fn(tx); err != nil {

--- a/backend-go/internal/dbutil/tx_test.go
+++ b/backend-go/internal/dbutil/tx_test.go
@@ -77,6 +77,28 @@ func TestWithTxRollsBackFnError(t *testing.T) {
 	}
 }
 
+func TestWithTxRollbackIgnoresCanceledContext(t *testing.T) {
+	inner := errors.New("bad write")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	tx := &fakeTx{}
+	db := &fakeBeginner{tx: tx}
+
+	err := WithTx(ctx, db, "begin thing", "commit thing", func(pgx.Tx) error {
+		return inner
+	})
+
+	if !errors.Is(err, inner) {
+		t.Fatalf("inner not returned: %v", err)
+	}
+	if tx.rollbackCtx == nil {
+		t.Fatal("rollback ctx missing")
+	}
+	if err := tx.rollbackCtx.Err(); err != nil {
+		t.Fatalf("rollback ctx canceled: %v", err)
+	}
+}
+
 func TestWithTxRollsBackCommitError(t *testing.T) {
 	inner := errors.New("commit lost")
 	tx := &fakeTx{commitErr: inner}
@@ -113,9 +135,10 @@ func (b *fakeBeginner) BeginTx(context.Context, pgx.TxOptions) (pgx.Tx, error) {
 }
 
 type fakeTx struct {
-	committed  bool
-	rolledBack bool
-	commitErr  error
+	committed   bool
+	rolledBack  bool
+	rollbackCtx context.Context
+	commitErr   error
 }
 
 func (tx *fakeTx) Begin(context.Context) (pgx.Tx, error) {
@@ -127,7 +150,8 @@ func (tx *fakeTx) Commit(context.Context) error {
 	return tx.commitErr
 }
 
-func (tx *fakeTx) Rollback(context.Context) error {
+func (tx *fakeTx) Rollback(ctx context.Context) error {
+	tx.rollbackCtx = ctx
 	tx.rolledBack = true
 	return nil
 }

--- a/backend-go/internal/dbutil/tx_test.go
+++ b/backend-go/internal/dbutil/tx_test.go
@@ -1,0 +1,159 @@
+package dbutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+var errFakeTxUnsupported = errors.New("fake tx method unsupported")
+
+func TestWithTxCommits(t *testing.T) {
+	tx := &fakeTx{}
+	db := &fakeBeginner{tx: tx}
+	called := false
+
+	err := WithTx(t.Context(), db, "begin thing", "commit thing", func(got pgx.Tx) error {
+		called = true
+		if got != tx {
+			t.Fatalf("tx = %p, want %p", got, tx)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !called {
+		t.Fatal("fn not called")
+	}
+	if !tx.committed {
+		t.Fatal("tx not committed")
+	}
+	if tx.rolledBack {
+		t.Fatal("tx rolled back after commit")
+	}
+}
+
+func TestWithTxWrapsBeginError(t *testing.T) {
+	inner := errors.New("down")
+	db := &fakeBeginner{beginErr: inner}
+
+	err := WithTx(t.Context(), db, "begin thing", "commit thing", func(pgx.Tx) error {
+		t.Fatal("fn called")
+		return nil
+	})
+
+	if !errors.Is(err, inner) {
+		t.Fatalf("inner not wrapped: %v", err)
+	}
+	if got := err.Error(); got != "begin thing: down" {
+		t.Fatalf("err = %q", got)
+	}
+}
+
+func TestWithTxRollsBackFnError(t *testing.T) {
+	inner := errors.New("bad write")
+	tx := &fakeTx{}
+	db := &fakeBeginner{tx: tx}
+
+	err := WithTx(t.Context(), db, "begin thing", "commit thing", func(pgx.Tx) error {
+		return inner
+	})
+
+	if !errors.Is(err, inner) {
+		t.Fatalf("inner not returned: %v", err)
+	}
+	if tx.committed {
+		t.Fatal("tx committed")
+	}
+	if !tx.rolledBack {
+		t.Fatal("tx not rolled back")
+	}
+}
+
+func TestWithTxRollsBackCommitError(t *testing.T) {
+	inner := errors.New("commit lost")
+	tx := &fakeTx{commitErr: inner}
+	db := &fakeBeginner{tx: tx}
+
+	err := WithTx(t.Context(), db, "begin thing", "commit thing", func(pgx.Tx) error {
+		return nil
+	})
+
+	if !errors.Is(err, inner) {
+		t.Fatalf("inner not wrapped: %v", err)
+	}
+	if got := err.Error(); got != "commit thing: commit lost" {
+		t.Fatalf("err = %q", got)
+	}
+	if !tx.rolledBack {
+		t.Fatal("tx not rolled back after commit error")
+	}
+}
+
+type fakeBeginner struct {
+	tx       pgx.Tx
+	beginErr error
+}
+
+func (b *fakeBeginner) BeginTx(context.Context, pgx.TxOptions) (pgx.Tx, error) {
+	if b.beginErr != nil {
+		return nil, b.beginErr
+	}
+	return b.tx, nil
+}
+
+type fakeTx struct {
+	committed  bool
+	rolledBack bool
+	commitErr  error
+}
+
+func (tx *fakeTx) Begin(context.Context) (pgx.Tx, error) {
+	return tx, nil
+}
+
+func (tx *fakeTx) Commit(context.Context) error {
+	tx.committed = true
+	return tx.commitErr
+}
+
+func (tx *fakeTx) Rollback(context.Context) error {
+	tx.rolledBack = true
+	return nil
+}
+
+func (tx *fakeTx) CopyFrom(context.Context, pgx.Identifier, []string, pgx.CopyFromSource) (int64, error) {
+	return 0, nil
+}
+
+func (tx *fakeTx) SendBatch(context.Context, *pgx.Batch) pgx.BatchResults {
+	return nil
+}
+
+func (tx *fakeTx) LargeObjects() pgx.LargeObjects {
+	return pgx.LargeObjects{}
+}
+
+func (tx *fakeTx) Prepare(context.Context, string, string) (*pgconn.StatementDescription, error) {
+	return nil, errFakeTxUnsupported
+}
+
+func (tx *fakeTx) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func (tx *fakeTx) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	return nil, errFakeTxUnsupported
+}
+
+func (tx *fakeTx) QueryRow(context.Context, string, ...any) pgx.Row {
+	return nil
+}
+
+func (tx *fakeTx) Conn() *pgx.Conn {
+	return nil
+}

--- a/backend-go/internal/dbutil/tx_test.go
+++ b/backend-go/internal/dbutil/tx_test.go
@@ -46,6 +46,9 @@ func TestWithTxWrapsBeginError(t *testing.T) {
 		return nil
 	})
 
+	if err == nil {
+		t.Fatal("err nil")
+	}
 	if !errors.Is(err, inner) {
 		t.Fatalf("inner not wrapped: %v", err)
 	}
@@ -83,6 +86,9 @@ func TestWithTxRollsBackCommitError(t *testing.T) {
 		return nil
 	})
 
+	if err == nil {
+		t.Fatal("err nil")
+	}
 	if !errors.Is(err, inner) {
 		t.Fatalf("inner not wrapped: %v", err)
 	}

--- a/backend-go/internal/debts/store.go
+++ b/backend-go/internal/debts/store.go
@@ -373,7 +373,7 @@ type UpdatePatch struct {
 
 // Update applies the patch.
 func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*DebtWithAccount, error) {
-	var updated *DebtWithAccount
+	var updated DebtWithAccount
 	err := dbutil.WithTx(ctx, s.pool, "begin update tx", "commit update", func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx,
 			`SELECT `+debtCols+` FROM debts WHERE id = $1 AND is_active = true FOR UPDATE`, id,
@@ -401,13 +401,13 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*DebtWithAcc
 		if err := row.Scan(&a.Name, &a.OwnerUserID); err != nil {
 			return fmt.Errorf("load account for debt: %w", err)
 		}
-		updated = &DebtWithAccount{Debt: *current, Account: a}
+		updated = DebtWithAccount{Debt: *current, Account: a}
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return updated, nil
+	return &updated, nil
 }
 
 // Delete soft-deletes a debt.

--- a/backend-go/internal/debts/store.go
+++ b/backend-go/internal/debts/store.go
@@ -373,47 +373,41 @@ type UpdatePatch struct {
 
 // Update applies the patch.
 func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*DebtWithAccount, error) {
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("begin update tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback(ctx)
+	var updated *DebtWithAccount
+	err := dbutil.WithTx(ctx, s.pool, "begin update tx", "commit update", func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx,
+			`SELECT `+debtCols+` FROM debts WHERE id = $1 AND is_active = true FOR UPDATE`, id,
+		)
+		current, err := scanDebt(row)
+		if err != nil {
+			return dbutil.MapErr(err, ErrNotFound, "lock debt")
 		}
-	}()
-	row := tx.QueryRow(ctx,
-		`SELECT `+debtCols+` FROM debts WHERE id = $1 AND is_active = true FOR UPDATE`, id,
-	)
-	current, err := scanDebt(row)
+		applyPatch(current, p)
+		if _, err := tx.Exec(ctx, `
+			UPDATE debts SET
+				name = $1, debt_type = $2, start_date = $3, initial_amount = $4,
+				interest_rate = $5, currency = $6, notes = $7
+			WHERE id = $8`,
+			current.Name, current.DebtType, current.StartDate, current.InitialAmount,
+			current.InterestRate, current.Currency, current.Notes, id,
+		); err != nil {
+			return fmt.Errorf("update debt: %w", err)
+		}
+		row = tx.QueryRow(ctx,
+			`SELECT name, owner_user_id FROM accounts WHERE id = $1`, current.AccountID,
+		)
+		var a AccountInfo
+		a.ID = current.AccountID
+		if err := row.Scan(&a.Name, &a.OwnerUserID); err != nil {
+			return fmt.Errorf("load account for debt: %w", err)
+		}
+		updated = &DebtWithAccount{Debt: *current, Account: a}
+		return nil
+	})
 	if err != nil {
-		return nil, dbutil.MapErr(err, ErrNotFound, "lock debt")
+		return nil, err
 	}
-	applyPatch(current, p)
-	if _, err := tx.Exec(ctx, `
-		UPDATE debts SET
-			name = $1, debt_type = $2, start_date = $3, initial_amount = $4,
-			interest_rate = $5, currency = $6, notes = $7
-		WHERE id = $8`,
-		current.Name, current.DebtType, current.StartDate, current.InitialAmount,
-		current.InterestRate, current.Currency, current.Notes, id,
-	); err != nil {
-		return nil, fmt.Errorf("update debt: %w", err)
-	}
-	row = tx.QueryRow(ctx,
-		`SELECT name, owner_user_id FROM accounts WHERE id = $1`, current.AccountID,
-	)
-	var a AccountInfo
-	a.ID = current.AccountID
-	if err := row.Scan(&a.Name, &a.OwnerUserID); err != nil {
-		return nil, fmt.Errorf("load account for debt: %w", err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return nil, fmt.Errorf("commit update: %w", err)
-	}
-	committed = true
-	return &DebtWithAccount{Debt: *current, Account: a}, nil
+	return updated, nil
 }
 
 // Delete soft-deletes a debt.


### PR DESCRIPTION
## Motivation

Reduce repeated store row-scan and transaction lifecycle code.

> Changelog: skip

## Implementation information

- Add tested dbutil.WithTx for begin/commit/rollback boilerplate.
- Reuse CollectRows in account, asset, and bond list methods.
- Adopt WithTx in account, asset, bond, and debt update paths.

## Supporting documentation

Phase 4 of backend refactor cleanup.