### PR TITLE
feat(holdings): per-account breakdown

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -5394,6 +5394,61 @@
                     "holdings": {
                       "items": {
                         "properties": {
+                          "accounts": {
+                            "items": {
+                              "properties": {
+                                "account_id": {
+                                  "type": "integer"
+                                },
+                                "account_name": {
+                                  "type": "string"
+                                },
+                                "average_cost": {
+                                  "type": "string"
+                                },
+                                "average_cost_pln": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "cost_basis": {
+                                  "type": "string"
+                                },
+                                "cost_basis_pln": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "market_value": {
+                                  "type": "string"
+                                },
+                                "market_value_pln": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "owner_user_id": {
+                                  "type": "integer"
+                                },
+                                "quantity": {
+                                  "type": "string"
+                                },
+                                "realized_gain": {
+                                  "type": "string"
+                                },
+                                "realized_gain_pln": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "unrealized_gain": {
+                                  "type": "string"
+                                },
+                                "unrealized_gain_pln": {
+                                  "nullable": true,
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
                           "average_cost": {
                             "type": "string"
                           },

--- a/backend-go/internal/accounts/handler.go
+++ b/backend-go/internal/accounts/handler.go
@@ -74,7 +74,7 @@ type Handler struct {
 // HoldingsValuator returns the live PLN market value per account derived
 // from the holdings ledger. Snapshot/current_value pre-fill consumes this
 // for stock/etf/bond/fund accounts so user-typed snapshots already match
-// what brokers show. Implemented by holdings.Store.
+// what brokers show. Implemented by holdings.Valuator.
 type HoldingsValuator interface {
 	AccountValuesPLN(ctx context.Context) (map[int]decimal.Decimal, error)
 }

--- a/backend-go/internal/accounts/handler.go
+++ b/backend-go/internal/accounts/handler.go
@@ -65,18 +65,39 @@ type listResponse struct {
 
 // Handler is the HTTP boundary for /api/accounts.
 type Handler struct {
-	store  *Store
-	cpi    CPILoader
-	logger *slog.Logger
+	store    *Store
+	cpi      CPILoader
+	holdings HoldingsValuator
+	logger   *slog.Logger
 }
 
-// NewHandler wires the store + CPI loader + logger. cpiStore may be nil in
-// tests; the real-yield columns then read as null on every account.
-func NewHandler(store *Store, cpiStore CPILoader, logger *slog.Logger) *Handler {
+// HoldingsValuator returns the live PLN market value per account derived
+// from the holdings ledger. Snapshot/current_value pre-fill consumes this
+// for stock/etf/bond/fund accounts so user-typed snapshots already match
+// what brokers show. Implemented by holdings.Store.
+type HoldingsValuator interface {
+	AccountValuesPLN(ctx context.Context) (map[int]decimal.Decimal, error)
+}
+
+// investmentCategories names the account categories whose current_value
+// gets overridden by the live holdings sum. Bank/cash categories keep the
+// snapshot-derived value (they don't have lots).
+var investmentCategories = map[string]bool{
+	"stock": true,
+	"etf":   true,
+	"bond":  true,
+	"fund":  true,
+}
+
+// NewHandler wires the store + CPI loader + holdings valuator + logger.
+// cpiStore may be nil in tests (real-yield columns become null). holdings
+// may be nil — then current_value falls back to the snapshot-derived value
+// for every account.
+func NewHandler(store *Store, cpiStore CPILoader, holdings HoldingsValuator, logger *slog.Logger) *Handler {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Handler{store: store, cpi: cpiStore, logger: logger}
+	return &Handler{store: store, cpi: cpiStore, holdings: holdings, logger: logger}
 }
 
 // realYieldCtx carries the per-request CPI snapshot used to compute real
@@ -172,6 +193,21 @@ func toResponse(a *Account, currentValue decimal.Decimal, ry realYieldCtx) respo
 	return out
 }
 
+// loadHoldingsValues fetches live PLN market value per account from the
+// holdings ledger. Returns nil on failure (logged) so the request still
+// succeeds with snapshot-derived values. Empty when no valuator wired.
+func (h *Handler) loadHoldingsValues(ctx context.Context) map[int]decimal.Decimal {
+	if h.holdings == nil {
+		return nil
+	}
+	vals, err := h.holdings.AccountValuesPLN(ctx)
+	if err != nil {
+		h.logger.Warn("accounts: holdings valuation failed", "err", err)
+		return nil
+	}
+	return vals
+}
+
 // realYieldCtxFor is the single-account variant of loadRealYieldCtx: when
 // the account has no nominal rate, the real-yield columns are null anyway,
 // so we skip the CPI round-trip entirely. Used by Create/Update where the
@@ -234,11 +270,17 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
+	holdingsValues := h.loadHoldingsValues(r.Context())
 	ry := h.loadRealYieldCtx(r.Context())
 	out := listResponse{Assets: []response{}, Liabilities: []response{}}
 	for i := range accounts {
 		a := &accounts[i]
 		cv := values[a.ID]
+		if investmentCategories[a.Category] {
+			if live, ok := holdingsValues[a.ID]; ok {
+				cv = live
+			}
+		}
 		resp := toResponse(a, cv, ry)
 		if a.Type == "asset" {
 			out.Assets = append(out.Assets, resp)

--- a/backend-go/internal/holdings/handler.go
+++ b/backend-go/internal/holdings/handler.go
@@ -330,6 +330,28 @@ type holdingRowResponse struct {
 	UnrealizedGainPLN  *string `json:"unrealized_gain_pln"`
 	RealizedGainPLN    *string `json:"realized_gain_pln"`
 	LatestQuoteRatePLN *string `json:"latest_quote_rate_pln"`
+
+	// Accounts is the per-account breakdown of this security position.
+	// Always present (possibly empty if quantities aggregate to zero per
+	// account). Snapshot pre-fill consumes these per-account totals.
+	Accounts []accountPositionResponse `json:"accounts"`
+}
+
+type accountPositionResponse struct {
+	AccountID         int     `json:"account_id"`
+	AccountName       string  `json:"account_name"`
+	OwnerUserID       int     `json:"owner_user_id"`
+	Quantity          string  `json:"quantity"`
+	AverageCost       string  `json:"average_cost"`
+	CostBasis         string  `json:"cost_basis"`
+	MarketValue       string  `json:"market_value"`
+	UnrealizedGain    string  `json:"unrealized_gain"`
+	RealizedGain      string  `json:"realized_gain"`
+	AverageCostPLN    *string `json:"average_cost_pln"`
+	CostBasisPLN      *string `json:"cost_basis_pln"`
+	MarketValuePLN    *string `json:"market_value_pln"`
+	UnrealizedGainPLN *string `json:"unrealized_gain_pln"`
+	RealizedGainPLN   *string `json:"realized_gain_pln"`
 }
 
 type holdingsResponse struct {
@@ -380,9 +402,42 @@ func (h *Handler) Holdings(w http.ResponseWriter, r *http.Request) {
 			row.UnrealizedGainPLN = &ug
 			row.LatestQuoteRatePLN = &rate
 		}
+		row.Accounts = make([]accountPositionResponse, 0, len(hr.Accounts))
+		for j := range hr.Accounts {
+			row.Accounts = append(row.Accounts, toAccountPosition(&hr.Accounts[j]))
+		}
 		out = append(out, row)
 	}
 	httputil.WriteJSON(w, http.StatusOK, holdingsResponse{Holdings: out})
+}
+
+func toAccountPosition(p *AccountPosition) accountPositionResponse {
+	resp := accountPositionResponse{
+		AccountID:      p.AccountID,
+		AccountName:    p.AccountName,
+		OwnerUserID:    p.OwnerUserID,
+		Quantity:       p.Running.Quantity.String(),
+		AverageCost:    p.Running.AverageCost.String(),
+		CostBasis:      p.Running.CostBasis.StringFixed(2),
+		MarketValue:    p.MarketValue.StringFixed(2),
+		UnrealizedGain: p.UnrealizedGain.StringFixed(2),
+		RealizedGain:   p.Running.RealizedGain.StringFixed(2),
+	}
+	if p.Running.HasPLN {
+		avg := p.Running.AverageCostPLN.StringFixed(4)
+		cb := p.Running.CostBasisPLN.StringFixed(2)
+		rg := p.Running.RealizedGainPLN.StringFixed(2)
+		resp.AverageCostPLN = &avg
+		resp.CostBasisPLN = &cb
+		resp.RealizedGainPLN = &rg
+	}
+	if p.HasPLN {
+		mv := p.MarketValuePLN.StringFixed(2)
+		ug := p.UnrealizedGainPLN.StringFixed(2)
+		resp.MarketValuePLN = &mv
+		resp.UnrealizedGainPLN = &ug
+	}
+	return resp
 }
 
 // --- shared helpers ---

--- a/backend-go/internal/holdings/store.go
+++ b/backend-go/internal/holdings/store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -59,6 +60,26 @@ type HoldingRow struct {
 	MarketValuePLN     decimal.Decimal
 	UnrealizedGainPLN  decimal.Decimal
 	LatestQuoteRatePLN decimal.Decimal
+
+	// Accounts is the per-account breakdown for this security. The same
+	// position appears in each account that has lots; the consolidated
+	// fields above are the sum/weighted-average across all of them.
+	Accounts []AccountPosition
+}
+
+// AccountPosition is the slice of a HoldingRow attributable to one account.
+// Cost basis is the weighted average across that account's lots only;
+// LatestQuote and FX rate are shared with the consolidated row.
+type AccountPosition struct {
+	AccountID         int
+	AccountName       string
+	OwnerUserID       int
+	Running           Running
+	MarketValue       decimal.Decimal
+	UnrealizedGain    decimal.Decimal
+	HasPLN            bool
+	MarketValuePLN    decimal.Decimal
+	UnrealizedGainPLN decimal.Decimal
 }
 
 // Sentinel errors.
@@ -340,6 +361,42 @@ func (s *Store) BulkUpsertAutomatedQuotes(ctx context.Context, rows []PriceQuote
 	return written, nil
 }
 
+// Valuator binds a Store + RateProvider so callers that don't want to deal
+// with FX wiring (notably accounts.Handler) can get per-account PLN values
+// through one method. Implements accounts.HoldingsValuator.
+type Valuator struct {
+	store *Store
+	rates RateProvider
+}
+
+// NewValuator wires a store + rates. rates may be nil — the valuator then
+// returns native-currency-zero for every account (PLN conversion needs FX).
+func NewValuator(store *Store, rates RateProvider) *Valuator {
+	return &Valuator{store: store, rates: rates}
+}
+
+// AccountValuesPLN returns the live PLN market value for every account that
+// holds at least one open position with FX data. Sums per-security MV PLN
+// across the account's lots.
+func (v *Valuator) AccountValuesPLN(ctx context.Context) (map[int]decimal.Decimal, error) {
+	rows, err := v.store.Holdings(ctx, v.rates)
+	if err != nil {
+		return nil, err
+	}
+	out := map[int]decimal.Decimal{}
+	for i := range rows {
+		accs := rows[i].Accounts
+		for j := range accs {
+			acct := &accs[j]
+			if !acct.HasPLN {
+				continue
+			}
+			out[acct.AccountID] = out[acct.AccountID].Add(acct.MarketValuePLN)
+		}
+	}
+	return out, nil
+}
+
 // LatestStooqQuoteTime returns the most recent created_at across price_quotes
 // rows tagged source='stooq'. Zero time when no stooq quotes exist yet.
 // Used by the quotes scheduler to decide whether to refresh on startup.
@@ -377,10 +434,36 @@ func (s *Store) latestQuotes(ctx context.Context) (map[int]PriceQuote, error) {
 	return out, rows.Err()
 }
 
+// accountMeta is the slice of accounts data Holdings needs to label the
+// per-account breakdown. Keyed by account id.
+type accountMeta struct {
+	Name        string
+	OwnerUserID int
+}
+
+func (s *Store) accountMeta(ctx context.Context) (map[int]accountMeta, error) {
+	rows, err := s.pool.Query(ctx, `SELECT id, name, owner_user_id FROM accounts`)
+	if err != nil {
+		return nil, fmt.Errorf("account meta: %w", err)
+	}
+	defer rows.Close()
+	out := map[int]accountMeta{}
+	for rows.Next() {
+		var id, owner int
+		var name string
+		if err := rows.Scan(&id, &name, &owner); err != nil {
+			return nil, fmt.Errorf("scan account meta: %w", err)
+		}
+		out[id] = accountMeta{Name: name, OwnerUserID: owner}
+	}
+	return out, rows.Err()
+}
+
 // Holdings replays every lot, groups by security, attaches the latest quote,
 // and returns one HoldingRow per security with non-zero quantity. When rates
 // is non-nil, PLN-converted fields are also populated using trade-date NBP
 // rates for cost basis and the latest-quote-date rate for market value.
+// Each row also exposes a per-account breakdown via HoldingRow.Accounts.
 func (s *Store) Holdings(ctx context.Context, rates RateProvider) ([]HoldingRow, error) {
 	securities, err := s.ListSecurities(ctx)
 	if err != nil {
@@ -394,35 +477,126 @@ func (s *Store) Holdings(ctx context.Context, rates RateProvider) ([]HoldingRow,
 	if err != nil {
 		return nil, err
 	}
-	bySec := map[int][]Lot{}
-	for i := range allLots {
-		l := &allLots[i]
-		bySec[l.SecurityID] = append(bySec[l.SecurityID], *l)
+	accounts, err := s.accountMeta(ctx)
+	if err != nil {
+		return nil, err
 	}
+	bySec, bySecAcct := groupLots(allLots)
 	out := []HoldingRow{}
 	for _, sec := range securities {
-		lots := bySec[sec.ID]
-		run, runErr := ComputeRunningPLN(ctx, lots, sec.Currency, rates)
-		if runErr != nil {
-			slog.Default().Warn("holdings: skipping security with bad lot history",
-				"security_id", sec.ID, "symbol", sec.Symbol, "err", runErr)
+		row, ok := s.buildHoldingRow(ctx, sec, bySec[sec.ID], bySecAcct[sec.ID], quotes, accounts, rates)
+		if !ok {
 			continue
 		}
-		if run.Quantity.IsZero() && run.RealizedGain.IsZero() {
-			continue
-		}
-		row := HoldingRow{Security: sec, Running: run}
-		if q, ok := quotes[sec.ID]; ok {
-			row.LatestQuote = q.Price
-			d := q.Date
-			row.LatestQuoteDate = &d
-		}
-		row.MarketValue = MarketValue(run, row.LatestQuote)
-		row.UnrealizedGain = UnrealizedGain(run, row.LatestQuote)
-		s.fillPLNValuation(ctx, &row, rates)
 		out = append(out, row)
 	}
 	return out, nil
+}
+
+// groupLots bins every lot by security_id and by (security_id, account_id).
+// Returned in lot insertion order, which matches ListLots' chronological sort.
+func groupLots(lots []Lot) (map[int][]Lot, map[int]map[int][]Lot) {
+	bySec := map[int][]Lot{}
+	bySecAcct := map[int]map[int][]Lot{}
+	for i := range lots {
+		l := &lots[i]
+		bySec[l.SecurityID] = append(bySec[l.SecurityID], *l)
+		if bySecAcct[l.SecurityID] == nil {
+			bySecAcct[l.SecurityID] = map[int][]Lot{}
+		}
+		bySecAcct[l.SecurityID][l.AccountID] = append(bySecAcct[l.SecurityID][l.AccountID], *l)
+	}
+	return bySec, bySecAcct
+}
+
+// buildHoldingRow runs ComputeRunningPLN for the consolidated security
+// position and then for every account that holds it, returning the assembled
+// HoldingRow. Skips (returns false) when the security has no open position
+// or its lot history is corrupted.
+func (s *Store) buildHoldingRow(
+	ctx context.Context,
+	sec Security,
+	allLots []Lot,
+	perAccount map[int][]Lot,
+	quotes map[int]PriceQuote,
+	accounts map[int]accountMeta,
+	rates RateProvider,
+) (HoldingRow, bool) {
+	run, runErr := ComputeRunningPLN(ctx, allLots, sec.Currency, rates)
+	if runErr != nil {
+		slog.Default().Warn("holdings: skipping security with bad lot history",
+			"security_id", sec.ID, "symbol", sec.Symbol, "err", runErr)
+		return HoldingRow{}, false
+	}
+	if run.Quantity.IsZero() && run.RealizedGain.IsZero() {
+		return HoldingRow{}, false
+	}
+	row := HoldingRow{Security: sec, Running: run}
+	if q, ok := quotes[sec.ID]; ok {
+		row.LatestQuote = q.Price
+		d := q.Date
+		row.LatestQuoteDate = &d
+	}
+	row.MarketValue = MarketValue(run, row.LatestQuote)
+	row.UnrealizedGain = UnrealizedGain(run, row.LatestQuote)
+	s.fillPLNValuation(ctx, &row, rates)
+
+	row.Accounts = s.buildAccountPositions(ctx, sec, perAccount, accounts, row.LatestQuote, rates, row.LatestQuoteRatePLN, row.HasPLN)
+	return row, true
+}
+
+// buildAccountPositions runs the cost-basis walk per account and returns one
+// AccountPosition per account that currently holds the security. Reuses the
+// consolidated row's FX rate (already looked up against latest-quote-date)
+// so per-account PLN math is consistent with the consolidated total.
+func (s *Store) buildAccountPositions(
+	ctx context.Context,
+	sec Security,
+	perAccount map[int][]Lot,
+	accounts map[int]accountMeta,
+	latestQuote decimal.Decimal,
+	rates RateProvider,
+	rowRatePLN decimal.Decimal,
+	rowHasPLN bool,
+) []AccountPosition {
+	out := []AccountPosition{}
+	for accountID, lots := range perAccount {
+		runAcct, err := ComputeRunningPLN(ctx, lots, sec.Currency, rates)
+		if err != nil {
+			slog.Default().Warn("holdings: skipping account with bad lot history",
+				"security_id", sec.ID, "account_id", accountID, "err", err)
+			continue
+		}
+		if runAcct.Quantity.IsZero() && runAcct.RealizedGain.IsZero() {
+			continue
+		}
+		meta := accounts[accountID]
+		pos := AccountPosition{
+			AccountID:      accountID,
+			AccountName:    meta.Name,
+			OwnerUserID:    meta.OwnerUserID,
+			Running:        runAcct,
+			MarketValue:    MarketValue(runAcct, latestQuote),
+			UnrealizedGain: UnrealizedGain(runAcct, latestQuote),
+		}
+		if rowHasPLN && runAcct.HasPLN && !rowRatePLN.IsZero() {
+			mvPLN := pos.MarketValue.Mul(rowRatePLN)
+			if sec.Currency == "PLN" {
+				mvPLN = pos.MarketValue
+			}
+			pos.HasPLN = true
+			pos.MarketValuePLN = mvPLN
+			pos.UnrealizedGainPLN = mvPLN.Sub(runAcct.CostBasisPLN)
+		}
+		out = append(out, pos)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].OwnerUserID != out[j].OwnerUserID {
+			return out[i].OwnerUserID < out[j].OwnerUserID
+		}
+		return out[i].AccountID < out[j].AccountID
+	})
+	return out
 }
 
 // fillPLNValuation converts MarketValue + UnrealizedGain to PLN using the FX

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -316,7 +316,8 @@ func registerCPIAndPayrollRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.
 
 func registerPortfolioRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 	aggregatesStore := aggregates.NewStore(pool)
-	accountsHandler := accounts.NewHandler(accounts.NewStore(pool, aggregatesStore), cpi.NewStore(pool), logger)
+	holdingsValuator := holdings.NewValuator(holdings.NewStore(pool), fx.NewService(pool, logger))
+	accountsHandler := accounts.NewHandler(accounts.NewStore(pool, aggregatesStore), cpi.NewStore(pool), holdingsValuator, logger)
 	r.Route("/api/accounts", func(r chi.Router) {
 		r.Get("/", accountsHandler.List)
 		r.Post("/", accountsHandler.Create)

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -3463,6 +3463,22 @@ export interface paths {
                     content: {
                         "application/json": {
                             holdings?: {
+                                accounts?: {
+                                    account_id?: number;
+                                    account_name?: string;
+                                    average_cost?: string;
+                                    average_cost_pln?: string | null;
+                                    cost_basis?: string;
+                                    cost_basis_pln?: string | null;
+                                    market_value?: string;
+                                    market_value_pln?: string | null;
+                                    owner_user_id?: number;
+                                    quantity?: string;
+                                    realized_gain?: string;
+                                    realized_gain_pln?: string | null;
+                                    unrealized_gain?: string;
+                                    unrealized_gain_pln?: string | null;
+                                }[];
                                 average_cost?: string;
                                 average_cost_pln?: string | null;
                                 cost_basis?: string;

--- a/src/routes/holdings/+page.svelte
+++ b/src/routes/holdings/+page.svelte
@@ -278,7 +278,7 @@
 			<table class="table table-hover text-sm">
 				<thead>
 					<tr>
-						<th>Symbol</th>
+						<th>Symbol / Konto</th>
 						<th>Nazwa</th>
 						<th class="text-right">Ilość</th>
 						<th class="text-right">Średnia cena</th>
@@ -291,11 +291,11 @@
 				</thead>
 				<tbody>
 					{#each data.holdings as h (h.security.id)}
-						<tr>
+						<tr class="bg-surface-100-900/40 font-semibold">
 							<td>
-								<div class="font-semibold">{h.security.symbol}</div>
+								<div>{h.security.symbol}</div>
 								{#if h.security.isin}
-									<div class="text-xs text-surface-600-400">{h.security.isin}</div>
+									<div class="text-xs font-normal text-surface-600-400">{h.security.isin}</div>
 								{/if}
 							</td>
 							<td>{h.security.name}</td>
@@ -303,20 +303,24 @@
 							<td class="text-right">
 								<div>{fmt(h.average_cost)} {h.security.currency}</div>
 								{#if h.average_cost_pln && h.security.currency !== 'PLN'}
-									<div class="text-xs text-surface-600-400">{fmt(h.average_cost_pln)} PLN</div>
+									<div class="text-xs font-normal text-surface-600-400">
+										{fmt(h.average_cost_pln)} PLN
+									</div>
 								{/if}
 							</td>
 							<td class="text-right">
 								<div>{fmt(h.cost_basis)} {h.security.currency}</div>
 								{#if h.cost_basis_pln && h.security.currency !== 'PLN'}
-									<div class="text-xs text-surface-600-400">{fmt(h.cost_basis_pln)} PLN</div>
+									<div class="text-xs font-normal text-surface-600-400">
+										{fmt(h.cost_basis_pln)} PLN
+									</div>
 								{/if}
 							</td>
 							<td class="text-right">
 								{#if h.latest_quote}
 									{fmt(h.latest_quote)}
 									{h.security.currency}
-									<div class="text-xs text-surface-600-400">
+									<div class="text-xs font-normal text-surface-600-400">
 										{h.latest_quote_date}{#if h.latest_quote_rate_pln && h.security.currency !== 'PLN'}
 											· {fmt(h.latest_quote_rate_pln)} PLN/{h.security.currency}{/if}
 									</div>
@@ -327,7 +331,9 @@
 							<td class="text-right">
 								<div>{fmt(h.market_value)} {h.security.currency}</div>
 								{#if h.market_value_pln && h.security.currency !== 'PLN'}
-									<div class="text-xs text-surface-600-400">{fmt(h.market_value_pln)} PLN</div>
+									<div class="text-xs font-normal text-surface-600-400">
+										{fmt(h.market_value_pln)} PLN
+									</div>
 								{/if}
 							</td>
 							<td
@@ -338,7 +344,7 @@
 								<div>{fmt(h.unrealized_gain)} {h.security.currency}</div>
 								{#if h.unrealized_gain_pln && h.security.currency !== 'PLN'}
 									<div
-										class="text-xs {Number(h.unrealized_gain_pln) >= 0
+										class="text-xs font-normal {Number(h.unrealized_gain_pln) >= 0
 											? 'text-success-500'
 											: 'text-error-500'} opacity-80"
 									>
@@ -354,7 +360,7 @@
 								<div>{fmt(h.realized_gain)} {h.security.currency}</div>
 								{#if h.realized_gain_pln && h.security.currency !== 'PLN'}
 									<div
-										class="text-xs {Number(h.realized_gain_pln) >= 0
+										class="text-xs font-normal {Number(h.realized_gain_pln) >= 0
 											? 'text-success-500'
 											: 'text-error-500'} opacity-80"
 									>
@@ -363,6 +369,56 @@
 								{/if}
 							</td>
 						</tr>
+						{#each h.accounts as a (a.account_id)}
+							<tr class="text-surface-700-300">
+								<td class="pl-6 text-xs">↳ {a.account_name}</td>
+								<td></td>
+								<td class="text-right">{fmtQty(a.quantity)}</td>
+								<td class="text-right">
+									<div>{fmt(a.average_cost)} {h.security.currency}</div>
+									{#if a.average_cost_pln && h.security.currency !== 'PLN'}
+										<div class="text-xs text-surface-600-400">{fmt(a.average_cost_pln)} PLN</div>
+									{/if}
+								</td>
+								<td class="text-right">
+									<div>{fmt(a.cost_basis)} {h.security.currency}</div>
+									{#if a.cost_basis_pln && h.security.currency !== 'PLN'}
+										<div class="text-xs text-surface-600-400">{fmt(a.cost_basis_pln)} PLN</div>
+									{/if}
+								</td>
+								<td class="text-right text-surface-600-400">—</td>
+								<td class="text-right">
+									<div>{fmt(a.market_value)} {h.security.currency}</div>
+									{#if a.market_value_pln && h.security.currency !== 'PLN'}
+										<div class="text-xs text-surface-600-400">{fmt(a.market_value_pln)} PLN</div>
+									{/if}
+								</td>
+								<td
+									class="text-right {Number(a.unrealized_gain) >= 0
+										? 'text-success-500'
+										: 'text-error-500'}"
+								>
+									<div>{fmt(a.unrealized_gain)} {h.security.currency}</div>
+									{#if a.unrealized_gain_pln && h.security.currency !== 'PLN'}
+										<div
+											class="text-xs {Number(a.unrealized_gain_pln) >= 0
+												? 'text-success-500'
+												: 'text-error-500'} opacity-80"
+										>
+											{fmt(a.unrealized_gain_pln)} PLN
+										</div>
+									{/if}
+								</td>
+								<td
+									class="text-right {Number(a.realized_gain) >= 0
+										? 'text-success-500'
+										: 'text-error-500'}"
+								>
+									{fmt(a.realized_gain)}
+									{h.security.currency}
+								</td>
+							</tr>
+						{/each}
 					{/each}
 				</tbody>
 			</table>

--- a/src/routes/holdings/+page.ts
+++ b/src/routes/holdings/+page.ts
@@ -12,6 +12,23 @@ export interface SecurityRow {
 	created_at: string;
 }
 
+export interface AccountPosition {
+	account_id: number;
+	account_name: string;
+	owner_user_id: number;
+	quantity: string;
+	average_cost: string;
+	cost_basis: string;
+	market_value: string;
+	unrealized_gain: string;
+	realized_gain: string;
+	average_cost_pln: string | null;
+	cost_basis_pln: string | null;
+	market_value_pln: string | null;
+	unrealized_gain_pln: string | null;
+	realized_gain_pln: string | null;
+}
+
 export interface HoldingRow {
 	security: SecurityRow;
 	quantity: string;
@@ -28,6 +45,7 @@ export interface HoldingRow {
 	unrealized_gain_pln: string | null;
 	realized_gain_pln: string | null;
 	latest_quote_rate_pln: string | null;
+	accounts: AccountPosition[];
 }
 
 export interface AccountOption {


### PR DESCRIPTION
## Motivation

The holdings table aggregated by ticker, so the same ETF held by
different owners/brokers (e.g. ISAC.UK in Ewa's IKE XTB + Marcin's
IKZE Mbank) merged into one row. Couldn't cross-reference broker
positions 1:1, and snapshot creation kept needing manual entry of
account balances that the holdings ledger already knew.

## Implementation information

**Backend** (`internal/holdings/`)
- `HoldingRow.Accounts []AccountPosition` — per-account slice of
  the consolidated position. Each AccountPosition runs
  `ComputeRunningPLN` on just that account's lots, reusing the
  consolidated `LatestQuote` + FX rate so per-account MV/PLN math
  is consistent with the total.
- `Store.Holdings` adds an `accountMeta` lookup and groups lots
  by `(security_id, account_id)` in addition to the existing
  per-security grouping.
- `Valuator` type binds Store + RateProvider and exposes
  `AccountValuesPLN(ctx) → map[account_id]MV_PLN` — implements
  `accounts.HoldingsValuator`.

**Backend** (`internal/accounts/`)
- `Handler` accepts a `HoldingsValuator`. In `List`, after the
  snapshot-derived `current_value` lookup, accounts whose category
  is in {stock, etf, bond, fund} get their value overridden with
  the live holdings sum. Snapshot form already reads
  `current_value`, so per-account live values auto-fill the next
  monthly snapshot.

**Frontend** (`src/routes/holdings/+page.svelte`)
- Security renders as a tonal header row with per-account sub-rows
  underneath ("↳ Account Name"). Each sub-row shows that account's
  qty/cost/MV/gain in native + PLN.

Alternatives considered:
- Replacing the consolidated row entirely with per-account rows —
  declined; consolidated row is still useful for "total exposure
  per ticker" view.
- Adding a `stooq_symbol` column and dropping `UNIQUE(symbol)` —
  not needed once per-account breakdown is available; deferred.

## Supporting documentation

n/a — incremental refactor on top of #656.

> Changelog: feat(holdings): per-account breakdown