### PR TITLE
feat(bonds): account_id + valuator

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -1693,6 +1693,10 @@
                     "bonds": {
                       "items": {
                         "properties": {
+                          "account_id": {
+                            "nullable": true,
+                            "type": "integer"
+                          },
                           "capitalize": {
                             "type": "boolean"
                           },
@@ -1773,6 +1777,10 @@
               "application/json": {
                 "schema": {
                   "properties": {
+                    "account_id": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
                     "capitalize": {
                       "type": "boolean"
                     },
@@ -2017,6 +2025,10 @@
               "application/json": {
                 "schema": {
                   "properties": {
+                    "account_id": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
                     "capitalize": {
                       "type": "boolean"
                     },
@@ -2095,6 +2107,10 @@
               "application/json": {
                 "schema": {
                   "properties": {
+                    "account_id": {
+                      "nullable": true,
+                      "type": "integer"
+                    },
                     "capitalize": {
                       "type": "boolean"
                     },

--- a/backend-go/internal/accounts/handler.go
+++ b/backend-go/internal/accounts/handler.go
@@ -65,16 +65,18 @@ type listResponse struct {
 
 // Handler is the HTTP boundary for /api/accounts.
 type Handler struct {
-	store    *Store
-	cpi      CPILoader
-	holdings HoldingsValuator
-	logger   *slog.Logger
+	store     *Store
+	cpi       CPILoader
+	valuators []HoldingsValuator
+	logger    *slog.Logger
 }
 
 // HoldingsValuator returns the live PLN market value per account derived
-// from the holdings ledger. Snapshot/current_value pre-fill consumes this
-// for stock/etf/bond/fund accounts so user-typed snapshots already match
-// what brokers show. Implemented by holdings.Valuator.
+// from some asset ledger. Snapshot/current_value pre-fill consumes the
+// merged result for stock/etf/bond/fund accounts so user-typed snapshots
+// already match what brokers/portals show. Implemented by both
+// holdings.Valuator (live MV from stocks/ETFs) and bonds.Valuator (live
+// compounded value from EDO/COI/…); the handler sums them per account.
 type HoldingsValuator interface {
 	AccountValuesPLN(ctx context.Context) (map[int]decimal.Decimal, error)
 }
@@ -89,15 +91,23 @@ var investmentCategories = map[string]bool{
 	"fund":  true,
 }
 
-// NewHandler wires the store + CPI loader + holdings valuator + logger.
-// cpiStore may be nil in tests (real-yield columns become null). holdings
-// may be nil — then current_value falls back to the snapshot-derived value
-// for every account.
-func NewHandler(store *Store, cpiStore CPILoader, holdings HoldingsValuator, logger *slog.Logger) *Handler {
+// NewHandler wires the store + CPI loader + zero-or-more valuators +
+// logger. cpiStore may be nil in tests (real-yield columns become null).
+// Valuators may be nil/empty — then current_value falls back to the
+// snapshot-derived value for every account.
+func NewHandler(store *Store, cpiStore CPILoader, logger *slog.Logger, valuators ...HoldingsValuator) *Handler {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Handler{store: store, cpi: cpiStore, holdings: holdings, logger: logger}
+	// Filter out nil valuators so callers can pass nil for an absent source
+	// without making the merge logic guard each call.
+	live := valuators[:0:0]
+	for _, v := range valuators {
+		if v != nil {
+			live = append(live, v)
+		}
+	}
+	return &Handler{store: store, cpi: cpiStore, valuators: live, logger: logger}
 }
 
 // realYieldCtx carries the per-request CPI snapshot used to compute real
@@ -193,19 +203,27 @@ func toResponse(a *Account, currentValue decimal.Decimal, ry realYieldCtx) respo
 	return out
 }
 
-// loadHoldingsValues fetches live PLN market value per account from the
-// holdings ledger. Returns nil on failure (logged) so the request still
-// succeeds with snapshot-derived values. Empty when no valuator wired.
+// loadHoldingsValues fetches live PLN per account from every wired
+// valuator and sums them. A single valuator failing is logged and dropped
+// — the request still succeeds with whichever sources returned cleanly,
+// and the snapshot fallback covers accounts no valuator knows about.
+// Returns nil when no valuator is wired so the caller short-circuits.
 func (h *Handler) loadHoldingsValues(ctx context.Context) map[int]decimal.Decimal {
-	if h.holdings == nil {
+	if len(h.valuators) == 0 {
 		return nil
 	}
-	vals, err := h.holdings.AccountValuesPLN(ctx)
-	if err != nil {
-		h.logger.Warn("accounts: holdings valuation failed", "err", err)
-		return nil
+	merged := map[int]decimal.Decimal{}
+	for _, v := range h.valuators {
+		vals, err := v.AccountValuesPLN(ctx)
+		if err != nil {
+			h.logger.Warn("accounts: valuator failed", "err", err)
+			continue
+		}
+		for id, amount := range vals {
+			merged[id] = merged[id].Add(amount)
+		}
 	}
-	return vals
+	return merged
 }
 
 // realYieldCtxFor is the single-account variant of loadRealYieldCtx: when

--- a/backend-go/internal/bonds/handler.go
+++ b/backend-go/internal/bonds/handler.go
@@ -91,6 +91,7 @@ type response struct {
 	PurchaseDate  wire.IsoDate  `json:"purchase_date"`
 	MaturityDate  wire.IsoDate  `json:"maturity_date"`
 	OwnerUserID   *int          `json:"owner_user_id"`
+	AccountID     *int          `json:"account_id"`
 	FirstYearRate float64       `json:"first_year_rate"`
 	Margin        float64       `json:"margin"`
 	Capitalize    bool          `json:"capitalize"`
@@ -153,6 +154,7 @@ type createRequest struct {
 	FaceValue     float64      `json:"face_value"`
 	PurchaseDate  wire.IsoDate `json:"purchase_date"`
 	OwnerUserID   *int         `json:"owner_user_id"`
+	AccountID     *int         `json:"account_id"`
 	FirstYearRate float64      `json:"first_year_rate"`
 	Margin        float64      `json:"margin"`
 	Capitalize    bool         `json:"capitalize"`
@@ -174,6 +176,7 @@ func (h *Handler) toResponse(b *TreasuryBond, yoy map[int]decimal.Decimal, month
 		PurchaseDate:  wire.IsoDate(b.PurchaseDate),
 		MaturityDate:  wire.IsoDate(MaturityDate(b)),
 		OwnerUserID:   b.OwnerUserID,
+		AccountID:     b.AccountID,
 		FirstYearRate: firstYear,
 		Margin:        margin,
 		Capitalize:    b.Capitalize,
@@ -339,6 +342,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		FaceValue:     decimal.NewFromFloat(req.FaceValue),
 		PurchaseDate:  time.Time(req.PurchaseDate),
 		OwnerUserID:   req.OwnerUserID,
+		AccountID:     req.AccountID,
 		FirstYearRate: decimal.NewFromFloat(req.FirstYearRate),
 		Margin:        decimal.NewFromFloat(req.Margin),
 		Capitalize:    req.Capitalize,

--- a/backend-go/internal/bonds/store.go
+++ b/backend-go/internal/bonds/store.go
@@ -24,12 +24,13 @@ func NewStore(pool *pgxpool.Pool) *Store {
 	return &Store{pool: pool}
 }
 
-const selectColumns = `id, type, series, face_value, purchase_date, owner_user_id,
+const selectColumns = `id, type, series, face_value, purchase_date, owner_user_id, account_id,
 		first_year_rate, margin, capitalize, is_active, created_at`
 
-// EnsureSchema creates the treasury_bonds table if missing. Idempotent so it
-// can run on every backend start — schema.sql only seeds empty databases, so
-// existing prod installs need the additive DDL here too.
+// EnsureSchema creates the treasury_bonds table if missing and runs additive
+// migrations for columns added after the initial schema. Idempotent so it
+// can run on every backend start — schema.sql only seeds empty databases,
+// so existing prod installs need the additive DDL here too.
 func (s *Store) EnsureSchema(ctx context.Context) error {
 	if _, err := s.pool.Exec(ctx, `
 		CREATE TABLE IF NOT EXISTS treasury_bonds (
@@ -47,6 +48,15 @@ func (s *Store) EnsureSchema(ctx context.Context) error {
 			CONSTRAINT treasury_bonds_owner_user_id_fkey FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE RESTRICT
 		)`); err != nil {
 		return fmt.Errorf("ensure treasury_bonds table: %w", err)
+	}
+	// Additive: account_id links a bond to its broker/wrapper account so the
+	// live current_value override can roll bonds into the right tile.
+	// Nullable; ON DELETE SET NULL so a deleted account doesn't cascade.
+	if _, err := s.pool.Exec(ctx, `
+		ALTER TABLE treasury_bonds
+		ADD COLUMN IF NOT EXISTS account_id integer
+		REFERENCES accounts(id) ON DELETE SET NULL`); err != nil {
+		return fmt.Errorf("add treasury_bonds.account_id: %w", err)
 	}
 	return nil
 }
@@ -80,11 +90,11 @@ func (s *Store) Get(ctx context.Context, id int) (*TreasuryBond, error) {
 func (s *Store) Create(ctx context.Context, b *TreasuryBond) (*TreasuryBond, error) {
 	row := s.pool.QueryRow(ctx, `
 		INSERT INTO treasury_bonds (
-			type, series, face_value, purchase_date, owner_user_id,
+			type, series, face_value, purchase_date, owner_user_id, account_id,
 			first_year_rate, margin, capitalize, is_active, created_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, true, $9)
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, true, $10)
 		RETURNING `+selectColumns,
-		string(b.Type), b.Series, b.FaceValue, b.PurchaseDate, b.OwnerUserID,
+		string(b.Type), b.Series, b.FaceValue, b.PurchaseDate, b.OwnerUserID, b.AccountID,
 		b.FirstYearRate, b.Margin, b.Capitalize, time.Now().UTC(),
 	)
 	created, err := scanBond(row)
@@ -95,8 +105,8 @@ func (s *Store) Create(ctx context.Context, b *TreasuryBond) (*TreasuryBond, err
 }
 
 // UpdatePatch is the sparse update; only set fields are applied. OwnerUserID
-// uses the explicit-null pattern (Set=true + nil) so the caller can clear
-// it.
+// and AccountID use the explicit-null pattern (Set=true + nil) so the caller
+// can clear them.
 type UpdatePatch struct {
 	Type           *BondType
 	Series         *string
@@ -104,6 +114,8 @@ type UpdatePatch struct {
 	PurchaseDate   *time.Time
 	OwnerUserIDSet bool
 	OwnerUserID    *int
+	AccountIDSet   bool
+	AccountID      *int
 	FirstYearRate  *decimal.Decimal
 	Margin         *decimal.Decimal
 	Capitalize     *bool
@@ -135,6 +147,9 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*TreasuryBon
 		if p.OwnerUserIDSet {
 			b.OwnerUserID = p.OwnerUserID
 		}
+		if p.AccountIDSet {
+			b.AccountID = p.AccountID
+		}
 		if p.FirstYearRate != nil {
 			b.FirstYearRate = *p.FirstYearRate
 		}
@@ -147,10 +162,11 @@ func (s *Store) Update(ctx context.Context, id int, p UpdatePatch) (*TreasuryBon
 		row = tx.QueryRow(ctx, `
 			UPDATE treasury_bonds SET
 				type = $1, series = $2, face_value = $3, purchase_date = $4,
-				owner_user_id = $5, first_year_rate = $6, margin = $7, capitalize = $8
-			WHERE id = $9
+				owner_user_id = $5, account_id = $6, first_year_rate = $7,
+				margin = $8, capitalize = $9
+			WHERE id = $10
 			RETURNING `+selectColumns,
-			string(b.Type), b.Series, b.FaceValue, b.PurchaseDate, b.OwnerUserID,
+			string(b.Type), b.Series, b.FaceValue, b.PurchaseDate, b.OwnerUserID, b.AccountID,
 			b.FirstYearRate, b.Margin, b.Capitalize, id,
 		)
 		loaded, err := scanBond(row)
@@ -197,7 +213,7 @@ func scanBond(row pgx.Row) (*TreasuryBond, error) {
 	var b TreasuryBond
 	var typ string
 	if err := row.Scan(
-		&b.ID, &typ, &b.Series, &b.FaceValue, &b.PurchaseDate, &b.OwnerUserID,
+		&b.ID, &typ, &b.Series, &b.FaceValue, &b.PurchaseDate, &b.OwnerUserID, &b.AccountID,
 		&b.FirstYearRate, &b.Margin, &b.Capitalize, &b.IsActive, &b.CreatedAt,
 	); err != nil {
 		return nil, err

--- a/backend-go/internal/bonds/types.go
+++ b/backend-go/internal/bonds/types.go
@@ -54,12 +54,16 @@ func (t BondType) MaturityMonths() int {
 // for jointly-owned ("Shared") bonds, matching the household-shared account
 // model elsewhere in the schema.
 type TreasuryBond struct {
-	ID            int
-	Type          BondType
-	Series        string
-	FaceValue     decimal.Decimal
-	PurchaseDate  time.Time
-	OwnerUserID   *int
+	ID           int
+	Type         BondType
+	Series       string
+	FaceValue    decimal.Decimal
+	PurchaseDate time.Time
+	OwnerUserID  *int
+	AccountID    *int // optional broker/wrapper account (e.g. IKE Obligacje,
+	// Obligacje PKO). Nullable so existing bond rows pre-account aren't
+	// orphaned; new rows are encouraged to set it so the live current_value
+	// override on accounts.Handler can roll bonds into the right tile.
 	FirstYearRate decimal.Decimal // annual %, e.g. 6.80
 	Margin        decimal.Decimal // annual %, applied on top of CPI YoY from year 2+
 	Capitalize    bool            // true: interest compounds; false: paid out yearly

--- a/backend-go/internal/bonds/validation.go
+++ b/backend-go/internal/bonds/validation.go
@@ -92,6 +92,16 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 			p.OwnerUserID = &id
 		}
 	}
+	if v, ok := raw["account_id"]; ok {
+		p.AccountIDSet = true
+		if !validation.IsNull(v) {
+			var id int
+			if err := json.Unmarshal(v, &id); err != nil {
+				return p, &httputil.ValidationError{Field: "account_id", Msg: "must be an integer"}
+			}
+			p.AccountID = &id
+		}
+	}
 	if vErr := patchRatePercent(raw, "first_year_rate", &p.FirstYearRate); vErr != nil {
 		return p, vErr
 	}

--- a/backend-go/internal/bonds/valuator.go
+++ b/backend-go/internal/bonds/valuator.go
@@ -1,0 +1,62 @@
+package bonds
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Valuator binds a Store + CPI source so accounts.Handler can override
+// `current_value` for bond-category accounts with the live sum from the
+// bond ledger. Mirrors holdings.Valuator's shape so the wiring in
+// server.go is symmetric. Implements accounts.HoldingsValuator interface
+// (any source of per-account PLN values fits the contract).
+type Valuator struct {
+	store  *Store
+	cpi    CPILoader
+	logger *slog.Logger
+	now    func() time.Time
+}
+
+// NewValuator wires the store + CPI loader. cpi may be nil — value math
+// then falls back to FirstYearRate per the bonds.calc fallback chain.
+func NewValuator(store *Store, cpiStore CPILoader, logger *slog.Logger) *Valuator {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Valuator{store: store, cpi: cpiStore, logger: logger, now: time.Now}
+}
+
+// AccountValuesPLN walks every active bond, computes its current value
+// via the same engine the handler uses, and sums per account_id. Bonds
+// without an account_id are dropped (they have no tile to roll into) so
+// the result is a sparse map of accounts that actually hold tracked
+// bonds. Same contract as holdings.Valuator.AccountValuesPLN — both
+// satisfy accounts.HoldingsValuator.
+func (v *Valuator) AccountValuesPLN(ctx context.Context) (map[int]decimal.Decimal, error) {
+	bonds, err := v.store.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	yoy, err := v.cpi.LoadYoYMap(ctx)
+	if err != nil {
+		v.logger.Warn("bonds.valuator: load annual cpi failed", "err", err)
+	}
+	monthly, err := v.cpi.LoadMonthlyYoYMap(ctx)
+	if err != nil {
+		v.logger.Warn("bonds.valuator: load monthly cpi failed", "err", err)
+	}
+	out := map[int]decimal.Decimal{}
+	now := v.now()
+	for i := range bonds {
+		b := &bonds[i]
+		if b.AccountID == nil {
+			continue
+		}
+		cur := CurrentValue(b, yoy, monthly, now)
+		out[*b.AccountID] = out[*b.AccountID].Add(cur)
+	}
+	return out, nil
+}

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -319,7 +319,11 @@ func registerCPIAndPayrollRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.
 func registerPortfolioRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
 	aggregatesStore := aggregates.NewStore(pool)
 	holdingsValuator := holdings.NewValuator(holdings.NewStore(pool), fx.NewService(pool, logger))
-	accountsHandler := accounts.NewHandler(accounts.NewStore(pool, aggregatesStore), cpi.NewStore(pool), holdingsValuator, logger)
+	bondsValuator := bonds.NewValuator(bonds.NewStore(pool), cpi.NewStore(pool), logger)
+	accountsHandler := accounts.NewHandler(
+		accounts.NewStore(pool, aggregatesStore), cpi.NewStore(pool), logger,
+		holdingsValuator, bondsValuator,
+	)
 	r.Route("/api/accounts", func(r chi.Router) {
 		r.Get("/", accountsHandler.List)
 		r.Post("/", accountsHandler.Create)

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -1249,6 +1249,7 @@ export interface paths {
                     content: {
                         "application/json": {
                             bonds?: {
+                                account_id?: number | null;
                                 capitalize?: boolean;
                                 /** Format: date-time */
                                 created_at?: string;
@@ -1297,6 +1298,7 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            account_id?: number | null;
                             capitalize?: boolean;
                             /** Format: date-time */
                             created_at?: string;
@@ -1468,6 +1470,7 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            account_id?: number | null;
                             capitalize?: boolean;
                             /** Format: date-time */
                             created_at?: string;
@@ -1513,6 +1516,7 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            account_id?: number | null;
                             capitalize?: boolean;
                             /** Format: date-time */
                             created_at?: string;

--- a/src/routes/bonds/+page.svelte
+++ b/src/routes/bonds/+page.svelte
@@ -59,6 +59,7 @@
 		face_value: number;
 		purchase_date: string;
 		owner_user_id: number | null;
+		account_id: number | null;
 		first_year_rate: number;
 		margin: number;
 		capitalize: boolean;
@@ -71,6 +72,7 @@
 		face_value: 1000,
 		purchase_date: today,
 		owner_user_id: null,
+		account_id: null,
 		...defaultsForType('EDO')
 	});
 
@@ -83,6 +85,7 @@
 			face_value: 1000,
 			purchase_date: today,
 			owner_user_id: null,
+			account_id: null,
 			...defaultsForType('EDO')
 		};
 		showForm = true;
@@ -97,6 +100,7 @@
 			face_value: bond.face_value,
 			purchase_date: bond.purchase_date,
 			owner_user_id: bond.owner_user_id,
+			account_id: bond.account_id,
 			first_year_rate: bond.first_year_rate,
 			margin: bond.margin,
 			capitalize: bond.capitalize
@@ -401,6 +405,16 @@
 					</label>
 
 					<label class="label">
+						<span class="font-semibold text-sm">Konto</span>
+						<select class="select" bind:value={formData.account_id}>
+							<option value={null}>—</option>
+							{#each data.accounts as a}
+								<option value={a.id}>{a.name}</option>
+							{/each}
+						</select>
+					</label>
+
+					<label class="label">
 						<span class="font-semibold text-sm">Stopa rok 1 (%)</span>
 						<input
 							type="number"
@@ -464,6 +478,7 @@
 							<th>Typ</th>
 							<th>Seria</th>
 							<th>Właściciel</th>
+							<th>Konto</th>
 							<th>Nominał</th>
 							<th>Wartość</th>
 							<th>Stopa roku</th>
@@ -478,6 +493,9 @@
 								<td class="font-medium">{bond.type}</td>
 								<td>{bond.series}</td>
 								<td>{ownerName(data.owners, bond.owner_user_id)}</td>
+								<td class="text-xs text-surface-700-300">
+									{data.accounts.find((a) => a.id === bond.account_id)?.name ?? '—'}
+								</td>
 								<td>{formatPLN(bond.face_value)}</td>
 								<td class="font-semibold text-primary-600-400">{formatPLN(bond.current_value)}</td>
 								<td>{bond.current_yield.toFixed(2)}%</td>

--- a/src/routes/bonds/+page.ts
+++ b/src/routes/bonds/+page.ts
@@ -10,12 +10,20 @@ export interface TreasuryBond {
 	purchase_date: string;
 	maturity_date: string;
 	owner_user_id: number | null;
+	account_id: number | null;
 	first_year_rate: number;
 	margin: number;
 	capitalize: boolean;
 	current_value: number;
 	current_yield: number;
 	created_at: string;
+}
+
+export interface AccountOption {
+	id: number;
+	name: string;
+	category: string;
+	owner_user_id: number | null;
 }
 
 export interface BondsResponse {
@@ -64,10 +72,11 @@ export interface MaturityLadderResponse {
 export const load: PageLoad = async ({ fetch }) => {
 	try {
 		const apiUrl = resolveApiUrl();
-		const [bondsRes, ownersRes, ladderRes] = await Promise.all([
+		const [bondsRes, ownersRes, ladderRes, accountsRes] = await Promise.all([
 			fetch(`${apiUrl}/api/bonds`),
 			fetch(`${apiUrl}/api/users`),
-			fetch(`${apiUrl}/api/bonds/maturity-ladder`)
+			fetch(`${apiUrl}/api/bonds/maturity-ladder`),
+			fetch(`${apiUrl}/api/accounts`)
 		]);
 		if (!bondsRes.ok) {
 			throw error(bondsRes.status, 'Failed to load treasury bonds');
@@ -77,7 +86,24 @@ export const load: PageLoad = async ({ fetch }) => {
 		const ladder: MaturityLadderResponse = ladderRes.ok
 			? await ladderRes.json()
 			: { events: [], next_maturity: null, tax_rate_pct: 19 };
-		return { ...bonds, owners, ladder };
+		// Filter to bond-category active accounts — those are the only valid
+		// targets for a treasury bond row. Anything else (mortgage, stock,
+		// real estate) would mis-roll into the wrong dashboard tile.
+		let accounts: AccountOption[] = [];
+		if (accountsRes.ok) {
+			const payload = await accountsRes.json();
+			accounts = [...(payload.assets ?? []), ...(payload.liabilities ?? [])]
+				.filter(
+					(a: { is_active: boolean; category: string }) => a.is_active && a.category === 'bond'
+				)
+				.map((a: { id: number; name: string; category: string; owner_user_id: number | null }) => ({
+					id: a.id,
+					name: a.name,
+					category: a.category,
+					owner_user_id: a.owner_user_id
+				}));
+		}
+		return { ...bonds, owners, ladder, accounts };
 	} catch (err) {
 		if (err instanceof Error && 'status' in err) throw err;
 		throw error(500, 'Failed to load treasury bonds');

--- a/src/routes/bonds/page.test.ts
+++ b/src/routes/bonds/page.test.ts
@@ -43,6 +43,7 @@ const emptyData = {
 	total_value: 0,
 	total_count: 0,
 	owners: [{ id: 1, name: 'Marcin' }],
+	accounts: [],
 	ladder: emptyLadder
 };
 
@@ -54,6 +55,7 @@ const sampleBond = {
 	purchase_date: '2024-01-01',
 	maturity_date: '2034-01-01',
 	owner_user_id: 1,
+	account_id: null,
 	first_year_rate: 6.8,
 	margin: 2.0,
 	capitalize: true,


### PR DESCRIPTION
## Motivation

Bonds were standalone in the schema — nothing linked an EDO row to
its broker/wrapper account (IKE Obligacje, IKZE Mbank, …). That blocked
the same "live current_value override" pattern stocks just got via
holdings.Valuator: the snapshot form's bond-account tile still needed
manual typing even though the bond ledger knew the live value.

## Implementation information

- Additive schema: `ALTER TABLE treasury_bonds ADD COLUMN IF NOT
  EXISTS account_id integer REFERENCES accounts(id) ON DELETE SET
  NULL`. Nullable so existing rows aren't orphaned; new rows are
  encouraged to set it. EnsureSchema runs idempotently on every boot.
- bond form: account picker filtered to active category=bond
  accounts. Owner picker stays as-is; account_id is the new optional
  link.
- bonds.Valuator: walks active bonds, computes CurrentValue per row
  via the same engine the handler uses (so monthly-CPI fixes apply),
  sums per account_id. Bonds without account_id are dropped.
- accounts.Handler.NewHandler signature flips from (..., holdings)
  to (..., valuators...). Variadic + nil-filtered so callers can
  pass zero, one, or many sources. loadHoldingsValues merges all
  per-account maps into one before the investment-category override.
  server.go wires both holdings + bonds valuators.

Frontend test fixtures get `account_id: null` + `accounts: []` to
match the new shape.

Alternatives considered:
- Inferring account from (owner, wrapper): doesn't work when a
  household has two bond accounts for the same owner (e.g. IKE
  Obligacje + Obligacje PKO both Marcin).
- Embedding bonds in the holdings.lots table: forces decimal share
  semantics that don't map to "1 EDO bond = 100 PLN face".

## Supporting documentation

n/a

> Changelog: feat(bonds): account_id + valuator