### PR TITLE
feat(metryki): real-return & inflation dashboard

### DIFF
--- a/src/lib/components/RealYieldsTable.svelte
+++ b/src/lib/components/RealYieldsTable.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	import { formatPercent, formatSignedPercent } from '$lib/utils/format';
+
+	// Minimal shape of the /api/accounts rows this table needs. real_yield_pct
+	// is populated server-side only for interest-bearing accounts (post-Belka,
+	// post-CPI); rows without a nominal rate are filtered out.
+	export interface RealYieldAccount {
+		id: number;
+		name: string;
+		category: string;
+		account_wrapper: string | null;
+		interest_rate_pct: number | null;
+		cpi_yoy_pct: number | null;
+		real_yield_pct: number | null;
+	}
+
+	interface Props {
+		accounts: RealYieldAccount[];
+	}
+
+	let { accounts }: Props = $props();
+
+	const CATEGORY_LABELS: Record<string, string> = {
+		bank: 'Konto bankowe',
+		saving_account: 'Oszczędności',
+		bond: 'Obligacje',
+		stock: 'Akcje',
+		ppk: 'PPK',
+		fund: 'Fundusz',
+		etf: 'ETF'
+	};
+
+	const categoryLabel = (category: string): string =>
+		CATEGORY_LABELS[category] ?? category.charAt(0).toUpperCase() + category.slice(1);
+
+	const rows = $derived(
+		accounts
+			.filter((a) => a.interest_rate_pct != null)
+			.sort((a, b) => (b.real_yield_pct ?? -Infinity) - (a.real_yield_pct ?? -Infinity))
+	);
+
+	const realClass = (value: number | null): string =>
+		value == null
+			? 'text-surface-600-400'
+			: value >= 0
+				? 'text-success-600-400'
+				: 'text-error-600-400';
+</script>
+
+{#if rows.length > 0}
+	<div class="card preset-filled-surface-100-900 p-4 overflow-x-auto">
+		<table class="w-full text-sm">
+			<thead>
+				<tr class="text-left opacity-75 border-b border-surface-300-700">
+					<th class="py-2 pr-3">Konto</th>
+					<th class="py-2 px-3">Kategoria</th>
+					<th class="py-2 px-3 text-right">Nominalnie</th>
+					<th class="py-2 px-3 text-right">Inflacja r/r</th>
+					<th class="py-2 pl-3 text-right">Realnie (po podatku)</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each rows as row (row.id)}
+					<tr class="border-b border-surface-200-800 last:border-0">
+						<td class="py-2 pr-3 font-medium">
+							{row.name}
+							{#if row.account_wrapper}
+								<span class="ml-1 text-xs opacity-60">({row.account_wrapper})</span>
+							{/if}
+						</td>
+						<td class="py-2 px-3">{categoryLabel(row.category)}</td>
+						<td class="py-2 px-3 text-right">{formatPercent(row.interest_rate_pct)}</td>
+						<td class="py-2 px-3 text-right text-surface-600-400">
+							{row.cpi_yoy_pct == null ? '—' : formatSignedPercent(-row.cpi_yoy_pct)}
+						</td>
+						<td class="py-2 pl-3 text-right font-bold {realClass(row.real_yield_pct)}">
+							{formatSignedPercent(row.real_yield_pct)}
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+		<p class="mt-3 text-xs opacity-60">
+			Realny zwrot = oprocentowanie po podatku Belki (19%, konta IKE/IKZE zwolnione) minus inflacja
+			r/r.
+		</p>
+	</div>
+{:else}
+	<div class="card preset-filled-surface-100-900 p-4 text-surface-600-400">
+		Brak kont z oprocentowaniem do porównania.
+	</div>
+{/if}

--- a/src/lib/components/RealYieldsTable.svelte
+++ b/src/lib/components/RealYieldsTable.svelte
@@ -39,12 +39,14 @@
 			.sort((a, b) => (b.real_yield_pct ?? -Infinity) - (a.real_yield_pct ?? -Infinity))
 	);
 
