### PR TITLE
feat(bonds): scrape Y1 rate + margin

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -1835,6 +1835,39 @@
         ]
       }
     },
+    "/api/bonds/lookup": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "first_year_rate": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "margin": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Look up Y1 rate + CPI margin for an emission (obligacjeskarbowe.pl)",
+        "tags": [
+          "bonds"
+        ]
+      }
+    },
     "/api/bonds/maturity-ladder": {
       "get": {
         "responses": {

--- a/backend-go/internal/bondrates/lookup.go
+++ b/backend-go/internal/bondrates/lookup.go
@@ -1,0 +1,156 @@
+// Package bondrates resolves Y1 interest rate + CPI margin for a Polish
+// retail treasury bond emission by scraping the public product page on
+// obligacjeskarbowe.pl. The Ministry publishes every emission's terms in a
+// "List emisyjny" PDF; the same numbers are rendered as HTML on each
+// emission's product page in a deterministic format, so we parse the HTML
+// instead of OCR-ing the PDF.
+//
+// No public JSON API exists for this data — dane.gov.pl has no per-emission
+// dataset and obligacjeskarbowe.pl ships only HTML/PDF. The product page
+// URL pattern + render is stable across types (EDO/COI/TOS/ROR/DOR/ROS/ROD)
+// so the same parser handles them all.
+package bondrates
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+const (
+	productBaseURL = "https://www.obligacjeskarbowe.pl"
+	userAgent      = "finance-buddy/1.0 (+https://finance.mskalski.dev)"
+	httpTimeout    = 8 * time.Second
+)
+
+// typePath maps our bond-type tag to the URL slug obligacjeskarbowe.pl uses.
+// Keys match holdings.types' constants (uppercase, no diacritics).
+var typePath = map[string]string{
+	"EDO": "obligacje-10-letnie-edo",
+	"COI": "obligacje-4-letnie-coi",
+	"TOS": "obligacje-3-letnie-tos",
+	"TOZ": "obligacje-3-letnie-tos", // legacy alias — TOZ was renamed to TOS
+	"DOR": "obligacje-2-letnie-dor",
+	"DOS": "obligacje-2-letnie-dor", // legacy alias — DOS was renamed to DOR
+	"ROR": "obligacje-roczne-ror",
+	"ROS": "obligacje-6-letnie-ros",
+	"ROD": "obligacje-12-letnie-rod",
+	"OTS": "obligacje-3-miesieczne-ots",
+}
+
+// Rate is the parsed emission terms.
+type Rate struct {
+	FirstYearRate decimal.Decimal // Y1 fixed coupon (percent, e.g. 7.25)
+	Margin        decimal.Decimal // CPI add-on for years 2+ (percent, e.g. 1.25)
+}
+
+// ErrUnknownType signals the requested bond type has no mapped URL path.
+var ErrUnknownType = errors.New("bondrates: unknown bond type")
+
+// ErrNotFound signals the product page returned 404 — series doesn't exist.
+var ErrNotFound = errors.New("bondrates: series not found")
+
+// ErrParse signals the HTML downloaded fine but the rate fields weren't
+// where we expected them. Usually means the page layout shifted upstream.
+var ErrParse = errors.New("bondrates: rate fields missing from page")
+
+// Fetcher resolves rates for one (type, series) pair.
+type Fetcher interface {
+	Lookup(ctx context.Context, bondType, series string) (Rate, error)
+}
+
+// ObligacjeSkarbowePLFetcher hits the public product page and extracts the
+// fixed Y1 rate + CPI margin. Stateless; reuse one instance.
+type ObligacjeSkarbowePLFetcher struct {
+	client *http.Client
+}
+
+// NewObligacjeSkarbowePLFetcher wires the default HTTP client with timeout.
+func NewObligacjeSkarbowePLFetcher() *ObligacjeSkarbowePLFetcher {
+	return &ObligacjeSkarbowePLFetcher{
+		client: &http.Client{Timeout: httpTimeout},
+	}
+}
+
+// Lookup fetches the rate for one emission. Series is case-insensitive; the
+// URL path on obligacjeskarbowe.pl is lowercase.
+func (f *ObligacjeSkarbowePLFetcher) Lookup(ctx context.Context, bondType, series string) (Rate, error) {
+	path, ok := typePath[strings.ToUpper(strings.TrimSpace(bondType))]
+	if !ok {
+		return Rate{}, fmt.Errorf("%w: %q", ErrUnknownType, bondType)
+	}
+	slug := strings.ToLower(strings.TrimSpace(series))
+	if slug == "" {
+		return Rate{}, errors.New("bondrates: empty series")
+	}
+	url := fmt.Sprintf("%s/oferta-obligacji/%s/%s/", productBaseURL, path, slug)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return Rate{}, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return Rate{}, fmt.Errorf("fetch product page: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return Rate{}, ErrNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return Rate{}, fmt.Errorf("product page http %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return Rate{}, fmt.Errorf("read body: %w", err)
+	}
+	return parseRate(string(body))
+}
+
+// rateLineRegex matches the rate description line. The Ministry renders it
+// as e.g. "7,25% w pierwszym rocznym okresie odsetkowym, w kolejnych …
+// marża 1,25% + inflacja". Both numbers use the Polish decimal comma.
+//
+// The leading rate is captured greedily — guarding against single-digit
+// integer-only renders ("4%") that pre-2017 emissions sometimes use.
+var rateLineRegex = regexp.MustCompile(
+	`([0-9]+(?:[,\.][0-9]+)?)\s*%\s*w\s*pierwszym\s*rocznym\s*okresie\s*odsetkowym` +
+		`[\s\S]{0,300}?marża\s*([0-9]+(?:[,\.][0-9]+)?)\s*%\s*\+\s*inflacja`,
+)
+
+// parseRate extracts Y1 + margin from the product page HTML. The regex is
+// anchored to phrases the Ministry uses on every inflation-indexed product
+// page; a layout shift will trip ErrParse rather than silently returning
+// wrong numbers.
+func parseRate(html string) (Rate, error) {
+	m := rateLineRegex.FindStringSubmatch(html)
+	if m == nil {
+		return Rate{}, ErrParse
+	}
+	y1, err := parsePolishDecimal(m[1])
+	if err != nil {
+		return Rate{}, fmt.Errorf("parse Y1 rate %q: %w", m[1], err)
+	}
+	margin, err := parsePolishDecimal(m[2])
+	if err != nil {
+		return Rate{}, fmt.Errorf("parse margin %q: %w", m[2], err)
+	}
+	return Rate{FirstYearRate: y1, Margin: margin}, nil
+}
+
+func parsePolishDecimal(s string) (decimal.Decimal, error) {
+	normalized := strings.ReplaceAll(strings.TrimSpace(s), ",", ".")
+	if _, err := strconv.ParseFloat(normalized, 64); err != nil {
+		return decimal.Decimal{}, err
+	}
+	return decimal.NewFromString(normalized)
+}

--- a/backend-go/internal/bondrates/lookup_test.go
+++ b/backend-go/internal/bondrates/lookup_test.go
@@ -1,0 +1,167 @@
+package bondrates
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+const edo0133HTMLSnippet = `
+<html>
+<body>
+  <h1>EDO0133</h1>
+  <div class="hero__rate">7,25<sub>%</sub></div>
+  <div class="oprocentowanie">
+    7,25% w pierwszym rocznym okresie odsetkowym, w kolejnych rocznych okresach odsetkowych: marża 1,25% + inflacja
+  </div>
+</body>
+</html>`
+
+const edo0335HTMLSnippet = `
+<p>Oprocentowanie</p>
+<p>6,55% w pierwszym rocznym okresie odsetkowym, w kolejnych
+   rocznych okresach odsetkowych: marża 2,00% + inflacja</p>`
+
+const coiHTMLSnippet = `
+<span>5,90% w pierwszym rocznym okresie odsetkowym, w kolejnych
+rocznych okresach odsetkowych: marża 1,25% + inflacja</span>`
+
+func d(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+func TestParseRate_EDO0133(t *testing.T) {
+	r, err := parseRate(edo0133HTMLSnippet)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !r.FirstYearRate.Equal(d("7.25")) {
+		t.Errorf("Y1 = %s, want 7.25", r.FirstYearRate)
+	}
+	if !r.Margin.Equal(d("1.25")) {
+		t.Errorf("margin = %s, want 1.25", r.Margin)
+	}
+}
+
+func TestParseRate_EDO0335(t *testing.T) {
+	r, err := parseRate(edo0335HTMLSnippet)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !r.FirstYearRate.Equal(d("6.55")) {
+		t.Errorf("Y1 = %s, want 6.55", r.FirstYearRate)
+	}
+	if !r.Margin.Equal(d("2.00")) {
+		t.Errorf("margin = %s, want 2.00", r.Margin)
+	}
+}
+
+func TestParseRate_COIFormat(t *testing.T) {
+	r, err := parseRate(coiHTMLSnippet)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !r.FirstYearRate.Equal(d("5.90")) {
+		t.Errorf("Y1 = %s, want 5.90", r.FirstYearRate)
+	}
+}
+
+func TestParseRate_MissingFieldsErrs(t *testing.T) {
+	_, err := parseRate("<html>nothing relevant here</html>")
+	if !errors.Is(err, ErrParse) {
+		t.Errorf("want ErrParse, got %v", err)
+	}
+}
+
+// redirectTransport rewrites every outgoing request to point at target.
+// Used to redirect the hardcoded productBaseURL at an httptest server.
+type redirectTransport struct{ target *url.URL }
+
+func (r *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = r.target.Scheme
+	req.URL.Host = r.target.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func TestLookup_UnknownTypeErrs(t *testing.T) {
+	f := NewObligacjeSkarbowePLFetcher()
+	_, err := f.Lookup(context.Background(), "XYZ", "XYZ0125")
+	if !errors.Is(err, ErrUnknownType) {
+		t.Errorf("want ErrUnknownType, got %v", err)
+	}
+}
+
+func TestLookup_EmptySeriesErrs(t *testing.T) {
+	f := NewObligacjeSkarbowePLFetcher()
+	_, err := f.Lookup(context.Background(), "EDO", "  ")
+	if err == nil {
+		t.Errorf("want error for empty series")
+	}
+}
+
+func TestLookup_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "/oferta-obligacji/obligacje-10-letnie-edo/edo0133/"
+		if r.URL.Path != want {
+			t.Errorf("path = %q, want %q", r.URL.Path, want)
+		}
+		_, _ = w.Write([]byte(edo0133HTMLSnippet))
+	}))
+	defer srv.Close()
+	target, _ := url.Parse(srv.URL)
+	f := NewObligacjeSkarbowePLFetcher()
+	f.client.Transport = &redirectTransport{target: target}
+	r, err := f.Lookup(context.Background(), "EDO", "EDO0133")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !r.FirstYearRate.Equal(d("7.25")) || !r.Margin.Equal(d("1.25")) {
+		t.Errorf("got Y1=%s margin=%s, want 7.25/1.25", r.FirstYearRate, r.Margin)
+	}
+}
+
+func TestLookup_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	target, _ := url.Parse(srv.URL)
+	f := NewObligacjeSkarbowePLFetcher()
+	f.client.Transport = &redirectTransport{target: target}
+	_, err := f.Lookup(context.Background(), "EDO", "edo9999")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestLookup_LegacyTypeAliases(t *testing.T) {
+	// TOZ → maps to TOS URL slug; DOS → DOR. Just verify the path is built
+	// correctly; rate parsing tested separately.
+	cases := []struct {
+		typ, slug string
+	}{
+		{"TOZ", "obligacje-3-letnie-tos"},
+		{"DOS", "obligacje-2-letnie-dor"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.typ, func(t *testing.T) {
+			seen := ""
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seen = r.URL.Path
+				_, _ = w.Write([]byte(edo0133HTMLSnippet))
+			}))
+			defer srv.Close()
+			target, _ := url.Parse(srv.URL)
+			f := NewObligacjeSkarbowePLFetcher()
+			f.client.Transport = &redirectTransport{target: target}
+			_, _ = f.Lookup(context.Background(), tc.typ, "x0125")
+			if !strings.Contains(seen, tc.slug) {
+				t.Errorf("path %q does not contain %q", seen, tc.slug)
+			}
+		})
+	}
+}

