### PR TITLE
fix(exposure): skip non-FIRE accounts

### DIFF
--- a/backend-go/internal/exposure/currency.go
+++ b/backend-go/internal/exposure/currency.go
@@ -95,11 +95,16 @@ func (s *Store) LatestByAccount(ctx context.Context) ([]accountValue, string, er
 	if err != nil {
 		return nil, "", fmt.Errorf("latest snapshot: %w", err)
 	}
+	// Skip excluded_from_fire accounts (primary residence, daily-spend ROR,
+	// …) — those are net-worth assets but not portfolio exposure. Matches
+	// the dashboard's fire_net_worth bucket.
 	rows, err := s.pool.Query(ctx, `
 		SELECT sv.account_id, a.category, UPPER(a.currency), sv.value
 		FROM snapshot_values sv
 		JOIN accounts a ON a.id = sv.account_id
-		WHERE sv.snapshot_id = $1 AND a.is_active = true
+		WHERE sv.snapshot_id = $1
+		  AND a.is_active = true
+		  AND a.excluded_from_fire = false
 	`, latestID)
 	if err != nil {
 		return nil, "", fmt.Errorf("query per-account values: %w", err)

--- a/src/lib/components/CurrencyExposureWidget.svelte
+++ b/src/lib/components/CurrencyExposureWidget.svelte
@@ -121,7 +121,7 @@
 				Ekspozycja walutowa
 			</h2>
 			<p class="text-sm text-surface-700-300">
-				Udział PLN vs walut obcych w ostatnim snapshotcie aktywów.
+				Udział PLN vs walut obcych w portfelu inwestycyjnym (bez mieszkania i ROR).
 			</p>
 		</div>
 		<div class="flex flex-wrap items-end gap-2">


### PR DESCRIPTION
## Motivation

Ekspozycja walutowa widget reported PLN at 88.7% on prod — apartment
(900k, excluded_from_fire=true) and ROR (40k, also excluded) were
dragged into the PLN bucket. They're net-worth assets but not
portfolio exposure; user can't rebalance currency in a flat.

## Implementation information

One-line SQL filter on the exposure store query:
`AND a.excluded_from_fire = false`. Matches the dashboard's
fire_net_worth filter so the two views agree on what counts as
investable.

Widget subtitle updated from "ostatnim snapshotcie aktywów" to
"portfel inwestycyjny (bez mieszkania i ROR)" to set the right
expectation.

## Supporting documentation

n/a

> Changelog: fix(exposure): skip non-FIRE accounts