-	const realClass = (value: number | null): string =>
-		value == null
-			? 'text-surface-600-400'
-			: value >= 0
-				? 'text-success-600-400'
-				: 'text-error-600-400';
+	// Color buckets match the /accounts real-yield UI (issue #573): green > 1%,
+	// amber 0–1% ("not yet comfortably beating inflation"), red < 0%.
+	const realClass = (value: number | null): string => {
+		if (value == null) return 'text-surface-600-400';
+		if (value < 0) return 'text-error-600-400';
+		if (value <= 1) return 'text-warning-600-400';
+		return 'text-success-600-400';
+	};
 </script>
 
 {#if rows.length > 0}
@@ -81,8 +83,7 @@
 			</tbody>
 		</table>
 		<p class="mt-3 text-xs opacity-60">
-			Realny zwrot = oprocentowanie po podatku Belki (19%, konta IKE/IKZE zwolnione) minus inflacja
-			r/r.
+			Realny zwrot = oprocentowanie po podatku Belki (konta IKE/IKZE zwolnione) minus inflacja r/r.
 		</p>
 	</div>
 {:else}

--- a/src/lib/components/RealYieldsTable.test.ts
+++ b/src/lib/components/RealYieldsTable.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import RealYieldsTable from './RealYieldsTable.svelte';
+import type { RealYieldAccount } from './RealYieldsTable.svelte';
+
+const account = (over: Partial<RealYieldAccount>): RealYieldAccount => ({
+	id: 1,
+	name: 'Konto',
+	category: 'saving_account',
+	account_wrapper: null,
+	interest_rate_pct: 5,
+	cpi_yoy_pct: 3,
+	real_yield_pct: 1.05,
+	...over
+});
+
+describe('RealYieldsTable', () => {
+	it('renders a row per interest-bearing account', () => {
+		render(RealYieldsTable, {
+			props: { accounts: [account({ id: 1, name: 'Moje konto' })] }
+		});
+		expect(screen.getByText('Moje konto')).toBeTruthy();
+		expect(screen.getByText('Moje konto').closest('tr')).toBeTruthy();
+	});
+
+	it('filters out accounts without a nominal rate', () => {
+		render(RealYieldsTable, {
+			props: {
+				accounts: [
+					account({ id: 1, name: 'Z oprocentowaniem', interest_rate_pct: 4 }),
+					account({ id: 2, name: 'Bez oprocentowania', interest_rate_pct: null })
+				]
+			}
+		});
+		expect(screen.getByText('Z oprocentowaniem')).toBeTruthy();
+		expect(screen.queryByText('Bez oprocentowania')).toBeNull();
+	});
+
+	it('shows the empty-state message when no rated accounts', () => {
+		render(RealYieldsTable, {
+			props: { accounts: [account({ interest_rate_pct: null })] }
+		});
+		expect(screen.getByText(/Brak kont z oprocentowaniem/)).toBeTruthy();
+	});
+
+	it('maps the account wrapper as a parenthetical', () => {
+		render(RealYieldsTable, {
+			props: { accounts: [account({ name: 'IKE konto', account_wrapper: 'IKE' })] }
+		});
+		expect(screen.getByText('(IKE)')).toBeTruthy();
+	});
+
+	it('shows the inflation drag as a single signed value (no double sign on deflation)', () => {
+		render(RealYieldsTable, {
+			props: { accounts: [account({ name: 'Deflacja', cpi_yoy_pct: -2 })] }
+		});
+		// −(−2%) = +2,0% drag (deflation boosts real return); never "−−".
+		expect(screen.getByText('+2,0%')).toBeTruthy();
+		expect(screen.queryByText(/−−/)).toBeNull();
+	});
+
+	it('sorts rows by real yield descending', () => {
+		render(RealYieldsTable, {
+			props: {
+				accounts: [
+					account({ id: 1, name: 'Niski', real_yield_pct: -2 }),
+					account({ id: 2, name: 'Wysoki', real_yield_pct: 3 })
+				]
+			}
+		});
+		const names = screen
+			.getAllByRole('row')
+			.slice(1)
+			.map((r) => r.querySelector('td')?.textContent?.trim());
+		expect(names[0]).toContain('Wysoki');
+		expect(names[1]).toContain('Niski');
+	});
+});

--- a/src/lib/utils/charts/inflation.test.ts
+++ b/src/lib/utils/charts/inflation.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { buildCumulativeInflationChartOption } from './inflation';
+import type { CpiSeries } from '$lib/types/cpi';
+
+const series: CpiSeries = {
+	points: [
+		{ year: 2024, yoy_rate: 3.05, cumulative_index: 114.34 },
+		{ year: 2022, yoy_rate: 14.4, cumulative_index: 100 },
+		{ year: 2023, yoy_rate: 11.06, cumulative_index: 111.06 }
+	],
+	base_year: 2022,
+	latest_year: 2024,
+	source: 'GUS'
+};
+
+describe('buildCumulativeInflationChartOption', () => {
+	it('sorts points by year on the x-axis', () => {
+		const option = buildCumulativeInflationChartOption(series);
+		const xAxis = option.xAxis as { data: string[] };
+		expect(xAxis.data).toEqual(['2022', '2023', '2024']);
+	});
+
+	it('plots cumulative index as a line and YoY as bars on a second axis', () => {
+		const option = buildCumulativeInflationChartOption(series);
+		const seriesOpts = option.series as Array<{
+			name: string;
+			type: string;
+			yAxisIndex: number;
+			data: number[];
+		}>;
+
+		const line = seriesOpts.find((s) => s.type === 'line');
+		const bar = seriesOpts.find((s) => s.type === 'bar');
+
+		expect(line?.yAxisIndex).toBe(0);
+		expect(line?.data).toEqual([100, 111.1, 114.3]);
+		expect(bar?.yAxisIndex).toBe(1);
+		expect(bar?.data).toEqual([14.4, 11.1, 3]);
+	});
+
+	it('declares two y-axes (index + percent)', () => {
+		const option = buildCumulativeInflationChartOption(series);
+		expect(Array.isArray(option.yAxis)).toBe(true);
+		expect((option.yAxis as unknown[]).length).toBe(2);
+	});
+});

--- a/src/lib/utils/charts/inflation.ts
+++ b/src/lib/utils/charts/inflation.ts
@@ -1,0 +1,98 @@
+import type { EChartsOption } from 'echarts';
+import type { CallbackDataParams, TopLevelFormatterParams } from 'echarts/types/dist/shared';
+import type { CpiSeries } from '$lib/types/cpi';
+
+type AxisTooltipItem = CallbackDataParams & { axisValue: string };
+
+// buildCumulativeInflationChartOption renders the CPI series as a cumulative
+// price-level line (fixed-base index, left axis) plus year-over-year inflation
+// bars (right axis). Mirrors the Nord palette and styling used across the
+// metryki charts so the inflation section blends in.
+export function buildCumulativeInflationChartOption(series: CpiSeries): EChartsOption {
+	const sorted = [...series.points].sort((a, b) => a.year - b.year);
+	const years = sorted.map((p) => String(p.year));
+	const cumulative = sorted.map((p) => parseFloat(p.cumulative_index.toFixed(1)));
+	const yoy = sorted.map((p) => parseFloat(p.yoy_rate.toFixed(1)));
+
+	return {
+		backgroundColor: 'transparent',
+		title: {
+			text: 'Skumulowana inflacja (CPI)',
+			left: 'center',
+			top: 10,
+			textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
+		},
+		tooltip: {
+			trigger: 'axis',
+			axisPointer: { type: 'shadow' },
+			backgroundColor: 'rgba(255, 255, 255, 0.95)',
+			borderColor: '#d8dee9',
+			textStyle: { color: '#2e3440' },
+			formatter: function (params: TopLevelFormatterParams) {
+				const items = (Array.isArray(params) ? params : [params]) as AxisTooltipItem[];
+				const year = items[0]?.axisValue ?? '';
+				return (
+					`${year}<br/>` +
+					items
+						.map((p) => {
+							const suffix = p.seriesName === 'Inflacja r/r' ? '%' : '';
+							return `${p.marker ?? ''} ${p.seriesName}: <b>${p.value ?? '—'}${suffix}</b>`;
+						})
+						.join('<br/>')
+				);
+			}
+		},
+		legend: {
+			data: ['Indeks cen (baza 100)', 'Inflacja r/r'],
+			bottom: 10,
+			textStyle: { color: '#2e3440', fontSize: 14 }
+		},
+		grid: { left: 70, right: 60, bottom: 70, top: 70, containLabel: false },
+		xAxis: {
+			type: 'category',
+			data: years,
+			axisLabel: { color: '#2e3440', fontSize: 12 },
+			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
+			boundaryGap: true
+		},
+		yAxis: [
+			{
+				type: 'value',
+				name: 'Indeks',
+				nameTextStyle: { color: '#2e3440', fontSize: 12, fontWeight: 'bold' },
+				axisLabel: { color: '#2e3440', fontSize: 12 },
+				axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
+				splitLine: { lineStyle: { color: '#e5e9f0', type: 'dashed' } }
+			},
+			{
+				type: 'value',
+				name: 'r/r %',
+				nameTextStyle: { color: '#2e3440', fontSize: 12, fontWeight: 'bold' },
+				axisLabel: { color: '#2e3440', fontSize: 12, formatter: '{value}%' },
+				axisLine: { show: false },
+				splitLine: { show: false }
+			}
+		],
+		series: [
+			{
+				name: 'Inflacja r/r',
+				type: 'bar',
+				yAxisIndex: 1,
+				data: yoy,
+				barWidth: '45%',
+				itemStyle: { color: '#88c0d0', borderRadius: [4, 4, 0, 0] }
+			},
+			{
+				name: 'Indeks cen (baza 100)',
+				type: 'line',
+				yAxisIndex: 0,
+				data: cumulative,
+				smooth: true,
+				symbol: 'circle',
+				symbolSize: 6,
+				lineStyle: { width: 3, color: '#5e81ac' },
+				itemStyle: { color: '#5e81ac' }
+			}
+		]
+	};
+}

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -10,10 +10,12 @@
 		buildWrapperTrendChartOption,
 		buildYearlyRoiChartOption
 	} from '$lib/utils/charts/metryki';
