### PR TITLE
fix(rules): graceful fallback on missing rule

### DIFF
--- a/backend-go/internal/accounts/handler.go
+++ b/backend-go/internal/accounts/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
 
 	"github.com/shopspring/decimal"
 
@@ -123,15 +124,29 @@ type realYieldCtx struct {
 // earned outside an IKE/IKZE wrapper, expressed as a percentage (e.g.
 // 19.0). Sourced from the centralized rules table (issue #545) as a
 // decimal — going through float64 here would inject rounding drift into a
-// financial calculation, so we read the rule's Value directly.
-var belkaRatePct = mustBelkaRatePct()
+// financial calculation, so we read the rule's Value directly. If the lookup
+// ever fails (rules table edited out from under us) we fall back to the
+// statutory 19% and log, mirroring bonds.getBelkaRate — degrading a yield
+// indicator beats crashing the accounts API.
+var (
+	belkaPctOnce     sync.Once
+	belkaPctVal      decimal.Decimal
+	belkaPctFallback = decimal.NewFromInt(19)
+	belkaPctRuleKey  = "capital_gains_tax_2026"
+)
 
-func mustBelkaRatePct() decimal.Decimal {
-	r, ok := rules.Get("capital_gains_tax_2026")
-	if !ok {
-		panic("accounts: rules table missing capital_gains_tax_2026")
-	}
-	return r.Value.Mul(decimal.NewFromInt(100))
+func belkaRatePct() decimal.Decimal {
+	belkaPctOnce.Do(func() {
+		r, ok := rules.Get(belkaPctRuleKey)
+		if !ok {
+			slog.Default().Warn("accounts: belka rule missing, using statutory fallback",
+				"key", belkaPctRuleKey, "fallback", belkaPctFallback.String())
+			belkaPctVal = belkaPctFallback
+			return
+		}
+		belkaPctVal = r.Value.Mul(decimal.NewFromInt(100))
+	})
+	return belkaPctVal
 }
 
 // isShieldedFromBelka reports whether interest in this wrapper is exempt
@@ -157,7 +172,7 @@ func isShieldedFromBelka(wrapper *string) bool {
 func computeRealYieldPct(nominalPct, cpiYoYPct decimal.Decimal, shielded bool) decimal.Decimal {
 	net := nominalPct
 	if !shielded {
-		net = nominalPct.Mul(decimal.NewFromInt(100).Sub(belkaRatePct)).Div(decimal.NewFromInt(100))
+		net = nominalPct.Mul(decimal.NewFromInt(100).Sub(belkaRatePct())).Div(decimal.NewFromInt(100))
 	}
 	return net.Sub(cpiYoYPct)
 }

--- a/backend-go/internal/retirement/pit.go
+++ b/backend-go/internal/retirement/pit.go
@@ -7,12 +7,12 @@ import "github.com/Automaat/finance-buddy/backend-go/internal/rules"
 // centralized rules table (#545) — the wrapping vars exist so callers
 // keep using local Go identifiers.
 var (
-	pitFreeAmount       = rules.MustFloat64("pit_free_amount_2026")
-	pitThresholdAnnual  = rules.MustFloat64("pit_threshold_first_2026")
-	pitLowRate          = rules.MustFloat64("pit_rate_first_2026")
-	pitHighRate         = rules.MustFloat64("pit_rate_second_2026")
-	solidarityThreshold = rules.MustFloat64("pit_solidarity_threshold_2026")
-	solidarityRate      = rules.MustFloat64("pit_solidarity_rate_2026")
+	pitFreeAmount       = rules.Float64Or("pit_free_amount_2026", 30000)
+	pitThresholdAnnual  = rules.Float64Or("pit_threshold_first_2026", 120000)
+	pitLowRate          = rules.Float64Or("pit_rate_first_2026", 0.12)
+	pitHighRate         = rules.Float64Or("pit_rate_second_2026", 0.32)
+	solidarityThreshold = rules.Float64Or("pit_solidarity_threshold_2026", 1000000)
+	solidarityRate      = rules.Float64Or("pit_solidarity_rate_2026", 0.04)
 )
 
 // MarginalPITRate returns the applicable marginal rate for the next zloty

--- a/backend-go/internal/rules/rules.go
+++ b/backend-go/internal/rules/rules.go
@@ -9,6 +9,7 @@
 package rules
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -273,15 +274,17 @@ func All() []Rule {
 	return out
 }
 
-// MustFloat64 returns the rule's Value as a float64 or panics if the key
-// is unknown. Use at package init time (or from a `var x = ...` block) to
-// pin a Go constant to the centralized table — the panic surfaces a typo
-// before the process serves traffic, which is what callers want for
-// long-lived defaults like default IKE/IKZE limits.
-func MustFloat64(key string) float64 {
+// Float64Or returns the rule's Value as a float64, or the supplied fallback
+// (logged at WARN) when the key is unknown. Use to pin a Go constant to the
+// centralized table without crashing the process if the table ever drifts —
+// callers pass the statutory default as the fallback, so a missing rule
+// degrades to a documented value instead of a panic.
+func Float64Or(key string, fallback float64) float64 {
 	r, ok := Get(key)
 	if !ok {
-		panic("rules: no rule with key " + key)
+		slog.Default().Warn("rules: missing rule, using fallback",
+			"key", key, "fallback", fallback)
+		return fallback
 	}
 	v, _ := r.Value.Float64()
 	return v

--- a/backend-go/internal/rules/rules_test.go
+++ b/backend-go/internal/rules/rules_test.go
@@ -60,24 +60,21 @@ func TestPolish2026Values(t *testing.T) {
 	}
 }
 
-func TestMustFloat64Resolves(t *testing.T) {
+func TestFloat64OrResolves(t *testing.T) {
 	t.Parallel()
-	if got := MustFloat64("ike_limit_2026"); got != 28260 {
-		t.Errorf("MustFloat64(ike_limit_2026) = %v, want 28260", got)
+	if got := Float64Or("ike_limit_2026", -1); got != 28260 {
+		t.Errorf("Float64Or(ike_limit_2026) = %v, want 28260", got)
 	}
-	if got := MustFloat64("pit_rate_first_2026"); got != 0.12 {
-		t.Errorf("MustFloat64(pit_rate_first_2026) = %v, want 0.12", got)
+	if got := Float64Or("pit_rate_first_2026", -1); got != 0.12 {
+		t.Errorf("Float64Or(pit_rate_first_2026) = %v, want 0.12", got)
 	}
 }
 
-func TestMustFloat64PanicsOnUnknown(t *testing.T) {
+func TestFloat64OrFallsBackOnUnknown(t *testing.T) {
 	t.Parallel()
-	defer func() {
-		if recover() == nil {
-			t.Error("expected panic on unknown key")
-		}
-	}()
-	MustFloat64("does_not_exist")
+	if got := Float64Or("does_not_exist", 42); got != 42 {
+		t.Errorf("Float64Or(does_not_exist, 42) = %v, want 42 (fallback)", got)
+	}
 }
 
 func TestRuleKeysAreUnique(t *testing.T) {

--- a/backend-go/internal/simulations/store.go
+++ b/backend-go/internal/simulations/store.go
@@ -17,8 +17,8 @@ import (
 // Sourced from the centralized rules table (#545) so the literal lives in
 // one place and carries citation metadata for the UI.
 var (
-	defaultIKELimit  = rules.MustFloat64("ike_limit_2026")
-	defaultIKZELimit = rules.MustFloat64("ikze_limit_2026")
+	defaultIKELimit  = rules.Float64Or("ike_limit_2026", 28260)
+	defaultIKZELimit = rules.Float64Or("ikze_limit_2026", 11304)
 )
 
 // Store handles the DB reads for prefill + the retirement-limit lookup.

--- a/backend-go/internal/simulations/taxrates.go
+++ b/backend-go/internal/simulations/taxrates.go
@@ -5,4 +5,4 @@ import "github.com/Automaat/finance-buddy/backend-go/internal/rules"
 // capitalGainsTaxRate is the Polish capital-gains tax ("podatek Belki"),
 // a flat 19% on investment gains. Sourced from the centralized rules
 // table (#545) — change there to update all callers.
-var capitalGainsTaxRate = rules.MustFloat64("capital_gains_tax_2026")
+var capitalGainsTaxRate = rules.Float64Or("capital_gains_tax_2026", 0.19)

--- a/backend-go/internal/simulations/validation.go
+++ b/backend-go/internal/simulations/validation.go
@@ -15,7 +15,7 @@ import (
 // PPK participant may lower their employee contribution from 2% to 0.5%.
 // Centralized via the rules package (#545) so the validator + frontend +
 // error message all read the same number.
-var ppkBelowThresholdSalary = rules.MustFloat64("ppk_below_threshold_2026")
+var ppkBelowThresholdSalary = rules.Float64Or("ppk_below_threshold_2026", 5767)
 
 // --- mortgage ---
 

--- a/backend-go/internal/zus/calculator.go
+++ b/backend-go/internal/zus/calculator.go
@@ -31,9 +31,9 @@ const (
 )
 
 var (
-	cap30x2026    = rules.MustFloat64("zus_cap_30x_2026")
-	pitRate       = rules.MustFloat64("pit_rate_first_2026")
-	annualFreeThr = rules.MustFloat64("pit_free_amount_2026")
+	cap30x2026    = rules.Float64Or("zus_cap_30x_2026", 282600)
+	pitRate       = rules.Float64Or("pit_rate_first_2026", 0.12)
+	annualFreeThr = rules.Float64Or("pit_free_amount_2026", 30000)
 )
 
 // lifeExpectancyMonths — GUS 2025 dalsze trwanie życia at retirement age.


### PR DESCRIPTION
## Motivation

Request paths could panic on a missing rule value (`accounts.mustBelkaRatePct`, `rules.MustFloat64`), so a drifted/edited rules table risked crashing the request and the process (#674).

## Implementation information

- `rules.MustFloat64` (panicked on unknown key) replaced by `rules.Float64Or(key, fallback)` — logs a WARN and returns the supplied statutory default instead of panicking. Every call site in `zus`, `retirement`, and `simulations` now passes its statutory default (values match the `Polish2026` table).
- `accounts` belka rate: the panicking `var belkaRatePct = mustBelkaRatePct()` is now a lazy `belkaRatePct()` (sync.Once + 19% fallback + WARN), mirroring the existing `bonds.getBelkaRate` pattern.
- No `panic(` path remains in the rules/accounts request flow; a missing rule degrades to a documented value.
- Tests updated: `Float64Or` resolve + fallback cases.

Closes #674

> Changelog: fix(rules): graceful fallback on missing rule