--- a/backend-go/internal/bonds/handler.go
+++ b/backend-go/internal/bonds/handler.go
@@ -8,12 +8,14 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
 
+	"github.com/Automaat/finance-buddy/backend-go/internal/bondrates"
 	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 	"github.com/Automaat/finance-buddy/backend-go/internal/rules"
@@ -53,20 +55,28 @@ type CPILoader interface {
 	LoadYoYMap(ctx context.Context) (map[int]decimal.Decimal, error)
 }
 
+// RateLookup resolves Y1 rate + CPI margin for an emission by scraping the
+// Ministry's product page (bondrates.ObligacjeSkarbowePLFetcher). May be
+// nil in tests; the /api/bonds/lookup endpoint then returns 503.
+type RateLookup interface {
+	Lookup(ctx context.Context, bondType, series string) (bondrates.Rate, error)
+}
+
 // Handler is the HTTP boundary for /api/bonds.
 type Handler struct {
 	store  *Store
 	cpi    CPILoader
+	rates  RateLookup
 	logger *slog.Logger
 	now    func() time.Time
 }
 
-// NewHandler wires the store + CPI loader + logger.
-func NewHandler(store *Store, cpiStore CPILoader, logger *slog.Logger) *Handler {
+// NewHandler wires the store + CPI loader + rate-lookup + logger.
+func NewHandler(store *Store, cpiStore CPILoader, rates RateLookup, logger *slog.Logger) *Handler {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Handler{store: store, cpi: cpiStore, logger: logger, now: time.Now}
+	return &Handler{store: store, cpi: cpiStore, rates: rates, logger: logger, now: time.Now}
 }
 
 // response is the wire shape for a single bond.
@@ -412,6 +422,62 @@ func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
 		return 0, false
 	}
 	return id, true