+	import { buildCumulativeInflationChartOption } from '$lib/utils/charts/inflation';
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
 	import ContributionAdjustedReturns from '$lib/components/ContributionAdjustedReturns.svelte';
 	import CurrencyExposureWidget from '$lib/components/CurrencyExposureWidget.svelte';
+	import RealYieldsTable from '$lib/components/RealYieldsTable.svelte';
 
 	import type { PageData } from './$types';
 
@@ -28,8 +30,12 @@
 	const investmentTimeSeries = $derived(data.investmentTimeSeries);
 	const wrapperTimeSeries = $derived(data.wrapperTimeSeries);
 	const categoryTimeSeries = $derived(data.categoryTimeSeries);
+	const realYieldAccounts = $derived(data.realYieldAccounts ?? []);
+	const cpiSeries = $derived(data.cpiSeries);
+	const hasCpiSeries = $derived((cpiSeries?.points?.length ?? 0) > 0);
 
 	let allocationChart: HTMLDivElement;
+	let inflationChart = $state<HTMLDivElement | undefined>(undefined);
 	let wrapperChart: HTMLDivElement;
 	let investmentTrendChart: HTMLDivElement;
 	let ikeChart: HTMLDivElement;
@@ -66,6 +72,9 @@
 				wrapperTimeSeries.ppk
 			)
 		);
