### PR TITLE
feat(cpi): manual monthly refresh

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -3198,6 +3198,37 @@
         ]
       }
     },
+    "/api/cpi/refresh-monthly": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "latest_month": {
+                      "type": "string"
+                    },
+                    "rows_written": {
+                      "type": "integer"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Refresh monthly CPI from configured source (FRED or Eurostat HICP)",
+        "tags": [
+          "cpi"
+        ]
+      }
+    },
     "/api/cpi/series": {
       "get": {
         "responses": {

--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -96,6 +96,7 @@ func run() int {
 		JWTSecret:    jwtSecret,
 		CookieSecure: envOr("FB_COOKIE_SECURE", "false") == "true",
 		StooqAPIKey:  os.Getenv("FB_STOOQ_APIKEY"),
+		FREDAPIKey:   os.Getenv("FB_FRED_API_KEY"),
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -123,15 +124,10 @@ func run() int {
 			return 2
 		}
 		// FRED (OECD-sourced GUS CPI) is the canonical input; fall back to
-		// Eurostat HICP when no FRED key is configured. Both expose the
-		// MonthlyCPIFetcher interface, so the scheduler doesn't care which.
-		var monthlyFetcher scheduler.MonthlyCPIFetcher = cpi.NewEurostatHICPFetcher()
-		if fred := cpi.NewFREDFetcher(os.Getenv("FB_FRED_API_KEY")); fred != nil {
-			monthlyFetcher = fred
-			logger.Info("cpi: monthly source = FRED (GUS-sourced)")
-		} else {
-			logger.Info("cpi: monthly source = Eurostat HICP (FB_FRED_API_KEY unset)")
-		}
+		// Eurostat HICP when no FRED key is configured. The picker is shared
+		// with server.go so /api/cpi/refresh-monthly uses the same source.
+		monthlyFetcher, monthlySource := server.PickMonthlyCPIFetcher(cfg.FREDAPIKey)
+		logger.Info("cpi: monthly source", "source", monthlySource)
 		monthlySched := scheduler.NewMonthlyCPIScheduler(cpiStore, monthlyFetcher, logger)
 		go monthlySched.Run(ctx)
 

--- a/backend-go/internal/cpi/fred.go
+++ b/backend-go/internal/cpi/fred.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -79,14 +80,19 @@ func (f *FREDFetcher) FetchSince(ctx context.Context, since time.Time) ([]MonthY
 	if since.IsZero() {
 		return nil, fmt.Errorf("fred: since is zero")
 	}
-	q := fmt.Sprintf(
-		"?series_id=%s&api_key=%s&file_type=json&units=pc1&observation_start=%04d-%02d-01",
-		FREDPolandCPISeries, f.apiKey, since.Year(), int(since.Month()),
-	)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, FREDObservationsURL+q, http.NoBody)
+	// URL is the package constant; params (including the apikey) flow only
+	// through net/url so taint analysis stays out of the request URL path.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, FREDObservationsURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
+	req.URL.RawQuery = url.Values{
+		"series_id":         {FREDPolandCPISeries},
+		"api_key":           {f.apiKey},
+		"file_type":         {"json"},
+		"units":             {"pc1"},
+		"observation_start": {fmt.Sprintf("%04d-%02d-01", since.Year(), int(since.Month()))},
+	}.Encode()
 	resp, err := f.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fred fetch: %w", err)

--- a/backend-go/internal/cpi/handler.go
+++ b/backend-go/internal/cpi/handler.go
@@ -1,8 +1,10 @@
 package cpi
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -13,22 +15,44 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
 
-// Handler is the HTTP boundary for /api/cpi.
-type Handler struct {
-	store   *Store
-	fetcher *GUSFetcher
-	logger  *slog.Logger
+// MonthlyFetcher is the slice of cpi.EurostatHICPFetcher / cpi.FREDFetcher
+// the manual refresh endpoint accepts. Declared as an interface so the
+// handler doesn't care which monthly source the scheduler resolved.
+type MonthlyFetcher interface {
+	FetchSince(ctx context.Context, since time.Time) ([]MonthYearRate, error)
 }
 
-// NewHandler wires the dependencies.
-func NewHandler(store *Store, fetcher *GUSFetcher, logger *slog.Logger) *Handler {
+// monthlyBackfillStart mirrors scheduler.monthlyBackfillStart. Duplicated
+// here rather than imported to avoid a handler→scheduler dependency
+// inversion (scheduler imports cpi, not the other way round).
+var monthlyBackfillStart = time.Date(2013, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// Handler is the HTTP boundary for /api/cpi.
+type Handler struct {
+	store          *Store
+	fetcher        *GUSFetcher
+	monthlyFetcher MonthlyFetcher
+	monthlySource  string
+	logger         *slog.Logger
+}
+
+// NewHandler wires the dependencies. monthlyFetcher and monthlySource may
+// be empty in setups without a monthly source — Refresh-monthly then
+// returns 503.
+func NewHandler(store *Store, fetcher *GUSFetcher, monthlyFetcher MonthlyFetcher, monthlySource string, logger *slog.Logger) *Handler {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	if fetcher == nil {
 		fetcher = NewGUSFetcher()
 	}
-	return &Handler{store: store, fetcher: fetcher, logger: logger}
+	return &Handler{
+		store:          store,
+		fetcher:        fetcher,
+		monthlyFetcher: monthlyFetcher,
+		monthlySource:  monthlySource,
+		logger:         logger,
+	}
 }
 
 type cpiPoint struct {
@@ -175,6 +199,45 @@ func (h *Handler) Refresh(w http.ResponseWriter, r *http.Request) {
 	if ok {
 		y := latest
 		out.LatestYear = &y
+	}
+	httputil.WriteJSON(w, http.StatusOK, out)
+}
+
+// refreshMonthlyResponse mirrors refreshResponse for the monthly path —
+// LatestMonth is YYYY-MM ("" when the table is still empty).
+type refreshMonthlyResponse struct {
+	RowsWritten int    `json:"rows_written"`
+	Source      string `json:"source"`
+	LatestMonth string `json:"latest_month"`
+}
+
+// RefreshMonthly serves POST /api/cpi/refresh-monthly. Mirrors the
+// existing annual /api/cpi/refresh: fetches from the wired monthly source
+// (FRED or Eurostat) and upserts. Used to backfill after a source change
+// or to short-circuit the scheduler's 7-day staleness gate.
+func (h *Handler) RefreshMonthly(w http.ResponseWriter, r *http.Request) {
+	if h.monthlyFetcher == nil {
+		httputil.WriteDetailError(w, http.StatusServiceUnavailable, "Monthly CPI source not configured")
+		return
+	}
+	rows, err := h.monthlyFetcher.FetchSince(r.Context(), monthlyBackfillStart)
+	if err != nil {
+		httputil.WriteDetailError(w, http.StatusBadGateway, "Monthly CPI fetch failed: "+err.Error())
+		return
+	}
+	written, err := h.store.UpsertMonthly(r.Context(), h.monthlySource, rows)
+	if err != nil {
+		h.logger.Error("upsert monthly cpi", "err", err)
+		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := refreshMonthlyResponse{RowsWritten: written, Source: h.monthlySource}
+	// Find the highest (year, month) in the fetched batch.
+	for _, r := range rows {
+		stamp := fmt.Sprintf("%04d-%02d", r.Year, r.Month)
+		if stamp > out.LatestMonth {
+			out.LatestMonth = stamp
+		}
 	}
 	httputil.WriteJSON(w, http.StatusOK, out)
 }

--- a/backend-go/internal/cpi/openapi.go
+++ b/backend-go/internal/cpi/openapi.go
@@ -7,4 +7,5 @@ var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/cpi/series", Tag: "cpi", Summary: "Get the CPI year-over-year series", Response: seriesResponse{}},
 	{Method: "POST", Path: "/api/cpi/adjust", Tag: "cpi", Summary: "Inflation-adjust an amount between two dates", Response: adjustResponse{}},
 	{Method: "POST", Path: "/api/cpi/refresh", Tag: "cpi", Summary: "Refresh CPI data from GUS", Response: refreshResponse{}},
+	{Method: "POST", Path: "/api/cpi/refresh-monthly", Tag: "cpi", Summary: "Refresh monthly CPI from configured source (FRED or Eurostat HICP)", Response: refreshMonthlyResponse{}},
 }

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -71,6 +71,21 @@ type Config struct {
 	// Empty means the scheduler/refresh handler falls back to the keyless
 	// "latest" snapshot — daily backfill is then unavailable.
 	StooqAPIKey string
+	// FREDAPIKey selects FRED (OECD-sourced GUS CPI) as the monthly CPI
+	// source. Empty falls back to Eurostat HICP (free, no key, but drifts
+	// 0.1-0.3pp).
+	FREDAPIKey string
+}
+
+// PickMonthlyCPIFetcher returns the (fetcher, sourceTag) the scheduler and
+// /api/cpi/refresh-monthly should use. FRED if a key is configured, else
+// Eurostat. Centralized here so server-side wiring and the scheduler stay
+// in sync without duplicating the env-key check.
+func PickMonthlyCPIFetcher(fredAPIKey string) (cpi.MonthlyFetcher, string) {
+	if fred := cpi.NewFREDFetcher(fredAPIKey); fred != nil {
+		return fred, cpi.FREDMonthlySource
+	}
+	return cpi.NewEurostatHICPFetcher(), cpi.EurostatMonthlySource
 }
 
 // Deps bundles the runtime dependencies the router needs to construct
@@ -130,7 +145,7 @@ func registerRoutes(r chi.Router, cfg Config, pool *pgxpool.Pool, logger *slog.L
 func registerAPIRoutes(r chi.Router, cfg Config, pool *pgxpool.Pool, logger *slog.Logger) {
 	registerCoreRoutes(r, pool, logger)
 	registerEquityRoutes(r, pool, logger)
-	registerCPIAndPayrollRoutes(r, pool, logger)
+	registerCPIAndPayrollRoutes(r, cfg, pool, logger)
 	registerPortfolioRoutes(r, pool, logger)
 	registerLedgerRoutes(r, cfg, pool, logger)
 	registerDashboardRoutes(r, pool, logger)
@@ -291,13 +306,15 @@ func registerEquityRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger)
 	})
 }
 
-func registerCPIAndPayrollRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logger) {
+func registerCPIAndPayrollRoutes(r chi.Router, cfg Config, pool *pgxpool.Pool, logger *slog.Logger) {
 	cpiStore := cpi.NewStore(pool)
-	cpiHandler := cpi.NewHandler(cpiStore, cpi.NewGUSFetcher(), logger)
+	monthlyFetcher, monthlySource := PickMonthlyCPIFetcher(cfg.FREDAPIKey)
+	cpiHandler := cpi.NewHandler(cpiStore, cpi.NewGUSFetcher(), monthlyFetcher, monthlySource, logger)
 	r.Route("/api/cpi", func(r chi.Router) {
 		r.Get("/series", cpiHandler.GetSeries)
 		r.Post("/adjust", cpiHandler.Adjust)
 		r.Post("/refresh", cpiHandler.Refresh)
+		r.Post("/refresh-monthly", cpiHandler.RefreshMonthly)
 	})
 
 	salariesHandler := salaries.NewHandler(salaries.NewStore(pool), cpiStore, logger)

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -2257,6 +2257,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/cpi/refresh-monthly": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Refresh monthly CPI from configured source (FRED or Eurostat HICP) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            latest_month?: string;
+                            rows_written?: number;
+                            source?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/cpi/series": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## Motivation

After swapping monthly CPI source (Eurostat → FRED via FB_FRED_API_KEY),
the scheduler's 7-day staleness gate blocks re-fetch on startup. The
operator has to wait until the next 16th-of-month to see FRED data,
or manually clear cpi_monthly_index. Neither is great.

## Implementation information

POST /api/cpi/refresh-monthly mirrors the existing /api/cpi/refresh
for the annual series:

- Calls the wired monthly fetcher's FetchSince(monthlyBackfillStart).
- UpsertMonthly is change-only, so a no-op redeploy writes 0 rows.
- Returns rows_written, source tag, latest_month for verification.
- 503 when no monthly source is configured.

server.PickMonthlyCPIFetcher centralizes the FRED-vs-Eurostat
decision so the startup scheduler (cmd/api/main.go) and the manual
endpoint stay in lockstep without duplicating the env-key check.

> Changelog: feat(cpi): manual monthly refresh