### PR TITLE
fix(server): enforce request read/write timeouts

### DIFF
--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -144,11 +144,11 @@ func run() int {
 		logger.Warn("no DB config (DATABASE_URL or PGHOST) — DB-backed endpoints will 404")
 	}
 
-	// WriteTimeout sits above the in-handler request timeout (server's
-	// middleware.Timeout) so that middleware can write its 504 before the
-	// connection's write deadline fires; it also clears the 2-min self-bound
-	// quotes-refresh pass. ReadTimeout/IdleTimeout bound slow or idle
-	// clients so a stalled peer can't pin a connection indefinitely.
+	// WriteTimeout is the hard connection-level write deadline. It sits above
+	// the in-handler request timeout (server's middleware.Timeout) so that
+	// deadline gets the chance to cancel the context first, and it clears the
+	// 2-min self-bound quotes-refresh pass. ReadTimeout/IdleTimeout bound slow
+	// or idle clients so a stalled peer can't pin a connection indefinitely.
 	srv := &http.Server{
 		Addr:              cfg.Addr,
 		Handler:           server.New(cfg, logger, deps),

--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -144,10 +144,18 @@ func run() int {
 		logger.Warn("no DB config (DATABASE_URL or PGHOST) — DB-backed endpoints will 404")
 	}
 
+	// WriteTimeout sits above the in-handler request timeout (server's
+	// middleware.Timeout) so that middleware can write its 504 before the
+	// connection's write deadline fires; it also clears the 2-min self-bound
+	// quotes-refresh pass. ReadTimeout/IdleTimeout bound slow or idle
+	// clients so a stalled peer can't pin a connection indefinitely.
 	srv := &http.Server{
 		Addr:              cfg.Addr,
 		Handler:           server.New(cfg, logger, deps),
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      180 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	errCh := make(chan error, 1)

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -111,10 +111,13 @@ func New(cfg Config, logger *slog.Logger, deps Deps) http.Handler {
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Recoverer)
-	// Per-request deadline: cancels r.Context() (propagated to pgx queries and
-	// outbound scrapes) so a stuck handler can't pin a connection. Sized above
-	// the 2-min self-bound /api/holdings/refresh-quotes pass; main.go's
-	// WriteTimeout sits higher still so the 504 lands before the write deadline.
+	// Per-request deadline. middleware.Timeout cancels r.Context() after
+	// requestTimeout, which context-aware work (pgx queries, outbound scrapes)
+	// observes and unwinds; it only writes a 504 if the handler returns past the
+	// deadline without having already written. So this is a cooperative backstop,
+	// not a hard kill of work that ignores context. Sized above the 2-min
+	// self-bound /api/holdings/refresh-quotes pass, and below main.go's
+	// WriteTimeout so the connection write deadline doesn't pre-empt it.
 	r.Use(middleware.Timeout(requestTimeout))
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   splitOrigins(cfg.CORSOrigins),

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -51,6 +51,11 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/zus"
 )
 
+// requestTimeout bounds every request via middleware.Timeout. Set above the
+// longest legitimate handler (the 2-min quotes-refresh self-bound) so it acts
+// as a backstop against stuck requests without cutting off real work.
+const requestTimeout = 150 * time.Second
+
 // Config holds the runtime knobs the server reads at startup.
 //
 // The caller (cmd/api) owns env-var loading and defaulting; New treats every
@@ -106,6 +111,11 @@ func New(cfg Config, logger *slog.Logger, deps Deps) http.Handler {
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Recoverer)
+	// Per-request deadline: cancels r.Context() (propagated to pgx queries and
+	// outbound scrapes) so a stuck handler can't pin a connection. Sized above
+	// the 2-min self-bound /api/holdings/refresh-quotes pass; main.go's
+	// WriteTimeout sits higher still so the 504 lands before the write deadline.
+	r.Use(middleware.Timeout(requestTimeout))
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   splitOrigins(cfg.CORSOrigins),
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},


### PR DESCRIPTION
## Motivation

`http.Server` set only `ReadHeaderTimeout`, so a slow external scrape (Stooq/GUS/Ministry) reached inside a request could hang a connection indefinitely and the Docker/Traefik front had no read/write bound (#675).

## Implementation information

- `http.Server` now sets `ReadTimeout` 30s, `WriteTimeout` 180s, `IdleTimeout` 120s (kept `ReadHeaderTimeout` 10s).
- Added a global `chi middleware.Timeout(150s)` that cancels `r.Context()`, propagating the deadline to pgx queries and outbound scrapes.
- Timeout layering: `middleware.Timeout` 150s sits above the only legitimately-long handler (`/api/holdings/refresh-quotes`, self-bound at 2 min via its own `context.WithTimeout`) so real work isn't cut off, and below `WriteTimeout` 180s so the 504 lands before the connection write deadline.

Closes #675

> Changelog: fix(server): enforce request read/write timeouts