### PR TITLE
fix(bonds): period-aware monthly CPI

### DIFF
--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -112,8 +112,18 @@ func run() int {
 		deps.Pool = pool
 
 		// CPI monthly-refresh scheduler — replaces the Python APScheduler job.
-		sched := scheduler.NewCPIScheduler(cpi.NewStore(pool), cpi.NewGUSFetcher(), logger)
+		cpiStore := cpi.NewStore(pool)
+		sched := scheduler.NewCPIScheduler(cpiStore, cpi.NewGUSFetcher(), logger)
 		go sched.Run(ctx)
+
+		// Monthly HICP YoY refresh — feeds the period-aware bond rate engine.
+		// EnsureMonthlySchema is idempotent and cheap; safe to run every boot.
+		if err := cpiStore.EnsureMonthlySchema(ctx); err != nil {
+			logger.Error("ensure cpi_monthly_index schema", "err", err)
+			return 2
+		}
+		monthlySched := scheduler.NewMonthlyCPIScheduler(cpiStore, cpi.NewEurostatHICPFetcher(), logger)
+		go monthlySched.Run(ctx)
 
 		// Daily recurring-transaction generator (issue #384).
 		recSched := recurring.NewScheduler(recurring.NewStore(pool), logger)

--- a/backend-go/internal/bonds/calc.go
+++ b/backend-go/internal/bonds/calc.go
@@ -4,23 +4,33 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 )
 
-// CurrentValue projects the bond's worth at `now`, given a CPI YoY map from
-// the cpi_index table (yoy_rate as published by GUS — 114.4 = +14.4%).
+// CurrentValue projects the bond's worth at `now`. Accepts both an annual
+// CPI YoY map (legacy fallback) and a monthly map; the monthly map wins
+// when populated because it matches the Ministry's per-period rate-setting
+// rule exactly.
 //
-// Rule per acceptance criteria:
-//   - Year 1 accrues at FirstYearRate.
-//   - Year N (N >= 2) accrues at (cpi_yoy_for_purchase_year+N-1) - 100 + Margin.
-//     Missing CPI years clamp to the closest known year so freshly issued
-//     bonds (current calendar year) don't read zero.
+// Rule per Ministry "list emisyjny" for EDO/COI/ROS/ROD:
+//
+//   - Year 1 accrues at FirstYearRate (fixed at emission).
+//   - Year N (N >= 2) accrues at (CPI YoY published in the month preceding
+//     period N's first month) - 100 + Margin. For a bond with period N
+//     starting at date D, the reference month is D.month-2 (with year wrap)
+//     — GUS publishes month X's reading mid-month X+1, so the YoY available
+//     when the Ministry sets the rate ~14 days before period start is the
+//     month-two-ago value.
+//   - When the monthly map lacks the exact reference month, fall back to
+//     the closest available month; when both maps are empty, fall back to
+//     FirstYearRate so a missing CPI refresh can't zero out portfolios.
 //   - Capitalize: each completed year multiplies the running value;
-//     non-capitalized bonds add `face_value * year_rate` per completed year
-//     (interest paid out rather than reinvested).
+//     non-capitalized bonds add `face_value * year_rate` per completed year.
 //   - Partial current year applies pro-rata at the same year's rate.
 //
 // Returns FaceValue when now is on/before PurchaseDate.
