### PR TITLE
fix(holdings): handle null owner_user_id

### DIFF
--- a/backend-go/internal/holdings/store.go
+++ b/backend-go/internal/holdings/store.go
@@ -449,12 +449,17 @@ func (s *Store) accountMeta(ctx context.Context) (map[int]accountMeta, error) {
 	defer rows.Close()
 	out := map[int]accountMeta{}
 	for rows.Next() {
-		var id, owner int
+		var id int
 		var name string
+		var owner *int // accounts.owner_user_id is nullable
 		if err := rows.Scan(&id, &name, &owner); err != nil {
 			return nil, fmt.Errorf("scan account meta: %w", err)
 		}
-		out[id] = accountMeta{Name: name, OwnerUserID: owner}
+		meta := accountMeta{Name: name}
+		if owner != nil {
+			meta.OwnerUserID = *owner
+		}
+		out[id] = meta
 	}
 	return out, rows.Err()
 }


### PR DESCRIPTION
## Motivation

Prod /api/holdings 500s after the per-account refactor (#660). At
least one account row has owner_user_id IS NULL — schema.sql:21
declares the column nullable — and the new accountMeta query scans
into a plain int, which pgx rejects on NULL.

## Implementation information

Scan into *int and default OwnerUserID to 0 when null. Front-end
already treats owner as a label; zero is fine for unassigned rows.
No schema or contract change.

## Supporting documentation

n/a

> Changelog: fix(holdings): handle null owner_user_id