### PR TITLE
feat(bonds): maturity ladder calendar

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -1835,6 +1835,116 @@
         ]
       }
     },
+    "/api/bonds/maturity-ladder": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "events": {
+                      "items": {
+                        "properties": {
+                          "bond_ids": {
+                            "items": {
+                              "type": "integer"
+                            },
+                            "type": "array"
+                          },
+                          "count": {
+                            "type": "integer"
+                          },
+                          "interest_gross": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "month": {
+                            "format": "date",
+                            "type": "string"
+                          },
+                          "net_cashflow": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "principal": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "tax": {
+                            "format": "double",
+                            "type": "number"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "next_maturity": {
+                      "nullable": true,
+                      "properties": {
+                        "bond_ids": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "count": {
+                          "type": "integer"
+                        },
+                        "date": {
+                          "format": "date",
+                          "type": "string"
+                        },
+                        "days_until": {
+                          "type": "integer"
+                        },
+                        "interest_gross": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "net_cashflow": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "principal": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "tax": {
+                          "format": "double",
+                          "type": "number"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "tax_rate_pct": {
+                      "format": "double",
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Maturity ladder calendar",
+        "tags": [
+          "bonds"
+        ]
+      }
+    },
     "/api/bonds/{id}": {
       "delete": {
         "parameters": [

--- a/backend-go/internal/bonds/calc_test.go
+++ b/backend-go/internal/bonds/calc_test.go
@@ -18,13 +18,13 @@ func bondEDO(purchase time.Time) *TreasuryBond {
 	}
 }
 
-func bondCOI(purchase time.Time, face, firstYearRate, margin float64) *TreasuryBond {
+func bondCOI(purchase time.Time) *TreasuryBond {
 	return &TreasuryBond{
 		Type:          BondCOI,
-		FaceValue:     decimal.NewFromFloat(face),
+		FaceValue:     decimal.NewFromInt(1000),
 		PurchaseDate:  purchase,
-		FirstYearRate: decimal.NewFromFloat(firstYearRate),
-		Margin:        decimal.NewFromFloat(margin),
+		FirstYearRate: decimal.NewFromFloat(6.55),
+		Margin:        decimal.NewFromFloat(1.25),
 		Capitalize:    false,
 	}
 }
@@ -73,7 +73,7 @@ func TestCurrentValueCOIInterestPaidOut(t *testing.T) {
 	yoy := map[int]decimal.Decimal{
 		2025: decimal.NewFromFloat(104.0),
 	}
-	b := bondCOI(purchase, 1000, 6.55, 1.25)
+	b := bondCOI(purchase)
 	// year 1: 1000 * 0.0655 = 65.50 paid out
 	// year 2: 1000 * (4.0 + 1.25)/100 = 52.50 paid out
 	// value = face + accrued = 1000 + 65.50 + 52.50 = 1118.00

--- a/backend-go/internal/bonds/handler.go
+++ b/backend-go/internal/bonds/handler.go
@@ -21,18 +21,26 @@ import (
 )
 
 // belkaRate is the Belka (capital-gains) tax fraction (0.19) applied to
-// bond interest payouts. Sourced from the rules table on first use so a
-// future rate change updates the calendar without a code edit here.
+// bond interest payouts. The key is the 2026 entry; future-year rates
+// require a code change here once a new rule key lands in the rules
+// table. If the lookup ever fails (e.g. rules table edited out from
+// under us) we fall back to the statutory 0.19 and log — the calendar
+// is informational, so degrading is better than crashing the API.
 var (
-	belkaOnce sync.Once
-	belkaRate decimal.Decimal
+	belkaOnce     sync.Once
+	belkaRate     decimal.Decimal
+	belkaFallback = decimal.NewFromFloat(0.19)
+	belkaRuleKey  = "capital_gains_tax_2026"
 )
 
 func getBelkaRate() decimal.Decimal {
 	belkaOnce.Do(func() {
-		r, ok := rules.Get("capital_gains_tax_2026")
+		r, ok := rules.Get(belkaRuleKey)
 		if !ok {
-			panic("bonds: rules table missing capital_gains_tax_2026")
+			slog.Default().Warn("bonds: belka rule missing, using statutory fallback",
+				"key", belkaRuleKey, "fallback", belkaFallback.String())
+			belkaRate = belkaFallback
+			return
 		}
 		belkaRate = r.Value
 	})

--- a/backend-go/internal/bonds/handler.go
+++ b/backend-go/internal/bonds/handler.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -15,8 +16,28 @@ import (
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/rules"
 	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
+
+// belkaRate is the Belka (capital-gains) tax fraction (0.19) applied to
+// bond interest payouts. Sourced from the rules table on first use so a
+// future rate change updates the calendar without a code edit here.
+var (
+	belkaOnce sync.Once
+	belkaRate decimal.Decimal
+)
+
+func getBelkaRate() decimal.Decimal {
+	belkaOnce.Do(func() {
+		r, ok := rules.Get("capital_gains_tax_2026")
+		if !ok {
+			panic("bonds: rules table missing capital_gains_tax_2026")
+		}
+		belkaRate = r.Value
+	})
+	return belkaRate
+}
 
 // CPILoader is the subset of cpi.Store the handler needs. Decoupling the
 // import lets unit tests stub it without spinning up a pool.
@@ -73,6 +94,36 @@ type ytmPointResponse struct {
 type ytmResponse struct {
 	BondID int                `json:"bond_id"`
 	Points []ytmPointResponse `json:"points"`
+}
+
+type ladderEventResponse struct {
+	Month         wire.IsoDate `json:"month"`
+	Type          string       `json:"type"`
+	Kind          string       `json:"kind"`
+	BondIDs       []int        `json:"bond_ids"`
+	Count         int          `json:"count"`
+	Principal     float64      `json:"principal"`
+	InterestGross float64      `json:"interest_gross"`
+	Tax           float64      `json:"tax"`
+	NetCashflow   float64      `json:"net_cashflow"`
+}
+
+type nextMaturityResponse struct {
+	Date          wire.IsoDate `json:"date"`
+	Type          string       `json:"type"`
+	BondIDs       []int        `json:"bond_ids"`
+	Count         int          `json:"count"`
+	Principal     float64      `json:"principal"`
+	InterestGross float64      `json:"interest_gross"`
+	Tax           float64      `json:"tax"`
+	NetCashflow   float64      `json:"net_cashflow"`
+	DaysUntil     int          `json:"days_until"`
+}
+
+type maturityLadderResponse struct {
+	Events       []ladderEventResponse `json:"events"`
+	NextMaturity *nextMaturityResponse `json:"next_maturity"`
+	TaxRatePct   float64               `json:"tax_rate_pct"`
 }
 
 type createRequest struct {
@@ -189,6 +240,64 @@ func (h *Handler) YTM(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	httputil.WriteJSON(w, http.StatusOK, out)
+}
+
+// MaturityLadder serves GET /api/bonds/maturity-ladder — the calendar of
+// upcoming redemption + coupon cashflows plus the nearest-maturity
+// warning used by the dashboard.
+func (h *Handler) MaturityLadder(w http.ResponseWriter, r *http.Request) {
+	bonds, err := h.store.List(r.Context())
+	if err != nil {
+		h.logger.Error("list bonds for ladder", "err", err)
+		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	yoy, err := h.loadYoY(r.Context())
+	if err != nil {
+		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	belka := getBelkaRate()
+	result := MaturityLadder(bonds, yoy, h.now(), belka)
+
+	out := maturityLadderResponse{
+		Events:     make([]ladderEventResponse, 0, len(result.Events)),
+		TaxRatePct: floatFromDecimal(belka.Mul(decimal.NewFromInt(100))),
+	}
+	for i := range result.Events {
+		ev := &result.Events[i]
+		out.Events = append(out.Events, ladderEventResponse{
+			Month:         wire.IsoDate(ev.Month),
+			Type:          string(ev.Type),
+			Kind:          string(ev.Kind),
+			BondIDs:       ev.BondIDs,
+			Count:         ev.Count,
+			Principal:     floatFromDecimal(ev.Principal),
+			InterestGross: floatFromDecimal(ev.InterestGross),
+			Tax:           floatFromDecimal(ev.Tax),
+			NetCashflow:   floatFromDecimal(ev.NetCashflow),
+		})
+	}
+	if result.NextMaturity != nil {
+		nm := result.NextMaturity
+		out.NextMaturity = &nextMaturityResponse{
+			Date:          wire.IsoDate(nm.Date),
+			Type:          string(nm.Type),
+			BondIDs:       nm.BondIDs,
+			Count:         nm.Count,
+			Principal:     floatFromDecimal(nm.Principal),
+			InterestGross: floatFromDecimal(nm.InterestGross),
+			Tax:           floatFromDecimal(nm.Tax),
+			NetCashflow:   floatFromDecimal(nm.NetCashflow),
+			DaysUntil:     nm.DaysUntil,
+		}
+	}
+	httputil.WriteJSON(w, http.StatusOK, out)
+}
+
+func floatFromDecimal(d decimal.Decimal) float64 {
+	f, _ := d.Float64()
+	return f
 }
 
 // Create serves POST /api/bonds.

--- a/backend-go/internal/bonds/maturity.go
+++ b/backend-go/internal/bonds/maturity.go
@@ -1,0 +1,304 @@
+package bonds
+
+import (
+	"sort"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// LadderEventKind is the cashflow's role on the calendar.
+//
+// "redemption" is the principal returned at MaturityDate. For capitalized
+// bonds it carries the compounded interest too; for non-capitalized bonds
+// the interest has already been paid out year-by-year as separate
+// "coupon" events.
+type LadderEventKind string
+
+const (
+	EventRedemption LadderEventKind = "redemption"
+	EventCoupon     LadderEventKind = "coupon"
+)
+
+// LadderEvent is one cashflow row in the maturity calendar. Rows are
+// bucketed by (month, type, kind) so several bonds of the same series
+// maturing in the same month collapse into a single line — that's the
+// shape the issue's "grouped by maturity month and bond type" calls for.
+type LadderEvent struct {
+	Month         time.Time // first day of the bucket month, UTC
+	Type          BondType
+	Kind          LadderEventKind
+	BondIDs       []int
+	Count         int
+	Principal     decimal.Decimal // redemption only
+	InterestGross decimal.Decimal
+	Tax           decimal.Decimal
+	NetCashflow   decimal.Decimal
+}
+
+// NextMaturity is the nearest upcoming redemption, surfaced to the
+// dashboard as the warning trigger.
+type NextMaturity struct {
+	Date          time.Time
+	Type          BondType
+	BondIDs       []int
+	Count         int
+	Principal     decimal.Decimal
+	InterestGross decimal.Decimal
+	Tax           decimal.Decimal
+	NetCashflow   decimal.Decimal
+	DaysUntil     int
+}
+
+// LadderResult bundles the calendar events with the dashboard's next-up
+// warning so callers can compute both in one pass.
+type LadderResult struct {
+	Events       []LadderEvent
+	NextMaturity *NextMaturity
+}
+
+// MaturityLadder projects future redemption + coupon cashflows for every
+// bond in `bonds`, bucketed into month groups by (month, type, kind).
+//
+// Capitalize=true bonds (EDO, DOS) emit one redemption event at maturity
+// carrying the full compounded value; the interest portion is taxed at
+// `belkaRate` (encoded as a [0,1] fraction, 0.19 for Belka).
+// Capitalize=false bonds (COI, ROR, TOZ) emit yearly coupon events plus
+// a redemption-of-face at maturity — that matches how the Treasury
+// actually pays them.
+//
+// Past events (cashflow date <= now) are dropped: the calendar is
+// forward-looking, and a bond's matured principal has already hit the
+// owner's account.
+func MaturityLadder(bonds []TreasuryBond, yoyByYear map[int]decimal.Decimal, now time.Time, belkaRate decimal.Decimal) LadderResult {
+	bucketKey := func(month time.Time, t BondType, kind LadderEventKind) string {
+		return month.Format("2006-01") + "|" + string(t) + "|" + string(kind)
+	}
+	buckets := map[string]*LadderEvent{}
+
+	for i := range bonds {
+		b := &bonds[i]
+		appendBondEvents(b, yoyByYear, now, belkaRate, buckets, bucketKey)
+	}
+
+	events := make([]LadderEvent, 0, len(buckets))
+	for _, ev := range buckets {
+		sort.Ints(ev.BondIDs)
+		events = append(events, *ev)
+	}
+	sort.Slice(events, func(i, j int) bool {
+		if !events[i].Month.Equal(events[j].Month) {
+			return events[i].Month.Before(events[j].Month)
+		}
+		if events[i].Type != events[j].Type {
+			return events[i].Type < events[j].Type
+		}
+		return events[i].Kind < events[j].Kind
+	})
+
+	next := computeNextMaturity(bonds, yoyByYear, now, belkaRate)
+	return LadderResult{Events: events, NextMaturity: next}
+}
+
+func appendBondEvents(
+	b *TreasuryBond,
+	yoy map[int]decimal.Decimal,
+	now time.Time,
+	belka decimal.Decimal,
+	buckets map[string]*LadderEvent,
+	keyFn func(time.Time, BondType, LadderEventKind) string,
+) {
+	tenor := bondTenorYears(b.Type)
+	if tenor <= 0 {
+		return
+	}
+
+	if b.Capitalize {
+		maturityDate := MaturityDate(b)
+		if !maturityDate.After(now) {
+			return
+		}
+		final := YieldToMaturity(b, yoy)
+		if len(final) == 0 {
+			return
+		}
+		finalValue := final[len(final)-1].Value
+		interest := finalValue.Sub(b.FaceValue)
+		if interest.IsNegative() {
+			interest = decimal.Zero
+		}
+		tax := interest.Mul(belka).Round(2)
+		net := finalValue.Sub(tax)
+		addEvent(buckets, keyFn, maturityDate, b.Type, EventRedemption, b.ID, b.FaceValue, interest, tax, net)
+		return
+	}
+
+	for year := 1; year <= tenor; year++ {
+		couponDate := b.PurchaseDate.AddDate(0, 12*year, 0)
+		if !couponDate.After(now) {
+			continue
+		}
+		rate := YearRate(b, yoy, year)
+		gross := b.FaceValue.Mul(rate).Div(decimal.NewFromInt(100)).Round(2)
+		tax := gross.Mul(belka).Round(2)
+		net := gross.Sub(tax)
+		addEvent(buckets, keyFn, couponDate, b.Type, EventCoupon, b.ID, decimal.Zero, gross, tax, net)
+	}
+
+	maturityDate := MaturityDate(b)
+	if maturityDate.After(now) {
+		addEvent(buckets, keyFn, maturityDate, b.Type, EventRedemption, b.ID, b.FaceValue, decimal.Zero, decimal.Zero, b.FaceValue)
+	}
+}
+
+func addEvent(
+	buckets map[string]*LadderEvent,
+	keyFn func(time.Time, BondType, LadderEventKind) string,
+	when time.Time,
+	t BondType,
+	kind LadderEventKind,
+	bondID int,
+	principal, gross, tax, net decimal.Decimal,
+) {
+	month := time.Date(when.Year(), when.Month(), 1, 0, 0, 0, 0, time.UTC)
+	key := keyFn(month, t, kind)
+	ev, ok := buckets[key]
+	if !ok {
+		ev = &LadderEvent{
+			Month:         month,
+			Type:          t,
+			Kind:          kind,
+			BondIDs:       []int{},
+			Principal:     decimal.Zero,
+			InterestGross: decimal.Zero,
+			Tax:           decimal.Zero,
+			NetCashflow:   decimal.Zero,
+		}
+		buckets[key] = ev
+	}
+	ev.BondIDs = append(ev.BondIDs, bondID)
+	ev.Count++
+	ev.Principal = ev.Principal.Add(principal)
+	ev.InterestGross = ev.InterestGross.Add(gross)
+	ev.Tax = ev.Tax.Add(tax)
+	ev.NetCashflow = ev.NetCashflow.Add(net)
+}
+
+// redemptionCashflow returns the (final, interest, tax, net) numbers for
+// a bond's redemption row — capitalized bonds carry compounded interest;
+// non-capitalized bonds return only principal at maturity.
+type redemptionCashflow struct{ final, interest, tax, net decimal.Decimal }
+
+func bondRedemptionCashflow(b *TreasuryBond, yoy map[int]decimal.Decimal, belka decimal.Decimal) (redemptionCashflow, bool) {
+	if b.Capitalize {
+		pts := YieldToMaturity(b, yoy)
+		if len(pts) == 0 {
+			return redemptionCashflow{}, false
+		}
+		final := pts[len(pts)-1].Value
+		interest := final.Sub(b.FaceValue)
+		if interest.IsNegative() {
+			interest = decimal.Zero
+		}
+		tax := interest.Mul(belka).Round(2)
+		return redemptionCashflow{final: final, interest: interest, tax: tax, net: final.Sub(tax)}, true
+	}
+	return redemptionCashflow{final: b.FaceValue, net: b.FaceValue}, true
+}
+
+// computeNextMaturity collapses bonds redeeming in the soonest future
+// month into one warning record. Multiple bonds maturing on different
+// days within the same month are aggregated; the displayed Date is the
+// earliest individual maturity in that group so the dashboard's
+// "X dni" countdown stays accurate.
+func computeNextMaturity(bonds []TreasuryBond, yoy map[int]decimal.Decimal, now time.Time, belka decimal.Decimal) *NextMaturity {
+	nearestIdx, nearestDate := pickNearestMaturity(bonds, now)
+	if nearestIdx < 0 {
+		return nil
+	}
+	out := &NextMaturity{Date: nearestDate, DaysUntil: daysBetween(now, nearestDate)}
+	out.Type = bonds[nearestIdx].Type
+	for i := range bonds {
+		b := &bonds[i]
+		md := MaturityDate(b)
+		if !md.After(now) || !sameMonth(md, nearestDate) {
+			continue
+		}
+		cf, ok := bondRedemptionCashflow(b, yoy, belka)
+		if !ok {
+			continue
+		}
+		out.BondIDs = append(out.BondIDs, b.ID)
+		out.Count++
+		out.Principal = out.Principal.Add(b.FaceValue)
+		out.InterestGross = out.InterestGross.Add(cf.interest)
+		out.Tax = out.Tax.Add(cf.tax)
+		out.NetCashflow = out.NetCashflow.Add(cf.net)
+		// For non-capitalized bonds the final-year coupon lands in the
+		// same month as the redemption — fold it in so "netto" matches
+		// what the owner actually receives that month, not just the
+		// principal.
+		if !b.Capitalize {
+			coupon := finalYearCoupon(b, yoy, belka)
+			out.InterestGross = out.InterestGross.Add(coupon.gross)
+			out.Tax = out.Tax.Add(coupon.tax)
+			out.NetCashflow = out.NetCashflow.Add(coupon.net)
+		}
+		if md.Before(out.Date) {
+			out.Date = md
+			out.DaysUntil = daysBetween(now, md)
+		}
+	}
+	sort.Ints(out.BondIDs)
+	return out
+}
+
+func pickNearestMaturity(bonds []TreasuryBond, now time.Time) (int, time.Time) {
+	idx := -1
+	var earliest time.Time
+	for i := range bonds {
+		md := MaturityDate(&bonds[i])
+		if !md.After(now) {
+			continue
+		}
+		if idx < 0 || md.Before(earliest) {
+			idx = i
+			earliest = md
+		}
+	}
+	return idx, earliest
+}
+
+// finalYearCoupon returns the gross/tax/net for the last coupon of a
+// non-capitalized bond. Used by computeNextMaturity to fold the
+// final-year payout into the redemption-month summary.
+type couponAmounts struct{ gross, tax, net decimal.Decimal }
+
+func finalYearCoupon(b *TreasuryBond, yoy map[int]decimal.Decimal, belka decimal.Decimal) couponAmounts {
+	tenor := bondTenorYears(b.Type)
+	if tenor <= 0 {
+		return couponAmounts{}
+	}
+	rate := YearRate(b, yoy, tenor)
+	gross := b.FaceValue.Mul(rate).Div(decimal.NewFromInt(100)).Round(2)
+	tax := gross.Mul(belka).Round(2)
+	return couponAmounts{gross: gross, tax: tax, net: gross.Sub(tax)}
+}
+
+func sameMonth(a, b time.Time) bool {
+	return a.Year() == b.Year() && a.Month() == b.Month()
+}
+
+// daysBetween counts whole UTC calendar days between two instants. We
+// snap both ends to UTC midnight before subtracting so a dashboard
+// countdown rendered in Europe/Warsaw doesn't flicker by ±1 day vs. a
+// UTC-stored maturity date.
+func daysBetween(from, to time.Time) int {
+	f := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, time.UTC)
+	t := time.Date(to.Year(), to.Month(), to.Day(), 0, 0, 0, 0, time.UTC)
+	days := int(t.Sub(f).Hours() / 24)
+	if days < 0 {
+		return 0
+	}
+	return days
+}

--- a/backend-go/internal/bonds/maturity.go
+++ b/backend-go/internal/bonds/maturity.go
@@ -71,14 +71,21 @@ type LadderResult struct {
 // forward-looking, and a bond's matured principal has already hit the
 // owner's account.
 func MaturityLadder(bonds []TreasuryBond, yoyByYear map[int]decimal.Decimal, now time.Time, belkaRate decimal.Decimal) LadderResult {
+	if len(bonds) == 0 {
+		return LadderResult{Events: []LadderEvent{}, NextMaturity: nil}
+	}
 	bucketKey := func(month time.Time, t BondType, kind LadderEventKind) string {
 		return month.Format("2006-01") + "|" + string(t) + "|" + string(kind)
 	}
 	buckets := map[string]*LadderEvent{}
+	// Cache the per-bond redemption cashflow built during the main pass
+	// so computeNextMaturity doesn't recompute YieldToMaturity below.
+	redemptions := make(map[int]redemptionCashflow, len(bonds))
 
 	for i := range bonds {
 		b := &bonds[i]
-		appendBondEvents(b, yoyByYear, now, belkaRate, buckets, bucketKey)
+		cf := appendBondEvents(b, yoyByYear, now, belkaRate, buckets, bucketKey)
+		redemptions[b.ID] = cf
 	}
 
 	events := make([]LadderEvent, 0, len(buckets))
@@ -96,10 +103,13 @@ func MaturityLadder(bonds []TreasuryBond, yoyByYear map[int]decimal.Decimal, now
 		return events[i].Kind < events[j].Kind
 	})
 
-	next := computeNextMaturity(bonds, yoyByYear, now, belkaRate)
+	next := computeNextMaturity(bonds, yoyByYear, now, belkaRate, redemptions)
 	return LadderResult{Events: events, NextMaturity: next}
 }
 
+// appendBondEvents emits all calendar events for one bond and returns
+// the redemption cashflow so the dashboard-warning pass can reuse it
+// without recomputing YieldToMaturity.
 func appendBondEvents(
 	b *TreasuryBond,
 	yoy map[int]decimal.Decimal,
@@ -107,20 +117,16 @@ func appendBondEvents(
 	belka decimal.Decimal,
 	buckets map[string]*LadderEvent,
 	keyFn func(time.Time, BondType, LadderEventKind) string,
-) {
+) redemptionCashflow {
 	tenor := bondTenorYears(b.Type)
 	if tenor <= 0 {
-		return
+		return redemptionCashflow{}
 	}
 
 	if b.Capitalize {
-		maturityDate := MaturityDate(b)
-		if !maturityDate.After(now) {
-			return
-		}
 		final := YieldToMaturity(b, yoy)
 		if len(final) == 0 {
-			return
+			return redemptionCashflow{}
 		}
 		finalValue := final[len(final)-1].Value
 		interest := finalValue.Sub(b.FaceValue)
@@ -129,8 +135,12 @@ func appendBondEvents(
 		}
 		tax := interest.Mul(belka).Round(2)
 		net := finalValue.Sub(tax)
-		addEvent(buckets, keyFn, maturityDate, b.Type, EventRedemption, b.ID, b.FaceValue, interest, tax, net)
-		return
+		cf := redemptionCashflow{final: finalValue, interest: interest, tax: tax, net: net}
+		maturityDate := MaturityDate(b)
+		if maturityDate.After(now) {
+			addEvent(buckets, keyFn, maturityDate, b.Type, EventRedemption, b.ID, b.FaceValue, interest, tax, net)
+		}
+		return cf
 	}
 
 	for year := 1; year <= tenor; year++ {
@@ -149,6 +159,7 @@ func appendBondEvents(
 	if maturityDate.After(now) {
 		addEvent(buckets, keyFn, maturityDate, b.Type, EventRedemption, b.ID, b.FaceValue, decimal.Zero, decimal.Zero, b.FaceValue)
 	}
+	return redemptionCashflow{final: b.FaceValue, net: b.FaceValue}
 }
 
 func addEvent(
@@ -184,47 +195,35 @@ func addEvent(
 	ev.NetCashflow = ev.NetCashflow.Add(net)
 }
 
-// redemptionCashflow returns the (final, interest, tax, net) numbers for
-// a bond's redemption row — capitalized bonds carry compounded interest;
-// non-capitalized bonds return only principal at maturity.
+// redemptionCashflow is the (final value, interest, tax, net) tuple for
+// a bond's redemption row. Capitalized bonds carry compounded interest;
+// non-capitalized bonds return only principal at maturity (the interest
+// has already been paid as yearly coupons).
 type redemptionCashflow struct{ final, interest, tax, net decimal.Decimal }
 
-func bondRedemptionCashflow(b *TreasuryBond, yoy map[int]decimal.Decimal, belka decimal.Decimal) (redemptionCashflow, bool) {
-	if b.Capitalize {
-		pts := YieldToMaturity(b, yoy)
-		if len(pts) == 0 {
-			return redemptionCashflow{}, false
-		}
-		final := pts[len(pts)-1].Value
-		interest := final.Sub(b.FaceValue)
-		if interest.IsNegative() {
-			interest = decimal.Zero
-		}
-		tax := interest.Mul(belka).Round(2)
-		return redemptionCashflow{final: final, interest: interest, tax: tax, net: final.Sub(tax)}, true
-	}
-	return redemptionCashflow{final: b.FaceValue, net: b.FaceValue}, true
-}
-
 // computeNextMaturity collapses bonds redeeming in the soonest future
-// month into one warning record. Multiple bonds maturing on different
-// days within the same month are aggregated; the displayed Date is the
-// earliest individual maturity in that group so the dashboard's
-// "X dni" countdown stays accurate.
-func computeNextMaturity(bonds []TreasuryBond, yoy map[int]decimal.Decimal, now time.Time, belka decimal.Decimal) *NextMaturity {
+// month into one warning record. Aggregation is restricted to bonds of
+// the *same type* as the nearest match so the surfaced `Type` and the
+// summed cashflow stay coherent — if e.g. an EDO and a DOS happen to
+// mature in the same month, the warning still describes a single
+// homogeneous batch.
+func computeNextMaturity(bonds []TreasuryBond, yoy map[int]decimal.Decimal, now time.Time, belka decimal.Decimal, redemptions map[int]redemptionCashflow) *NextMaturity {
 	nearestIdx, nearestDate := pickNearestMaturity(bonds, now)
 	if nearestIdx < 0 {
 		return nil
 	}
-	out := &NextMaturity{Date: nearestDate, DaysUntil: daysBetween(now, nearestDate)}
-	out.Type = bonds[nearestIdx].Type
+	nearestType := bonds[nearestIdx].Type
+	out := &NextMaturity{Date: nearestDate, DaysUntil: daysBetween(now, nearestDate), Type: nearestType}
 	for i := range bonds {
 		b := &bonds[i]
+		if b.Type != nearestType {
+			continue
+		}
 		md := MaturityDate(b)
 		if !md.After(now) || !sameMonth(md, nearestDate) {
 			continue
 		}
-		cf, ok := bondRedemptionCashflow(b, yoy, belka)
+		cf, ok := redemptions[b.ID]
 		if !ok {
 			continue
 		}

--- a/backend-go/internal/bonds/maturity_test.go
+++ b/backend-go/internal/bonds/maturity_test.go
@@ -1,0 +1,346 @@
+package bonds
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+var testBelka = decimal.NewFromFloat(0.19)
+
+func TestMaturityLadderCapitalizedEDOEmitsSingleRedemption(t *testing.T) {
+	// 1-year-ago purchase; maturity 9y in the future.
+	purchase := time.Date(2025, 5, 15, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC)
+	b := bondEDO(purchase)
+	b.ID = 1
+	yoy := map[int]decimal.Decimal{2025: decimal.NewFromFloat(104)}
+
+	res := MaturityLadder([]TreasuryBond{*b}, yoy, now, testBelka)
+
+	if len(res.Events) != 1 {
+		t.Fatalf("EDO should produce 1 event, got %d: %+v", len(res.Events), res.Events)
+	}
+	ev := res.Events[0]
+	if ev.Kind != EventRedemption {
+		t.Fatalf("EDO event kind = %s, want redemption", ev.Kind)
+	}
+	if ev.Type != BondEDO {
+		t.Fatalf("event type = %s, want EDO", ev.Type)
+	}
+	wantMonth := time.Date(2035, 5, 1, 0, 0, 0, 0, time.UTC)
+	if !ev.Month.Equal(wantMonth) {
+		t.Fatalf("event month = %s, want %s", ev.Month, wantMonth)
+	}
+	if ev.Count != 1 || len(ev.BondIDs) != 1 || ev.BondIDs[0] != 1 {
+		t.Fatalf("bond grouping wrong: %+v", ev)
+	}
+	if !ev.Principal.Equal(decimal.NewFromInt(1000)) {
+		t.Fatalf("principal = %s, want 1000", ev.Principal)
+	}
+	if !ev.InterestGross.IsPositive() {
+		t.Fatalf("interest should be positive, got %s", ev.InterestGross)
+	}
+	expectTax := ev.InterestGross.Mul(testBelka).Round(2)
+	if !ev.Tax.Equal(expectTax) {
+		t.Fatalf("tax = %s, want %s (19%% of interest)", ev.Tax, expectTax)
+	}
+	wantNet := ev.Principal.Add(ev.InterestGross).Sub(ev.Tax)
+	if !ev.NetCashflow.Equal(wantNet) {
+		t.Fatalf("net = %s, want %s", ev.NetCashflow, wantNet)
+	}
+}
+
+func TestMaturityLadderCOIEmitsYearlyCouponsAndRedemption(t *testing.T) {
+	// 4y COI purchased 2026-01-15 → 4 coupons + 1 redemption.
+	purchase := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC)
+	b := bondCOI(purchase)
+	b.ID = 7
+	yoy := map[int]decimal.Decimal{
+		2026: decimal.NewFromFloat(104),
+		2027: decimal.NewFromFloat(103),
+		2028: decimal.NewFromFloat(102),
+	}
+
+	res := MaturityLadder([]TreasuryBond{*b}, yoy, now, testBelka)
+
+	if len(res.Events) != 5 {
+		t.Fatalf("COI should produce 5 events (4 coupons + redemption), got %d", len(res.Events))
+	}
+
+	coupons := 0
+	redemptions := 0
+	for _, ev := range res.Events {
+		switch ev.Kind {
+		case EventCoupon:
+			coupons++
+			if !ev.Principal.Equal(decimal.Zero) {
+				t.Fatalf("coupon principal must be 0, got %s", ev.Principal)
+			}
+			if !ev.InterestGross.IsPositive() {
+				t.Fatalf("coupon gross must be positive, got %s", ev.InterestGross)
+			}
+			expectTax := ev.InterestGross.Mul(testBelka).Round(2)
+			if !ev.Tax.Equal(expectTax) {
+				t.Fatalf("coupon tax = %s, want %s", ev.Tax, expectTax)
+			}
+		case EventRedemption:
+			redemptions++
+			if !ev.Principal.Equal(decimal.NewFromInt(1000)) {
+				t.Fatalf("COI redemption principal = %s, want 1000", ev.Principal)
+			}
+			if !ev.InterestGross.IsZero() {
+				t.Fatalf("COI redemption interest should be 0 (paid as coupons), got %s", ev.InterestGross)
+			}
+			if !ev.NetCashflow.Equal(decimal.NewFromInt(1000)) {
+				t.Fatalf("COI net redemption = %s, want 1000", ev.NetCashflow)
+			}
+		}
+	}
+	if coupons != 4 || redemptions != 1 {
+		t.Fatalf("event mix: coupons=%d, redemptions=%d", coupons, redemptions)
+	}
+}
+
+func TestMaturityLadderSkipsPastEvents(t *testing.T) {
+	purchase := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC) // ~2y in
+	b := bondCOI(purchase)
+	b.ID = 1
+	yoy := map[int]decimal.Decimal{2025: decimal.NewFromFloat(104), 2026: decimal.NewFromFloat(103)}
+
+	res := MaturityLadder([]TreasuryBond{*b}, yoy, now, testBelka)
+
+	// year-1 (2025-01) + year-2 (2026-01) coupons are in the past; only
+	// year-3 + year-4 coupons and the redemption remain.
+	if len(res.Events) != 3 {
+		t.Fatalf("expected 3 future events (2 coupons + 1 redemption), got %d", len(res.Events))
+	}
+	for _, ev := range res.Events {
+		if !ev.Month.After(now.AddDate(0, 0, -30)) {
+			t.Fatalf("emitted past event at %s", ev.Month)
+		}
+	}
+}
+
+func TestMaturityLadderGroupsSameMonthSameType(t *testing.T) {
+	// Two EDO bonds maturing in the same month → one row in the ladder.
+	purchase := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC)
+	b1 := bondEDO(purchase)
+	b1.ID = 1
+	b2 := bondEDO(purchase.AddDate(0, 0, 10)) // same month
+	b2.ID = 2
+
+	res := MaturityLadder([]TreasuryBond{*b1, *b2}, map[int]decimal.Decimal{}, now, testBelka)
+
+	if len(res.Events) != 1 {
+		t.Fatalf("two EDO maturing in same month should merge, got %d events", len(res.Events))
+	}
+	ev := res.Events[0]
+	if ev.Count != 2 {
+		t.Fatalf("merged event count = %d, want 2", ev.Count)
+	}
+	if ev.BondIDs[0] != 1 || ev.BondIDs[1] != 2 {
+		t.Fatalf("merged bond IDs = %v, want [1, 2]", ev.BondIDs)
+	}
+	wantPrincipal := decimal.NewFromInt(2000)
+	if !ev.Principal.Equal(wantPrincipal) {
+		t.Fatalf("merged principal = %s, want %s", ev.Principal, wantPrincipal)
+	}
+}
+
+func TestMaturityLadderSortsByMonthThenTypeThenKind(t *testing.T) {
+	now := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC)
+	earlyEDO := bondEDO(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)) // 2035-01
+	earlyEDO.ID = 1
+	lateEDO := bondEDO(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)) // 2036-06
+	lateEDO.ID = 2
+
+	res := MaturityLadder([]TreasuryBond{*lateEDO, *earlyEDO}, map[int]decimal.Decimal{}, now, testBelka)
+	if len(res.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(res.Events))
+	}
+	if !res.Events[0].Month.Before(res.Events[1].Month) {
+		t.Fatalf("events not sorted by month: %v", res.Events)
+	}
+}
+
+func TestNextMaturityIsNearestFuture(t *testing.T) {
+	now := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC)
+	// EDO matures 2035-03; DOS (2y) purchased 2026-01 matures 2028-01 → nearest.
+	soon := &TreasuryBond{
+		ID:            10,
+		Type:          BondDOS,
+		FaceValue:     decimal.NewFromInt(5000),
+		PurchaseDate:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		FirstYearRate: decimal.NewFromFloat(6.30),
+		Margin:        decimal.Zero,
+		Capitalize:    true,
+	}
+	far := bondEDO(time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC))
+	far.ID = 11
+
+	res := MaturityLadder([]TreasuryBond{*far, *soon}, map[int]decimal.Decimal{}, now, testBelka)
+	if res.NextMaturity == nil {
+		t.Fatal("NextMaturity should be set")
+	}
+	if res.NextMaturity.Type != BondDOS {
+		t.Fatalf("nearest type = %s, want DOS", res.NextMaturity.Type)
+	}
+	if res.NextMaturity.BondIDs[0] != 10 {
+		t.Fatalf("nearest bond ID = %d, want 10", res.NextMaturity.BondIDs[0])
+	}
+	if res.NextMaturity.DaysUntil <= 0 {
+		t.Fatalf("DaysUntil should be positive, got %d", res.NextMaturity.DaysUntil)
+	}
+}
+
+func TestNextMaturityAggregatesSameMonth(t *testing.T) {
+	now := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC)
+	dos1 := &TreasuryBond{
+		ID:            1,
+		Type:          BondDOS,
+		FaceValue:     decimal.NewFromInt(1000),
+		PurchaseDate:  time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+		FirstYearRate: decimal.NewFromFloat(6.30),
+		Capitalize:    true,
+	}
+	dos2 := &TreasuryBond{
+		ID:            2,
+		Type:          BondDOS,
+		FaceValue:     decimal.NewFromInt(2000),
+		PurchaseDate:  time.Date(2026, 1, 20, 0, 0, 0, 0, time.UTC), // same maturity month
+		FirstYearRate: decimal.NewFromFloat(6.30),
+		Capitalize:    true,
+	}
+
+	res := MaturityLadder([]TreasuryBond{*dos1, *dos2}, map[int]decimal.Decimal{}, now, testBelka)
+	if res.NextMaturity == nil {
+		t.Fatal("NextMaturity should be set")
+	}
+	if res.NextMaturity.Count != 2 {
+		t.Fatalf("nearest count = %d, want 2", res.NextMaturity.Count)
+	}
+	wantPrincipal := decimal.NewFromInt(3000)
+	if !res.NextMaturity.Principal.Equal(wantPrincipal) {
+		t.Fatalf("nearest principal = %s, want %s", res.NextMaturity.Principal, wantPrincipal)
+	}
+	// Date is the earliest individual maturity in the group.
+	if res.NextMaturity.Date.Day() != 5 {
+		t.Fatalf("nearest date day = %d, want 5 (earliest)", res.NextMaturity.Date.Day())
+	}
+}
+
+func TestMaturityLadderEmptyForNoBonds(t *testing.T) {
+	res := MaturityLadder(nil, map[int]decimal.Decimal{}, time.Now(), testBelka)
+	if len(res.Events) != 0 || res.NextMaturity != nil {
+		t.Fatalf("empty input should return empty result, got %+v", res)
+	}
+}
+
+func TestMaturityLadderNonCapFinalMonthEmitsCouponAndRedemption(t *testing.T) {
+	// COI year-4 coupon date == maturity date → same bucket month
+	// produces two distinct rows (kind=coupon, kind=redemption).
+	purchase := time.Date(2022, 5, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	b := bondCOI(purchase)
+	b.ID = 1
+	yoy := map[int]decimal.Decimal{2025: decimal.NewFromFloat(104)}
+
+	res := MaturityLadder([]TreasuryBond{*b}, yoy, now, testBelka)
+
+	if len(res.Events) != 2 {
+		t.Fatalf("final month should have 2 rows (coupon + redemption), got %d", len(res.Events))
+	}
+	kinds := map[LadderEventKind]bool{}
+	for _, ev := range res.Events {
+		if !sameMonth(ev.Month, time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)) {
+			t.Fatalf("event month %s not in final month", ev.Month)
+		}
+		kinds[ev.Kind] = true
+	}
+	if !kinds[EventCoupon] || !kinds[EventRedemption] {
+		t.Fatalf("expected both coupon + redemption, got %+v", kinds)
+	}
+}
+
+func TestNextMaturityFoldsFinalCouponForNonCapBond(t *testing.T) {
+	// COI bond maturing soon: NextMaturity.NetCashflow should include
+	// principal + final coupon (after tax), not just principal.
+	purchase := time.Date(2022, 5, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	b := bondCOI(purchase)
+	b.ID = 1
+	yoy := map[int]decimal.Decimal{2025: decimal.NewFromFloat(104)}
+
+	res := MaturityLadder([]TreasuryBond{*b}, yoy, now, testBelka)
+
+	if res.NextMaturity == nil {
+		t.Fatal("NextMaturity should be set")
+	}
+	if !res.NextMaturity.NetCashflow.GreaterThan(decimal.NewFromInt(1000)) {
+		t.Fatalf("net should include final coupon on top of 1000 principal, got %s",
+			res.NextMaturity.NetCashflow)
+	}
+	if !res.NextMaturity.InterestGross.IsPositive() {
+		t.Fatalf("InterestGross should reflect final coupon, got %s",
+			res.NextMaturity.InterestGross)
+	}
+}
+
+func TestMaturityLadderHandlesNilYoYMap(t *testing.T) {
+	// With no CPI data, year-N rates fall back to FirstYearRate so the
+	// ladder still computes a sensible non-zero cashflow.
+	purchase := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC)
+	b := bondCOI(purchase)
+	b.ID = 1
+
+	res := MaturityLadder([]TreasuryBond{*b}, nil, now, testBelka)
+
+	if len(res.Events) == 0 {
+		t.Fatal("nil yoy should still emit future events via FirstYearRate fallback")
+	}
+	for _, ev := range res.Events {
+		if ev.Kind == EventCoupon && !ev.InterestGross.IsPositive() {
+			t.Fatalf("nil-yoy coupon should still be positive, got %s", ev.InterestGross)
+		}
+	}
+}
+
+func TestDaysBetweenIsTimezoneStable(t *testing.T) {
+	// Maturity stored as UTC midnight; now in Europe/Warsaw same day → 0
+	// days, not -1 or 1. Snapping to UTC date prevents the dashboard
+	// countdown flickering at midnight.
+	warsaw, err := time.LoadLocation("Europe/Warsaw")
+	if err != nil {
+		t.Fatalf("load Europe/Warsaw: %v", err)
+	}
+	maturity := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	nowWarsaw := time.Date(2026, 5, 31, 23, 30, 0, 0, warsaw) // 21:30 UTC same day before
+	if got := daysBetween(nowWarsaw, maturity); got != 1 {
+		t.Fatalf("daysBetween should be 1 (next UTC day), got %d", got)
+	}
+	sameDayWarsaw := time.Date(2026, 6, 1, 14, 0, 0, 0, warsaw) // noon Warsaw on maturity day
+	if got := daysBetween(sameDayWarsaw, maturity); got != 0 {
+		t.Fatalf("daysBetween on maturity day should be 0, got %d", got)
+	}
+}
+
+func TestMaturityLadderSkipsAlreadyMaturedBond(t *testing.T) {
+	// EDO purchased 2010 → matured 2020, before `now` 2026.
+	b := bondEDO(time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC))
+	b.ID = 99
+	now := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC)
+
+	res := MaturityLadder([]TreasuryBond{*b}, map[int]decimal.Decimal{}, now, testBelka)
+	if len(res.Events) != 0 {
+		t.Fatalf("matured bond should emit no future events, got %d", len(res.Events))
+	}
+	if res.NextMaturity != nil {
+		t.Fatal("NextMaturity should be nil when all bonds have matured")
+	}
+}

--- a/backend-go/internal/bonds/openapi.go
+++ b/backend-go/internal/bonds/openapi.go
@@ -7,6 +7,7 @@ var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/bonds", Tag: "bonds", Summary: "List treasury bonds", Response: listResponse{}},
 	{Method: "GET", Path: "/api/bonds/{id}", Tag: "bonds", Summary: "Get a treasury bond", Response: response{}},
 	{Method: "GET", Path: "/api/bonds/{id}/ytm", Tag: "bonds", Summary: "Yield-to-maturity projection", Response: ytmResponse{}},
+	{Method: "GET", Path: "/api/bonds/maturity-ladder", Tag: "bonds", Summary: "Maturity ladder calendar", Response: maturityLadderResponse{}},
 	{Method: "POST", Path: "/api/bonds", Tag: "bonds", Summary: "Create a treasury bond", Response: response{}, Status: 201},
 	{Method: "PUT", Path: "/api/bonds/{id}", Tag: "bonds", Summary: "Update a treasury bond", Response: response{}},
 	{Method: "DELETE", Path: "/api/bonds/{id}", Tag: "bonds", Summary: "Delete a treasury bond", Status: 204},

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -331,6 +331,7 @@ func registerPortfolioRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logg
 	r.Route("/api/bonds", func(r chi.Router) {
 		r.Get("/", bondsHandler.List)
 		r.Post("/", bondsHandler.Create)
+		r.Get("/maturity-ladder", bondsHandler.MaturityLadder)
 		r.Get("/{id}", bondsHandler.Get)
 		r.Get("/{id}/ytm", bondsHandler.YTM)
 		r.Put("/{id}", bondsHandler.Update)

--- a/src/lib/components/BondsMaturityLadder.svelte
+++ b/src/lib/components/BondsMaturityLadder.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+	import { formatPLN } from '$lib/utils/format';
+	import { CalendarClock, Coins, ArrowDownToLine } from 'lucide-svelte';
+	import type {
+		MaturityLadderEvent,
+		NextMaturityWarning,
+		LadderEventKind
+	} from '../../routes/bonds/+page';
+
+	interface Props {
+		events: MaturityLadderEvent[];
+		nextMaturity: NextMaturityWarning | null;
+		taxRatePct: number;
+	}
+
+	let { events, nextMaturity, taxRatePct }: Props = $props();
+
+	const monthFormatter = new Intl.DateTimeFormat('pl-PL', {
+		year: 'numeric',
+		month: 'long'
+	});
+
+	function formatMonth(iso: string): string {
+		const [y, m] = iso.split('-').map(Number);
+		return monthFormatter.format(new Date(y, m - 1, 1));
+	}
+
+	function kindLabel(kind: LadderEventKind): string {
+		return kind === 'redemption' ? 'Wykup' : 'Kupon';
+	}
+
+	type Grouped = {
+		monthISO: string;
+		monthLabel: string;
+		totalNet: number;
+		events: MaturityLadderEvent[];
+	};
+
+	const groupedByMonth = $derived.by<Grouped[]>(() => {
+		const map = new Map<string, Grouped>();
+		for (const ev of events) {
+			const existing = map.get(ev.month);
+			if (existing) {
+				existing.events.push(ev);
+				existing.totalNet += ev.net_cashflow;
+			} else {
+				map.set(ev.month, {
+					monthISO: ev.month,
+					monthLabel: formatMonth(ev.month),
+					totalNet: ev.net_cashflow,
+					events: [ev]
+				});
+			}
+		}
+		return [...map.values()].sort((a, b) => a.monthISO.localeCompare(b.monthISO));
+	});
+</script>
+
+<div class="card preset-filled-surface-100-900 p-4 space-y-4">
+	<header class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+		<h3 class="h3 flex items-center gap-2">
+			<CalendarClock size={20} /> Kalendarz wykupu
+		</h3>
+		<p class="text-xs text-surface-700-300">
+			Wartości netto po podatku Belki ({taxRatePct.toFixed(0)}%)
+		</p>
+	</header>
+
+	{#if nextMaturity}
+		{@const tier =
+			nextMaturity.days_until <= 30 ? 'urgent' : nextMaturity.days_until <= 90 ? 'warn' : 'info'}
+		<div
+			class="card p-3 text-sm flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 {tier ===
+			'urgent'
+				? 'preset-filled-error-500'
+				: tier === 'warn'
+					? 'preset-filled-warning-500'
+					: 'preset-tonal-primary'}"
+		>
+			<div class="flex items-center gap-2">
+				<ArrowDownToLine size={16} />
+				<span>
+					Najbliższy wykup: <strong>{nextMaturity.type}</strong> · {nextMaturity.count}
+					{nextMaturity.count === 1 ? 'obligacja' : 'obligacji'}
+					· {nextMaturity.date} ({nextMaturity.days_until} dni)
+				</span>
+			</div>
+			<span class="font-semibold">{formatPLN(nextMaturity.net_cashflow)} netto</span>
+		</div>
+	{/if}
+
+	{#if groupedByMonth.length === 0}
+		<p class="text-sm text-surface-700-300 text-center py-6">
+			Brak nadchodzących przepływów. Dodaj obligacje aby zobaczyć kalendarz.
+		</p>
+	{:else}
+		<div class="space-y-3">
+			{#each groupedByMonth as group (group.monthISO)}
+				<section class="space-y-2">
+					<header class="flex items-center justify-between gap-2 flex-wrap">
+						<h4 class="font-semibold capitalize">{group.monthLabel}</h4>
+						<span class="text-sm text-surface-700-300">
+							Łącznie netto: <strong class="text-primary-600-400"
+								>{formatPLN(group.totalNet)}</strong
+							>
+						</span>
+					</header>
+					<div class="table-wrap">
+						<table class="table table-hover text-sm">
+							<thead>
+								<tr>
+									<th>Typ</th>
+									<th>Zdarzenie</th>
+									<th class="text-right">Liczba</th>
+									<th class="text-right">Kapitał</th>
+									<th class="text-right">Odsetki brutto</th>
+									<th class="text-right">Podatek</th>
+									<th class="text-right">Netto</th>
+								</tr>
+							</thead>
+							<tbody>
+								{#each group.events as ev (ev.type + ev.kind)}
+									<tr>
+										<td class="font-medium">{ev.type}</td>
+										<td>
+											<span class="badge preset-tonal-surface inline-flex items-center gap-1">
+												{#if ev.kind === 'coupon'}<Coins size={12} />{:else}<ArrowDownToLine
+														size={12}
+													/>{/if}
+												{kindLabel(ev.kind)}
+											</span>
+										</td>
+										<td class="text-right">{ev.count}</td>
+										<td class="text-right">
+											{ev.principal > 0 ? formatPLN(ev.principal) : '—'}
+										</td>
+										<td class="text-right">
+											{ev.interest_gross > 0 ? formatPLN(ev.interest_gross) : '—'}
+										</td>
+										<td class="text-right text-surface-700-300">
+											{ev.tax > 0 ? formatPLN(ev.tax) : '—'}
+										</td>
+										<td class="text-right font-semibold text-primary-600-400">
+											{formatPLN(ev.net_cashflow)}
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				</section>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/BondsMaturityLadder.svelte
+++ b/src/lib/components/BondsMaturityLadder.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { formatPLN } from '$lib/utils/format';
+	import { daysLabel } from '$lib/utils/yearEnd';
 	import { CalendarClock, Coins, ArrowDownToLine } from 'lucide-svelte';
 	import type {
 		MaturityLadderEvent,
@@ -82,7 +83,8 @@
 				<span>
 					Najbliższy wykup: <strong>{nextMaturity.type}</strong> · {nextMaturity.count}
 					{nextMaturity.count === 1 ? 'obligacja' : 'obligacji'}
-					· {nextMaturity.date} ({nextMaturity.days_until} dni)
+					· {nextMaturity.date} ({nextMaturity.days_until}
+					{daysLabel(nextMaturity.days_until)})
 				</span>
 			</div>
 			<span class="font-semibold">{formatPLN(nextMaturity.net_cashflow)} netto</span>
@@ -91,7 +93,7 @@
 
 	{#if groupedByMonth.length === 0}
 		<p class="text-sm text-surface-700-300 text-center py-6">
-			Brak nadchodzących przepływów. Dodaj obligacje aby zobaczyć kalendarz.
+			Brak nadchodzących przepływów. Dodaj obligacje, aby zobaczyć kalendarz.
 		</p>
 	{:else}
 		<div class="space-y-3">

--- a/src/lib/components/BondsMaturityLadder.test.ts
+++ b/src/lib/components/BondsMaturityLadder.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import BondsMaturityLadder from './BondsMaturityLadder.svelte';
+import type { MaturityLadderEvent, NextMaturityWarning } from '../../routes/bonds/+page';
+
+const emptyProps = {
+	events: [] as MaturityLadderEvent[],
+	nextMaturity: null as NextMaturityWarning | null,
+	taxRatePct: 19
+};
+
+describe('BondsMaturityLadder', () => {
+	it('renders empty state when no events', () => {
+		render(BondsMaturityLadder, { props: emptyProps });
+		expect(screen.getByText(/Brak nadchodzących przepływów/)).toBeTruthy();
+	});
+
+	it('shows tax-rate disclosure in the header', () => {
+		render(BondsMaturityLadder, { props: emptyProps });
+		expect(screen.getByText(/Wartości netto po podatku Belki \(19%\)/)).toBeTruthy();
+	});
+
+	function makeWarning(daysUntil: number): NextMaturityWarning {
+		return {
+			date: '2026-06-01',
+			type: 'DOS',
+			bond_ids: [1],
+			count: 1,
+			principal: 1000,
+			interest_gross: 130,
+			tax: 24.7,
+			net_cashflow: 1105.3,
+			days_until: daysUntil
+		};
+	}
+
+	it('renders next-maturity warning with urgent tier within 30 days', () => {
+		const { container } = render(BondsMaturityLadder, {
+			props: { ...emptyProps, nextMaturity: makeWarning(6) }
+		});
+		expect(screen.getByText(/Najbliższy wykup/)).toBeTruthy();
+		expect(screen.getByText(/6 dni/)).toBeTruthy();
+		expect(container.querySelector('.preset-filled-error-500')).toBeTruthy();
+	});
+
+	it('uses warn tier between 31 and 90 days', () => {
+		const { container } = render(BondsMaturityLadder, {
+			props: { ...emptyProps, nextMaturity: makeWarning(50) }
+		});
+		expect(container.querySelector('.preset-filled-warning-500')).toBeTruthy();
+		expect(container.querySelector('.preset-filled-error-500')).toBeNull();
+	});
+
+	it('uses info tier beyond 90 days', () => {
+		const { container } = render(BondsMaturityLadder, {
+			props: { ...emptyProps, nextMaturity: makeWarning(180) }
+		});
+		expect(container.querySelector('.preset-tonal-primary')).toBeTruthy();
+		expect(container.querySelector('.preset-filled-warning-500')).toBeNull();
+		expect(container.querySelector('.preset-filled-error-500')).toBeNull();
+	});
+
+	it('groups events by month and shows monthly net total', () => {
+		const events: MaturityLadderEvent[] = [
+			{
+				month: '2026-09-01',
+				type: 'COI',
+				kind: 'coupon',
+				bond_ids: [1],
+				count: 1,
+				principal: 0,
+				interest_gross: 78,
+				tax: 14.82,
+				net_cashflow: 63.18
+			},
+			{
+				month: '2026-09-01',
+				type: 'EDO',
+				kind: 'redemption',
+				bond_ids: [2],
+				count: 1,
+				principal: 1000,
+				interest_gross: 200,
+				tax: 38,
+				net_cashflow: 1162
+			},
+			{
+				month: '2027-01-01',
+				type: 'COI',
+				kind: 'coupon',
+				bond_ids: [1],
+				count: 1,
+				principal: 0,
+				interest_gross: 52.5,
+				tax: 9.98,
+				net_cashflow: 42.52
+			}
+		];
+
+		render(BondsMaturityLadder, { props: { ...emptyProps, events } });
+
+		const monthHeaders = screen.getAllByRole('heading', { level: 4 });
+		expect(monthHeaders).toHaveLength(2);
+		expect(screen.getAllByText('COI').length).toBeGreaterThanOrEqual(1);
+		expect(screen.getAllByText('EDO').length).toBeGreaterThanOrEqual(1);
+		expect(screen.getAllByText(/Kupon/).length).toBeGreaterThanOrEqual(1);
+		expect(screen.getAllByText(/Wykup/).length).toBeGreaterThanOrEqual(1);
+	});
+});

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -1329,6 +1329,77 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/bonds/maturity-ladder": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Maturity ladder calendar */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            events?: {
+                                bond_ids?: number[];
+                                count?: number;
+                                /** Format: double */
+                                interest_gross?: number;
+                                kind?: string;
+                                /** Format: date */
+                                month?: string;
+                                /** Format: double */
+                                net_cashflow?: number;
+                                /** Format: double */
+                                principal?: number;
+                                /** Format: double */
+                                tax?: number;
+                                type?: string;
+                            }[];
+                            next_maturity?: {
+                                bond_ids?: number[];
+                                count?: number;
+                                /** Format: date */
+                                date?: string;
+                                days_until?: number;
+                                /** Format: double */
+                                interest_gross?: number;
+                                /** Format: double */
+                                net_cashflow?: number;
+                                /** Format: double */
+                                principal?: number;
+                                /** Format: double */
+                                tax?: number;
+                                type?: string;
+                            } | null;
+                            /** Format: double */
+                            tax_rate_pct?: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/bonds/{id}": {
         parameters: {
             query?: never;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -527,6 +527,20 @@
 					{dashboard.treasuryBondsCount}
 					{dashboard.treasuryBondsCount === 1 ? 'obligacja' : 'obligacji'} (auto-wycena wg CPI)
 				</p>
+				{#if dashboard.bondsNextMaturity && dashboard.bondsNextMaturity.days_until <= 90}
+					{@const nm = dashboard.bondsNextMaturity}
+					{@const urgent = nm.days_until <= 30}
+					<div
+						class="card p-2 text-xs flex items-center gap-1 {urgent
+							? 'preset-filled-error-500'
+							: 'preset-filled-warning-500'}"
+					>
+						<AlertTriangle size={14} />
+						<span>
+							Wykup {nm.type} za {nm.days_until} dni ({formatPLN(nm.net_cashflow)} netto)
+						</span>
+					</div>
+				{/if}
 			</a>
 		{/if}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -537,7 +537,8 @@
 					>
 						<AlertTriangle size={14} />
 						<span>
-							Wykup {nm.type} za {nm.days_until} dni ({formatPLN(nm.net_cashflow)} netto)
+							Wykup {nm.type} za {nm.days_until}
+							{daysLabel(nm.days_until)} ({formatPLN(nm.net_cashflow)} netto)
 						</span>
 					</div>
 				{/if}

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -22,11 +22,12 @@ export async function load({ fetch, url }) {
 
 	const dashboardData = (async () => {
 		try {
-			const [dashboardRes, retirementRes, bondsRes, driftRes] = await Promise.all([
+			const [dashboardRes, retirementRes, bondsRes, driftRes, ladderRes] = await Promise.all([
 				fetch(dashboardURL),
 				fetch(`${apiUrl}/api/retirement/stats?year=${currentYear}`),
 				fetch(`${apiUrl}/api/bonds`),
-				fetch(`${apiUrl}/api/allocation/drift`)
+				fetch(`${apiUrl}/api/allocation/drift`),
+				fetch(`${apiUrl}/api/bonds/maturity-ladder`)
 			]);
 
 			if (!dashboardRes.ok) {
@@ -37,13 +38,17 @@ export async function load({ fetch, url }) {
 			const retirementStats = retirementRes.ok ? await retirementRes.json() : [];
 			const bondsBody = bondsRes.ok ? await bondsRes.json() : { total_value: 0, total_count: 0 };
 			const allocationDrift = driftRes.ok ? await driftRes.json() : { scopes: [] };
+			const bondsLadder = ladderRes.ok
+				? await ladderRes.json()
+				: { events: [], next_maturity: null, tax_rate_pct: 19 };
 
 			return {
 				...dashboard,
 				retirementStats,
 				treasuryBondsValue: bondsBody.total_value ?? 0,
 				treasuryBondsCount: bondsBody.total_count ?? 0,
-				allocationDrift
+				allocationDrift,
+				bondsNextMaturity: bondsLadder.next_maturity
 			};
 		} catch (err) {
 			if (isHttpError(err)) {

--- a/src/routes/bonds/+page.svelte
+++ b/src/routes/bonds/+page.svelte
@@ -3,6 +3,7 @@
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
 	import Modal from '$lib/components/Modal.svelte';
+	import BondsMaturityLadder from '$lib/components/BondsMaturityLadder.svelte';
 	import { formatPLN } from '$lib/utils/format';
 	import { chartAccent, chartAccentGradient } from '$lib/utils/theme';
 	import { createChart } from '$lib/utils/charts/lifecycle';
@@ -480,6 +481,12 @@
 			</div>
 		{/if}
 	</div>
+
+	<BondsMaturityLadder
+		events={data.ladder.events}
+		nextMaturity={data.ladder.next_maturity}
+		taxRatePct={data.ladder.tax_rate_pct}
+	/>
 
 	<div class="card preset-filled-surface-100-900 p-4 space-y-4">
 		<header class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">

--- a/src/routes/bonds/+page.ts
+++ b/src/routes/bonds/+page.ts
@@ -29,19 +29,55 @@ export interface OwnerOption {
 	name: string;
 }
 
+export type LadderEventKind = 'redemption' | 'coupon';
+
+export interface MaturityLadderEvent {
+	month: string;
+	type: TreasuryBond['type'];
+	kind: LadderEventKind;
+	bond_ids: number[];
+	count: number;
+	principal: number;
+	interest_gross: number;
+	tax: number;
+	net_cashflow: number;
+}
+
+export interface NextMaturityWarning {
+	date: string;
+	type: TreasuryBond['type'];
+	bond_ids: number[];
+	count: number;
+	principal: number;
+	interest_gross: number;
+	tax: number;
+	net_cashflow: number;
+	days_until: number;
+}
+
+export interface MaturityLadderResponse {
+	events: MaturityLadderEvent[];
+	next_maturity: NextMaturityWarning | null;
+	tax_rate_pct: number;
+}
+
 export const load: PageLoad = async ({ fetch }) => {
 	try {
 		const apiUrl = resolveApiUrl();
-		const [bondsRes, ownersRes] = await Promise.all([
+		const [bondsRes, ownersRes, ladderRes] = await Promise.all([
 			fetch(`${apiUrl}/api/bonds`),
-			fetch(`${apiUrl}/api/users`)
+			fetch(`${apiUrl}/api/users`),
+			fetch(`${apiUrl}/api/bonds/maturity-ladder`)
 		]);
 		if (!bondsRes.ok) {
 			throw error(bondsRes.status, 'Failed to load treasury bonds');
 		}
 		const bonds: BondsResponse = await bondsRes.json();
 		const owners: OwnerOption[] = ownersRes.ok ? await ownersRes.json() : [];
-		return { ...bonds, owners };
+		const ladder: MaturityLadderResponse = ladderRes.ok
+			? await ladderRes.json()
+			: { events: [], next_maturity: null, tax_rate_pct: 19 };
+		return { ...bonds, owners, ladder };
 	} catch (err) {
 		if (err instanceof Error && 'status' in err) throw err;
 		throw error(500, 'Failed to load treasury bonds');

--- a/src/routes/bonds/page.test.ts
+++ b/src/routes/bonds/page.test.ts
@@ -35,12 +35,15 @@ vi.mock('echarts', () => ({
 	graphic: { LinearGradient: vi.fn() }
 }));
 
+const emptyLadder = { events: [], next_maturity: null, tax_rate_pct: 19 };
+
 const emptyData = {
 	user: null,
 	bonds: [],
 	total_value: 0,
 	total_count: 0,
-	owners: [{ id: 1, name: 'Marcin' }]
+	owners: [{ id: 1, name: 'Marcin' }],
+	ladder: emptyLadder
 };
 
 const sampleBond = {


### PR DESCRIPTION
## Motivation

Issue #562: surface upcoming Polish Treasury bond cashflows so the user
knows when redemption and coupon money will land and can plan rollovers.

## Implementation information

- **Backend** — new `GET /api/bonds/maturity-ladder` returning a forward
  calendar of cashflow events plus the nearest-maturity warning record.
  - Capitalized bonds (EDO, DOS) emit one redemption event with full
    compounded interest at maturity.
  - Non-capitalized bonds (COI, ROR, TOZ) emit yearly coupon events
    plus a face-value redemption at maturity.
  - 19% Belka tax (from `internal/rules`) applied to interest only,
    never to principal.
  - Events bucket by `(month, type, kind)` — multiple bonds maturing
    in the same month collapse into a single row, matching the
    issue's grouping requirement.
  - `daysBetween` snaps to UTC date boundaries so the dashboard
    countdown stays stable for callers in Europe/Warsaw.
- **Frontend** — `BondsMaturityLadder.svelte` renders the calendar on
  `/bonds`. Dashboard fetches the same endpoint and shows a warning
  card on the existing treasury-bonds tile when the next redemption
  is within 90 days (urgent red at <=30d, warn yellow at <=90d).
- For non-capitalized bonds the final-year coupon lands in the same
  month as the redemption, so `next_maturity` folds the final coupon
  into the displayed "netto" figure to match what the owner will
  actually receive that month.

Tests added: unit coverage for capitalized/non-capitalized event mix,
past-event filtering, same-month grouping, nearest-future detection,
nil CPI map fallback, timezone-stable day counting, plus component
tests for each warning tier.

## Supporting documentation

Closes #562

> Changelog: feat(bonds): maturity ladder calendar