### PR TITLE
chore(holdings): rename to Akcje

### DIFF
--- a/src/routes/investments/holdings/+page.svelte
+++ b/src/routes/investments/holdings/+page.svelte
@@ -256,13 +256,13 @@
 </script>
 
 <svelte:head>
-	<title>Holdings | Finansowa Forteca</title>
+	<title>Akcje | Finansowa Forteca</title>
 </svelte:head>
 
 <div class="space-y-6">
 	<div class="flex flex-wrap items-start justify-between gap-3">
 		<div>
-			<h1 class="h1">Holdings</h1>
+			<h1 class="h1">Akcje</h1>
 			<p class="text-sm text-surface-700-300">
 				Pozycje skonsolidowane po tickerze: ilość, średnia cena, zysk zrealizowany i niezrealizowany
 				na podstawie ręcznych notowań.


### PR DESCRIPTION
## Motivation

Page H1 + title still read "Holdings"; rest of the UI is in Polish
and the tab is already "Akcje / ETF". Cosmetic consistency.

## Implementation information

Two-line change in /investments/holdings/+page.svelte.

> Changelog: chore(holdings): rename to Akcje