### PR TITLE
feat(cpi): optional FRED monthly source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ FB_COOKIE_SECURE=false
 # Empty/unset still works — the scheduler falls back to the keyless intraday
 # snapshot, but historical backfill is unavailable.
 FB_STOOQ_APIKEY=
+# FRED API key — optional. When set, monthly CPI is sourced from FRED's
+# POLCPIALLMINMEI series (OECD-published GUS CPI, exact match to Ministry
+# rate-setting). When unset, falls back to Eurostat HICP which drifts
+# 0.1-0.3pp. Free signup at https://fredaccount.stlouisfed.org/apikey
+FB_FRED_API_KEY=
 
 # Frontend
 # Backend URL for server-side rendering (SvelteKit server -> backend).

--- a/backend-go/README.md
+++ b/backend-go/README.md
@@ -18,16 +18,17 @@ On startup backend-go applies `internal/db/schema.sql` to an empty database
 
 Environment variables:
 
-| Var                 | Default                 | Purpose                                                                                                           |
-| ------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `FB_ADDR`           | `:8000`                 | Listen address                                                                                                    |
-| `CORS_ORIGINS`      | `http://localhost:3000` | Comma-separated allowed origins                                                                                   |
-| `DATABASE_URL`      | —                       | Postgres DSN (or use the `PG*` libpq env vars)                                                                    |
-| `FB_JWT_SECRET`     | — (required)            | Signs session cookies                                                                                             |
-| `FB_ADMIN_USERNAME` | `admin`                 | Admin user reseeded on every startup                                                                              |
-| `FB_ADMIN_PASSWORD` | — (required)            | Admin password reseeded on every startup                                                                          |
-| `FB_COOKIE_SECURE`  | `false`                 | Mark session cookie Secure (HTTPS-only deploys)                                                                   |
-| `FB_STOOQ_APIKEY`   | —                       | Stooq daily-history apikey for holdings backfill. Empty → keyless intraday snapshot only, no historical backfill. |
+| Var                 | Default                 | Purpose                                                                                                                                                                        |
+| ------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `FB_ADDR`           | `:8000`                 | Listen address                                                                                                                                                                 |
+| `CORS_ORIGINS`      | `http://localhost:3000` | Comma-separated allowed origins                                                                                                                                                |
+| `DATABASE_URL`      | —                       | Postgres DSN (or use the `PG*` libpq env vars)                                                                                                                                 |
+| `FB_JWT_SECRET`     | — (required)            | Signs session cookies                                                                                                                                                          |
+| `FB_ADMIN_USERNAME` | `admin`                 | Admin user reseeded on every startup                                                                                                                                           |
+| `FB_ADMIN_PASSWORD` | — (required)            | Admin password reseeded on every startup                                                                                                                                       |
+| `FB_COOKIE_SECURE`  | `false`                 | Mark session cookie Secure (HTTPS-only deploys)                                                                                                                                |
+| `FB_STOOQ_APIKEY`   | —                       | Stooq daily-history apikey for holdings backfill. Empty → keyless intraday snapshot only, no historical backfill.                                                              |
+| `FB_FRED_API_KEY`   | —                       | FRED apikey for monthly Polish CPI (POLCPIALLMINMEI). Empty → Eurostat HICP fallback (drifts 0.1-0.3pp vs Ministry GUS CPI). Free signup at fredaccount.stlouisfed.org/apikey. |
 
 ## Layout
 