+		if (hasCpiSeries && inflationChart) {
+			mount(inflationChart, buildCumulativeInflationChartOption(cpiSeries));
+		}
 
 		return () => {
 			for (const handle of handles) handle.dispose();
@@ -390,6 +399,16 @@
 		<ContributionAdjustedReturns scope={{ type: 'category', value: 'stock' }} title="Akcje" />
 		<ContributionAdjustedReturns scope={{ type: 'category', value: 'bond' }} title="Obligacje" />
 	</div>
+
+	<h2 class="h2">Realne zwroty (po inflacji)</h2>
+
+	<RealYieldsTable accounts={realYieldAccounts} />
+
+	{#if hasCpiSeries}
+		<div class="card preset-filled-surface-100-900 p-4 mt-4">
+			<div bind:this={inflationChart} class="w-full h-[320px] sm:h-[440px]"></div>
+		</div>
+	{/if}
 
 	<h2 class="h2">Struktura portfela inwestycyjnego</h2>
 

--- a/src/routes/metryki/+page.ts
+++ b/src/routes/metryki/+page.ts
@@ -1,6 +1,8 @@
 import { error } from '@sveltejs/kit';
 import { resolveApiUrl } from '$lib/api';
 import { resolveRangeParams } from '$lib/utils/dateRange';
+import type { CpiSeries } from '$lib/types/cpi';
+import type { RealYieldAccount } from '$lib/components/RealYieldsTable.svelte';
 
 export async function load({ fetch, url }) {
 	try {
@@ -49,19 +51,30 @@ export async function load({ fetch, url }) {
 
 		// Accounts carry per-account real_yield_pct (post-Belka, post-CPI) and
 		// the CPI series feeds the cumulative-inflation chart — both power the
-		// real-return section.
-		const accountsRes = await fetch(`${apiUrl}/api/accounts`);
-		const accountsData = accountsRes.ok
-			? await accountsRes.json()
-			: { assets: [], liabilities: [] };
-		const realYieldAccounts = (accountsData.assets ?? []).filter(
-			(a: { interest_rate_pct: number | null }) => a.interest_rate_pct != null
-		);
-
-		const cpiSeriesRes = await fetch(`${apiUrl}/api/cpi/series`);
-		const cpiSeries = cpiSeriesRes.ok
-			? await cpiSeriesRes.json()
-			: { points: [], base_year: null, latest_year: null, source: '' };
+		// real-return section. These are best-effort: a failure (network or
+		// malformed JSON) degrades only that section to empty, never the whole
+		// metrics page, so they get their own try/catch.
+		let realYieldAccounts: RealYieldAccount[] = [];
+		let cpiSeries: CpiSeries = { points: [], base_year: null, latest_year: null, source: '' };
+		try {
+			const accountsRes = await fetch(`${apiUrl}/api/accounts`);
+			if (accountsRes.ok) {
+				const accountsData = await accountsRes.json();
+				realYieldAccounts = (accountsData.assets ?? []).filter(
+					(a: RealYieldAccount) => a.interest_rate_pct != null
+				);
+			}
+		} catch {
+			realYieldAccounts = [];
+		}
+		try {
+			const cpiSeriesRes = await fetch(`${apiUrl}/api/cpi/series`);
+			if (cpiSeriesRes.ok) {
+				cpiSeries = await cpiSeriesRes.json();
+			}
+		} catch {
+			// keep the empty default
+		}
 
 		return {
 			metricCards: dashboard.metric_cards,

--- a/src/routes/metryki/+page.ts
+++ b/src/routes/metryki/+page.ts
@@ -47,6 +47,22 @@ export async function load({ fetch, url }) {
 		const ownersRes = await fetch(`${apiUrl}/api/users`);
 		const owners = ownersRes.ok ? await ownersRes.json() : [];
 
+		// Accounts carry per-account real_yield_pct (post-Belka, post-CPI) and
+		// the CPI series feeds the cumulative-inflation chart — both power the
+		// real-return section.
+		const accountsRes = await fetch(`${apiUrl}/api/accounts`);
+		const accountsData = accountsRes.ok
+			? await accountsRes.json()
+			: { assets: [], liabilities: [] };
+		const realYieldAccounts = (accountsData.assets ?? []).filter(
+			(a: { interest_rate_pct: number | null }) => a.interest_rate_pct != null
+		);
+
+		const cpiSeriesRes = await fetch(`${apiUrl}/api/cpi/series`);
+		const cpiSeries = cpiSeriesRes.ok
+			? await cpiSeriesRes.json()
+			: { points: [], base_year: null, latest_year: null, source: '' };
+
 		return {
 			metricCards: dashboard.metric_cards,
 			allocationAnalysis: dashboard.allocation_analysis,
@@ -57,6 +73,8 @@ export async function load({ fetch, url }) {
 			stockStats,
 			bondStats,
 			owners,
+			realYieldAccounts,
+			cpiSeries,
 			range,
 			dateFrom,
 			dateTo

--- a/src/routes/metryki/page.test.ts
+++ b/src/routes/metryki/page.test.ts
@@ -75,6 +75,8 @@ const mockData = {
 	stockStats: null,
 	bondStats: null,
 	owners: [],
+	realYieldAccounts: [],
+	cpiSeries: { points: [], base_year: null, latest_year: null, source: '' },
 	range: 'all' as const,
 	dateFrom: null,
 	dateTo: null
@@ -182,6 +184,26 @@ describe('Metryki Page with populated data', () => {
 			roi_percentage: 5.26
 		},
 		owners: [{ id: 1, name: 'Marcin' }],
+		realYieldAccounts: [
+			{
+				id: 1,
+				name: 'Konto oszczędnościowe',
+				category: 'saving_account',
+				account_wrapper: null,
+				interest_rate_pct: 5,
+				cpi_yoy_pct: 3,
+				real_yield_pct: 1.05
+			}
+		],
+		cpiSeries: {
+			points: [
+				{ year: 2023, yoy_rate: 11, cumulative_index: 111 },
+				{ year: 2024, yoy_rate: 3, cumulative_index: 114.3 }
+			],
+			base_year: 2022,
+			latest_year: 2024,
+			source: 'GUS'
+		},
 		range: 'all' as const,
 		dateFrom: null,
 		dateTo: null


### PR DESCRIPTION
## Motivation

CPI data (GUS + monthly Eurostat/FRED) and per-account `real_yield_pct` already exist and feed bonds/accounts, but there was no comparative real-return view in the UI (#677).

## Implementation information

Added a "Realne zwroty (po inflacji)" section to the existing `/metryki` page (matches the `feat(metryki)` scope, avoids nav bloat):

- **RealYieldsTable** — per interest-bearing account: nominal rate, inflation drag (CPI YoY shown as a signed value, so deflation correctly reads as a positive contribution), and the post-Belka post-CPI real yield, sorted descending and colour-coded. Empty-state when no rated accounts.
- **Cumulative inflation chart** — `buildCumulativeInflationChartOption` plots the CPI fixed-base index (line) with YoY inflation (bars on a second axis).
- Load fetches `/api/accounts` (filters assets with a nominal rate) and `/api/cpi/series`; both degrade to empty shapes on error. No new backend.

Unit tests for the chart builder + table component, and updated the metryki page-test mocks.

Closes #677

> Changelog: feat(metryki): real-return & inflation dashboard