+}
+
+// lookupResponse is the body of GET /api/bonds/lookup.
+type lookupResponse struct {
+	FirstYearRate float64 `json:"first_year_rate"`
+	Margin        float64 `json:"margin"`
+	Source        string  `json:"source"`
+}
+
+// Lookup serves GET /api/bonds/lookup?type=EDO&series=EDO0133. Resolves Y1
+// rate + CPI margin from the Ministry's product page so the user doesn't
+// have to type them in by hand when adding a bond. Returns 404 on unknown
+// series, 503 when no rate provider is wired, 502 when the upstream page
+// is unparseable.
+func (h *Handler) Lookup(w http.ResponseWriter, r *http.Request) {
+	if h.rates == nil {
+		httputil.WriteDetailError(w, http.StatusServiceUnavailable, "Rate lookup not configured")
+		return
+	}
+	bondType := strings.TrimSpace(r.URL.Query().Get("type"))
+	series := strings.TrimSpace(r.URL.Query().Get("series"))
+	if bondType == "" {
+		httputil.WriteQueryValidationError(w, "type", "required")
+		return
+	}
+	if series == "" {
+		httputil.WriteQueryValidationError(w, "series", "required")
+		return
+	}
+	rate, err := h.rates.Lookup(r.Context(), bondType, series)
+	switch {
+	case errors.Is(err, bondrates.ErrNotFound):
+		httputil.WriteDetailError(w, http.StatusNotFound,
+			"Series not found in Ministry catalog")
+		return
+	case errors.Is(err, bondrates.ErrUnknownType):
+		httputil.WriteQueryValidationError(w, "type", "unsupported bond type")
+		return
+	case errors.Is(err, bondrates.ErrParse):
+		h.logger.Warn("bonds: rate parse failed", "type", bondType, "series", series)
+		httputil.WriteDetailError(w, http.StatusBadGateway,
+			"Could not parse rate from Ministry page")
+		return
+	case err != nil:
+		h.logger.Warn("bonds: rate lookup failed", "type", bondType, "series", series, "err", err)
+		httputil.WriteDetailError(w, http.StatusBadGateway,
+			"Could not reach Ministry page")
+		return
+	}
+	y1, _ := rate.FirstYearRate.Float64()
+	margin, _ := rate.Margin.Float64()
+	httputil.WriteJSON(w, http.StatusOK, lookupResponse{
+		FirstYearRate: y1,
+		Margin:        margin,
+		Source:        "obligacjeskarbowe.pl",
+	})
 }
 
 // Sanity: keep the package's cpi import alive even if the production wiring