--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -116,13 +116,23 @@ func run() int {
 		sched := scheduler.NewCPIScheduler(cpiStore, cpi.NewGUSFetcher(), logger)
 		go sched.Run(ctx)
 
-		// Monthly HICP YoY refresh — feeds the period-aware bond rate engine.
+		// Monthly CPI YoY refresh — feeds the period-aware bond rate engine.
 		// EnsureMonthlySchema is idempotent and cheap; safe to run every boot.
 		if err := cpiStore.EnsureMonthlySchema(ctx); err != nil {
 			logger.Error("ensure cpi_monthly_index schema", "err", err)
 			return 2
 		}
-		monthlySched := scheduler.NewMonthlyCPIScheduler(cpiStore, cpi.NewEurostatHICPFetcher(), logger)
+		// FRED (OECD-sourced GUS CPI) is the canonical input; fall back to
+		// Eurostat HICP when no FRED key is configured. Both expose the
+		// MonthlyCPIFetcher interface, so the scheduler doesn't care which.
+		var monthlyFetcher scheduler.MonthlyCPIFetcher = cpi.NewEurostatHICPFetcher()
+		if fred := cpi.NewFREDFetcher(os.Getenv("FB_FRED_API_KEY")); fred != nil {
+			monthlyFetcher = fred
+			logger.Info("cpi: monthly source = FRED (GUS-sourced)")
+		} else {
+			logger.Info("cpi: monthly source = Eurostat HICP (FB_FRED_API_KEY unset)")
+		}
+		monthlySched := scheduler.NewMonthlyCPIScheduler(cpiStore, monthlyFetcher, logger)
 		go monthlySched.Run(ctx)
 
 		// Daily recurring-transaction generator (issue #384).

--- a/backend-go/internal/cpi/fred.go
+++ b/backend-go/internal/cpi/fred.go
@@ -1,0 +1,153 @@
+package cpi
+
+// FRED fetcher for Polish monthly CPI YoY. FRED's POLCPIALLMINMEI is sourced
+// from OECD which mirrors GUS national CPI exactly — matching the Ministry's
+// rate-setting input perfectly (Eurostat HICP, our default, drifts 0.1-0.3pp
+// because HICP uses a slightly different basket).
+//
+// Free with one-time API key signup at https://fredaccount.stlouisfed.org/apikey
+// (32-char alpha-numeric). When FB_FRED_API_KEY is unset the scheduler falls
+// back to Eurostat.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+const (
+	// FREDObservationsURL is FRED's series-observations endpoint.
+	FREDObservationsURL = "https://api.stlouisfed.org/fred/series/observations"
+	// FREDPolandCPISeries is the OECD-sourced Polish all-items CPI.
+	FREDPolandCPISeries = "POLCPIALLMINMEI"
+	// FREDMonthlySource is the source tag stored in cpi_monthly_index.
+	FREDMonthlySource = "fred-polcpiallminmei"
+
+	fredHTTPTimeout = 8 * time.Second
+)
+
+// ErrFREDMissingKey signals an empty FB_FRED_API_KEY at construction. The
+// scheduler treats this as "FRED disabled" and falls back to Eurostat.
+var ErrFREDMissingKey = errors.New("cpi: FRED api key required")
+
+// FREDFetcher hits FRED's observations endpoint with units=pc1 to get
+// pre-computed YoY percent change.
+type FREDFetcher struct {
+	client *http.Client
+	apiKey string
+}
+
+// NewFREDFetcher wires the fetcher. apiKey must be the 32-char key issued
+// by FRED; empty returns nil so the scheduler can branch cleanly.
+func NewFREDFetcher(apiKey string) *FREDFetcher {
+	if strings.TrimSpace(apiKey) == "" {
+		return nil
+	}
+	return &FREDFetcher{
+		client: &http.Client{Timeout: fredHTTPTimeout},
+		apiKey: apiKey,
+	}
+}
+
+// fredObservation is one row from the FRED observations endpoint.
+type fredObservation struct {
+	Date  string `json:"date"`
+	Value string `json:"value"` // "." for missing
+}
+
+type fredResponse struct {
+	Observations []fredObservation `json:"observations"`
+}
+
+// FetchSince returns Polish CPI YoY values from `since` (inclusive)
+// onwards, sorted ascending by (year, month). `since` is a YYYY-MM-01 in
+// any timezone; only the year-month is used.
+//
+// FRED's units=pc1 returns the YoY percent change directly (e.g. 6.6 for
+// +6.6%); we add 100 to match the GUS convention used elsewhere in this
+// package (114.4 = +14.4%).
+func (f *FREDFetcher) FetchSince(ctx context.Context, since time.Time) ([]MonthYearRate, error) {
+	if since.IsZero() {
+		return nil, fmt.Errorf("fred: since is zero")
+	}
+	q := fmt.Sprintf(
+		"?series_id=%s&api_key=%s&file_type=json&units=pc1&observation_start=%04d-%02d-01",
+		FREDPolandCPISeries, f.apiKey, since.Year(), int(since.Month()),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, FREDObservationsURL+q, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fred fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, fmt.Errorf("fred http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var body fredResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decode fred: %w", err)
+	}
+	return parseFRED(body.Observations)
+}
+
+func parseFRED(obs []fredObservation) ([]MonthYearRate, error) {
+	out := make([]MonthYearRate, 0, len(obs))
+	for _, o := range obs {
+		if o.Value == "" || o.Value == "." {
+			continue // FRED's sentinel for not-yet-published months
+		}
+		year, month, err := parseFREDDate(o.Date)
+		if err != nil {
+			return nil, fmt.Errorf("parse date %q: %w", o.Date, err)
+		}
+		yoy, err := decimal.NewFromString(o.Value)
+		if err != nil {
+			return nil, fmt.Errorf("parse yoy %q: %w", o.Value, err)
+		}
+		out = append(out, MonthYearRate{
+			Year:  year,
+			Month: month,
+			YoY:   yoy.Add(decimal.NewFromInt(100)),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Year != out[j].Year {
+			return out[i].Year < out[j].Year
+		}
+		return out[i].Month < out[j].Month
+	})
+	return out, nil
+}
+
+func parseFREDDate(s string) (int, int, error) {
+	// FRED dates are always YYYY-MM-DD; we only care about year-month.
+	parts := strings.SplitN(s, "-", 3)
+	if len(parts) < 2 {
+		return 0, 0, fmt.Errorf("expected YYYY-MM-DD, got %q", s)
+	}
+	y, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("year %q: %w", parts[0], err)
+	}
+	m, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("month %q: %w", parts[1], err)
+	}
+	if m < 1 || m > 12 {
+		return 0, 0, fmt.Errorf("month %d out of range", m)
+	}
+	return y, m, nil
+}

