### PR TITLE
feat(holdings): Stooq quotes + PLN valuation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ FB_ADMIN_USERNAME=admin
 FB_ADMIN_PASSWORD=replace-with-strong-admin-password
 # Set true only when the app is served over HTTPS.
 FB_COOKIE_SECURE=false
+# Stooq API key for daily-history backfill of holdings price quotes.
+# Get one at https://stooq.com/q/d/?s=isac.uk&get_apikey (free, captcha).
+# Empty/unset still works — the scheduler falls back to the keyless intraday
+# snapshot, but historical backfill is unavailable.
+FB_STOOQ_APIKEY=
 
 # Frontend
 # Backend URL for server-side rendering (SvelteKit server -> backend).

--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -5397,7 +5397,15 @@
                           "average_cost": {
                             "type": "string"
                           },
+                          "average_cost_pln": {
+                            "nullable": true,
+                            "type": "string"
+                          },
                           "cost_basis": {
+                            "type": "string"
+                          },
+                          "cost_basis_pln": {
+                            "nullable": true,
                             "type": "string"
                           },
                           "latest_quote": {
@@ -5408,13 +5416,25 @@
                             "nullable": true,
                             "type": "string"
                           },
+                          "latest_quote_rate_pln": {
+                            "nullable": true,
+                            "type": "string"
+                          },
                           "market_value": {
+                            "type": "string"
+                          },
+                          "market_value_pln": {
+                            "nullable": true,
                             "type": "string"
                           },
                           "quantity": {
                             "type": "string"
                           },
                           "realized_gain": {
+                            "type": "string"
+                          },
+                          "realized_gain_pln": {
+                            "nullable": true,
                             "type": "string"
                           },
                           "security": {
@@ -5445,6 +5465,10 @@
                             "type": "object"
                           },
                           "unrealized_gain": {
+                            "type": "string"
+                          },
+                          "unrealized_gain_pln": {
+                            "nullable": true,
                             "type": "string"
                           }
                         },
@@ -5588,6 +5612,40 @@
           }
         },
         "summary": "Delete a lot",
+        "tags": [
+          "holdings"
+        ]
+      }
+    },
+    "/api/holdings/refresh-quotes": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "failed": {
+                      "type": "integer"
+                    },
+                    "skipped_manual": {
+                      "type": "integer"
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "written": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Pull latest quotes from Stooq for all securities",
         "tags": [
           "holdings"
         ]

--- a/backend-go/README.md
+++ b/backend-go/README.md
@@ -18,11 +18,16 @@ On startup backend-go applies `internal/db/schema.sql` to an empty database
 
 Environment variables:
 
-| Var            | Default                 | Purpose                                        |
-| -------------- | ----------------------- | ---------------------------------------------- |
-| `FB_ADDR`      | `:8000`                 | Listen address                                 |
-| `CORS_ORIGINS` | `http://localhost:3000` | Comma-separated allowed origins                |
-| `DATABASE_URL` | —                       | Postgres DSN (or use the `PG*` libpq env vars) |
+| Var                 | Default                 | Purpose                                                                                                           |
+| ------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `FB_ADDR`           | `:8000`                 | Listen address                                                                                                    |
+| `CORS_ORIGINS`      | `http://localhost:3000` | Comma-separated allowed origins                                                                                   |
+| `DATABASE_URL`      | —                       | Postgres DSN (or use the `PG*` libpq env vars)                                                                    |
+| `FB_JWT_SECRET`     | — (required)            | Signs session cookies                                                                                             |
+| `FB_ADMIN_USERNAME` | `admin`                 | Admin user reseeded on every startup                                                                              |
+| `FB_ADMIN_PASSWORD` | — (required)            | Admin password reseeded on every startup                                                                          |
+| `FB_COOKIE_SECURE`  | `false`                 | Mark session cookie Secure (HTTPS-only deploys)                                                                   |
+| `FB_STOOQ_APIKEY`   | —                       | Stooq daily-history apikey for holdings backfill. Empty → keyless intraday snapshot only, no historical backfill. |
 
 ## Layout
 

--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -24,6 +24,8 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/bonds"
 	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 	"github.com/Automaat/finance-buddy/backend-go/internal/db"
+	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
+	"github.com/Automaat/finance-buddy/backend-go/internal/quotes"
 	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/scheduler"
 	"github.com/Automaat/finance-buddy/backend-go/internal/server"
@@ -93,6 +95,7 @@ func run() int {
 		CORSOrigins:  envOrPresent("CORS_ORIGINS", "http://localhost:3000"),
 		JWTSecret:    jwtSecret,
 		CookieSecure: envOr("FB_COOKIE_SECURE", "false") == "true",
+		StooqAPIKey:  os.Getenv("FB_STOOQ_APIKEY"),
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -115,6 +118,12 @@ func run() int {
 		// Daily recurring-transaction generator (issue #384).
 		recSched := recurring.NewScheduler(recurring.NewStore(pool), logger)
 		go recSched.Run(ctx)
+
+		// Daily Stooq price-quote refresh for holdings securities.
+		hStore := holdings.NewStore(pool)
+		stooq := quotes.NewStooqFetcher(cfg.StooqAPIKey)
+		quotesSched := quotes.NewScheduler(hStore, stooq, logger)
+		go quotesSched.Run(ctx)
 	} else {
 		logger.Warn("no DB config (DATABASE_URL or PGHOST) — DB-backed endpoints will 404")
 	}

--- a/backend-go/internal/holdings/costbasis.go
+++ b/backend-go/internal/holdings/costbasis.go
@@ -11,11 +11,20 @@
 package holdings
 
 import (
+	"context"
 	"errors"
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 )
+
+// RateProvider abstracts NBP rate lookups so cost-basis math stays testable
+// without a Postgres/network roundtrip. Same shape as pit38.RateProvider.
+type RateProvider interface {
+	GetRateToPLN(ctx context.Context, currency string, onDate time.Time) (fx.Result, error)
+}
 
 // Side discriminates a Lot row.
 type Side string
@@ -55,6 +64,15 @@ type Running struct {
 	TotalBought  decimal.Decimal // gross deposits — for return-attribution
 	TotalSold    decimal.Decimal // gross proceeds — same
 	FeesPaid     decimal.Decimal
+
+	// PLN-parallel fields populated only by ComputeRunningPLN. Each buy converts
+	// (qty*price + fee) at trade-date NBP rate and rolls into AverageCostPLN.
+	// HasPLN gates downstream rendering — zero values are ambiguous (a true
+	// zero gain vs. unconverted) without it.
+	HasPLN          bool
+	AverageCostPLN  decimal.Decimal
+	CostBasisPLN    decimal.Decimal
+	RealizedGainPLN decimal.Decimal
 }
 
 // ErrOversell is returned by ComputeRunning when a sell lot exceeds the
@@ -110,6 +128,80 @@ func ComputeRunning(lots []Lot) (Running, error) {
 		}
 	}
 	r.CostBasis = r.Quantity.Mul(r.AverageCost)
+	return r, nil
+}
+
+// ComputeRunningPLN replays a chronologically sorted lot history while
+// maintaining a parallel PLN weighted-average using each lot's trade-date NBP
+// rate. Same algorithm as ComputeRunning but also populates Running.HasPLN +
+// PLN fields. When any rate lookup misses, PLN fields stay zero and HasPLN
+// stays false — caller falls back to native-currency rendering.
+//
+// Currency=PLN is treated as 1:1 and HasPLN is always true.
+func ComputeRunningPLN(ctx context.Context, lots []Lot, currency string, rates RateProvider) (Running, error) {
+	var r Running
+	if rates == nil {
+		return ComputeRunning(lots)
+	}
+	var avgPLN decimal.Decimal
+	allConverted := true
+	for i := range lots {
+		l := &lots[i]
+		rate, err := rates.GetRateToPLN(ctx, currency, l.Date)
+		if err != nil {
+			return Running{}, err
+		}
+		switch l.Side {
+		case SideBuy:
+			lotCost := l.Quantity.Mul(l.Price).Add(l.Fee)
+			lotCostPLN, ok := fx.ToPLN(&lotCost, currency, rate)
+			if !ok {
+				allConverted = false
+			}
+			newQty := r.Quantity.Add(l.Quantity)
+			if newQty.IsZero() {
+				r.AverageCost = decimal.Zero
+				avgPLN = decimal.Zero
+			} else {
+				existing := r.Quantity.Mul(r.AverageCost)
+				existingPLN := r.Quantity.Mul(avgPLN)
+				r.AverageCost = existing.Add(lotCost).Div(newQty)
+				avgPLN = existingPLN.Add(lotCostPLN).Div(newQty)
+			}
+			r.Quantity = newQty
+			r.TotalBought = r.TotalBought.Add(lotCost)
+			r.FeesPaid = r.FeesPaid.Add(l.Fee)
+		case SideSell:
+			if l.Quantity.GreaterThan(r.Quantity) {
+				return Running{}, ErrOversell
+			}
+			gain := l.Price.Sub(r.AverageCost).Mul(l.Quantity).Sub(l.Fee)
+			r.RealizedGain = r.RealizedGain.Add(gain)
+			proceeds := l.Quantity.Mul(l.Price).Sub(l.Fee)
+			r.TotalSold = r.TotalSold.Add(proceeds)
+			proceedsPLN, ok := fx.ToPLN(&proceeds, currency, rate)
+			if !ok {
+				allConverted = false
+			}
+			costPLN := l.Quantity.Mul(avgPLN)
+			gainPLN := proceedsPLN.Sub(costPLN)
+			r.RealizedGainPLN = r.RealizedGainPLN.Add(gainPLN)
+			r.Quantity = r.Quantity.Sub(l.Quantity)
+			r.FeesPaid = r.FeesPaid.Add(l.Fee)
+			if r.Quantity.IsZero() {
+				r.AverageCost = decimal.Zero
+				avgPLN = decimal.Zero
+			}
+		}
+	}
+	r.CostBasis = r.Quantity.Mul(r.AverageCost)
+	if allConverted {
+		r.HasPLN = true
+		r.AverageCostPLN = avgPLN
+		r.CostBasisPLN = r.Quantity.Mul(avgPLN)
+	} else {
+		r.RealizedGainPLN = decimal.Zero
+	}
 	return r, nil
 }
 