--- a/backend-go/internal/bonds/openapi.go
+++ b/backend-go/internal/bonds/openapi.go
@@ -8,6 +8,7 @@ var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/bonds/{id}", Tag: "bonds", Summary: "Get a treasury bond", Response: response{}},
 	{Method: "GET", Path: "/api/bonds/{id}/ytm", Tag: "bonds", Summary: "Yield-to-maturity projection", Response: ytmResponse{}},
 	{Method: "GET", Path: "/api/bonds/maturity-ladder", Tag: "bonds", Summary: "Maturity ladder calendar", Response: maturityLadderResponse{}},
+	{Method: "GET", Path: "/api/bonds/lookup", Tag: "bonds", Summary: "Look up Y1 rate + CPI margin for an emission (obligacjeskarbowe.pl)", Response: lookupResponse{}},
 	{Method: "POST", Path: "/api/bonds", Tag: "bonds", Summary: "Create a treasury bond", Response: response{}, Status: 201},
 	{Method: "PUT", Path: "/api/bonds/{id}", Tag: "bonds", Summary: "Update a treasury bond", Response: response{}},
 	{Method: "DELETE", Path: "/api/bonds/{id}", Tag: "bonds", Summary: "Delete a treasury bond", Status: 204},

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/allocation"
 	"github.com/Automaat/finance-buddy/backend-go/internal/assets"
 	"github.com/Automaat/finance-buddy/backend-go/internal/auth"