--- a/backend-go/internal/cpi/fred_test.go
+++ b/backend-go/internal/cpi/fred_test.go
@@ -1,0 +1,48 @@
+package cpi
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestParseFRED(t *testing.T) {
+	obs := []fredObservation{
+		{Date: "2023-11-01", Value: "6.6"},
+		{Date: "2024-11-01", Value: "4.7"},
+		{Date: "2025-11-01", Value: "2.9"},
+		{Date: "2026-04-01", Value: "."}, // not yet published
+	}
+	out, err := parseFRED(obs)
+	if err != nil {
+		t.Fatalf("parseFRED: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("rows = %d, want 3 (sentinel skipped)", len(out))
+	}
+	// Sorted ascending; YoY stored in GUS form (114.4 == +14.4%).
+	if out[0].Year != 2023 || out[0].Month != 11 {
+		t.Errorf("row 0 = %v, want 2023-11", out[0])
+	}
+	if !out[0].YoY.Equal(decimal.RequireFromString("106.6")) {
+		t.Errorf("row 0 YoY = %s, want 106.6", out[0].YoY)
+	}
+	if !out[2].YoY.Equal(decimal.RequireFromString("102.9")) {
+		t.Errorf("row 2 YoY = %s, want 102.9", out[2].YoY)
+	}
+}
+
+func TestNewFREDFetcher_EmptyKeyReturnsNil(t *testing.T) {
+	if f := NewFREDFetcher(""); f != nil {
+		t.Errorf("empty key should yield nil fetcher")
+	}
+	if f := NewFREDFetcher("   "); f != nil {
+		t.Errorf("whitespace key should yield nil fetcher")
+	}
+}
+
+func TestNewFREDFetcher_KeyReturnsFetcher(t *testing.T) {
+	if f := NewFREDFetcher("abc123"); f == nil {
+		t.Errorf("non-empty key should yield fetcher")
+	}
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,6 +31,7 @@ services:
       - FB_ADMIN_PASSWORD=${FB_ADMIN_PASSWORD:-admin}
       - FB_COOKIE_SECURE=false
       - FB_STOOQ_APIKEY=${FB_STOOQ_APIKEY:-}
+      - FB_FRED_API_KEY=${FB_FRED_API_KEY:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - FB_ADMIN_PASSWORD=${FB_ADMIN_PASSWORD:?FB_ADMIN_PASSWORD must be set}
       - FB_COOKIE_SECURE=${FB_COOKIE_SECURE:-false}
       - FB_STOOQ_APIKEY=${FB_STOOQ_APIKEY:-}
+      - FB_FRED_API_KEY=${FB_FRED_API_KEY:-}
     ports:
       - '8000:8000'
     restart: unless-stopped


### PR DESCRIPTION
## Motivation

Eurostat HICP (current default) drifts 0.1-0.3pp from the Ministry's
rate-setting input, leaving a ~0.27% residual on bond values vs PKO.
Polish GUS CPI is the authoritative source but GUS BDL has no monthly
API. FRED's POLCPIALLMINMEI is OECD-sourced from GUS — exact match —
and free with a one-time API key signup.

## Implementation information

- `cpi.FREDFetcher` hits `api.stlouisfed.org/fred/series/observations`
  with `units=pc1` (pre-computed YoY %). Parses observations, returns
  values in our 100+pct GUS form (`106.6` = +6.6%). Constructor returns
  nil on empty key so `main.go` can branch cleanly without a wrapper.
- `main.go`: FRED if `FB_FRED_API_KEY` is set, else Eurostat. Source
  choice logged at startup so an operator can grep for
  `monthly source =` to see which is active.
- `FB_FRED_API_KEY` documented in `.env.example`, `docker-compose.yml`,
  `docker-compose.dev.yml`, `backend-go/README.md` env table.

No schema or behavior change when the key is absent — Eurostat remains
the fallback as before, so this PR is fully backwards-compatible.

To enable on prod: signup at fredaccount.stlouisfed.org/apikey, add
`finance_fred_api_key` to sops, wire into home-nas
deploy-finance-buddy.yml (same pattern as Stooq).

## Supporting documentation

n/a

> Changelog: feat(cpi): optional FRED monthly source