### PR TITLE
fix(exposure): bucket by holdings currency

### DIFF
--- a/backend-go/internal/exposure/currency.go
+++ b/backend-go/internal/exposure/currency.go
@@ -57,16 +57,31 @@ type Store struct {
 // NewStore wraps a pool.
 func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
 
-// row mirrors one (currency, sum(value)) pair.
+// row mirrors one (currency, sum(value)) pair. Used internally by the
+// handler after the per-account snapshot values have been allocated across
+// security currencies via the holdings breakdown.
 type row struct {
 	currency string
 	valuePLN decimal.Decimal
 }
 
-// LatestByCurrency returns total PLN value per account currency from the
-// most recent snapshot. Active accounts only — soft-deleted ones are
-// excluded so the chart matches what the user can actually invest from.
-func (s *Store) LatestByCurrency(ctx context.Context) ([]row, string, error) {
+// accountValue is one row's slice of the latest snapshot: which account,
+// what category, what nominal currency, what PLN value. The handler walks
+// these and decides per row whether to bucket as accounts.currency (cash
+// accounts, real estate, …) or to fan out across the security currencies
+// the account actually holds (stock/etf/bond/fund accounts).
+type accountValue struct {
+	accountID int
+	category  string
+	currency  string
+	valuePLN  decimal.Decimal
+}
+
+// LatestByAccount returns one row per (active account, latest snapshot
+// value). Used by the handler to decide per-row whether the value should
+// bucket as accounts.currency or fan out by underlying holdings currency.
+// Returns ("") snapshotDate when there are no snapshots yet.
+func (s *Store) LatestByAccount(ctx context.Context) ([]accountValue, string, error) {
 	var (
 		latestID   int
 		latestDate string
@@ -75,34 +90,97 @@ func (s *Store) LatestByCurrency(ctx context.Context) ([]row, string, error) {
 		SELECT id, to_char(date, 'YYYY-MM-DD')
 		FROM snapshots ORDER BY date DESC, id DESC LIMIT 1`).Scan(&latestID, &latestDate)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return []row{}, "", nil
+		return []accountValue{}, "", nil
 	}
 	if err != nil {
 		return nil, "", fmt.Errorf("latest snapshot: %w", err)
 	}
 	rows, err := s.pool.Query(ctx, `
-		SELECT UPPER(a.currency) AS currency, SUM(sv.value)
+		SELECT sv.account_id, a.category, UPPER(a.currency), sv.value
 		FROM snapshot_values sv
 		JOIN accounts a ON a.id = sv.account_id
 		WHERE sv.snapshot_id = $1 AND a.is_active = true
-		GROUP BY UPPER(a.currency)
 	`, latestID)
 	if err != nil {
-		return nil, "", fmt.Errorf("query currency totals: %w", err)
+		return nil, "", fmt.Errorf("query per-account values: %w", err)
 	}
 	defer rows.Close()
-	out := []row{}
+	out := []accountValue{}
 	for rows.Next() {
-		var r row
-		if err := rows.Scan(&r.currency, &r.valuePLN); err != nil {
-			return nil, "", fmt.Errorf("scan currency total: %w", err)
+		var v accountValue
+		if err := rows.Scan(&v.accountID, &v.category, &v.currency, &v.valuePLN); err != nil {
+			return nil, "", fmt.Errorf("scan per-account value: %w", err)
 		}
-		out = append(out, r)
+		out = append(out, v)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, "", fmt.Errorf("iterate currency totals: %w", err)
+		return nil, "", fmt.Errorf("iterate per-account values: %w", err)
 	}
 	return out, latestDate, nil
+}
+
+// investmentCategories names the account categories whose snapshot value
+// should fan out across underlying holdings currencies. Bank/cash/real-estate
+// accounts keep the accounts.currency attribution.
+var investmentCategories = map[string]bool{
+	"stock": true,
+	"etf":   true,
+	"bond":  true,
+	"fund":  true,
+}
+
+// HoldingsBreakdown returns per-account per-currency live MV PLN. Mirrors
+// holdings.Valuator.AccountCurrencyBreakdownPLN; declared here as an
+// interface so tests can stub the holdings dep without spinning up a real
+// Postgres-backed Valuator.
+type HoldingsBreakdown interface {
+	AccountCurrencyBreakdownPLN(ctx context.Context) (map[int]map[string]decimal.Decimal, error)
+}
+
+// bucketByCurrency walks the latest snapshot values and bucketizes them
+// into per-currency PLN totals. For accounts in investmentCategories that
+// have a live holdings breakdown, the snapshot value is split across
+// currencies in proportion to the live MV ratio — so an IKE XTB account
+// whose snapshot value is 53 495 PLN and whose holdings are 100% USD
+// attributes the full 53 495 PLN to USD instead of PLN. Falls back to
+// accounts.currency when no breakdown exists (empty holdings, bank/cash
+// accounts, etc.).
+func bucketByCurrency(values []accountValue, breakdown map[int]map[string]decimal.Decimal) []row {
+	totals := map[string]decimal.Decimal{}
+	for i := range values {
+		v := &values[i]
+		buckets, ok := breakdown[v.accountID]
+		if ok && investmentCategories[v.category] && len(buckets) > 0 {
+			addProportional(totals, v.valuePLN, buckets)
+			continue
+		}
+		totals[v.currency] = totals[v.currency].Add(v.valuePLN)
+	}
+	out := make([]row, 0, len(totals))
+	for ccy, val := range totals {
+		out = append(out, row{currency: ccy, valuePLN: val})
+	}
+	return out
+}
+
+// addProportional splits `total` across the keys of `weights` in proportion
+// to the weight values and adds each share into `dst`. When weights sum to
+// zero (all positions valued at zero), `total` falls through to a single
+// "PLN" bucket — same fallback as a cash account, since a zero-value
+// holdings ratio carries no currency signal.
+func addProportional(dst map[string]decimal.Decimal, total decimal.Decimal, weights map[string]decimal.Decimal) {
+	sum := decimal.Zero
+	for _, w := range weights {
+		sum = sum.Add(w)
+	}
+	if sum.IsZero() {
+		dst["PLN"] = dst["PLN"].Add(total)
+		return
+	}
+	for ccy, w := range weights {
+		share := total.Mul(w).Div(sum)
+		dst[ccy] = dst[ccy].Add(share)
+	}
 }
 
 // BuildReport collapses raw per-currency values into percentages and the
@@ -164,16 +242,19 @@ func abs(v float64) float64 {
 
 // Handler is the HTTP boundary for /api/exposure.
 type Handler struct {
-	store  *Store
-	logger *slog.Logger
+	store    *Store
+	holdings HoldingsBreakdown
+	logger   *slog.Logger
 }
 
-// NewHandler wires the store + logger.
-func NewHandler(store *Store, logger *slog.Logger) *Handler {
+// NewHandler wires the store + holdings breakdown + logger. holdings may
+// be nil in tests; the report then attributes every investment account by
+// accounts.currency (the pre-#662 behavior).
+func NewHandler(store *Store, holdings HoldingsBreakdown, logger *slog.Logger) *Handler {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Handler{store: store, logger: logger}
+	return &Handler{store: store, holdings: holdings, logger: logger}
 }
 
 // Currency serves GET /api/exposure/currency[?target_pln_pct=X&tolerance=Y].
@@ -185,12 +266,23 @@ func (h *Handler) Currency(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteQueryValidationError(w, vErr.field, vErr.msg)
 		return
 	}
-	rows, snapshotDate, err := h.store.LatestByCurrency(r.Context())
+	values, snapshotDate, err := h.store.LatestByAccount(r.Context())
 	if err != nil {
 		h.logger.Error("exposure currency", "err", err)
 		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
+	breakdown := map[int]map[string]decimal.Decimal{}
+	if h.holdings != nil {
+		b, err := h.holdings.AccountCurrencyBreakdownPLN(r.Context())
+		if err != nil {
+			h.logger.Warn("exposure: holdings breakdown failed, falling back to account.currency",
+				"err", err)
+		} else {
+			breakdown = b
+		}
+	}
+	rows := bucketByCurrency(values, breakdown)
 	rep := BuildReport(rows, snapshotDate, target, tolerance)
 	httputil.WriteJSON(w, http.StatusOK, rep)
 }

--- a/backend-go/internal/exposure/currency_test.go
+++ b/backend-go/internal/exposure/currency_test.go
@@ -97,3 +97,110 @@ func TestBuildReport_DriftBandOutOfTolerance(t *testing.T) {
 		t.Errorf("within_tolerance = true, want false (drift -20 > tolerance 5)")
 	}
 }
+
+// bucketByCurrency tests cover the new investment-account fan-out logic
+// that replaces the old "GROUP BY accounts.currency" aggregation.
+
+func TestBucketByCurrency_BankAccountUsesAccountCurrency(t *testing.T) {
+	// Bank account (category=bank) — no holdings ratio applies.
+	rows := bucketByCurrency([]accountValue{
+		{accountID: 1, category: "bank", currency: "PLN", valuePLN: d("10000")},
+	}, nil)
+	if len(rows) != 1 || rows[0].currency != "PLN" || !rows[0].valuePLN.Equal(d("10000")) {
+		t.Fatalf("got %+v, want one PLN/10000 row", rows)
+	}
+}
+
+func TestBucketByCurrency_InvestmentAccountFansOutByHoldings(t *testing.T) {
+	// IKE XTB (PLN-settled, category=etf) holds USD-denominated ISAC.UK.
+	// Snapshot value 53 495 PLN should attribute entirely to USD.
+	breakdown := map[int]map[string]decimal.Decimal{
+		15: {"USD": d("53495.15")},
+	}
+	rows := bucketByCurrency([]accountValue{
+		{accountID: 15, category: "etf", currency: "PLN", valuePLN: d("53495.15")},
+	}, breakdown)
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0].currency != "USD" {
+		t.Errorf("currency = %s, want USD", rows[0].currency)
+	}
+	if !rows[0].valuePLN.Equal(d("53495.15")) {
+		t.Errorf("value = %s, want 53495.15", rows[0].valuePLN)
+	}
+}
+
+func TestBucketByCurrency_MixedHoldingsSplitProportionally(t *testing.T) {
+	// Hypothetical IKZE Mbank holding 60% USD ISAC + 40% EUR IUSQ.
+	// Snapshot value 10 000 PLN → 6 000 USD bucket, 4 000 EUR bucket.
+	breakdown := map[int]map[string]decimal.Decimal{
+		14: {"USD": d("60"), "EUR": d("40")}, // ratios; magnitudes don't matter
+	}
+	rows := bucketByCurrency([]accountValue{
+		{accountID: 14, category: "etf", currency: "PLN", valuePLN: d("10000")},
+	}, breakdown)
+	got := map[string]decimal.Decimal{}
+	for _, r := range rows {
+		got[r.currency] = r.valuePLN
+	}
+	if !got["USD"].Equal(d("6000")) {
+		t.Errorf("USD = %s, want 6000", got["USD"])
+	}
+	if !got["EUR"].Equal(d("4000")) {
+		t.Errorf("EUR = %s, want 4000", got["EUR"])
+	}
+}
+
+func TestBucketByCurrency_InvestmentWithoutHoldingsFallsBackToAccountCurrency(t *testing.T) {
+	// Empty holdings (no lots) — must fall back to accounts.currency, not
+	// silently swallow the value.
+	rows := bucketByCurrency([]accountValue{
+		{accountID: 99, category: "stock", currency: "PLN", valuePLN: d("5000")},
+	}, map[int]map[string]decimal.Decimal{})
+	if len(rows) != 1 || rows[0].currency != "PLN" || !rows[0].valuePLN.Equal(d("5000")) {
+		t.Fatalf("got %+v, want PLN/5000 fallback", rows)
+	}
+}
+
+func TestBucketByCurrency_MixedAccountsTotalPreserved(t *testing.T) {
+	// Realistic mix: PLN savings + USD-holding IKE XTB + EUR-holding IKZE
+	// Bossa + a real-estate row. Totals must be preserved across buckets.
+	breakdown := map[int]map[string]decimal.Decimal{
+		15: {"USD": d("53495.15")},
+		16: {"EUR": d("59462.54")},
+	}
+	rows := bucketByCurrency([]accountValue{
+		{accountID: 1, category: "bank", currency: "PLN", valuePLN: d("20000")},
+		{accountID: 15, category: "etf", currency: "PLN", valuePLN: d("53495.15")},
+		{accountID: 16, category: "etf", currency: "PLN", valuePLN: d("59462.54")},
+		{accountID: 7, category: "real_estate", currency: "PLN", valuePLN: d("450000")},
+	}, breakdown)
+	totals := map[string]decimal.Decimal{}
+	for _, r := range rows {
+		totals[r.currency] = r.valuePLN
+	}
+	if !totals["PLN"].Equal(d("470000")) {
+		t.Errorf("PLN = %s, want 470000 (bank + real_estate)", totals["PLN"])
+	}
+	if !totals["USD"].Equal(d("53495.15")) {
+		t.Errorf("USD = %s, want 53495.15", totals["USD"])
+	}
+	if !totals["EUR"].Equal(d("59462.54")) {
+		t.Errorf("EUR = %s, want 59462.54", totals["EUR"])
+	}
+}
+
+func TestBucketByCurrency_ZeroWeightsFallBackToPLN(t *testing.T) {
+	// Edge case: holdings exist but valued at zero (e.g. all positions
+	// closed). Fall back to a single PLN bucket so the value isn't lost.
+	breakdown := map[int]map[string]decimal.Decimal{
+		15: {"USD": decimal.Zero},
+	}
+	rows := bucketByCurrency([]accountValue{
+		{accountID: 15, category: "etf", currency: "PLN", valuePLN: d("1000")},
+	}, breakdown)
+	if len(rows) != 1 || rows[0].currency != "PLN" || !rows[0].valuePLN.Equal(d("1000")) {
+		t.Fatalf("got %+v, want PLN/1000 fallback on zero weights", rows)
+	}
+}

--- a/backend-go/internal/holdings/store.go
+++ b/backend-go/internal/holdings/store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -392,6 +393,36 @@ func (v *Valuator) AccountValuesPLN(ctx context.Context) (map[int]decimal.Decima
 				continue
 			}
 			out[acct.AccountID] = out[acct.AccountID].Add(acct.MarketValuePLN)
+		}
+	}
+	return out, nil
+}
+
+// AccountCurrencyBreakdownPLN groups each account's open positions by their
+// security's quoted currency and returns per-currency PLN market value. Used
+// by the exposure widget to attribute a PLN-settled investment account's
+// snapshot value across the foreign currencies it's actually exposed to
+// (an IKE XTB holding USD-denominated ISAC.UK looks like PLN to
+// accounts.currency but is USD exposure economically).
+func (v *Valuator) AccountCurrencyBreakdownPLN(ctx context.Context) (map[int]map[string]decimal.Decimal, error) {
+	rows, err := v.store.Holdings(ctx, v.rates)
+	if err != nil {
+		return nil, err
+	}
+	out := map[int]map[string]decimal.Decimal{}
+	for i := range rows {
+		sec := &rows[i].Security
+		accs := rows[i].Accounts
+		for j := range accs {
+			acct := &accs[j]
+			if !acct.HasPLN {
+				continue
+			}
+			ccy := strings.ToUpper(sec.Currency)
+			if out[acct.AccountID] == nil {
+				out[acct.AccountID] = map[string]decimal.Decimal{}
+			}
+			out[acct.AccountID][ccy] = out[acct.AccountID][ccy].Add(acct.MarketValuePLN)
 		}
 	}
 	return out, nil

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -212,7 +212,8 @@ func registerDashboardRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logg
 	dashHandler := dashboard.NewHandler(dashboard.NewStore(pool), logger)
 	r.Get("/api/dashboard", dashHandler.Get)
 
-	expHandler := exposure.NewHandler(exposure.NewStore(pool), logger)
+	expValuator := holdings.NewValuator(holdings.NewStore(pool), fx.NewService(pool, logger))
+	expHandler := exposure.NewHandler(exposure.NewStore(pool), expValuator, logger)
 	r.Get("/api/exposure/currency", expHandler.Currency)
 }
 


### PR DESCRIPTION
## Motivation

The Ekspozycja walutowa widget reported every PLN-settled investment
account as PLN exposure even when the underlying ETFs were USD or
EUR. With ~174k PLN of MSCI ACWI ETFs across IKE XTB / IKZE Mbank /
IKZE Bossa, the chart underreported USD exposure by ~115k and EUR
by ~59k. Conceptual mismatch: accounts.currency is the broker's
settlement currency, not the economic exposure currency.

## Implementation information

- New holdings.Valuator.AccountCurrencyBreakdownPLN(ctx) returns
  per-account per-security-currency live MV PLN.
- exposure.Store.LatestByCurrency replaced by LatestByAccount —
  returns one row per (account, category, accounts.currency, value).
- exposure.bucketByCurrency walks each snapshot row; for
  investment-category accounts (stock/etf/bond/fund) with a live
  holdings breakdown, splits the snapshot value across security
  currencies proportionally to the live MV ratio. Bank/cash/real
  estate accounts keep accounts.currency. Empty holdings or
  zero-weight ratios fall back to accounts.currency so values are
  never silently dropped.

Snapshot value remains source of truth for per-account totals; only
currency attribution comes from holdings. API response shape
unchanged.

Alternatives considered:
- Expanding snapshot_values into one row per (account, currency) at
  save time. Bigger schema churn, retroactive snapshots have no
  breakdown.
- Splitting investment accounts into per-currency sub-accounts.
  Breaks the moment a single broker holds two currencies (e.g.
  IKZE Mbank holds USD ISAC + USD CSPX today, could add EUR
  tomorrow).

## Supporting documentation

n/a

> Changelog: fix(exposure): bucket by holdings currency