+	"github.com/Automaat/finance-buddy/backend-go/internal/bondrates"
 	"github.com/Automaat/finance-buddy/backend-go/internal/bonds"
 	bonusevents "github.com/Automaat/finance-buddy/backend-go/internal/bonus_events"
 	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
@@ -342,10 +343,14 @@ func registerPortfolioRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logg
 		r.Put("/{id}", snapshotsHandler.Update)
 	})
 
-	bondsHandler := bonds.NewHandler(bonds.NewStore(pool), cpi.NewStore(pool), logger)
+	bondsHandler := bonds.NewHandler(
+		bonds.NewStore(pool), cpi.NewStore(pool),
+		bondrates.NewObligacjeSkarbowePLFetcher(), logger,
+	)
 	r.Route("/api/bonds", func(r chi.Router) {
 		r.Get("/", bondsHandler.List)
 		r.Post("/", bondsHandler.Create)
+		r.Get("/lookup", bondsHandler.Lookup)
 		r.Get("/maturity-ladder", bondsHandler.MaturityLadder)
 		r.Get("/{id}", bondsHandler.Get)
 		r.Get("/{id}/ytm", bondsHandler.YTM)

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -1329,6 +1329,48 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/bonds/lookup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Look up Y1 rate + CPI margin for an emission (obligacjeskarbowe.pl) */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: double */
+                            first_year_rate?: number;
+                            /** Format: double */
+                            margin?: number;
+                            source?: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/bonds/maturity-ladder": {
         parameters: {
             query?: never;

--- a/src/routes/bonds/+page.svelte
+++ b/src/routes/bonds/+page.svelte
@@ -49,6 +49,7 @@
 	let editingBond: TreasuryBond | null = $state(null);
 	let saving = $state(false);
 	let formError = $state('');
+	let lookingUp = $state(false);
 	let showDeleteModal = $state(false);
 	let bondToDelete: number | null = $state(null);
 
@@ -115,6 +116,29 @@
 		if (editingBond) return;
 		const d = defaultsForType(formData.type);
 		formData = { ...formData, ...d };
+	}
+
+	async function lookupRate() {
+		formError = '';
+		lookingUp = true;
+		try {
+			const params = new URLSearchParams({ type: formData.type, series: formData.series });
+			const res = await fetch(`${apiUrl}/api/bonds/lookup?${params}`);
+			if (!res.ok) {
+				const d = await res.json().catch(() => ({ detail: res.statusText }));
+				throw new Error(d.detail ?? res.statusText);
+			}
+			const body = (await res.json()) as { first_year_rate: number; margin: number };
+			formData = {
+				...formData,
+				first_year_rate: body.first_year_rate,
+				margin: body.margin
+			};
+		} catch (err) {
+			if (err instanceof Error) formError = `Pobieranie stopy: ${err.message}`;
+		} finally {
+			lookingUp = false;
+		}
 	}
 
 	async function handleSubmit() {
@@ -329,13 +353,24 @@
 
 					<label class="label">
 						<span class="font-semibold text-sm">Seria</span>
-						<input
-							type="text"
-							class="input"
-							bind:value={formData.series}
-							required
-							placeholder="np. EDO0535"
-						/>
+						<div class="flex gap-2">
+							<input
+								type="text"
+								class="input"
+								bind:value={formData.series}
+								required
+								placeholder="np. EDO0535"
+							/>
+							<button
+								type="button"
+								class="btn preset-tonal-surface whitespace-nowrap"
+								onclick={lookupRate}
+								disabled={lookingUp || !formData.series || !formData.type}
+								title="Pobierz stopę z obligacjeskarbowe.pl"
+							>
+								{lookingUp ? '…' : 'Pobierz stopę'}
+							</button>
+						</div>
 					</label>
 
 					<label class="label">


### PR DESCRIPTION
## Motivation

When adding a bond, user had to look up Y1 rate + CPI margin from the
Ministry letter PDF by hand. Best-guess defaults in the form were 0.15%
off for the 6 PKO EDO bonds, which compounds over 10 years. The
Ministry publishes the canonical numbers on every emission's product
page on obligacjeskarbowe.pl, but there's no JSON API.

## Implementation information

New `internal/bondrates` package:
- `ObligacjeSkarbowePLFetcher` hits
  `obligacjeskarbowe.pl/oferta-obligacji/<type-slug>/<series>/`
- URL slug per bond type (EDO/COI/TOS/ROR/DOR/ROS/ROD) plus legacy
  TOZ→TOS and DOS→DOR aliases for older app data.
- Regex anchored to "X% w pierwszym rocznym okresie odsetkowym, w
  kolejnych ... marża Y% + inflacja" — the same phrase every
  inflation-indexed product page renders. Polish decimal comma
  handled. Layout shift trips ErrParse instead of returning
  wrong numbers.
- Stateless; 8s timeout; 1 MiB body cap.

New endpoint `GET /api/bonds/lookup?type=&series=`:
- 200 with `{first_year_rate, margin, source}`
- 404 ErrNotFound
- 502 upstream unparseable / unreachable
- 400 unknown type / missing param
- 503 fetcher not wired (test deploys)

Frontend: bond form gets a "Pobierz stopę" button next to the series
field. Disabled until type + series typed. On click fills both rate
fields from the lookup.

Alternatives considered:
- dane.gov.pl open data — no per-emission interest dataset.
- PDF parsing per-series tabela odsetkowa — brittle layout shifts.
- Hardcoded table of historical emissions — wouldn't cover future
  ones; the user already has older bonds spanning Jan 2023 to Mar
  2025.

## Supporting documentation

n/a

> Changelog: feat(bonds): scrape Y1 rate + margin