### PR TITLE
fix(health): probe DB connectivity in /health

### DIFF
--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -6,10 +6,12 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -111,7 +113,13 @@ func New(cfg Config, logger *slog.Logger, deps Deps) http.Handler {
 		AllowCredentials: true,
 	}))
 
-	r.Get("/health", healthHandler(logger))
+	// Pass a nil pinger (not a typed-nil *pgxpool.Pool) when there's no pool,
+	// so the health probe's nil check works and avoids a panic on Ping.
+	var healthPool pinger
+	if deps.Pool != nil {
+		healthPool = deps.Pool
+	}
+	r.Get("/health", healthHandler(logger, healthPool))
 
 	if deps.Pool != nil {
 		registerRoutes(r, cfg, deps.Pool, logger)
@@ -392,9 +400,30 @@ func registerPortfolioRoutes(r chi.Router, pool *pgxpool.Pool, logger *slog.Logg
 	})
 }
 
-func healthHandler(logger *slog.Logger) http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
+// pinger is the subset of *pgxpool.Pool the health probe needs. Narrowed to an
+// interface so /health-only tests can pass a nil pool (skips the DB probe).
+type pinger interface {
+	Ping(ctx context.Context) error
+}
+
+func healthHandler(logger *slog.Logger, pool pinger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		// A nil pool means the router was built without DB deps (health-only
+		// tests); report ok so those keep passing. With a real pool, a failed
+		// ping means Traefik/Docker should treat the backend as unready.
+		if pool != nil {
+			ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+			defer cancel()
+			if err := pool.Ping(ctx); err != nil {
+				logger.Error("health ping failed", "err", err)
+				w.WriteHeader(http.StatusServiceUnavailable)
+				if encErr := json.NewEncoder(w).Encode(map[string]string{"status": "unavailable"}); encErr != nil {
+					logger.Error("encode health response", "err", encErr)
+				}
+				return
+			}
+		}
 		if err := json.NewEncoder(w).Encode(map[string]string{"status": "ok"}); err != nil {
 			logger.Error("encode health response", "err", err)
 		}

--- a/backend-go/internal/server/server_test.go
+++ b/backend-go/internal/server/server_test.go
@@ -1,13 +1,19 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
 )
+
+type fakePinger struct{ err error }
+
+func (f fakePinger) Ping(context.Context) error { return f.err }
 
 func TestHealthEndpoint(t *testing.T) {
 	srv := httptest.NewServer(New(Config{CORSOrigins: "*"}, slog.New(slog.DiscardHandler), Deps{}))
@@ -35,6 +41,38 @@ func TestHealthEndpoint(t *testing.T) {
 	}
 	if got := body["status"]; got != "ok" {
 		t.Fatalf("status field = %q, want %q", got, "ok")
+	}
+}
+
+func TestHealthHandlerDBProbe(t *testing.T) {
+	cases := []struct {
+		name       string
+		pool       pinger
+		wantStatus int
+		wantField  string
+	}{
+		{"nil pool reports ok", nil, http.StatusOK, "ok"},
+		{"healthy ping reports ok", fakePinger{err: nil}, http.StatusOK, "ok"},
+		{"failed ping reports 503", fakePinger{err: errors.New("pool down")}, http.StatusServiceUnavailable, "unavailable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := healthHandler(slog.New(slog.DiscardHandler), tc.pool)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", http.NoBody)
+			rec := httptest.NewRecorder()
+			h(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			var body map[string]string
+			if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if got := body["status"]; got != tc.wantField {
+				t.Fatalf("status field = %q, want %q", got, tc.wantField)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Motivation

`GET /health` returned `{"status":"ok"}` unconditionally (#673). A dead or broken pgx pool still reported healthy, so Traefik kept routing to a broken backend and the Docker `HEALTHCHECK` was meaningless.

## Implementation information

- `healthHandler` now takes a `pinger` (the `Ping(ctx)` subset of `*pgxpool.Pool`) and runs a 2s-timeout `pool.Ping`, returning `503 {"status":"unavailable"}` on failure, `200 {"status":"ok"}` otherwise.
- Wiring keeps a bare-`nil` `pinger` when there's no pool (health-only tests) to dodge the typed-nil interface gotcha and avoid a panic on `Ping`.
- The `api healthcheck` subcommand already exits non-zero on non-200, so the Docker `HEALTHCHECK` now reflects real readiness with no further change.
- Table-driven test covers nil pool / healthy ping / failed ping.

Closes #673

> Changelog: fix(health): probe DB connectivity in /health