--- a/backend-go/internal/holdings/costbasis_test.go
+++ b/backend-go/internal/holdings/costbasis_test.go
@@ -1,12 +1,33 @@
 package holdings
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 )
+
+// stubRates returns rate r for every lookup, found=true. For tests.
+type stubRates struct{ r decimal.Decimal }
+
+func (s stubRates) GetRateToPLN(_ context.Context, _ string, _ time.Time) (fx.Result, error) {
+	return fx.Result{Rate: s.r, Found: true}, nil
+}
+
+// dateRates returns per-date rates; lookups for missing dates return found=false.
+type dateRates map[string]decimal.Decimal
+
+func (m dateRates) GetRateToPLN(_ context.Context, _ string, on time.Time) (fx.Result, error) {
+	key := on.UTC().Format("2006-01-02")
+	if v, ok := m[key]; ok {
+		return fx.Result{Rate: v, Found: true}, nil
+	}
+	return fx.Result{}, nil
+}
 
 func d(s string) decimal.Decimal {
 	v, _ := decimal.NewFromString(s)
@@ -151,6 +172,86 @@ func TestMarketValue_QuotedUsesQuote(t *testing.T) {
 	r := Running{Quantity: d("10"), AverageCost: d("100"), CostBasis: d("1000")}
 	if !MarketValue(r, d("150")).Equal(d("1500")) {
 		t.Errorf("quote should give 1500")
+	}
+}
+
+func TestComputeRunningPLN_WeightedPLNAverage(t *testing.T) {
+	rates := dateRates{
+		"2025-05-02": d("3.7881"),
+		"2025-05-09": d("3.7988"),
+		"2026-05-26": d("3.6576"),
+	}
+	lots := []Lot{
+		{Side: SideBuy, Quantity: d("75.3421"), Price: d("89.310"), Date: date(t, "2025-05-02")},
+		{Side: SideBuy, Quantity: d("1.4583"), Price: d("90.013"), Date: date(t, "2025-05-09")},
+		{Side: SideBuy, Quantity: d("44.3344"), Price: d("121.070"), Date: date(t, "2026-05-26")},
+	}
+	r, err := ComputeRunningPLN(context.Background(), lots, "USD", rates)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !r.HasPLN {
+		t.Fatalf("expected HasPLN true")
+	}
+	// Per-lot opening PLN: 75.3421*89.310*3.7881 + 1.4583*90.013*3.7988 + 44.3344*121.070*3.6576 ≈ 45620.27.
+	// Compare with 0.5 PLN tolerance to absorb decimal rounding.
+	want := d("45620.27")
+	diff := r.CostBasisPLN.Sub(want).Abs()
+	if diff.GreaterThan(d("0.5")) {
+		t.Errorf("CostBasisPLN = %s, want ≈ 45620.27 (diff %s)", r.CostBasisPLN.StringFixed(2), diff)
+	}
+	if r.RealizedGainPLN.Cmp(decimal.Zero) != 0 {
+		t.Errorf("RealizedGainPLN should be zero (no sells), got %s", r.RealizedGainPLN)
+	}
+}
+
+func TestComputeRunningPLN_MissingRateLeavesPLNZero(t *testing.T) {
+	// One lot date has no rate — function should still return successfully
+	// but with HasPLN=false so the caller falls back to native rendering.
+	rates := dateRates{"2025-05-02": d("3.7881")}
+	lots := []Lot{
+		{Side: SideBuy, Quantity: d("10"), Price: d("100"), Date: date(t, "2025-05-02")},
+		{Side: SideBuy, Quantity: d("10"), Price: d("110"), Date: date(t, "2025-06-01")}, // no rate
+	}
+	r, err := ComputeRunningPLN(context.Background(), lots, "USD", rates)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if r.HasPLN {
+		t.Errorf("HasPLN should be false on partial coverage")
+	}
+	if !r.AverageCost.Equal(d("105")) {
+		t.Errorf("native AverageCost = %s, want 105", r.AverageCost)
+	}
+}
+
+func TestComputeRunningPLN_PLNCurrencyPassesThrough(t *testing.T) {
+	r, err := ComputeRunningPLN(context.Background(), []Lot{
+		{Side: SideBuy, Quantity: d("10"), Price: d("100"), Date: date(t, "2024-01-01")},
+	}, "PLN", stubRates{r: d("1")})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !r.HasPLN {
+		t.Errorf("HasPLN should be true for PLN")
+	}
+	if !r.CostBasisPLN.Equal(d("1000")) {
+		t.Errorf("CostBasisPLN = %s, want 1000", r.CostBasisPLN)
+	}
+}
+
+func TestComputeRunningPLN_NilRatesActsLikeComputeRunning(t *testing.T) {
+	r, err := ComputeRunningPLN(context.Background(), []Lot{
+		{Side: SideBuy, Quantity: d("10"), Price: d("100"), Date: date(t, "2024-01-01")},
+	}, "USD", nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if r.HasPLN {
+		t.Errorf("HasPLN should stay false with nil rates")
+	}
+	if !r.AverageCost.Equal(d("100")) {
+		t.Errorf("AverageCost = %s, want 100", r.AverageCost)
 	}
 }
 

--- a/backend-go/internal/holdings/handler.go
+++ b/backend-go/internal/holdings/handler.go
@@ -32,15 +32,17 @@ const (
 // Handler is the HTTP boundary for /api/holdings.
 type Handler struct {
 	store  *Store
+	rates  RateProvider
 	logger *slog.Logger
 }
 
-// NewHandler wires store + logger.
-func NewHandler(store *Store, logger *slog.Logger) *Handler {
+// NewHandler wires store + rates + logger. rates may be nil — Holdings then
+// returns native-currency fields only and skips PLN conversion.
+func NewHandler(store *Store, rates RateProvider, logger *slog.Logger) *Handler {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Handler{store: store, logger: logger}
+	return &Handler{store: store, rates: rates, logger: logger}
 }
 
 // --- security wire types ---
@@ -319,6 +321,15 @@ type holdingRowResponse struct {
 	MarketValue     string           `json:"market_value"`
 	UnrealizedGain  string           `json:"unrealized_gain"`
 	RealizedGain    string           `json:"realized_gain"`
+
+	// PLN-converted fields. Null when no FX rate was available for any lot
+	// date or the latest quote date; the UI then renders native currency only.
+	AverageCostPLN     *string `json:"average_cost_pln"`
+	CostBasisPLN       *string `json:"cost_basis_pln"`
+	MarketValuePLN     *string `json:"market_value_pln"`
+	UnrealizedGainPLN  *string `json:"unrealized_gain_pln"`
+	RealizedGainPLN    *string `json:"realized_gain_pln"`
+	LatestQuoteRatePLN *string `json:"latest_quote_rate_pln"`
 }
 
 type holdingsResponse struct {
@@ -327,7 +338,7 @@ type holdingsResponse struct {
 
 // Holdings serves GET /api/holdings.
 func (h *Handler) Holdings(w http.ResponseWriter, r *http.Request) {
-	rows, err := h.store.Holdings(r.Context())
+	rows, err := h.store.Holdings(r.Context(), h.rates)
 	if err != nil {
 		h.logger.Error("holdings", "err", err)
 		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
@@ -352,6 +363,22 @@ func (h *Handler) Holdings(w http.ResponseWriter, r *http.Request) {
 		if hr.LatestQuoteDate != nil {
 			d := hr.LatestQuoteDate.UTC().Format("2006-01-02")
 			row.LatestQuoteDate = &d
+		}
+		if hr.Running.HasPLN {
+			avg := hr.Running.AverageCostPLN.StringFixed(4)
+			cb := hr.Running.CostBasisPLN.StringFixed(2)
+			rg := hr.Running.RealizedGainPLN.StringFixed(2)
+			row.AverageCostPLN = &avg
+			row.CostBasisPLN = &cb
+			row.RealizedGainPLN = &rg
+		}
+		if hr.HasPLN {
+			mv := hr.MarketValuePLN.StringFixed(2)
+			ug := hr.UnrealizedGainPLN.StringFixed(2)
+			rate := hr.LatestQuoteRatePLN.StringFixed(4)
+			row.MarketValuePLN = &mv
+			row.UnrealizedGainPLN = &ug
+			row.LatestQuoteRatePLN = &rate
 		}
 		out = append(out, row)
 	}

--- a/backend-go/internal/holdings/openapi.go
+++ b/backend-go/internal/holdings/openapi.go
@@ -17,4 +17,15 @@ var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/holdings/lots", Tag: "holdings", Summary: "List lots (filterable by account_id/security_id)", Response: listLotsResponse{}},
 	{Method: "POST", Path: "/api/holdings/lots", Tag: "holdings", Summary: "Create a lot", Status: http.StatusCreated, Response: lotResponse{}},
 	{Method: "DELETE", Path: "/api/holdings/lots/{id}", Tag: "holdings", Summary: "Delete a lot", Status: http.StatusNoContent},
+	{Method: "POST", Path: "/api/holdings/refresh-quotes", Tag: "holdings", Summary: "Pull latest quotes from Stooq for all securities", Response: refreshQuotesResponse{}},
+}
+
+// refreshQuotesResponse mirrors quotes.RefreshResponse so the OpenAPI
+// generator sees it from the holdings tag without dragging a quotes import
+// into apispec (which would create a cycle via httputil).
+type refreshQuotesResponse struct {
+	Total         int `json:"total"`
+	Written       int `json:"written"`
+	SkippedManual int `json:"skipped_manual"`
+	Failed        int `json:"failed"`
 }

--- a/backend-go/internal/holdings/store.go
+++ b/backend-go/internal/holdings/store.go
@@ -10,6 +10,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/fx"
 )
 
 // Store is the persistence boundary for securities, lots and price quotes.
@@ -49,6 +51,14 @@ type HoldingRow struct {
 	LatestQuoteDate *time.Time
 	MarketValue     decimal.Decimal
 	UnrealizedGain  decimal.Decimal
+
+	// PLN-converted fields. Populated when Running.HasPLN is true and an FX
+	// rate exists for LatestQuoteDate. LatestQuoteRatePLN is the rate used
+	// for MarketValuePLN/UnrealizedGainPLN — exposed so the UI can show it.
+	HasPLN             bool
+	MarketValuePLN     decimal.Decimal
+	UnrealizedGainPLN  decimal.Decimal
+	LatestQuoteRatePLN decimal.Decimal
 }
 
 // Sentinel errors.
@@ -213,6 +223,26 @@ func (s *Store) UpsertQuote(ctx context.Context, q PriceQuote) (PriceQuote, erro
 	return scanQuote(row)
 }
 
+// UpsertAutomatedQuote writes a quote without overwriting a manual entry for
+// the same (security_id, date). Used by scheduled fetchers (Stooq) so the
+// user's explicit price wins over any provider price for the same day.
+// Returns true when the row was written or refreshed, false when a manual
+// quote already occupied the slot.
+func (s *Store) UpsertAutomatedQuote(ctx context.Context, q PriceQuote) (bool, error) {
+	tag, err := s.pool.Exec(ctx, `
+		INSERT INTO price_quotes (security_id, date, price, source)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (security_id, date) DO UPDATE
+		SET price = EXCLUDED.price, source = EXCLUDED.source
+		WHERE price_quotes.source = EXCLUDED.source`,
+		q.SecurityID, q.Date, q.Price, q.Source,
+	)
+	if err != nil {
+		return false, fmt.Errorf("upsert automated quote: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
 // ListQuotes returns all quotes for a security, ordered by date desc.
 func (s *Store) ListQuotes(ctx context.Context, securityID int) ([]PriceQuote, error) {
 	rows, err := s.pool.Query(ctx, `SELECT `+quoteCols+` FROM price_quotes WHERE security_id = $1 ORDER BY date DESC`, securityID)
@@ -243,6 +273,89 @@ func (s *Store) DeleteQuote(ctx context.Context, id int) error {
 	return nil
 }
 
+// LastStooqQuoteDate returns the latest stored stooq quote date for a
+// security. Zero time when none exist yet — caller uses min(lot.date) as
+// the backfill start.
+func (s *Store) LastStooqQuoteDate(ctx context.Context, securityID int) (time.Time, error) {
+	var t *time.Time
+	err := s.pool.QueryRow(ctx, `
+		SELECT MAX(date) FROM price_quotes
+		WHERE security_id = $1 AND source = 'stooq'`, securityID).Scan(&t)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("last stooq quote date: %w", err)
+	}
+	if t == nil {
+		return time.Time{}, nil
+	}
+	return *t, nil
+}
+
+// FirstLotDate returns the earliest lot date for a security. Zero time when
+// there are no lots — used as the backfill start when no stooq history exists.
+func (s *Store) FirstLotDate(ctx context.Context, securityID int) (time.Time, error) {
+	var t *time.Time
+	err := s.pool.QueryRow(ctx, `
+		SELECT MIN(date) FROM lots WHERE security_id = $1`, securityID).Scan(&t)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("first lot date: %w", err)
+	}
+	if t == nil {
+		return time.Time{}, nil
+	}
+	return *t, nil
+}
+
+// BulkUpsertAutomatedQuotes writes many quotes in a single transaction,
+// preserving rows tagged source != EXCLUDED.source (i.e. manual entries).
+// Returns the count of rows actually written or refreshed.
+func (s *Store) BulkUpsertAutomatedQuotes(ctx context.Context, rows []PriceQuote) (int, error) {
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("begin bulk upsert: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	const q = `
+		INSERT INTO price_quotes (security_id, date, price, source)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (security_id, date) DO UPDATE
+		SET price = EXCLUDED.price, source = EXCLUDED.source
+		WHERE price_quotes.source = EXCLUDED.source`
+	written := 0
+	for i := range rows {
+		r := &rows[i]
+		tag, err := tx.Exec(ctx, q, r.SecurityID, r.Date, r.Price, r.Source)
+		if err != nil {
+			return 0, fmt.Errorf("bulk upsert row %d: %w", i, err)
+		}
+		if tag.RowsAffected() > 0 {
+			written++
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("commit bulk upsert: %w", err)
+	}
+	return written, nil
+}
+
+// LatestStooqQuoteTime returns the most recent created_at across price_quotes
+// rows tagged source='stooq'. Zero time when no stooq quotes exist yet.
+// Used by the quotes scheduler to decide whether to refresh on startup.
+func (s *Store) LatestStooqQuoteTime(ctx context.Context) (time.Time, error) {
+	var t *time.Time
+	err := s.pool.QueryRow(ctx, `
+		SELECT MAX(created_at) FROM price_quotes WHERE source = 'stooq'`).Scan(&t)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("latest stooq quote time: %w", err)
+	}
+	if t == nil {
+		return time.Time{}, nil
+	}
+	return *t, nil
+}
+
 // latestQuotes returns latest price per security as of now.
 func (s *Store) latestQuotes(ctx context.Context) (map[int]PriceQuote, error) {
 	rows, err := s.pool.Query(ctx, `
@@ -265,8 +378,10 @@ func (s *Store) latestQuotes(ctx context.Context) (map[int]PriceQuote, error) {
 }
 
 // Holdings replays every lot, groups by security, attaches the latest quote,
-// and returns one HoldingRow per security with non-zero quantity.
-func (s *Store) Holdings(ctx context.Context) ([]HoldingRow, error) {
+// and returns one HoldingRow per security with non-zero quantity. When rates
+// is non-nil, PLN-converted fields are also populated using trade-date NBP
+// rates for cost basis and the latest-quote-date rate for market value.
+func (s *Store) Holdings(ctx context.Context, rates RateProvider) ([]HoldingRow, error) {
 	securities, err := s.ListSecurities(ctx)
 	if err != nil {
 		return nil, err
@@ -287,10 +402,8 @@ func (s *Store) Holdings(ctx context.Context) ([]HoldingRow, error) {
 	out := []HoldingRow{}
 	for _, sec := range securities {
 		lots := bySec[sec.ID]
-		run, runErr := ComputeRunning(lots)
+		run, runErr := ComputeRunningPLN(ctx, lots, sec.Currency, rates)
 		if runErr != nil {
-			// Skip securities with corrupted lot histories rather than failing
-			// the whole endpoint. Log so the corruption is visible in ops.
 			slog.Default().Warn("holdings: skipping security with bad lot history",
 				"security_id", sec.ID, "symbol", sec.Symbol, "err", runErr)
 			continue
@@ -306,7 +419,36 @@ func (s *Store) Holdings(ctx context.Context) ([]HoldingRow, error) {
 		}
 		row.MarketValue = MarketValue(run, row.LatestQuote)
 		row.UnrealizedGain = UnrealizedGain(run, row.LatestQuote)
+		s.fillPLNValuation(ctx, &row, rates)
 		out = append(out, row)
 	}
 	return out, nil
+}
+
+// fillPLNValuation converts MarketValue + UnrealizedGain to PLN using the FX
+// rate for the latest-quote date (or today if no quote). Leaves PLN fields
+// zero on lookup miss — UI degrades to native-currency display.
+func (s *Store) fillPLNValuation(ctx context.Context, row *HoldingRow, rates RateProvider) {
+	if rates == nil || !row.Running.HasPLN {
+		return
+	}
+	rateDate := time.Now().UTC()
+	if row.LatestQuoteDate != nil {
+		rateDate = *row.LatestQuoteDate
+	}
+	rate, err := rates.GetRateToPLN(ctx, row.Security.Currency, rateDate)
+	if err != nil {
+		slog.Default().Warn("holdings: fx lookup failed for market value",
+			"security_id", row.Security.ID, "symbol", row.Security.Symbol, "err", err)
+		return
+	}
+	mv := row.MarketValue
+	mvPLN, ok := fx.ToPLN(&mv, row.Security.Currency, rate)
+	if !ok {
+		return
+	}
+	row.HasPLN = true
+	row.MarketValuePLN = mvPLN
+	row.LatestQuoteRatePLN = rate.Rate
+	row.UnrealizedGainPLN = mvPLN.Sub(row.Running.CostBasisPLN)
 }

--- a/backend-go/internal/quotes/handler.go
+++ b/backend-go/internal/quotes/handler.go
@@ -1,0 +1,60 @@
+package quotes
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+)
+
+// RefreshHandler exposes POST /api/holdings/refresh-quotes — the user-driven
+// "fetch now" trigger. Reuses the scheduler's refreshOne so the behavior
+// matches the daily job exactly (gap-fill via Daily, fall back to Latest).
+type RefreshHandler struct {
+	scheduler *Scheduler
+	store     HoldingsStore
+	logger    *slog.Logger
+}
+
+// NewRefreshHandler wires the dependencies. The scheduler is used purely as
+// a per-security refresh primitive — its Run loop is not started here.
+func NewRefreshHandler(store HoldingsStore, fetcher Fetcher, logger *slog.Logger) *RefreshHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &RefreshHandler{
+		scheduler: NewScheduler(store, fetcher, logger),
+		store:     store,
+		logger:    logger,
+	}
+}
+
+// RefreshResponse is the body of POST /api/holdings/refresh-quotes.
+type RefreshResponse struct {
+	Total         int `json:"total"`
+	Written       int `json:"written"`
+	SkippedManual int `json:"skipped_manual"`
+	Failed        int `json:"failed"`
+}
+
+// Refresh runs an on-demand Stooq refresh pass and returns per-security
+// totals. Same logic as scheduler.refresh, just synchronous + with a
+// response payload.
+func (h *RefreshHandler) Refresh(w http.ResponseWriter, r *http.Request) {
+	totals := h.run(r.Context())
+	httputil.WriteJSON(w, http.StatusOK, RefreshResponse(totals))
+}
+
+func (h *RefreshHandler) run(ctx context.Context) RefreshTotals {
+	secs, err := h.store.ListSecurities(ctx)
+	if err != nil {
+		h.logger.Warn("refresh-quotes: list securities failed", "err", err)
+		return RefreshTotals{}
+	}
+	totals := RefreshTotals{Total: len(secs)}
+	for _, sec := range secs {
+		h.scheduler.refreshOne(ctx, sec, &totals)
+	}
+	return totals
+}

--- a/backend-go/internal/quotes/handler.go
+++ b/backend-go/internal/quotes/handler.go
@@ -4,9 +4,16 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 )
+
+// refreshTimeout caps the synchronous Stooq pass. Picked so a single user
+// click can't outlive typical proxy timeouts (Traefik default ~3min) — with
+// the Stooq fetcher's 8s per-request timeout this leaves headroom for ~15
+// securities even when both Daily and the Latest fallback run.
+const refreshTimeout = 2 * time.Minute
 
 // RefreshHandler exposes POST /api/holdings/refresh-quotes — the user-driven
 // "fetch now" trigger. Reuses the scheduler's refreshOne so the behavior
@@ -40,21 +47,28 @@ type RefreshResponse struct {
 
 // Refresh runs an on-demand Stooq refresh pass and returns per-security
 // totals. Same logic as scheduler.refresh, just synchronous + with a
-// response payload.
+// response payload. The pass is bounded by refreshTimeout so a stuck
+// upstream can't pin the request goroutine indefinitely.
 func (h *RefreshHandler) Refresh(w http.ResponseWriter, r *http.Request) {
-	totals := h.run(r.Context())
+	ctx, cancel := context.WithTimeout(r.Context(), refreshTimeout)
+	defer cancel()
+	totals, err := h.run(ctx)
+	if err != nil {
+		h.logger.Error("refresh-quotes: list securities failed", "err", err)
+		httputil.WriteDetailError(w, http.StatusInternalServerError, "Failed to list securities")
+		return
+	}
 	httputil.WriteJSON(w, http.StatusOK, RefreshResponse(totals))
 }
 
-func (h *RefreshHandler) run(ctx context.Context) RefreshTotals {
+func (h *RefreshHandler) run(ctx context.Context) (RefreshTotals, error) {
 	secs, err := h.store.ListSecurities(ctx)
 	if err != nil {
-		h.logger.Warn("refresh-quotes: list securities failed", "err", err)
-		return RefreshTotals{}
+		return RefreshTotals{}, err
 	}
 	totals := RefreshTotals{Total: len(secs)}
 	for _, sec := range secs {
 		h.scheduler.refreshOne(ctx, sec, &totals)
 	}
-	return totals
+	return totals, nil
 }

--- a/backend-go/internal/quotes/scheduler.go
+++ b/backend-go/internal/quotes/scheduler.go
@@ -1,0 +1,244 @@
+package quotes
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
+)
+
+const (
+	// QuotesSource tags rows written by the Stooq scheduler. Frontend uses
+	// it to distinguish auto-pulled vs. manual quotes.
+	QuotesSource = "stooq"
+
+	refreshHour   = 18 // 18:00 Europe/Warsaw — after EU market close
+	refreshMinute = 5
+	startupStale  = 18 * time.Hour
+)
+
+// Fetcher fetches Stooq quotes. Latest is keyless; Daily requires apikey.
+// Implemented by StooqFetcher; an interface so the scheduler can be tested
+// without HTTP.
+type Fetcher interface {
+	Latest(ctx context.Context, symbol string) (Quote, error)
+	Daily(ctx context.Context, symbol string, from, to time.Time) ([]Quote, error)
+}
+
+// HoldingsStore is the slice of holdings.Store the scheduler needs.
+type HoldingsStore interface {
+	ListSecurities(ctx context.Context) ([]holdings.Security, error)
+	LastStooqQuoteDate(ctx context.Context, securityID int) (time.Time, error)
+	FirstLotDate(ctx context.Context, securityID int) (time.Time, error)
+	UpsertAutomatedQuote(ctx context.Context, q holdings.PriceQuote) (bool, error)
+	BulkUpsertAutomatedQuotes(ctx context.Context, rows []holdings.PriceQuote) (int, error)
+	LatestStooqQuoteTime(ctx context.Context) (time.Time, error)
+}
+
+// backfillPadDays is how far before the first lot date we start a brand-new
+// security's history pull — a small buffer so the chart has a visible
+// pre-purchase baseline.
+const backfillPadDays = 7
+
+// Scheduler refreshes prices from a Fetcher once a day. Modeled after
+// scheduler.CPIScheduler — single-instance, hand-rolled timer, no cron lib.
+type Scheduler struct {
+	store   HoldingsStore
+	fetcher Fetcher
+	logger  *slog.Logger
+	now     func() time.Time
+	loc     *time.Location
+}
+
+// NewScheduler wires the scheduler. Falls back to UTC if Europe/Warsaw tzdata
+// is missing (matches CPI scheduler).
+func NewScheduler(store HoldingsStore, fetcher Fetcher, logger *slog.Logger) *Scheduler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	loc, err := time.LoadLocation("Europe/Warsaw")
+	if err != nil {
+		logger.Warn("quotes: Europe/Warsaw tz unavailable, using UTC", "err", err)
+		loc = time.UTC
+	}
+	return &Scheduler{
+		store:   store,
+		fetcher: fetcher,
+		logger:  logger,
+		now:     time.Now,
+		loc:     loc,
+	}
+}
+
+// Run does a stale-check refresh, then loops daily until ctx is canceled.
+// Intended to run in its own goroutine.
+func (s *Scheduler) Run(ctx context.Context) {
+	s.startupRefresh(ctx)
+	for {
+		now := s.now().In(s.loc)
+		next := nextRefresh(now)
+		wait := max(next.Sub(now), 0)
+		s.logger.Info("quotes: next refresh", "at", next.Format(time.RFC3339))
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			s.logger.Info("quotes: stopped")
+			return
+		case <-timer.C:
+			s.refresh(ctx)
+		}
+	}
+}
+
+func (s *Scheduler) startupRefresh(ctx context.Context) {
+	last, err := s.store.LatestStooqQuoteTime(ctx)
+	if err != nil {
+		s.logger.Warn("quotes: staleness check failed", "err", err)
+		return
+	}
+	if last.IsZero() || s.now().UTC().Sub(last) > startupStale {
+		s.logger.Info("quotes: stale at startup, refreshing", "last", last)
+		s.refresh(ctx)
+	}
+}
+
+// refresh runs a full pass: gap-fill each security from its last stored
+// stooq date to today via Daily; fall back to Latest when the daily endpoint
+// is unavailable (no apikey, or it errored). One bad security must not stop
+// the rest — every error is logged and skipped.
+func (s *Scheduler) refresh(ctx context.Context) {
+	secs, err := s.store.ListSecurities(ctx)
+	if err != nil {
+		s.logger.Warn("quotes: list securities failed", "err", err)
+		return
+	}
+	totals := RefreshTotals{Total: len(secs)}
+	for _, sec := range secs {
+		s.refreshOne(ctx, sec, &totals)
+	}
+	s.logger.Info("quotes: refresh complete",
+		"written", totals.Written, "skipped_manual", totals.SkippedManual,
+		"failed", totals.Failed, "total", totals.Total)
+}
+
+// RefreshTotals is the per-pass counter shared between scheduler runs and
+// the on-demand HTTP handler.
+type RefreshTotals struct {
+	Total         int
+	Written       int
+	SkippedManual int
+	Failed        int
+}
+
+// refreshOne handles a single security: pick the right date window, fetch,
+// upsert, and bump the counters in place.
+func (s *Scheduler) refreshOne(ctx context.Context, sec holdings.Security, totals *RefreshTotals) {
+	from, ok, err := s.backfillStart(ctx, sec.ID)
+	if err != nil {
+		s.logger.Warn("quotes: backfill-start lookup failed", "symbol", sec.Symbol, "err", err)
+		totals.Failed++
+		return
+	}
+	if !ok {
+		// No lots and no prior history — nothing to value yet, skip.
+		return
+	}
+	today := s.now().UTC().Truncate(24 * time.Hour)
+	if from.After(today) {
+		return // already current
+	}
+	rows, err := s.fetcher.Daily(ctx, sec.Symbol, from, today)
+	if err == nil {
+		s.persistDaily(ctx, sec, rows, totals)
+		return
+	}
+	if !errors.Is(err, ErrNoAPIKey) {
+		s.logger.Warn("quotes: daily fetch failed, falling back to latest",
+			"symbol", sec.Symbol, "err", err)
+	}
+	s.persistLatest(ctx, sec, totals)
+}
+
+// backfillStart returns the first date we should request from Stooq for sec.
+// (zero, false, nil) means "nothing to do" (no lots and no history).
+func (s *Scheduler) backfillStart(ctx context.Context, securityID int) (time.Time, bool, error) {
+	last, err := s.store.LastStooqQuoteDate(ctx, securityID)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if !last.IsZero() {
+		return last.AddDate(0, 0, 1), true, nil
+	}
+	first, err := s.store.FirstLotDate(ctx, securityID)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if first.IsZero() {
+		return time.Time{}, false, nil
+	}
+	return first.AddDate(0, 0, -backfillPadDays), true, nil
+}
+
+func (s *Scheduler) persistDaily(ctx context.Context, sec holdings.Security, rows []Quote, totals *RefreshTotals) {
+	if len(rows) == 0 {
+		return
+	}
+	batch := make([]holdings.PriceQuote, len(rows))
+	for i, q := range rows {
+		batch[i] = holdings.PriceQuote{
+			SecurityID: sec.ID,
+			Date:       q.Date,
+			Price:      q.Close,
+			Source:     QuotesSource,
+		}
+	}
+	written, err := s.store.BulkUpsertAutomatedQuotes(ctx, batch)
+	if err != nil {
+		s.logger.Warn("quotes: bulk upsert failed", "symbol", sec.Symbol, "err", err)
+		totals.Failed++
+		return
+	}
+	totals.Written += written
+	totals.SkippedManual += len(batch) - written
+}
+
+func (s *Scheduler) persistLatest(ctx context.Context, sec holdings.Security, totals *RefreshTotals) {
+	q, err := s.fetcher.Latest(ctx, sec.Symbol)
+	if err != nil {
+		if errors.Is(err, ErrNoData) {
+			s.logger.Info("quotes: no data", "symbol", sec.Symbol)
+		} else {
+			s.logger.Warn("quotes: latest fetch failed", "symbol", sec.Symbol, "err", err)
+		}
+		totals.Failed++
+		return
+	}
+	ok, err := s.store.UpsertAutomatedQuote(ctx, holdings.PriceQuote{
+		SecurityID: sec.ID,
+		Date:       q.Date,
+		Price:      q.Close,
+		Source:     QuotesSource,
+	})
+	if err != nil {
+		s.logger.Warn("quotes: upsert failed", "symbol", sec.Symbol, "err", err)
+		totals.Failed++
+		return
+	}
+	if ok {
+		totals.Written++
+	} else {
+		totals.SkippedManual++
+	}
+}
+
+// nextRefresh returns the next 18:05 strictly after `from`, in from's location.
+func nextRefresh(from time.Time) time.Time {
+	cand := time.Date(from.Year(), from.Month(), from.Day(), refreshHour, refreshMinute, 0, 0, from.Location())
+	if !cand.After(from) {
+		cand = cand.AddDate(0, 0, 1)
+	}
+	return cand
+}

--- a/backend-go/internal/quotes/scheduler.go
+++ b/backend-go/internal/quotes/scheduler.go
@@ -99,6 +99,11 @@ func (s *Scheduler) startupRefresh(ctx context.Context) {
 		s.logger.Warn("quotes: staleness check failed", "err", err)
 		return
 	}
+	// Both sides are nominally UTC: price_quotes.created_at is `timestamp
+	// without time zone` defaulted to `now() at time zone 'utc'`, and pgx
+	// scans naive timestamps with time.UTC. s.now().UTC() makes the same
+	// assumption explicit on the application side. If price_quotes ever
+	// migrates to timestamptz, both branches still subtract correctly.
 	if last.IsZero() || s.now().UTC().Sub(last) > startupStale {
 		s.logger.Info("quotes: stale at startup, refreshing", "last", last)
 		s.refresh(ctx)

--- a/backend-go/internal/quotes/scheduler_test.go
+++ b/backend-go/internal/quotes/scheduler_test.go
@@ -1,0 +1,219 @@
+package quotes
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
+)
+
+// fakeStore is an in-memory HoldingsStore for scheduler tests.
+type fakeStore struct {
+	securities    []holdings.Security
+	lastStooq     map[int]time.Time
+	firstLot      map[int]time.Time
+	manualDates   map[int]map[string]bool // (security, date) → don't overwrite
+	written       []holdings.PriceQuote
+	latestStooqAt time.Time
+	now           time.Time
+}
+
+func newFakeStore(secs []holdings.Security) *fakeStore {
+	return &fakeStore{
+		securities:  secs,
+		lastStooq:   map[int]time.Time{},
+		firstLot:    map[int]time.Time{},
+		manualDates: map[int]map[string]bool{},
+	}
+}
+
+func (f *fakeStore) ListSecurities(_ context.Context) ([]holdings.Security, error) {
+	return f.securities, nil
+}
+
+func (f *fakeStore) LastStooqQuoteDate(_ context.Context, id int) (time.Time, error) {
+	return f.lastStooq[id], nil
+}
+
+func (f *fakeStore) FirstLotDate(_ context.Context, id int) (time.Time, error) {
+	return f.firstLot[id], nil
+}
+
+func (f *fakeStore) LatestStooqQuoteTime(_ context.Context) (time.Time, error) {
+	return f.latestStooqAt, nil
+}
+
+func (f *fakeStore) UpsertAutomatedQuote(_ context.Context, q holdings.PriceQuote) (bool, error) {
+	if f.manualDates[q.SecurityID][q.Date.Format("2006-01-02")] {
+		return false, nil
+	}
+	f.written = append(f.written, q)
+	return true, nil
+}
+
+func (f *fakeStore) BulkUpsertAutomatedQuotes(_ context.Context, rows []holdings.PriceQuote) (int, error) {
+	n := 0
+	for _, q := range rows {
+		if f.manualDates[q.SecurityID][q.Date.Format("2006-01-02")] {
+			continue
+		}
+		f.written = append(f.written, q)
+		n++
+	}
+	return n, nil
+}
+
+// fakeFetcher tracks what Daily/Latest was called with and replays canned data.
+type fakeFetcher struct {
+	dailyErr       error
+	daily          []Quote
+	latest         Quote
+	latestErr      error
+	dailyCalledFor []time.Time // start dates
+	latestCalls    int
+}
+
+func (f *fakeFetcher) Latest(_ context.Context, _ string) (Quote, error) {
+	f.latestCalls++
+	return f.latest, f.latestErr
+}
+
+func (f *fakeFetcher) Daily(_ context.Context, _ string, from, _ time.Time) ([]Quote, error) {
+	f.dailyCalledFor = append(f.dailyCalledFor, from)
+	if f.dailyErr != nil {
+		return nil, f.dailyErr
+	}
+	return f.daily, nil
+}
+
+func sec(id int, sym string) holdings.Security {
+	return holdings.Security{ID: id, Symbol: sym, Currency: "USD"}
+}
+
+func dec(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+func mustDay(t *testing.T, s string) time.Time {
+	t.Helper()
+	d, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return d
+}
+
+func TestScheduler_GapFillFromLastStooq(t *testing.T) {
+	store := newFakeStore([]holdings.Security{
+		sec(1, "ISAC.UK"),
+		sec(2, "CSPX.UK"),
+	})
+	store.lastStooq[1] = mustDay(t, "2026-05-20")
+	store.lastStooq[2] = mustDay(t, "2026-05-25")
+	store.now = mustDay(t, "2026-05-27")
+	fetcher := &fakeFetcher{daily: []Quote{
+		{Symbol: "X", Date: mustDay(t, "2026-05-26"), Close: dec("100")},
+	}}
+	s := NewScheduler(store, fetcher, slog.Default())
+	s.now = func() time.Time { return store.now }
+	s.refresh(context.Background())
+	if len(fetcher.dailyCalledFor) != 2 {
+		t.Fatalf("daily calls = %d, want 2", len(fetcher.dailyCalledFor))
+	}
+	if got := fetcher.dailyCalledFor[0].Format("2006-01-02"); got != "2026-05-21" {
+		t.Errorf("sec 1 daily start = %s, want 2026-05-21", got)
+	}
+	if got := fetcher.dailyCalledFor[1].Format("2006-01-02"); got != "2026-05-26" {
+		t.Errorf("sec 2 daily start = %s, want 2026-05-26", got)
+	}
+}
+
+func TestScheduler_FirstRunUsesFirstLotMinusPad(t *testing.T) {
+	store := newFakeStore([]holdings.Security{sec(1, "ISAC.UK")})
+	store.firstLot[1] = mustDay(t, "2025-05-02")
+	store.now = mustDay(t, "2026-05-27")
+	fetcher := &fakeFetcher{daily: []Quote{
+		{Symbol: "ISAC.UK", Date: mustDay(t, "2025-05-02"), Close: dec("89.31")},
+	}}
+	s := NewScheduler(store, fetcher, slog.Default())
+	s.now = func() time.Time { return store.now }
+	s.refresh(context.Background())
+	if got := fetcher.dailyCalledFor[0].Format("2006-01-02"); got != "2025-04-25" {
+		t.Errorf("daily start = %s, want 2025-04-25 (firstLot - 7d)", got)
+	}
+}
+
+func TestScheduler_SkipsSecurityWithNoLotsOrHistory(t *testing.T) {
+	store := newFakeStore([]holdings.Security{sec(1, "WIPE.UK")})
+	store.now = mustDay(t, "2026-05-27")
+	fetcher := &fakeFetcher{}
+	s := NewScheduler(store, fetcher, slog.Default())
+	s.now = func() time.Time { return store.now }
+	s.refresh(context.Background())
+	if len(fetcher.dailyCalledFor) != 0 {
+		t.Errorf("should not call Daily with no lots, got %d calls", len(fetcher.dailyCalledFor))
+	}
+	if fetcher.latestCalls != 0 {
+		t.Errorf("should not call Latest with no lots, got %d", fetcher.latestCalls)
+	}
+}
+
+func TestScheduler_FallsBackToLatestWhenNoAPIKey(t *testing.T) {
+	store := newFakeStore([]holdings.Security{sec(1, "ISAC.UK")})
+	store.lastStooq[1] = mustDay(t, "2026-05-26")
+	store.now = mustDay(t, "2026-05-27")
+	fetcher := &fakeFetcher{
+		dailyErr: ErrNoAPIKey,
+		latest:   Quote{Symbol: "ISAC.UK", Date: mustDay(t, "2026-05-27"), Close: dec("121.4")},
+	}
+	s := NewScheduler(store, fetcher, slog.Default())
+	s.now = func() time.Time { return store.now }
+	s.refresh(context.Background())
+	if fetcher.latestCalls != 1 {
+		t.Errorf("latest calls = %d, want 1 fallback", fetcher.latestCalls)
+	}
+	if len(store.written) != 1 {
+		t.Errorf("written = %d, want 1", len(store.written))
+	}
+}
+
+func TestScheduler_BulkUpsertPreservesManual(t *testing.T) {
+	store := newFakeStore([]holdings.Security{sec(1, "ISAC.UK")})
+	store.lastStooq[1] = mustDay(t, "2026-05-19")
+	store.now = mustDay(t, "2026-05-22")
+	store.manualDates[1] = map[string]bool{"2026-05-21": true}
+	fetcher := &fakeFetcher{daily: []Quote{
+		{Symbol: "ISAC.UK", Date: mustDay(t, "2026-05-20"), Close: dec("119")},
+		{Symbol: "ISAC.UK", Date: mustDay(t, "2026-05-21"), Close: dec("118.68")}, // manual wins
+		{Symbol: "ISAC.UK", Date: mustDay(t, "2026-05-22"), Close: dec("120.09")},
+	}}
+	s := NewScheduler(store, fetcher, slog.Default())
+	s.now = func() time.Time { return store.now }
+	s.refresh(context.Background())
+	if len(store.written) != 2 {
+		t.Errorf("written = %d, want 2 (manual 21st skipped)", len(store.written))
+	}
+}
+
+func TestScheduler_AlreadyCurrentDoesNothing(t *testing.T) {
+	store := newFakeStore([]holdings.Security{sec(1, "ISAC.UK")})
+	store.lastStooq[1] = mustDay(t, "2026-05-27")
+	store.now = mustDay(t, "2026-05-27")
+	fetcher := &fakeFetcher{}
+	s := NewScheduler(store, fetcher, slog.Default())
+	s.now = func() time.Time { return store.now }
+	s.refresh(context.Background())
+	if len(fetcher.dailyCalledFor) != 0 || fetcher.latestCalls != 0 {
+		t.Errorf("should be no-op when up to date; daily=%d latest=%d",
+			len(fetcher.dailyCalledFor), fetcher.latestCalls)
+	}
+}
+
+// Compile-time assertion that fakeStore satisfies HoldingsStore (catches
+// drift when the interface changes).
+var (
+	_ HoldingsStore = (*fakeStore)(nil)
+	_ Fetcher       = (*fakeFetcher)(nil)
+)

--- a/backend-go/internal/quotes/stooq.go
+++ b/backend-go/internal/quotes/stooq.go
@@ -104,19 +104,16 @@ func parseStooqLatest(r io.Reader, sym string) (Quote, error) {
 	if err != nil {
 		return Quote{}, fmt.Errorf("read header: %w", err)
 	}
-	idx := map[string]int{}
-	for i, name := range header {
-		idx[strings.ToLower(strings.TrimSpace(name))] = i
-	}
-	needed := []string{"date", "close"}
-	for _, n := range needed {
-		if _, ok := idx[n]; !ok {
-			return Quote{}, fmt.Errorf("stooq missing %q column", n)
-		}
+	idx, err := csvColumns(header, "date", "close")
+	if err != nil {
+		return Quote{}, err
 	}
 	row, err := reader.Read()
 	if err != nil {
 		return Quote{}, fmt.Errorf("read row: %w", err)
+	}
+	if !rowHas(row, idx["date"], idx["close"]) {
+		return Quote{}, fmt.Errorf("stooq row truncated: %d cols, want > %d", len(row), maxIdx(idx))
 	}
 	if row[idx["date"]] == "N/D" || row[idx["close"]] == "N/D" {
 		return Quote{}, ErrNoData
@@ -134,6 +131,43 @@ func parseStooqLatest(r io.Reader, sym string) (Quote, error) {
 		Date:   d,
 		Close:  price,
 	}, nil
+}
+
+// csvColumns indexes header by lowercase name and verifies every needed
+// column is present. Returned map is keyed by lowercase column name.
+func csvColumns(header []string, needed ...string) (map[string]int, error) {
+	idx := map[string]int{}
+	for i, name := range header {
+		idx[strings.ToLower(strings.TrimSpace(name))] = i
+	}
+	for _, n := range needed {
+		if _, ok := idx[n]; !ok {
+			return nil, fmt.Errorf("stooq missing %q column", n)
+		}
+	}
+	return idx, nil
+}
+
+// rowHas reports whether row has cells at every supplied index. Guards the
+// CSV parsers against panics when Stooq returns short/malformed rows
+// (FieldsPerRecord = -1 doesn't enforce uniform width).
+func rowHas(row []string, idxs ...int) bool {
+	for _, i := range idxs {
+		if i >= len(row) {
+			return false
+		}
+	}
+	return true
+}
+
+func maxIdx(idx map[string]int) int {
+	m := 0
+	for _, v := range idx {
+		if v > m {
+			m = v
+		}
+	}
+	return m
 }
 
 // Daily fetches the daily history for symbol in [from, to] inclusive from
@@ -186,14 +220,9 @@ func parseStooqDaily(r io.Reader, sym string) ([]Quote, error) {
 		}
 		return nil, fmt.Errorf("read header: %w", err)
 	}
-	idx := map[string]int{}
-	for i, name := range header {
-		idx[strings.ToLower(strings.TrimSpace(name))] = i
-	}
-	for _, n := range []string{"date", "close"} {
-		if _, ok := idx[n]; !ok {
-			return nil, fmt.Errorf("stooq daily missing %q column", n)
-		}
+	idx, err := csvColumns(header, "date", "close")
+	if err != nil {
+		return nil, fmt.Errorf("stooq daily: %w", err)
 	}
 	out := []Quote{}
 	upperSym := strings.ToUpper(sym)
@@ -204,6 +233,9 @@ func parseStooqDaily(r io.Reader, sym string) ([]Quote, error) {
 		}
 		if err != nil {
 			return nil, fmt.Errorf("read row: %w", err)
+		}
+		if !rowHas(row, idx["date"], idx["close"]) {
+			return nil, fmt.Errorf("stooq daily row truncated: %d cols", len(row))
 		}
 		if row[idx["date"]] == "" || row[idx["close"]] == "" {
 			continue

--- a/backend-go/internal/quotes/stooq.go
+++ b/backend-go/internal/quotes/stooq.go
@@ -1,0 +1,222 @@
+// Package quotes fetches latest market quotes from external providers and
+// upserts them into the price_quotes table.
+//
+// Stooq's "light" CSV endpoint (q/l/?s=…&f=sd2t2ohlcv&h&e=csv) returns one
+// row per symbol with the latest intraday snapshot. UCITS ETF coverage is
+// good (isac.uk, cspx.uk, eunl.de, …); prices are in the symbol's native
+// trading currency. The security row declares that currency at creation
+// time — Stooq's price is stored as-is, no conversion.
+package quotes
+
+import (
+	"context"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+const (
+	stooqLatestURL  = "https://stooq.com/q/l/"
+	stooqHistoryURL = "https://stooq.com/q/d/l/"
+	stooqUserAgent  = "finance-buddy/1.0 (+https://finance.mskalski.dev)"
+	httpTimeout     = 8 * time.Second
+)
+
+// Quote is a single latest snapshot.
+type Quote struct {
+	Symbol string
+	Date   time.Time
+	Close  decimal.Decimal
+}
+
+// ErrNoData signals Stooq returned a row but with N/D fields — the symbol
+// exists in their universe but has no price for today (delisted, market
+// closed, or unknown).
+var ErrNoData = errors.New("quotes: stooq returned N/D")
+
+// StooqFetcher is the Stooq HTTP client. Stateless; reuse one instance.
+// apiKey gates the daily-history endpoint; Latest works without one.
+type StooqFetcher struct {
+	client *http.Client
+	apiKey string
+}
+
+// NewStooqFetcher wires the fetcher with default timeout. apiKey can be empty
+// — Latest still works (Stooq's intraday endpoint is keyless), but Daily
+// will return ErrNoAPIKey.
+func NewStooqFetcher(apiKey string) *StooqFetcher {
+	return &StooqFetcher{
+		client: &http.Client{Timeout: httpTimeout},
+		apiKey: strings.TrimSpace(apiKey),
+	}
+}
+
+// ErrNoAPIKey signals Daily was called without FB_STOOQ_APIKEY configured.
+// Stooq gates daily-history downloads behind a captcha-issued key.
+var ErrNoAPIKey = errors.New("quotes: stooq apikey required for daily history")
+
+// Latest fetches the latest snapshot for symbol. Returns (Quote, nil) on
+// success, (zero, ErrNoData) when Stooq has no data for the symbol, or
+// (zero, err) on network / parse failure. The destination URL is built from
+// a package constant; the symbol is encoded as a query parameter so taint
+// flows only through net/url, not into the request URL path.
+func (f *StooqFetcher) Latest(ctx context.Context, symbol string) (Quote, error) {
+	sym := strings.ToLower(strings.TrimSpace(symbol))
+	if sym == "" {
+		return Quote{}, errors.New("quotes: empty symbol")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, stooqLatestURL, http.NoBody)
+	if err != nil {
+		return Quote{}, fmt.Errorf("build request: %w", err)
+	}
+	req.URL.RawQuery = url.Values{
+		"s": {sym},
+		"f": {"sd2t2ohlcv"},
+		"h": {""},
+		"e": {"csv"},
+	}.Encode()
+	req.Header.Set("User-Agent", stooqUserAgent)
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return Quote{}, fmt.Errorf("stooq request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return Quote{}, fmt.Errorf("stooq http %d", resp.StatusCode)
+	}
+	return parseStooqLatest(resp.Body, sym)
+}
+
+// parseStooqLatest reads the CSV stream and returns the first data row.
+// Header: Symbol,Date,Time,Open,High,Low,Close,Volume.
+func parseStooqLatest(r io.Reader, sym string) (Quote, error) {
+	reader := csv.NewReader(r)
+	reader.FieldsPerRecord = -1
+	header, err := reader.Read()
+	if err != nil {
+		return Quote{}, fmt.Errorf("read header: %w", err)
+	}
+	idx := map[string]int{}
+	for i, name := range header {
+		idx[strings.ToLower(strings.TrimSpace(name))] = i
+	}
+	needed := []string{"date", "close"}
+	for _, n := range needed {
+		if _, ok := idx[n]; !ok {
+			return Quote{}, fmt.Errorf("stooq missing %q column", n)
+		}
+	}
+	row, err := reader.Read()
+	if err != nil {
+		return Quote{}, fmt.Errorf("read row: %w", err)
+	}
+	if row[idx["date"]] == "N/D" || row[idx["close"]] == "N/D" {
+		return Quote{}, ErrNoData
+	}
+	d, err := time.Parse("2006-01-02", row[idx["date"]])
+	if err != nil {
+		return Quote{}, fmt.Errorf("parse date %q: %w", row[idx["date"]], err)
+	}
+	price, err := decimal.NewFromString(row[idx["close"]])
+	if err != nil {
+		return Quote{}, fmt.Errorf("parse close %q: %w", row[idx["close"]], err)
+	}
+	return Quote{
+		Symbol: strings.ToUpper(sym),
+		Date:   d,
+		Close:  price,
+	}, nil
+}
+
+// Daily fetches the daily history for symbol in [from, to] inclusive from
+// Stooq's q/d/l/?i=d endpoint (apikey required). Returns rows sorted by
+// date ascending; empty slice when Stooq has no rows in the window.
+func (f *StooqFetcher) Daily(ctx context.Context, symbol string, from, to time.Time) ([]Quote, error) {
+	if f.apiKey == "" {
+		return nil, ErrNoAPIKey
+	}
+	sym := strings.ToLower(strings.TrimSpace(symbol))
+	if sym == "" {
+		return nil, errors.New("quotes: empty symbol")
+	}
+	if to.Before(from) {
+		return nil, fmt.Errorf("quotes: to %s before from %s", to.Format("2006-01-02"), from.Format("2006-01-02"))
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, stooqHistoryURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.URL.RawQuery = url.Values{
+		"s":      {sym},
+		"i":      {"d"},
+		"d1":     {from.Format("20060102")},
+		"d2":     {to.Format("20060102")},
+		"apikey": {f.apiKey},
+	}.Encode()
+	req.Header.Set("User-Agent", stooqUserAgent)
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("stooq daily request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("stooq daily http %d", resp.StatusCode)
+	}
+	return parseStooqDaily(resp.Body, sym)
+}
+
+// parseStooqDaily reads the daily-history CSV. Header:
+// Date,Open,High,Low,Close,Volume — no symbol column.
+func parseStooqDaily(r io.Reader, sym string) ([]Quote, error) {
+	reader := csv.NewReader(r)
+	reader.FieldsPerRecord = -1
+	header, err := reader.Read()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return []Quote{}, nil
+		}
+		return nil, fmt.Errorf("read header: %w", err)
+	}
+	idx := map[string]int{}
+	for i, name := range header {
+		idx[strings.ToLower(strings.TrimSpace(name))] = i
+	}
+	for _, n := range []string{"date", "close"} {
+		if _, ok := idx[n]; !ok {
+			return nil, fmt.Errorf("stooq daily missing %q column", n)
+		}
+	}
+	out := []Quote{}
+	upperSym := strings.ToUpper(sym)
+	for {
+		row, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read row: %w", err)
+		}
+		if row[idx["date"]] == "" || row[idx["close"]] == "" {
+			continue
+		}
+		d, err := time.Parse("2006-01-02", row[idx["date"]])
+		if err != nil {
+			return nil, fmt.Errorf("parse date %q: %w", row[idx["date"]], err)
+		}
+		price, err := decimal.NewFromString(row[idx["close"]])
+		if err != nil {
+			return nil, fmt.Errorf("parse close %q: %w", row[idx["close"]], err)
+		}
+		out = append(out, Quote{Symbol: upperSym, Date: d, Close: price})
+	}
+	return out, nil
+}

--- a/backend-go/internal/quotes/stooq_test.go
+++ b/backend-go/internal/quotes/stooq_test.go
@@ -1,0 +1,158 @@
+package quotes
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestParseStooqLatest_Success(t *testing.T) {
+	csv := "Symbol,Date,Time,Open,High,Low,Close,Volume\nISAC.UK,2026-05-27,11:41:18,121.13,121.49,121.10,121.48,21839\n"
+	q, err := parseStooqLatest(strings.NewReader(csv), "isac.uk")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if q.Symbol != "ISAC.UK" {
+		t.Errorf("Symbol = %q, want ISAC.UK", q.Symbol)
+	}
+	if !q.Close.Equal(decimal.RequireFromString("121.48")) {
+		t.Errorf("Close = %s, want 121.48", q.Close)
+	}
+	if q.Date.Format("2006-01-02") != "2026-05-27" {
+		t.Errorf("Date = %s, want 2026-05-27", q.Date)
+	}
+}
+
+func TestParseStooqLatest_NoData(t *testing.T) {
+	csv := "Symbol,Date,Time,Open,High,Low,Close,Volume\nNONSENSE.XX,N/D,N/D,N/D,N/D,N/D,N/D,N/D\n"
+	_, err := parseStooqLatest(strings.NewReader(csv), "nonsense.xx")
+	if !errors.Is(err, ErrNoData) {
+		t.Errorf("want ErrNoData, got %v", err)
+	}
+}
+
+// redirectTransport rewrites every outgoing request to point at target.
+// Used to redirect Latest's hardcoded Stooq URL at an httptest server.
+type redirectTransport struct {
+	target *url.URL
+}
+
+func (r *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = r.target.Scheme
+	req.URL.Host = r.target.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func TestStooqFetcher_Latest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("s"); got != "isac.uk" {
+			t.Errorf("symbol = %q, want isac.uk", got)
+		}
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write([]byte("Symbol,Date,Time,Open,High,Low,Close,Volume\nISAC.UK,2026-05-27,11:41:18,121.13,121.49,121.10,121.48,21839\n"))
+	}))
+	defer srv.Close()
+	target, _ := url.Parse(srv.URL)
+	f := NewStooqFetcher("")
+	f.client.Transport = &redirectTransport{target: target}
+	q, err := f.Latest(context.Background(), "ISAC.UK")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !q.Close.Equal(decimal.RequireFromString("121.48")) {
+		t.Errorf("Close = %s, want 121.48", q.Close)
+	}
+}
+
+func TestStooqFetcher_Http500(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	target, _ := url.Parse(srv.URL)
+	f := NewStooqFetcher("")
+	f.client.Transport = &redirectTransport{target: target}
+	_, err := f.Latest(context.Background(), "isac.uk")
+	if err == nil || !strings.Contains(err.Error(), "stooq http 500") {
+		t.Errorf("want http 500 error, got %v", err)
+	}
+}
+
+func TestStooqFetcher_EmptySymbolError(t *testing.T) {
+	f := NewStooqFetcher("")
+	_, err := f.Latest(context.Background(), "  ")
+	if err == nil {
+		t.Errorf("want error for empty symbol")
+	}
+}
+
+func TestParseStooqDaily_Success(t *testing.T) {
+	csv := "Date,Open,High,Low,Close,Volume\n2026-05-20,118.16,119.22,117.55,119,526880\n2026-05-21,118.97,119.45,118.51,118.68,208618\n"
+	rows, err := parseStooqDaily(strings.NewReader(csv), "isac.uk")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0].Date.Format("2006-01-02") != "2026-05-20" {
+		t.Errorf("row 0 date = %s, want 2026-05-20", rows[0].Date)
+	}
+	if !rows[0].Close.Equal(decimal.RequireFromString("119")) {
+		t.Errorf("row 0 close = %s, want 119", rows[0].Close)
+	}
+	if rows[1].Symbol != "ISAC.UK" {
+		t.Errorf("symbol = %q, want ISAC.UK", rows[1].Symbol)
+	}
+}
+
+func TestParseStooqDaily_EmptyBody(t *testing.T) {
+	rows, err := parseStooqDaily(strings.NewReader(""), "isac.uk")
+	if err != nil {
+		t.Fatalf("unexpected err on empty body: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("want empty rows on EOF, got %d", len(rows))
+	}
+}
+
+func TestStooqFetcher_DailyRequiresAPIKey(t *testing.T) {
+	f := NewStooqFetcher("")
+	_, err := f.Daily(context.Background(), "isac.uk", time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC), time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC))
+	if !errors.Is(err, ErrNoAPIKey) {
+		t.Errorf("want ErrNoAPIKey, got %v", err)
+	}
+}
+
+func TestStooqFetcher_Daily(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("apikey") != "test-key" {
+			t.Errorf("apikey = %q, want test-key", q.Get("apikey"))
+		}
+		if q.Get("s") != "isac.uk" || q.Get("i") != "d" || q.Get("d1") != "20260520" || q.Get("d2") != "20260527" {
+			t.Errorf("query = %v, want s=isac.uk i=d d1=20260520 d2=20260527", q)
+		}
+		_, _ = w.Write([]byte("Date,Open,High,Low,Close,Volume\n2026-05-20,118.16,119.22,117.55,119,526880\n"))
+	}))
+	defer srv.Close()
+	target, _ := url.Parse(srv.URL)
+	f := NewStooqFetcher("test-key")
+	f.client.Transport = &redirectTransport{target: target}
+	rows, err := f.Daily(context.Background(), "ISAC.UK",
+		time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
 	"github.com/Automaat/finance-buddy/backend-go/internal/investment"
 	"github.com/Automaat/finance-buddy/backend-go/internal/pit38"
+	"github.com/Automaat/finance-buddy/backend-go/internal/quotes"
 	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
 	"github.com/Automaat/finance-buddy/backend-go/internal/rules"
@@ -65,6 +66,10 @@ type Config struct {
 	// CookieSecure marks the session cookie Secure (FB_COOKIE_SECURE).
 	// Off by default so plain-HTTP local/LAN deploys work.
 	CookieSecure bool
+	// StooqAPIKey unlocks the Stooq daily-history endpoint (FB_STOOQ_APIKEY).
+	// Empty means the scheduler/refresh handler falls back to the keyless
+	// "latest" snapshot — daily backfill is then unavailable.
+	StooqAPIKey string
 }
 
 // Deps bundles the runtime dependencies the router needs to construct
@@ -117,20 +122,20 @@ func registerRoutes(r chi.Router, cfg Config, pool *pgxpool.Pool, logger *slog.L
 		r.With(auth.RequireAdmin).Get("/api/auth/users", authHandler.ListUsers)
 		r.With(auth.RequireAdmin).Post("/api/auth/users", authHandler.CreateUser)
 		r.With(auth.RequireAdmin).Put("/api/auth/users/{id}", authHandler.UpdateUser)
-		registerAPIRoutes(r, pool, logger)
+		registerAPIRoutes(r, cfg, pool, logger)
 	})
 }
 
-func registerAPIRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
+func registerAPIRoutes(r chi.Router, cfg Config, pool *pgxpool.Pool, logger *slog.Logger) {
 	registerCoreRoutes(r, pool, logger)
 	registerEquityRoutes(r, pool, logger)
 	registerCPIAndPayrollRoutes(r, pool, logger)
 	registerPortfolioRoutes(r, pool, logger)
-	registerLedgerRoutes(r, pool, logger)
+	registerLedgerRoutes(r, cfg, pool, logger)
 	registerDashboardRoutes(r, pool, logger)
 }
 
-func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
+func registerLedgerRoutes(r chi.Router, cfg Config, pool *pgxpool.Pool, logger *slog.Logger) {
 	txStore := transactions.NewStore(pool)
 	txHandler := transactions.NewHandler(txStore, logger)
 	r.Get("/api/accounts/{account_id}/transactions", txHandler.ListForAccount)
@@ -180,17 +185,7 @@ func registerLedgerRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	r.Get("/api/investment/bond-stats", invHandler.BondStats)
 	r.Get("/api/investment/returns", invHandler.Returns)
 
-	hStore := holdings.NewStore(pool)
-	hHandler := holdings.NewHandler(hStore, logger)
-	r.Get("/api/holdings", hHandler.Holdings)
-	r.Get("/api/holdings/securities", hHandler.ListSecurities)
-	r.Post("/api/holdings/securities", hHandler.CreateSecurity)
-	r.Delete("/api/holdings/securities/{id}", hHandler.DeleteSecurity)
-	r.Get("/api/holdings/securities/{id}/quotes", hHandler.ListQuotes)
-	r.Post("/api/holdings/securities/{id}/quotes", hHandler.UpsertQuote)
-	r.Get("/api/holdings/lots", hHandler.ListLots)
-	r.Post("/api/holdings/lots", hHandler.CreateLot)
-	r.Delete("/api/holdings/lots/{id}", hHandler.DeleteLot)
+	registerHoldingsRoutes(r, cfg.StooqAPIKey, pool, logger)
 
 	registerPIT38Routes(r, pool, logger)
 
@@ -224,6 +219,24 @@ func registerDashboardRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logg
 func registerPIT38Routes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 	pitHandler := pit38.NewHandler(pit38.NewStore(pool), fx.NewService(pool, logger), logger)
 	r.Get("/api/pit38/realized", pitHandler.Realized)
+}
+
+func registerHoldingsRoutes(r chi.Router, stooqAPIKey string, pool *pgxpool.Pool, logger *slog.Logger) {
+	hStore := holdings.NewStore(pool)
+	hHandler := holdings.NewHandler(hStore, fx.NewService(pool, logger), logger)
+	r.Get("/api/holdings", hHandler.Holdings)
+	r.Get("/api/holdings/securities", hHandler.ListSecurities)
+	r.Post("/api/holdings/securities", hHandler.CreateSecurity)
+	r.Delete("/api/holdings/securities/{id}", hHandler.DeleteSecurity)
+	r.Get("/api/holdings/securities/{id}/quotes", hHandler.ListQuotes)
+	r.Post("/api/holdings/securities/{id}/quotes", hHandler.UpsertQuote)
+	r.Get("/api/holdings/lots", hHandler.ListLots)
+	r.Post("/api/holdings/lots", hHandler.CreateLot)
+	r.Delete("/api/holdings/lots/{id}", hHandler.DeleteLot)
+
+	stooq := quotes.NewStooqFetcher(stooqAPIKey)
+	refresh := quotes.NewRefreshHandler(hStore, stooq, logger)
+	r.Post("/api/holdings/refresh-quotes", refresh.Refresh)
 }
 
 func registerCoreRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,6 +30,7 @@ services:
       - FB_ADMIN_USERNAME=${FB_ADMIN_USERNAME:-admin}
       - FB_ADMIN_PASSWORD=${FB_ADMIN_PASSWORD:-admin}
       - FB_COOKIE_SECURE=false
+      - FB_STOOQ_APIKEY=${FB_STOOQ_APIKEY:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - FB_ADMIN_USERNAME=${FB_ADMIN_USERNAME:-admin}
       - FB_ADMIN_PASSWORD=${FB_ADMIN_PASSWORD:?FB_ADMIN_PASSWORD must be set}
       - FB_COOKIE_SECURE=${FB_COOKIE_SECURE:-false}
+      - FB_STOOQ_APIKEY=${FB_STOOQ_APIKEY:-}
     ports:
       - '8000:8000'
     restart: unless-stopped

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -3464,12 +3464,17 @@ export interface paths {
                         "application/json": {
                             holdings?: {
                                 average_cost?: string;
+                                average_cost_pln?: string | null;
                                 cost_basis?: string;
+                                cost_basis_pln?: string | null;
                                 latest_quote?: string | null;
                                 latest_quote_date?: string | null;
+                                latest_quote_rate_pln?: string | null;
                                 market_value?: string;
+                                market_value_pln?: string | null;
                                 quantity?: string;
                                 realized_gain?: string;
+                                realized_gain_pln?: string | null;
                                 security?: {
                                     asset_type?: string;
                                     created_at?: string;
@@ -3480,6 +3485,7 @@ export interface paths {
                                     symbol?: string;
                                 };
                                 unrealized_gain?: string;
+                                unrealized_gain_pln?: string | null;
                             }[];
                         };
                     };
@@ -3603,6 +3609,47 @@ export interface paths {
                 };
             };
         };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/holdings/refresh-quotes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Pull latest quotes from Stooq for all securities */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            failed?: number;
+                            skipped_manual?: number;
+                            total?: number;
+                            written?: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;

--- a/src/routes/holdings/+page.svelte
+++ b/src/routes/holdings/+page.svelte
@@ -6,7 +6,7 @@
 	import { confirm } from '$lib/stores/confirm.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import PIT38Report from '$lib/components/PIT38Report.svelte';
-	import { Plus, Trash2, BarChart } from 'lucide-svelte';
+	import { Plus, Trash2, BarChart, RefreshCw } from 'lucide-svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
@@ -22,6 +22,7 @@
 	let lotModalOpen = $state(false);
 	let quoteModalOpen = $state(false);
 	let saving = $state(false);
+	let refreshing = $state(false);
 
 	let securityForm = $state({
 		symbol: '',
@@ -200,6 +201,36 @@
 		if (Number.isNaN(n)) return s;
 		return n.toLocaleString('pl-PL', { maximumFractionDigits: 6 });
 	}
+
+	async function refreshQuotes() {
+		refreshing = true;
+		try {
+			const apiUrl = resolveApiUrl();
+			const res = await fetch(`${apiUrl}/api/holdings/refresh-quotes`, {
+				method: 'POST'
+			});
+			if (!res.ok) {
+				const d = await res.json().catch(() => ({ detail: res.statusText }));
+				throw new Error(d.detail ?? res.statusText);
+			}
+			const body = (await res.json()) as {
+				total: number;
+				written: number;
+				skipped_manual: number;
+				failed: number;
+			};
+			toast.success(
+				`Stooq: ${body.written}/${body.total} zaktualizowano` +
+					(body.skipped_manual > 0 ? ` · ${body.skipped_manual} ręcznych pominięto` : '') +
+					(body.failed > 0 ? ` · ${body.failed} błędów` : '')
+			);
+			await invalidateAll();
+		} catch (err) {
+			if (err instanceof Error) toast.error(err.message);
+		} finally {
+			refreshing = false;
+		}
+	}
 </script>
 
 <svelte:head>
@@ -216,6 +247,16 @@
 			</p>
 		</div>
 		<div class="flex gap-2">
+			<button
+				type="button"
+				class="btn preset-tonal-surface"
+				onclick={refreshQuotes}
+				disabled={refreshing}
+				title="Pobierz aktualne ceny z Stooq"
+			>
+				<RefreshCw size={16} class={refreshing ? 'animate-spin' : ''} />
+				<span>{refreshing ? 'Aktualizuję…' : 'Aktualizuj ceny'}</span>
+			</button>
 			<button type="button" class="btn preset-tonal-surface" onclick={openSecurityModal}>
 				<Plus size={16} /><span>Nowy papier</span>
 			</button>
@@ -259,31 +300,67 @@
 							</td>
 							<td>{h.security.name}</td>
 							<td class="text-right">{fmtQty(h.quantity)}</td>
-							<td class="text-right">{fmt(h.average_cost)} {h.security.currency}</td>
-							<td class="text-right">{fmt(h.cost_basis)} {h.security.currency}</td>
+							<td class="text-right">
+								<div>{fmt(h.average_cost)} {h.security.currency}</div>
+								{#if h.average_cost_pln && h.security.currency !== 'PLN'}
+									<div class="text-xs text-surface-600-400">{fmt(h.average_cost_pln)} PLN</div>
+								{/if}
+							</td>
+							<td class="text-right">
+								<div>{fmt(h.cost_basis)} {h.security.currency}</div>
+								{#if h.cost_basis_pln && h.security.currency !== 'PLN'}
+									<div class="text-xs text-surface-600-400">{fmt(h.cost_basis_pln)} PLN</div>
+								{/if}
+							</td>
 							<td class="text-right">
 								{#if h.latest_quote}
 									{fmt(h.latest_quote)}
 									{h.security.currency}
-									<div class="text-xs text-surface-600-400">{h.latest_quote_date}</div>
+									<div class="text-xs text-surface-600-400">
+										{h.latest_quote_date}{#if h.latest_quote_rate_pln && h.security.currency !== 'PLN'}
+											· {fmt(h.latest_quote_rate_pln)} PLN/{h.security.currency}{/if}
+									</div>
 								{:else}
 									<span class="text-surface-600-400">—</span>
 								{/if}
 							</td>
-							<td class="text-right">{fmt(h.market_value)} {h.security.currency}</td>
+							<td class="text-right">
+								<div>{fmt(h.market_value)} {h.security.currency}</div>
+								{#if h.market_value_pln && h.security.currency !== 'PLN'}
+									<div class="text-xs text-surface-600-400">{fmt(h.market_value_pln)} PLN</div>
+								{/if}
+							</td>
 							<td
 								class="text-right {Number(h.unrealized_gain) >= 0
 									? 'text-success-500'
 									: 'text-error-500'}"
 							>
-								{fmt(h.unrealized_gain)}
+								<div>{fmt(h.unrealized_gain)} {h.security.currency}</div>
+								{#if h.unrealized_gain_pln && h.security.currency !== 'PLN'}
+									<div
+										class="text-xs {Number(h.unrealized_gain_pln) >= 0
+											? 'text-success-500'
+											: 'text-error-500'} opacity-80"
+									>
+										{fmt(h.unrealized_gain_pln)} PLN
+									</div>
+								{/if}
 							</td>
 							<td
 								class="text-right {Number(h.realized_gain) >= 0
 									? 'text-success-500'
 									: 'text-error-500'}"
 							>
-								{fmt(h.realized_gain)}
+								<div>{fmt(h.realized_gain)} {h.security.currency}</div>
+								{#if h.realized_gain_pln && h.security.currency !== 'PLN'}
+									<div
+										class="text-xs {Number(h.realized_gain_pln) >= 0
+											? 'text-success-500'
+											: 'text-error-500'} opacity-80"
+									>
+										{fmt(h.realized_gain_pln)} PLN
+									</div>
+								{/if}
 							</td>
 						</tr>
 					{/each}

--- a/src/routes/holdings/+page.ts
+++ b/src/routes/holdings/+page.ts
@@ -22,6 +22,12 @@ export interface HoldingRow {
 	market_value: string;
 	unrealized_gain: string;
 	realized_gain: string;
+	average_cost_pln: string | null;
+	cost_basis_pln: string | null;
+	market_value_pln: string | null;
+	unrealized_gain_pln: string | null;
+	realized_gain_pln: string | null;
+	latest_quote_rate_pln: string | null;
 }
 
 export interface AccountOption {


### PR DESCRIPTION
## Motivation

Holdings tab showed only native-currency values (USD for ISAC.UK
positions) — no PLN equivalent matching XTB's app. Latest quotes had to be
typed in by hand, with no historical price history per ticker.

This PR wires the existing NBP FX service into holdings for PLN cost basis +
market value, and adds Stooq integration for auto-pulled daily quotes with
gap-fill backfill from the first lot date.

## Implementation information

**FX in holdings** (already had `internal/fx` with NBP-backed cache):
- New `ComputeRunningPLN(ctx, lots, currency, rates)` walks lots chronologically,
  maintaining a parallel PLN weighted-average cost using each trade-date NBP
  rate. Same algorithm as `pit38.ComputeReport`.
- `HoldingRow` gains `MarketValuePLN`, `UnrealizedGainPLN`, `CostBasisPLN`,
  `AverageCostPLN`, `RealizedGainPLN`, `LatestQuoteRatePLN`. Nulls when any
  required FX rate is missing — UI degrades to native rendering.
- Frontend renders the PLN value as a subline under each native cell.

**Stooq integration** (new `internal/quotes` package):
- `StooqFetcher.Latest(symbol)` — keyless `q/l/?…` single-day snapshot.
- `StooqFetcher.Daily(symbol, from, to)` — `q/d/l/?…&apikey=…` daily history.
- `Scheduler` runs at 18:05 Europe/Warsaw (after EU close); on startup if
  stale (>18h since last write).
- Gap-fill: per security, `from = max(lastStooqDate+1, firstLot-7d)`;
  fall back to `Latest` when `ErrNoAPIKey`.
- `BulkUpsertAutomatedQuotes` preserves manual quotes
  (`WHERE source = EXCLUDED.source`).
- `POST /api/holdings/refresh-quotes` for user-pressed "now" pull —
  same primitive as the scheduler.
- New env: `FB_STOOQ_APIKEY` (free, one-time captcha at
  stooq.com/q/d/?get_apikey). Empty = keyless degraded mode.

Alternatives considered:
- Yahoo Finance fallback — declined; symbol mapping (ISAC.UK → ISAC.L) adds
  schema churn for marginal benefit when Stooq's keyless captcha is a 1-min
  hurdle.
- Generic scheduler infra — declined; copied the CPI scheduler shape
  (hand-rolled timer, single-instance) for consistency.

## Supporting documentation

n/a — incremental feature.

> Changelog: feat(holdings): Stooq quotes + PLN valuation