-func CurrentValue(b *TreasuryBond, yoyByYear map[int]decimal.Decimal, now time.Time) decimal.Decimal {
+func CurrentValue(b *TreasuryBond, yoyByYear map[int]decimal.Decimal, monthly map[cpi.YearMonth]decimal.Decimal, now time.Time) decimal.Decimal {
 	if !now.After(b.PurchaseDate) {
 		return b.FaceValue
 	}
@@ -37,7 +47,7 @@ func CurrentValue(b *TreasuryBond, yoyByYear map[int]decimal.Decimal, now time.T
 	value := b.FaceValue
 	accruedPayout := decimal.Zero
 	for yearIdx := 1; yearIdx <= completedYears; yearIdx++ {
-		rate := yearRate(b, yoyByYear, yearIdx)
+		rate := yearRate(b, yoyByYear, monthly, yearIdx)
 		if b.Capitalize {
 			value = value.Mul(decimal.NewFromInt(1).Add(rate.Div(decimal.NewFromInt(100))))
 		} else {
@@ -45,7 +55,7 @@ func CurrentValue(b *TreasuryBond, yoyByYear map[int]decimal.Decimal, now time.T
 		}
 	}
 	if fraction.IsPositive() {
-		rate := yearRate(b, yoyByYear, completedYears+1)
+		rate := yearRate(b, yoyByYear, monthly, completedYears+1)
 		if b.Capitalize {
 			factor := decimal.NewFromInt(1).Add(rate.Mul(fraction).Div(decimal.NewFromInt(100)))
 			value = value.Mul(factor)
@@ -64,13 +74,20 @@ func CurrentValue(b *TreasuryBond, yoyByYear map[int]decimal.Decimal, now time.T
 // Exposed for the YTM projection so the frontend can render the
 // per-year coupon line; the calculator inside CurrentValue calls the same
 // path.
-func YearRate(b *TreasuryBond, yoyByYear map[int]decimal.Decimal, yearIdx int) decimal.Decimal {
-	return yearRate(b, yoyByYear, yearIdx)
+func YearRate(b *TreasuryBond, yoyByYear map[int]decimal.Decimal, monthly map[cpi.YearMonth]decimal.Decimal, yearIdx int) decimal.Decimal {
+	return yearRate(b, yoyByYear, monthly, yearIdx)
 }
 
-func yearRate(b *TreasuryBond, yoyByYear map[int]decimal.Decimal, yearIdx int) decimal.Decimal {
+func yearRate(b *TreasuryBond, yoyByYear map[int]decimal.Decimal, monthly map[cpi.YearMonth]decimal.Decimal, yearIdx int) decimal.Decimal {
 	if yearIdx <= 1 {
 		return b.FirstYearRate
+	}
+	// Monthly map (Eurostat HICP) is the canonical source — matches the
+	// Ministry's per-period rate-setting rule. Annual map kept as fallback
+	// for environments where the monthly scheduler hasn't run yet.
+	if yoy, ok := lookupMonthlyYoY(b, monthly, yearIdx); ok {
+		inflation := yoy.Sub(decimal.NewFromInt(100))
+		return inflation.Add(b.Margin)
 	}
 	cpiYear := b.PurchaseDate.Year() + yearIdx - 1
 	yoy := lookupYoY(yoyByYear, cpiYear)
@@ -82,6 +99,44 @@ func yearRate(b *TreasuryBond, yoyByYear map[int]decimal.Decimal, yearIdx int) d
 	}
 	inflation := yoy.Sub(decimal.NewFromInt(100))
 	return inflation.Add(b.Margin)
+}
+
+// lookupMonthlyYoY returns the CPI YoY value the Ministry would use to
+// set rate for bond year `yearIdx`. Period N starts at purchase + (N-1)
+// years; reference month is two months before that period's first month
+// (GUS releases month X's reading mid-month X+1, so the most recent value
+// available 14 days before period start is the month-two-ago YoY).
+//
+// Falls back to the closest earlier month present in `monthly` (drift
+// during transient publishing gaps). Returns (_, false) when the map is
+// empty so the caller can chain through to the annual fallback.
+func lookupMonthlyYoY(b *TreasuryBond, monthly map[cpi.YearMonth]decimal.Decimal, yearIdx int) (decimal.Decimal, bool) {
+	if len(monthly) == 0 {
+		return decimal.Decimal{}, false
+	}
+	periodStart := b.PurchaseDate.AddDate(0, 12*(yearIdx-1), 0)
+	refYear, refMonth := periodStart.Year(), int(periodStart.Month())-2
+	for refMonth < 1 {
+		refYear--
+		refMonth += 12
+	}
+	if v, ok := monthly[cpi.YearMonth{Year: refYear, Month: refMonth}]; ok {
+		return v, true
+	}
+	// Walk back month-by-month for up to 12 months to bridge a publishing
+	// gap. Beyond 12 we treat the data as missing and let the annual
+	// fallback take over.
+	for step := 1; step <= 12; step++ {
+		y, m := refYear, refMonth-step
+		for m < 1 {
+			y--
+			m += 12
+		}
+		if v, ok := monthly[cpi.YearMonth{Year: y, Month: m}]; ok {
+			return v, true
+		}
+	}
+	return decimal.Decimal{}, false
 }
 
 // lookupYoY returns the YoY for the requested year, clamping to the
@@ -164,7 +219,7 @@ type YTMPoint struct {
 // YieldToMaturity projects the bond's value at the end of each year until
 // MaturityDate, using the same rate rules CurrentValue applies. Used by
 // the /bonds page chart.
-func YieldToMaturity(b *TreasuryBond, yoyByYear map[int]decimal.Decimal) []YTMPoint {
+func YieldToMaturity(b *TreasuryBond, yoyByYear map[int]decimal.Decimal, monthly map[cpi.YearMonth]decimal.Decimal) []YTMPoint {
 	if b.Type.MaturityMonths() <= 0 {
 		return []YTMPoint{}
 	}
@@ -179,7 +234,7 @@ func YieldToMaturity(b *TreasuryBond, yoyByYear map[int]decimal.Decimal) []YTMPo
 		YearRate: decimal.Zero,
 	})
 	for y := 1; y <= years; y++ {
-		rate := yearRate(b, yoyByYear, y)
+		rate := yearRate(b, yoyByYear, monthly, y)
 		if b.Capitalize {
 			value = value.Mul(decimal.NewFromInt(1).Add(rate.Div(decimal.NewFromInt(100))))
 		} else {

--- a/backend-go/internal/bonds/calc_test.go
+++ b/backend-go/internal/bonds/calc_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 )
 
 func bondEDO(purchase time.Time) *TreasuryBond {
@@ -32,7 +34,7 @@ func bondCOI(purchase time.Time) *TreasuryBond {
 func TestCurrentValueBeforePurchaseIsFaceValue(t *testing.T) {
 	b := bondEDO(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	now := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
-	got := CurrentValue(b, map[int]decimal.Decimal{2025: decimal.NewFromFloat(105)}, now)
+	got := CurrentValue(b, map[int]decimal.Decimal{2025: decimal.NewFromFloat(105)}, nil, now)
 	if !got.Equal(decimal.NewFromInt(1000)) {
 		t.Fatalf("pre-purchase value should be face, got %s", got)
 	}
@@ -43,7 +45,7 @@ func TestCurrentValueYear1PartialEDO(t *testing.T) {
 	purchase := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	now := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC) // ~half-year in
 	b := bondEDO(purchase)
-	got := CurrentValue(b, map[int]decimal.Decimal{}, now)
+	got := CurrentValue(b, map[int]decimal.Decimal{}, nil, now)
 	want := decimal.NewFromFloat(1034.00)
 	if got.Sub(want).Abs().GreaterThan(decimal.NewFromFloat(0.1)) {
 		t.Fatalf("year1 partial = %s, want %s", got, want)
@@ -60,7 +62,7 @@ func TestCurrentValueYear2EDOCompounding(t *testing.T) {
 	b := bondEDO(purchase)
 	// year 1: 1000 * 1.0680 = 1068.0
 	// year 2: 1068.0 * (1 + (4.0 + 2.0)/100) = 1068.0 * 1.06 = 1132.08
-	got := CurrentValue(b, yoy, now)
+	got := CurrentValue(b, yoy, nil, now)
 	want := decimal.NewFromFloat(1132.08)
 	if !got.Equal(want) {
 		t.Fatalf("year2 EDO compounded = %s, want %s", got, want)
@@ -77,7 +79,7 @@ func TestCurrentValueCOIInterestPaidOut(t *testing.T) {
 	// year 1: 1000 * 0.0655 = 65.50 paid out
 	// year 2: 1000 * (4.0 + 1.25)/100 = 52.50 paid out
 	// value = face + accrued = 1000 + 65.50 + 52.50 = 1118.00
-	got := CurrentValue(b, yoy, now)
+	got := CurrentValue(b, yoy, nil, now)
 	want := decimal.NewFromFloat(1118.00)
 	if !got.Equal(want) {
 		t.Fatalf("COI accrued = %s, want %s", got, want)
@@ -86,7 +88,7 @@ func TestCurrentValueCOIInterestPaidOut(t *testing.T) {
 
 func TestYearRateFallsBackToFirstYearWhenCPIEmpty(t *testing.T) {
 	b := bondEDO(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
-	r := YearRate(b, map[int]decimal.Decimal{}, 3)
+	r := YearRate(b, map[int]decimal.Decimal{}, nil, 3)
 	if !r.Equal(b.FirstYearRate) {
 		t.Fatalf("empty CPI should fall back to first-year rate, got %s", r)
 	}
@@ -97,7 +99,7 @@ func TestYearRateClampsFutureYearsToLatestKnown(t *testing.T) {
 	b := bondEDO(purchase)
 	yoy := map[int]decimal.Decimal{2025: decimal.NewFromFloat(103.5)}
 	// Year 5 => purchase_year + 5 - 1 = 2028, not in map → clamp to latest = 2025.
-	r := YearRate(b, yoy, 5)
+	r := YearRate(b, yoy, nil, 5)
 	want := decimal.NewFromFloat(5.5) // (103.5 - 100) + 2.0
 	if !r.Equal(want) {
 		t.Fatalf("year 5 rate = %s, want %s", r, want)
@@ -108,7 +110,7 @@ func TestYieldToMaturityEDOReturnsTenSamples(t *testing.T) {
 	purchase := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	b := bondEDO(purchase)
 	yoy := map[int]decimal.Decimal{2025: decimal.NewFromFloat(104)}
-	pts := YieldToMaturity(b, yoy)
+	pts := YieldToMaturity(b, yoy, nil)
 	// 1 anchor (year 0) + 10 yearly samples
 	if len(pts) != 11 {
 		t.Fatalf("expected 11 YTM points, got %d", len(pts))
@@ -129,12 +131,88 @@ func TestCurrentValueCapsAtMaturity(t *testing.T) {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // 16y past, EDO matures at 10y
 	b := bondEDO(purchase)
 	yoy := map[int]decimal.Decimal{2020: decimal.NewFromFloat(103)}
-	got := CurrentValue(b, yoy, now)
+	got := CurrentValue(b, yoy, nil, now)
 	// Bond should equal its end-of-year-10 value, not continue compounding.
-	pts := YieldToMaturity(b, yoy)
+	pts := YieldToMaturity(b, yoy, nil)
 	want := pts[10].Value
 	if !got.Equal(want) {
 		t.Fatalf("post-maturity should cap at year-10 value; got %s want %s", got, want)
+	}
+}
+
+// TestYearRateMonthlyOverridesAnnual verifies the Eurostat monthly map
+// supersedes the annual fallback when both are present, with the reference
+// month being (period_start.month - 2).
+func TestYearRateMonthlyOverridesAnnual(t *testing.T) {
+	// EDO purchased 2023-01-10, margin 1.25%. Period 2 starts 2024-01-10 →
+	// reference month is Nov 2023. Monthly map provides 106.6 (+6.6%) for
+	// that month; annual map provides 103.6 for 2024 (would yield 4.85%).
+	b := &TreasuryBond{
+		Type:          BondEDO,
+		FaceValue:     decimal.NewFromInt(1000),
+		PurchaseDate:  time.Date(2023, 1, 10, 0, 0, 0, 0, time.UTC),
+		FirstYearRate: decimal.NewFromFloat(7.25),
+		Margin:        decimal.NewFromFloat(1.25),
+		Capitalize:    true,
+	}
+	monthly := map[cpi.YearMonth]decimal.Decimal{
+		{Year: 2023, Month: 11}: decimal.NewFromFloat(106.6),
+	}
+	annual := map[int]decimal.Decimal{2024: decimal.NewFromFloat(103.6)}
+	r := YearRate(b, annual, monthly, 2)
+	want := decimal.NewFromFloat(7.85) // 6.6 + 1.25
+	if !r.Equal(want) {
+		t.Errorf("Y2 rate = %s, want %s (monthly should override)", r, want)
+	}
+	// Without the monthly value, falls back to annual.
+	rFallback := YearRate(b, annual, nil, 2)
+	wantFallback := decimal.NewFromFloat(4.85) // 3.6 + 1.25
+	if !rFallback.Equal(wantFallback) {
+		t.Errorf("Y2 fallback = %s, want %s (annual)", rFallback, wantFallback)
+	}
+}
+
+// TestYearRateMonthlyWalksBackOnGap covers a Eurostat publishing delay:
+// the strict reference month is missing, but an earlier month is present.
+// The lookup must walk back rather than silently falling through to annual.
+func TestYearRateMonthlyWalksBackOnGap(t *testing.T) {
+	b := &TreasuryBond{
+		Type:          BondEDO,
+		FaceValue:     decimal.NewFromInt(1000),
+		PurchaseDate:  time.Date(2023, 1, 10, 0, 0, 0, 0, time.UTC),
+		FirstYearRate: decimal.NewFromFloat(7.25),
+		Margin:        decimal.NewFromFloat(1.25),
+		Capitalize:    true,
+	}
+	monthly := map[cpi.YearMonth]decimal.Decimal{
+		// Strict ref Nov 2023 missing; Oct 2023 available.
+		{Year: 2023, Month: 10}: decimal.NewFromFloat(106.6),
+	}
+	r := YearRate(b, nil, monthly, 2)
+	if !r.Equal(decimal.NewFromFloat(7.85)) {
+		t.Errorf("Y2 with month gap = %s, want 7.85 (walked back to Oct)", r)
+	}
+}
+
+// TestYearRateMonthlyYearWrap covers period-start month 1 or 2 where the
+// reference month falls in the previous year.
+func TestYearRateMonthlyYearWrap(t *testing.T) {
+	// Purchase 2024-02-15 → period 2 starts 2025-02-15 → ref = Dec 2024.
+	b := &TreasuryBond{
+		Type:          BondEDO,
+		FaceValue:     decimal.NewFromInt(1000),
+		PurchaseDate:  time.Date(2024, 2, 15, 0, 0, 0, 0, time.UTC),
+		FirstYearRate: decimal.NewFromFloat(6.85),
+		Margin:        decimal.NewFromFloat(1.5),
+		Capitalize:    true,
+	}
+	monthly := map[cpi.YearMonth]decimal.Decimal{
+		{Year: 2024, Month: 12}: decimal.NewFromFloat(104.7),
+	}
+	r := YearRate(b, nil, monthly, 2)
+	want := decimal.NewFromFloat(6.2) // 4.7 + 1.5
+	if !r.Equal(want) {
+		t.Errorf("Y2 with year wrap = %s, want %s", r, want)
 	}
 }
 

--- a/backend-go/internal/bonds/handler.go
+++ b/backend-go/internal/bonds/handler.go
@@ -50,9 +50,12 @@ func getBelkaRate() decimal.Decimal {
 }
 
 // CPILoader is the subset of cpi.Store the handler needs. Decoupling the
-// import lets unit tests stub it without spinning up a pool.
+// import lets unit tests stub it without spinning up a pool. LoadMonthlyYoYMap
+// returns the period-aware reference used by the rate engine; an empty
+// map disables the monthly path and falls back to annual CPI.
 type CPILoader interface {
 	LoadYoYMap(ctx context.Context) (map[int]decimal.Decimal, error)
+	LoadMonthlyYoYMap(ctx context.Context) (map[cpi.YearMonth]decimal.Decimal, error)
 }
 
 // RateLookup resolves Y1 rate + CPI margin for an emission by scraping the
@@ -155,13 +158,13 @@ type createRequest struct {
 	Capitalize    bool         `json:"capitalize"`
 }
 
-func (h *Handler) toResponse(b *TreasuryBond, yoy map[int]decimal.Decimal) response {
+func (h *Handler) toResponse(b *TreasuryBond, yoy map[int]decimal.Decimal, monthly map[cpi.YearMonth]decimal.Decimal) response {
 	face, _ := b.FaceValue.Float64()
 	firstYear, _ := b.FirstYearRate.Float64()
 	margin, _ := b.Margin.Float64()
-	current := CurrentValue(b, yoy, h.now())
+	current := CurrentValue(b, yoy, monthly, h.now())
 	currentFloat, _ := current.Float64()
-	yieldRate, _ := YearRate(b, yoy, currentBondYear(b, h.now())).Float64()
+	yieldRate, _ := YearRate(b, yoy, monthly, currentBondYear(b, h.now())).Float64()
 
 	return response{
 		ID:            b.ID,
@@ -198,11 +201,12 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
+	monthly := h.loadMonthlyYoY(r.Context())
 	out := listResponse{Bonds: make([]response, 0, len(bonds))}
 	total := decimal.Zero
 	for i := range bonds {
-		out.Bonds = append(out.Bonds, h.toResponse(&bonds[i], yoy))
-		total = total.Add(CurrentValue(&bonds[i], yoy, h.now()))
+		out.Bonds = append(out.Bonds, h.toResponse(&bonds[i], yoy, monthly))
+		total = total.Add(CurrentValue(&bonds[i], yoy, monthly, h.now()))
 	}
 	t, _ := total.Float64()
 	out.TotalValue = t
@@ -226,7 +230,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	httputil.WriteJSON(w, http.StatusOK, h.toResponse(b, yoy))
+	httputil.WriteJSON(w, http.StatusOK, h.toResponse(b, yoy, h.loadMonthlyYoY(r.Context())))
 }
 
 // YTM serves GET /api/bonds/{id}/ytm — the yield-to-maturity projection.
@@ -245,7 +249,7 @@ func (h *Handler) YTM(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	pts := YieldToMaturity(b, yoy)
+	pts := YieldToMaturity(b, yoy, h.loadMonthlyYoY(r.Context()))
 	out := ytmResponse{BondID: b.ID, Points: make([]ytmPointResponse, 0, len(pts))}
 	for _, p := range pts {
 		v, _ := p.Value.Float64()
@@ -276,7 +280,7 @@ func (h *Handler) MaturityLadder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	belka := getBelkaRate()
-	result := MaturityLadder(bonds, yoy, h.now(), belka)
+	result := MaturityLadder(bonds, yoy, h.loadMonthlyYoY(r.Context()), h.now(), belka)
 
 	out := maturityLadderResponse{
 		Events:     make([]ladderEventResponse, 0, len(result.Events)),
@@ -350,7 +354,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	httputil.WriteJSON(w, http.StatusCreated, h.toResponse(created, yoy))
+	httputil.WriteJSON(w, http.StatusCreated, h.toResponse(created, yoy, h.loadMonthlyYoY(r.Context())))
 }
 
 // Update serves PUT /api/bonds/{id}.
@@ -379,7 +383,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
-	httputil.WriteJSON(w, http.StatusOK, h.toResponse(b, yoy))
+	httputil.WriteJSON(w, http.StatusOK, h.toResponse(b, yoy, h.loadMonthlyYoY(r.Context())))
 }
 
 // Delete serves DELETE /api/bonds/{id}.
@@ -412,6 +416,20 @@ func (h *Handler) loadYoY(ctx context.Context) (map[int]decimal.Decimal, error) 
 		return nil, err
 	}
 	return yoy, nil
+}
+
+// loadMonthlyYoY pulls the Eurostat HICP table. An empty map (table not
+// yet seeded by the scheduler) is not an error — calc.go falls back to
+// the annual yoy series. A real DB error is logged and swallowed for the
+// same reason: we'd rather degrade than 500 the bonds page over a CPI
+// scheduler hiccup.
+func (h *Handler) loadMonthlyYoY(ctx context.Context) map[cpi.YearMonth]decimal.Decimal {
+	m, err := h.cpi.LoadMonthlyYoYMap(ctx)
+	if err != nil {
+		h.logger.Warn("load monthly cpi (falling back to annual)", "err", err)
+		return nil
+	}
+	return m
 }
 
 func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {

--- a/backend-go/internal/bonds/maturity.go
+++ b/backend-go/internal/bonds/maturity.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 )
 
 // LadderEventKind is the cashflow's role on the calendar.
@@ -70,7 +72,7 @@ type LadderResult struct {
 // Past events (cashflow date <= now) are dropped: the calendar is
 // forward-looking, and a bond's matured principal has already hit the
 // owner's account.
-func MaturityLadder(bonds []TreasuryBond, yoyByYear map[int]decimal.Decimal, now time.Time, belkaRate decimal.Decimal) LadderResult {
+func MaturityLadder(bonds []TreasuryBond, yoyByYear map[int]decimal.Decimal, monthly map[cpi.YearMonth]decimal.Decimal, now time.Time, belkaRate decimal.Decimal) LadderResult {
 	if len(bonds) == 0 {
 		return LadderResult{Events: []LadderEvent{}, NextMaturity: nil}
 	}
@@ -84,7 +86,7 @@ func MaturityLadder(bonds []TreasuryBond, yoyByYear map[int]decimal.Decimal, now
 
 	for i := range bonds {
 		b := &bonds[i]
-		cf := appendBondEvents(b, yoyByYear, now, belkaRate, buckets, bucketKey)
+		cf := appendBondEvents(b, yoyByYear, monthly, now, belkaRate, buckets, bucketKey)
 		redemptions[b.ID] = cf
 	}
 
@@ -103,7 +105,7 @@ func MaturityLadder(bonds []TreasuryBond, yoyByYear map[int]decimal.Decimal, now
 		return events[i].Kind < events[j].Kind
 	})
 
-	next := computeNextMaturity(bonds, yoyByYear, now, belkaRate, redemptions)
+	next := computeNextMaturity(bonds, yoyByYear, monthly, now, belkaRate, redemptions)
 	return LadderResult{Events: events, NextMaturity: next}
 }
 
@@ -113,6 +115,7 @@ func MaturityLadder(bonds []TreasuryBond, yoyByYear map[int]decimal.Decimal, now
 func appendBondEvents(
 	b *TreasuryBond,
 	yoy map[int]decimal.Decimal,
+	monthly map[cpi.YearMonth]decimal.Decimal,
 	now time.Time,
 	belka decimal.Decimal,
 	buckets map[string]*LadderEvent,
@@ -124,7 +127,7 @@ func appendBondEvents(
 	}
 
 	if b.Capitalize {
-		final := YieldToMaturity(b, yoy)
+		final := YieldToMaturity(b, yoy, monthly)
 		if len(final) == 0 {
 			return redemptionCashflow{}
 		}
@@ -148,7 +151,7 @@ func appendBondEvents(
 		if !couponDate.After(now) {
 			continue
 		}
-		rate := YearRate(b, yoy, year)
+		rate := YearRate(b, yoy, monthly, year)
 		gross := b.FaceValue.Mul(rate).Div(decimal.NewFromInt(100)).Round(2)
 		tax := gross.Mul(belka).Round(2)
 		net := gross.Sub(tax)
@@ -207,7 +210,7 @@ type redemptionCashflow struct{ final, interest, tax, net decimal.Decimal }
 // summed cashflow stay coherent — if e.g. an EDO and a DOS happen to
 // mature in the same month, the warning still describes a single
 // homogeneous batch.
-func computeNextMaturity(bonds []TreasuryBond, yoy map[int]decimal.Decimal, now time.Time, belka decimal.Decimal, redemptions map[int]redemptionCashflow) *NextMaturity {
+func computeNextMaturity(bonds []TreasuryBond, yoy map[int]decimal.Decimal, monthly map[cpi.YearMonth]decimal.Decimal, now time.Time, belka decimal.Decimal, redemptions map[int]redemptionCashflow) *NextMaturity {
 	nearestIdx, nearestDate := pickNearestMaturity(bonds, now)
 	if nearestIdx < 0 {
 		return nil
@@ -238,7 +241,7 @@ func computeNextMaturity(bonds []TreasuryBond, yoy map[int]decimal.Decimal, now 
 		// what the owner actually receives that month, not just the
 		// principal.
 		if !b.Capitalize {
-			coupon := finalYearCoupon(b, yoy, belka)
+			coupon := finalYearCoupon(b, yoy, monthly, belka)
 			out.InterestGross = out.InterestGross.Add(coupon.gross)
 			out.Tax = out.Tax.Add(coupon.tax)
 			out.NetCashflow = out.NetCashflow.Add(coupon.net)
@@ -273,12 +276,12 @@ func pickNearestMaturity(bonds []TreasuryBond, now time.Time) (int, time.Time) {
 // final-year payout into the redemption-month summary.
 type couponAmounts struct{ gross, tax, net decimal.Decimal }
 
-func finalYearCoupon(b *TreasuryBond, yoy map[int]decimal.Decimal, belka decimal.Decimal) couponAmounts {
+func finalYearCoupon(b *TreasuryBond, yoy map[int]decimal.Decimal, monthly map[cpi.YearMonth]decimal.Decimal, belka decimal.Decimal) couponAmounts {
 	tenor := bondTenorYears(b.Type)
 	if tenor <= 0 {
 		return couponAmounts{}
 	}
-	rate := YearRate(b, yoy, tenor)
+	rate := YearRate(b, yoy, monthly, tenor)
 	gross := b.FaceValue.Mul(rate).Div(decimal.NewFromInt(100)).Round(2)
 	tax := gross.Mul(belka).Round(2)
 	return couponAmounts{gross: gross, tax: tax, net: gross.Sub(tax)}

--- a/backend-go/internal/bonds/maturity_test.go
+++ b/backend-go/internal/bonds/maturity_test.go
@@ -17,7 +17,7 @@ func TestMaturityLadderCapitalizedEDOEmitsSingleRedemption(t *testing.T) {
 	b.ID = 1
 	yoy := map[int]decimal.Decimal{2025: decimal.NewFromFloat(104)}
 
-	res := MaturityLadder([]TreasuryBond{*b}, yoy, now, testBelka)
+	res := MaturityLadder([]TreasuryBond{*b}, yoy, nil, now, testBelka)
 
 	if len(res.Events) != 1 {
 		t.Fatalf("EDO should produce 1 event, got %d: %+v", len(res.Events), res.Events)
@@ -64,7 +64,7 @@ func TestMaturityLadderCOIEmitsYearlyCouponsAndRedemption(t *testing.T) {
 		2028: decimal.NewFromFloat(102),
 	}
 
-	res := MaturityLadder([]TreasuryBond{*b}, yoy, now, testBelka)
+	res := MaturityLadder([]TreasuryBond{*b}, yoy, nil, now, testBelka)
 
 	if len(res.Events) != 5 {
 		t.Fatalf("COI should produce 5 events (4 coupons + redemption), got %d", len(res.Events))
@@ -111,7 +111,7 @@ func TestMaturityLadderSkipsPastEvents(t *testing.T) {
 	b.ID = 1
 	yoy := map[int]decimal.Decimal{2025: decimal.NewFromFloat(104), 2026: decimal.NewFromFloat(103)}
 
-	res := MaturityLadder([]TreasuryBond{*b}, yoy, now, testBelka)
+	res := MaturityLadder([]TreasuryBond{*b}, yoy, nil, now, testBelka)
 
 	// year-1 (2025-01) + year-2 (2026-01) coupons are in the past; only
 	// year-3 + year-4 coupons and the redemption remain.
@@ -134,7 +134,7 @@ func TestMaturityLadderGroupsSameMonthSameType(t *testing.T) {
 	b2 := bondEDO(purchase.AddDate(0, 0, 10)) // same month
 	b2.ID = 2
 
-	res := MaturityLadder([]TreasuryBond{*b1, *b2}, map[int]decimal.Decimal{}, now, testBelka)
+	res := MaturityLadder([]TreasuryBond{*b1, *b2}, map[int]decimal.Decimal{}, nil, now, testBelka)
 
 	if len(res.Events) != 1 {
 		t.Fatalf("two EDO maturing in same month should merge, got %d events", len(res.Events))
@@ -159,7 +159,7 @@ func TestMaturityLadderSortsByMonthThenTypeThenKind(t *testing.T) {
 	lateEDO := bondEDO(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)) // 2036-06
 	lateEDO.ID = 2
 
-	res := MaturityLadder([]TreasuryBond{*lateEDO, *earlyEDO}, map[int]decimal.Decimal{}, now, testBelka)
+	res := MaturityLadder([]TreasuryBond{*lateEDO, *earlyEDO}, map[int]decimal.Decimal{}, nil, now, testBelka)
 	if len(res.Events) != 2 {
 		t.Fatalf("expected 2 events, got %d", len(res.Events))
 	}
@@ -183,7 +183,7 @@ func TestNextMaturityIsNearestFuture(t *testing.T) {
 	far := bondEDO(time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC))
 	far.ID = 11
 
-	res := MaturityLadder([]TreasuryBond{*far, *soon}, map[int]decimal.Decimal{}, now, testBelka)
+	res := MaturityLadder([]TreasuryBond{*far, *soon}, map[int]decimal.Decimal{}, nil, now, testBelka)
 	if res.NextMaturity == nil {
 		t.Fatal("NextMaturity should be set")
 	}
@@ -217,7 +217,7 @@ func TestNextMaturityAggregatesSameMonth(t *testing.T) {
 		Capitalize:    true,
 	}
 
-	res := MaturityLadder([]TreasuryBond{*dos1, *dos2}, map[int]decimal.Decimal{}, now, testBelka)
+	res := MaturityLadder([]TreasuryBond{*dos1, *dos2}, map[int]decimal.Decimal{}, nil, now, testBelka)
 	if res.NextMaturity == nil {
 		t.Fatal("NextMaturity should be set")
 	}
@@ -235,7 +235,7 @@ func TestNextMaturityAggregatesSameMonth(t *testing.T) {
 }
 
 func TestMaturityLadderEmptyForNoBonds(t *testing.T) {
-	res := MaturityLadder(nil, map[int]decimal.Decimal{}, time.Now(), testBelka)
+	res := MaturityLadder(nil, map[int]decimal.Decimal{}, nil, time.Now(), testBelka)
 	if len(res.Events) != 0 || res.NextMaturity != nil {
 		t.Fatalf("empty input should return empty result, got %+v", res)
 	}
@@ -250,7 +250,7 @@ func TestMaturityLadderNonCapFinalMonthEmitsCouponAndRedemption(t *testing.T) {
 	b.ID = 1
 	yoy := map[int]decimal.Decimal{2025: decimal.NewFromFloat(104)}
 
-	res := MaturityLadder([]TreasuryBond{*b}, yoy, now, testBelka)
+	res := MaturityLadder([]TreasuryBond{*b}, yoy, nil, now, testBelka)
 
 	if len(res.Events) != 2 {
 		t.Fatalf("final month should have 2 rows (coupon + redemption), got %d", len(res.Events))
@@ -276,7 +276,7 @@ func TestNextMaturityFoldsFinalCouponForNonCapBond(t *testing.T) {
 	b.ID = 1
 	yoy := map[int]decimal.Decimal{2025: decimal.NewFromFloat(104)}
 
-	res := MaturityLadder([]TreasuryBond{*b}, yoy, now, testBelka)
+	res := MaturityLadder([]TreasuryBond{*b}, yoy, nil, now, testBelka)
 
 	if res.NextMaturity == nil {
 		t.Fatal("NextMaturity should be set")
@@ -299,7 +299,7 @@ func TestMaturityLadderHandlesNilYoYMap(t *testing.T) {
 	b := bondCOI(purchase)
 	b.ID = 1
 
-	res := MaturityLadder([]TreasuryBond{*b}, nil, now, testBelka)
+	res := MaturityLadder([]TreasuryBond{*b}, nil, nil, now, testBelka)
 
 	if len(res.Events) == 0 {
 		t.Fatal("nil yoy should still emit future events via FirstYearRate fallback")
@@ -336,7 +336,7 @@ func TestMaturityLadderSkipsAlreadyMaturedBond(t *testing.T) {
 	b.ID = 99
 	now := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC)
 
-	res := MaturityLadder([]TreasuryBond{*b}, map[int]decimal.Decimal{}, now, testBelka)
+	res := MaturityLadder([]TreasuryBond{*b}, map[int]decimal.Decimal{}, nil, now, testBelka)
 	if len(res.Events) != 0 {
 		t.Fatalf("matured bond should emit no future events, got %d", len(res.Events))
 	}

--- a/backend-go/internal/bonds/store.go
+++ b/backend-go/internal/bonds/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
 
+	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 	"github.com/Automaat/finance-buddy/backend-go/internal/dbutil"
 )
 
@@ -181,11 +182,13 @@ func (s *Store) Delete(ctx context.Context, id int) error {
 }
 
 // TotalCurrentValue sums CurrentValue across every active bond for the
-// dashboard "Obligacje skarbowe" tile. yoyByYear is the cpi_index map.
-func TotalCurrentValue(bonds []TreasuryBond, yoyByYear map[int]decimal.Decimal, now time.Time) decimal.Decimal {
+// dashboard "Obligacje skarbowe" tile. yoyByYear is the cpi_index map;
+// monthly is the period-aware Eurostat HICP map (empty falls back to
+// annual).
+func TotalCurrentValue(bonds []TreasuryBond, yoyByYear map[int]decimal.Decimal, monthly map[cpi.YearMonth]decimal.Decimal, now time.Time) decimal.Decimal {
 	total := decimal.Zero
 	for i := range bonds {
-		total = total.Add(CurrentValue(&bonds[i], yoyByYear, now))
+		total = total.Add(CurrentValue(&bonds[i], yoyByYear, monthly, now))
 	}
 	return total
 }

--- a/backend-go/internal/cpi/eurostat.go
+++ b/backend-go/internal/cpi/eurostat.go
@@ -1,0 +1,143 @@
+package cpi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+const (
+	// EurostatHICPURL is the prc_hicp_manr endpoint — monthly HICP annual
+	// rate of change for Poland, all-items.
+	EurostatHICPURL = "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr"
+	// EurostatMonthlySource is the source tag stored in cpi_monthly_index.
+	EurostatMonthlySource = "eurostat-hicp-manr"
+
+	eurostatHTTPTimeout = 8 * time.Second
+)
+
+// EurostatHICPFetcher hits Eurostat's open data API for Polish HICP YoY.
+// Stateless; reuse one instance per scheduler.
+type EurostatHICPFetcher struct {
+	client *http.Client
+}
+
+// NewEurostatHICPFetcher wires a default HTTP client.
+func NewEurostatHICPFetcher() *EurostatHICPFetcher {
+	return &EurostatHICPFetcher{
+		client: &http.Client{Timeout: eurostatHTTPTimeout},
+	}
+}
+
+// eurostatPayload mirrors the JSON-stat 2.0 shape returned by the
+// dissemination API. Only the fields the parser needs are decoded; the rest
+// of the response (label, source, dimension metadata) is ignored.
+type eurostatPayload struct {
+	Value     map[string]json.RawMessage `json:"value"`
+	Dimension struct {
+		Time struct {
+			Category struct {
+				Index map[string]int `json:"index"`
+			} `json:"category"`
+		} `json:"time"`
+	} `json:"dimension"`
+}
+
+// FetchSince returns Polish HICP YoY values from `since` (inclusive)
+// onwards, sorted ascending by (year, month). `since` is a YYYY-MM-01 in
+// any timezone; the day component is ignored.
+func (f *EurostatHICPFetcher) FetchSince(ctx context.Context, since time.Time) ([]MonthYearRate, error) {
+	if since.IsZero() {
+		return nil, fmt.Errorf("eurostat: since is zero")
+	}
+	q := fmt.Sprintf("?format=JSON&geo=PL&coicop=CP00&sinceTimePeriod=%04d-%02d",
+		since.Year(), int(since.Month()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, EurostatHICPURL+q, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("eurostat fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("eurostat http %d", resp.StatusCode)
+	}
+	var body eurostatPayload
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decode eurostat: %w", err)
+	}
+	return parseEurostat(&body)
+}
+
+// parseEurostat walks the JSON-stat dimension index and pairs every time
+// label (e.g. "2023-11") with its numeric value at the same index. Missing
+// or non-numeric values are skipped — Eurostat occasionally serializes
+// null for a still-unpublished month.
+func parseEurostat(body *eurostatPayload) ([]MonthYearRate, error) {
+	out := make([]MonthYearRate, 0, len(body.Value))
+	for label, idx := range body.Dimension.Time.Category.Index {
+		raw, ok := body.Value[strconv.Itoa(idx)]
+		if !ok || len(raw) == 0 || string(raw) == "null" {
+			continue
+		}
+		var f float64
+		if err := json.Unmarshal(raw, &f); err != nil {
+			continue
+		}
+		year, month, err := parseEurostatMonth(label)
+		if err != nil {
+			return nil, fmt.Errorf("parse time label %q: %w", label, err)
+		}
+		// Eurostat exposes the YoY % as a plain number (e.g. 6.3 for +6.3%).
+		// Convert via string to avoid float→decimal precision drift, then
+		// add 100 so the value matches the GUS convention used elsewhere in
+		// this package (114.4 = +14.4%).
+		dec, err := decimal.NewFromString(strconv.FormatFloat(f, 'f', -1, 64))
+		if err != nil {
+			return nil, fmt.Errorf("decimal %v: %w", f, err)
+		}
+		out = append(out, MonthYearRate{
+			Year:  year,
+			Month: month,
+			YoY:   dec.Add(decimal.NewFromInt(100)),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Year != out[j].Year {
+			return out[i].Year < out[j].Year
+		}
+		return out[i].Month < out[j].Month
+	})
+	return out, nil
+}
+
+func parseEurostatMonth(label string) (int, int, error) {
+	// JSON-stat formats Eurostat monthly periods as "YYYY-MM".
+	parts := strings.SplitN(label, "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("expected YYYY-MM, got %q", label)
+	}
+	y, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("year %q: %w", parts[0], err)
+	}
+	m, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("month %q: %w", parts[1], err)
+	}
+	if m < 1 || m > 12 {
+		return 0, 0, fmt.Errorf("month %d out of range", m)
+	}
+	return y, m, nil
+}

--- a/backend-go/internal/cpi/eurostat_test.go
+++ b/backend-go/internal/cpi/eurostat_test.go
@@ -1,0 +1,88 @@
+package cpi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+const eurostatFixture = `{
+  "version": "2.0",
+  "value": {"0": 6.6, "1": 4.7, "2": 3.6, "3": null},
+  "dimension": {
+    "time": {
+      "category": {
+        "index": {
+          "2023-11": 0,
+          "2024-11": 1,
+          "2025-11": 2,
+          "2026-04": 3
+        }
+      }
+    }
+  }
+}`
+
+func TestParseEurostat(t *testing.T) {
+	var body eurostatPayload
+	if err := decodeJSONString(eurostatFixture, &body); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	out, err := parseEurostat(&body)
+	if err != nil {
+		t.Fatalf("parseEurostat: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("rows = %d, want 3 (null skipped)", len(out))
+	}
+	// Sorted ascending by (year, month).
+	if out[0].Year != 2023 || out[0].Month != 11 {
+		t.Errorf("row 0 = %v, want 2023-11", out[0])
+	}
+	// Eurostat reports 6.6 (delta YoY); we store 106.6 to match GUS form.
+	if !out[0].YoY.Equal(decimal.RequireFromString("106.6")) {
+		t.Errorf("row 0 YoY = %s, want 106.6", out[0].YoY)
+	}
+	if !out[1].YoY.Equal(decimal.RequireFromString("104.7")) {
+		t.Errorf("row 1 YoY = %s, want 104.7", out[1].YoY)
+	}
+	if !out[2].YoY.Equal(decimal.RequireFromString("103.6")) {
+		t.Errorf("row 2 YoY = %s, want 103.6", out[2].YoY)
+	}
+}
+
+func TestParseEurostatMonth(t *testing.T) {
+	cases := []struct {
+		in        string
+		y, m      int
+		shouldErr bool
+	}{
+		{"2023-11", 2023, 11, false},
+		{"2024-01", 2024, 1, false},
+		{"2024-13", 0, 0, true},
+		{"bad", 0, 0, true},
+	}
+	for _, c := range cases {
+		y, m, err := parseEurostatMonth(c.in)
+		if c.shouldErr {
+			if err == nil {
+				t.Errorf("%q: want error", c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%q: unexpected err %v", c.in, err)
+			continue
+		}
+		if y != c.y || m != c.m {
+			t.Errorf("%q = (%d,%d), want (%d,%d)", c.in, y, m, c.y, c.m)
+		}
+	}
+}
+
+// decodeJSONString is a tiny helper so the test fixture stays inline.
+func decodeJSONString(s string, dst any) error {
+	return json.NewDecoder(strings.NewReader(s)).Decode(dst)
+}

--- a/backend-go/internal/cpi/monthly.go
+++ b/backend-go/internal/cpi/monthly.go
@@ -1,0 +1,172 @@
+// Monthly CPI data path. The Ministry's "list emisyjny" formula for
+// inflation-indexed retail bonds (EDO, COI, ROS, ROD) reads as:
+//
+//	rate for okres odsetkowy N = margin + CPI YoY published in the month
+//	preceding the first month of the period
+//
+// E.g. an EDO purchased on 2023-01-10 with period 2 starting 2024-01-10
+// uses the YoY value published in December 2023 — which is the YoY for
+// November 2023 (GUS releases month X's reading around day 15 of month
+// X+1). So the reference is always two months before the period's first
+// month.
+//
+// Annual CPI (cpi_index) is too coarse: it would attribute the period-2
+// rate to the 2024 annual YoY (3.6%) when the actual Nov-2023 monthly
+// figure was ~6.6%. That mismatch was the source of the ~0.3% systematic
+// undervaluation observed against PKO portfolio screenshots.
+//
+// Data source: Eurostat HICP monthly (prc_hicp_manr, Poland, all-items,
+// annual rate of change). HICP differs from the Ministry's reference
+// (GUS national CPI) by ~0.1-0.3pp; the residual error is documented in
+// internal/bonds/calc.go.
+package cpi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/shopspring/decimal"
+)
+
+// MonthYearRate is one (year, month, yoy_rate) tuple.
+type MonthYearRate struct {
+	Year  int
+	Month int // 1-12
+	YoY   decimal.Decimal
+}
+
+// YearMonth is the composite key used by LoadMonthlyYoYMap. Compares
+// cleanly when year/month are within the documented ranges (1900–9999, 1–12).
+type YearMonth struct {
+	Year  int
+	Month int
+}
+
+// EnsureMonthlySchema creates cpi_monthly_index if missing. Idempotent so
+// it can run on every startup like the other EnsureSchema helpers.
+func (s *Store) EnsureMonthlySchema(ctx context.Context) error {
+	_, err := s.pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS cpi_monthly_index (
+			year integer NOT NULL,
+			month integer NOT NULL,
+			yoy_rate numeric(8,4) NOT NULL,
+			source character varying(64) NOT NULL,
+			fetched_at timestamp with time zone NOT NULL DEFAULT (now() at time zone 'utc'),
+			PRIMARY KEY (year, month)
+		)`)
+	if err != nil {
+		return fmt.Errorf("create cpi_monthly_index: %w", err)
+	}
+	return nil
+}
+
+// LoadMonthlyYoYMap returns YearMonth → yoy_rate for every cpi_monthly_index
+// row. Used by bonds.calc to look up the period-aware reference rate.
+func (s *Store) LoadMonthlyYoYMap(ctx context.Context) (map[YearMonth]decimal.Decimal, error) {
+	rows, err := s.pool.Query(ctx, `SELECT year, month, yoy_rate FROM cpi_monthly_index`)
+	if err != nil {
+		return nil, fmt.Errorf("select cpi_monthly_index: %w", err)
+	}
+	defer rows.Close()
+	out := map[YearMonth]decimal.Decimal{}
+	for rows.Next() {
+		var y, m int
+		var rate decimal.Decimal
+		if err := rows.Scan(&y, &m, &rate); err != nil {
+			return nil, fmt.Errorf("scan cpi_monthly_index: %w", err)
+		}
+		out[YearMonth{Year: y, Month: m}] = rate
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate cpi_monthly_index: %w", err)
+	}
+	return out, nil
+}
+
+// NeedsMonthlyRefresh mirrors NeedsRefresh but for cpi_monthly_index.
+func (s *Store) NeedsMonthlyRefresh(ctx context.Context, staleAfter time.Duration) (bool, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT fetched_at FROM cpi_monthly_index ORDER BY fetched_at DESC LIMIT 1`,
+	)
+	var latest time.Time
+	if err := row.Scan(&latest); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return true, nil
+		}
+		return false, fmt.Errorf("monthly cpi staleness check: %w", err)
+	}
+	return time.Since(latest) > staleAfter, nil
+}
+
+// UpsertMonthly applies the (year, month, yoy_rate) batch. Same change-only
+// semantics as Upsert: rows whose rate hasn't moved are skipped. Returns
+// the count of rows actually written or refreshed.
+func (s *Store) UpsertMonthly(ctx context.Context, source string, rows []MonthYearRate) (int, error) {
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("begin monthly upsert: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	written, err := writeMonthlyRows(ctx, tx, source, rows)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("commit monthly upsert: %w", err)
+	}
+	committed = true
+	return written, nil
+}
+
+func writeMonthlyRows(ctx context.Context, tx pgx.Tx, source string, rows []MonthYearRate) (int, error) {
+	existing := map[YearMonth]decimal.Decimal{}
+	q, err := tx.Query(ctx, `SELECT year, month, yoy_rate FROM cpi_monthly_index FOR UPDATE`)
+	if err != nil {
+		return 0, fmt.Errorf("lock cpi_monthly_index: %w", err)
+	}
+	for q.Next() {
+		var y, m int
+		var rate decimal.Decimal
+		if err := q.Scan(&y, &m, &rate); err != nil {
+			q.Close()
+			return 0, fmt.Errorf("scan existing cpi_monthly_index: %w", err)
+		}
+		existing[YearMonth{Year: y, Month: m}] = rate
+	}
+	q.Close()
+	if err := q.Err(); err != nil {
+		return 0, fmt.Errorf("iterate cpi_monthly_index: %w", err)
+	}
+	written := 0
+	now := time.Now().UTC()
+	for _, r := range rows {
+		if current, ok := existing[YearMonth{Year: r.Year, Month: r.Month}]; ok && current.Equal(r.YoY) {
+			continue
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO cpi_monthly_index (year, month, yoy_rate, source, fetched_at)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT (year, month) DO UPDATE SET
+				yoy_rate = EXCLUDED.yoy_rate,
+				source = EXCLUDED.source,
+				fetched_at = EXCLUDED.fetched_at
+			WHERE cpi_monthly_index.yoy_rate IS DISTINCT FROM EXCLUDED.yoy_rate`,
+			r.Year, r.Month, r.YoY, source, now,
+		); err != nil {
+			return written, fmt.Errorf("upsert cpi_monthly_index %d-%02d: %w", r.Year, r.Month, err)
+		}
+		written++
+	}
+	return written, nil
+}

--- a/backend-go/internal/scheduler/monthly_cpi.go
+++ b/backend-go/internal/scheduler/monthly_cpi.go
@@ -1,0 +1,108 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
+)
+
+// monthlyBackfillStart is how far back the scheduler asks Eurostat for
+// HICP YoY values on first run. Covers every retail bond emission you'd
+// plausibly hold today (EDO 10y issued ≥ 2014 hits period 11+ today, so
+// 2014 is the practical floor; we go a year earlier for headroom).
+var monthlyBackfillStart = time.Date(2013, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// MonthlyCPIStore is the slice of *cpi.Store the monthly scheduler uses.
+type MonthlyCPIStore interface {
+	NeedsMonthlyRefresh(ctx context.Context, staleAfter time.Duration) (bool, error)
+	UpsertMonthly(ctx context.Context, source string, rows []cpi.MonthYearRate) (int, error)
+}
+
+// MonthlyCPIFetcher is the slice of *cpi.EurostatHICPFetcher used.
+type MonthlyCPIFetcher interface {
+	FetchSince(ctx context.Context, since time.Time) ([]cpi.MonthYearRate, error)
+}
+
+// MonthlyCPIScheduler runs the monthly-CPI refresh loop. Modeled after
+// CPIScheduler — single instance, hand-rolled timer, same 16th-of-month
+// cadence (Eurostat usually publishes a new month around day 17, so by
+// day 16 we capture the prior month's release).
+type MonthlyCPIScheduler struct {
+	store   MonthlyCPIStore
+	fetcher MonthlyCPIFetcher
+	logger  *slog.Logger
+	now     func() time.Time
+	loc     *time.Location
+}
+
+// NewMonthlyCPIScheduler wires the scheduler. Falls back to UTC if the
+// Europe/Warsaw zone isn't available (missing tzdata).
+func NewMonthlyCPIScheduler(store MonthlyCPIStore, fetcher MonthlyCPIFetcher, logger *slog.Logger) *MonthlyCPIScheduler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	loc, err := time.LoadLocation("Europe/Warsaw")
+	if err != nil {
+		logger.Warn("scheduler: Europe/Warsaw tz unavailable, using UTC", "err", err)
+		loc = time.UTC
+	}
+	return &MonthlyCPIScheduler{
+		store:   store,
+		fetcher: fetcher,
+		logger:  logger,
+		now:     time.Now,
+		loc:     loc,
+	}
+}
+
+// Run does the startup staleness check, then loops firing the monthly
+// refresh until ctx is canceled.
+func (s *MonthlyCPIScheduler) Run(ctx context.Context) {
+	s.startupRefresh(ctx)
+	for {
+		now := s.now().In(s.loc)
+		next := nextRefresh(now)
+		wait := max(next.Sub(now), 0)
+		s.logger.Info("scheduler: next monthly CPI refresh", "at", next.Format(time.RFC3339))
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			s.logger.Info("scheduler: monthly CPI stopped")
+			return
+		case <-timer.C:
+			s.refresh(ctx)
+		}
+	}
+}
+
+func (s *MonthlyCPIScheduler) startupRefresh(ctx context.Context) {
+	stale, err := s.store.NeedsMonthlyRefresh(ctx, cpiStaleAfter)
+	if err != nil {
+		s.logger.Warn("scheduler: monthly CPI staleness check failed", "err", err)
+		return
+	}
+	if stale {
+		s.logger.Info("scheduler: monthly CPI stale at startup, refreshing")
+		s.refresh(ctx)
+	}
+}
+
+// refresh fetches Eurostat HICP YoY values from monthlyBackfillStart and
+// upserts them. The upsert is change-only so most refreshes write nothing.
+func (s *MonthlyCPIScheduler) refresh(ctx context.Context) {
+	rows, err := s.fetcher.FetchSince(ctx, monthlyBackfillStart)
+	if err != nil {
+		s.logger.Warn("scheduler: Eurostat fetch failed", "err", err)
+		return
+	}
+	written, err := s.store.UpsertMonthly(ctx, cpi.EurostatMonthlySource, rows)
+	if err != nil {
+		s.logger.Warn("scheduler: monthly CPI upsert failed", "err", err)
+		return
+	}
+	s.logger.Info("scheduler: monthly CPI refresh complete",
+		"rows_written", written, "rows_seen", len(rows))
+}


### PR DESCRIPTION
## Motivation

After comparing the bond ledger to PKO portfolio screenshots, the app
undervalued every pre-2024 EDO emission by ~0.3% — concentrated on
period 2 (year 2024-01-10 → 2025-01-10) where annual CPI for 2024 was
3.6% but the Ministry actually applied the Nov-2023 monthly YoY of
~6.6%. Engine used `cpiYear = PurchaseDate.Year() + yearIdx - 1` and
looked up annual cpi_index — wrong reference window.

## Implementation information

**New table** `cpi_monthly_index(year, month, yoy_rate, source,
fetched_at)`, bootstrapped via EnsureMonthlySchema on startup.

**Fetcher** `cpi.EurostatHICPFetcher` hits
`https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/prc_hicp_manr?geo=PL&coicop=CP00`
— free, no key, JSON. Eurostat HICP differs from the Ministry's
reference (GUS national CPI) by ~0.1-0.3pp; documented inline. GUS
BDL was checked but has no monthly CPI variable, only annual (217230)
and quarterly (P2496).

**Scheduler** `MonthlyCPIScheduler` mirrors the CPI scheduler shape:
16th-of-month at 04:00 Europe/Warsaw + startup-if-stale, single
instance, hand-rolled timer. Backfills to 2013 on first run to cover
every EDO emission a household might still hold.

**Rate engine** `bonds.calc.yearRate` accepts a monthly map. For
period N starting at date D, ref = first-month-of-period minus 2
(with year wrap when period starts in Jan/Feb). Walks back up to 12
months on Eurostat publishing gaps. Falls through to the annual map,
then to FirstYearRate, so a missing scheduler run can't zero out a
portfolio.

**Threading**: HoldingsHandler.toResponse / List / Get / YTM /
MaturityLadder / TotalCurrentValue / finalYearCoupon / appendBondEvents
/ computeNextMaturity all take the monthly map. Pre-existing tests
pass `nil` to keep the legacy annual code path covered. 3 new tests
pin the override / walk-back / year-wrap branches.

Alternatives considered:

- FRED POLCPIALLMINMEI (uses GUS CPI exactly) — requires free API key.
  Extra env var + signup not worth the 0.1-0.3pp accuracy gain over
  Eurostat HICP.
- Per-emission PDF "tabela odsetkowa" scraping — brittle PDF parsing;
  CPI engine works for any future emission with zero per-bond config.
- Hardcoded rates per emission — wouldn't cover new bond purchases.

## Supporting documentation

n/a

> Changelog: fix(bonds): period-aware monthly CPI