### PR TITLE
feat(exposure): dedicated currency exposure page

### DIFF
--- a/src/lib/nav/routes.ts
+++ b/src/lib/nav/routes.ts
@@ -12,7 +12,8 @@ import {
 	Settings,
 	Target,
 	Briefcase,
-	Compass
+	Compass,
+	Globe
 } from 'lucide-svelte';
 
 export const NAV_ROUTES = [
@@ -25,6 +26,7 @@ export const NAV_ROUTES = [
 	{ href: '/transactions', label: 'Transakcje', icon: ArrowRightLeft },
 	{ href: '/assets', label: 'Majątek', icon: Home },
 	{ href: '/investments/holdings', label: 'Inwestycje', icon: Briefcase },
+	{ href: '/ekspozycja', label: 'Ekspozycja', icon: Globe },
 	{ href: '/debts', label: 'Zobowiązania', icon: ClipboardList },
 	{ href: '/goals', label: 'Cele', icon: Target },
 	{ href: '/snapshots', label: 'Snapshoty', icon: Camera },

--- a/src/lib/types/exposure.ts
+++ b/src/lib/types/exposure.ts
@@ -1,0 +1,26 @@
+// Wire shapes for GET /api/exposure/currency. The response is per-currency
+// aggregates across the investment portfolio (PLN vs USD/EUR/GBP/CHF…) with an
+// optional drift band when a target PLN share is supplied.
+
+export interface CurrencyBucket {
+	currency: string;
+	value_pln: number;
+	percent: number;
+}
+
+export interface DriftBand {
+	target_pln_pct: number;
+	actual_pln_pct: number;
+	drift_pln_pct: number;
+	within_tolerance: boolean;
+	tolerance_pct: number;
+}
+
+export interface CurrencyExposureReport {
+	currencies: CurrencyBucket[];
+	total_pln: number;
+	pln_pct: number;
+	foreign_pct: number;
+	snapshot_date: string;
+	drift?: DriftBand;
+}

--- a/src/routes/ekspozycja/+page.svelte
+++ b/src/routes/ekspozycja/+page.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+	import { Globe } from 'lucide-svelte';
+	import { formatPLN } from '$lib/utils/format';
+	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
+	import type { PageData } from './$types';
+
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
+
+	const report = $derived(data.report);
+
+	// Local form state seeded from the URL-driven load; Apply pushes it back to
+	// the query string so the drift band is shareable and survives reloads.
+	let targetInput = $state<number | null>(untrack(() => data.targetPLNPct));
+	let toleranceInput = $state<number>(untrack(() => data.tolerance));
+
+	$effect(() => {
+		targetInput = data.targetPLNPct;
+		toleranceInput = data.tolerance;
+	});
+
+	const palette = [
+		'#3b82f6',
+		'#ef4444',
+		'#10b981',
+		'#f59e0b',
+		'#a855f7',
+		'#06b6d4',
+		'#84cc16',
+		'#ec4899'
+	];
+
+	const colorFor = (currency: string, index: number): string =>
+		currency === 'PLN' ? '#1e40af' : palette[index % palette.length];
+
+	let container: HTMLDivElement | undefined = $state();
+	let handle: ChartHandle | null = null;
+
+	$effect(() => {
+		if (!container || report.currencies.length === 0) {
+			handle?.dispose();
+			handle = null;
+			return;
+		}
+		if (!handle) handle = createChart(container);
+		const pieData = report.currencies.map((c, i) => ({
+			name: c.currency,
+			value: c.value_pln,
+			itemStyle: { color: colorFor(c.currency, i) }
+		}));
+		handle.chart.setOption({
+			tooltip: {
+				trigger: 'item',
+				formatter: (p: { name: string; value: number; percent: number }) =>
+					`${p.name}<br/>${formatPLN(p.value)} (${p.percent.toFixed(1)}%)`
+			},
+			legend: { bottom: 0 },
+			series: [
+				{
+					type: 'pie',
+					radius: ['45%', '70%'],
+					avoidLabelOverlap: false,
+					label: { show: true, formatter: '{b}: {d}%' },
+					data: pieData
+				}
+			]
+		});
+		return () => {
+			handle?.dispose();
+			handle = null;
+		};
+	});
+
+	function applyTarget(event: SubmitEvent) {
+		event.preventDefault();
+		const params = new URLSearchParams($page.url.searchParams);
+		if (targetInput != null && Number.isFinite(targetInput)) {
+			params.set('target_pln_pct', String(targetInput));
+			params.set('tolerance', String(toleranceInput ?? 5));
+		} else {
+			params.delete('target_pln_pct');
+			params.delete('tolerance');
+		}
+		const qs = params.toString();
+		void goto(qs ? `/ekspozycja?${qs}` : '/ekspozycja', { keepFocus: true });
+	}
+
+	function clearTarget() {
+		targetInput = null;
+		void goto('/ekspozycja', { keepFocus: true });
+	}
+</script>
+
+<svelte:head>
+	<title>Ekspozycja walutowa - Finance Buddy</title>
+</svelte:head>
+
+<div class="space-y-6">
+	<div class="flex items-center gap-2">
+		<Globe size={28} class="text-primary-500" />
+		<h1 class="h1">Ekspozycja walutowa</h1>
+	</div>
+	<p class="text-surface-700-300">
+		Udział PLN vs walut obcych w portfelu inwestycyjnym (bez mieszkania i ROR). Ustaw docelowy
+		udział PLN, aby zobaczyć dryft względem celu.
+	</p>
+
+	<form
+		class="card preset-filled-surface-100-900 p-4 flex flex-wrap items-end gap-3"
+		onsubmit={applyTarget}
+	>
+		<label class="label">
+			<span class="text-xs font-semibold">Cel PLN (%)</span>
+			<input
+				type="number"
+				min="0"
+				max="100"
+				step="1"
+				class="input w-28"
+				bind:value={targetInput}
+				placeholder="—"
+			/>
+		</label>
+		<label class="label">
+			<span class="text-xs font-semibold">Tolerancja (pp)</span>
+			<input
+				type="number"
+				min="0"
+				max="50"
+				step="1"
+				class="input w-24"
+				bind:value={toleranceInput}
+			/>
+		</label>
+		<button type="submit" class="btn preset-filled-primary-500">Zastosuj</button>
+		{#if report.drift}
+			<button type="button" class="btn preset-tonal-surface" onclick={clearTarget}>Wyczyść</button>
+		{/if}
+	</form>
+
+	{#if report.currencies.length === 0}
+		<div class="card preset-filled-surface-100-900 p-6 text-surface-700-300">
+			Brak snapshotu lub aktywnych kont — dodaj pierwszy snapshot, aby zobaczyć ekspozycję.
+		</div>
+	{:else}
+		<div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+			<div class="card preset-tonal-surface p-4">
+				<div class="text-xs text-surface-600-400">Udział PLN</div>
+				<div class="text-2xl font-bold">{report.pln_pct.toFixed(1)}%</div>
+			</div>
+			<div class="card preset-tonal-surface p-4">
+				<div class="text-xs text-surface-600-400">Waluty obce</div>
+				<div class="text-2xl font-bold">{report.foreign_pct.toFixed(1)}%</div>
+			</div>
+			<div class="card preset-tonal-surface p-4">
+				<div class="text-xs text-surface-600-400">Wartość portfela</div>
+				<div class="text-2xl font-bold">{formatPLN(report.total_pln)}</div>
+			</div>
+			<div class="card preset-tonal-surface p-4">
+				<div class="text-xs text-surface-600-400">Snapshot</div>
+				<div class="text-2xl font-bold">{report.snapshot_date}</div>
+			</div>
+		</div>
+
+		{#if report.drift}
+			{@const within = report.drift.within_tolerance}
+			<div class="card {within ? 'preset-tonal-success' : 'preset-tonal-warning'} p-4">
+				<div class="text-sm font-semibold">
+					Dryft względem celu {report.drift.target_pln_pct}% PLN
+				</div>
+				<div class="text-3xl font-bold">
+					{report.drift.drift_pln_pct >= 0 ? '+' : ''}{report.drift.drift_pln_pct.toFixed(1)} pp
+				</div>
+				<div class="text-sm">
+					Aktualnie {report.drift.actual_pln_pct.toFixed(1)}% ·
+					{within
+						? `w tolerancji ±${report.drift.tolerance_pct} pp`
+						: `poza pasmem ±${report.drift.tolerance_pct} pp`}
+				</div>
+			</div>
+		{/if}
+
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+			<div class="card preset-filled-surface-100-900 p-4">
+				<div
+					bind:this={container}
+					role="img"
+					aria-label="Wykres kołowy udziału walut w portfelu"
+					class="w-full h-[320px]"
+				></div>
+			</div>
+			<div class="card preset-filled-surface-100-900 p-4 overflow-x-auto">
+				<table class="w-full text-sm">
+					<thead>
+						<tr class="text-left opacity-75 border-b border-surface-300-700">
+							<th class="py-2 pr-3">Waluta</th>
+							<th class="py-2 px-3 text-right">Wartość (PLN)</th>
+							<th class="py-2 pl-3">Udział</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each report.currencies as bucket, i (bucket.currency)}
+							<tr class="border-b border-surface-200-800 last:border-0">
+								<td class="py-2 pr-3 font-semibold">{bucket.currency}</td>
+								<td class="py-2 px-3 text-right">{formatPLN(bucket.value_pln)}</td>
+								<td class="py-2 pl-3">
+									<div class="flex items-center gap-2">
+										<div class="flex-1 h-2 rounded-full bg-surface-200-800 overflow-hidden">
+											<div
+												class="h-full rounded-full"
+												style="width: {Math.min(bucket.percent, 100)}%; background: {colorFor(
+													bucket.currency,
+													i
+												)}"
+											></div>
+										</div>
+										<span class="w-12 text-right tabular-nums">{bucket.percent.toFixed(1)}%</span>
+									</div>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/routes/ekspozycja/+page.ts
+++ b/src/routes/ekspozycja/+page.ts
@@ -1,0 +1,38 @@
+import { error } from '@sveltejs/kit';
+import { resolveApiUrl } from '$lib/api';
+import type { CurrencyExposureReport } from '$lib/types/exposure';
+import type { PageLoad } from './$types';
+
+// Target PLN share + tolerance are URL-driven so the drift band is shareable
+// and survives reloads. A valid target_pln_pct turns on the drift band; an
+// absent/invalid one fetches the plain breakdown.
+export const load: PageLoad = async ({ fetch, url }) => {
+	const apiUrl = resolveApiUrl();
+
+	const targetParamRaw = url.searchParams.get('target_pln_pct');
+	const targetNum = targetParamRaw === null ? null : Number(targetParamRaw);
+	const hasTarget =
+		targetNum !== null && Number.isFinite(targetNum) && targetNum >= 0 && targetNum <= 100;
+
+	const toleranceRaw = url.searchParams.get('tolerance');
+	const toleranceNum = toleranceRaw === null ? 5 : Number(toleranceRaw);
+	const tolerance = Number.isFinite(toleranceNum) && toleranceNum >= 0 ? toleranceNum : 5;
+
+	const params = new URLSearchParams();
+	if (hasTarget) {
+		params.set('target_pln_pct', String(targetNum));
+		params.set('tolerance', String(tolerance));
+	}
+	const qs = params.toString();
+	const res = await fetch(`${apiUrl}/api/exposure/currency${qs ? `?${qs}` : ''}`);
+	if (!res.ok) {
+		throw error(res.status, 'Nie udało się pobrać ekspozycji walutowej');
+	}
+	const report: CurrencyExposureReport = await res.json();
+
+	return {
+		report,
+		targetPLNPct: hasTarget ? targetNum : null,
+		tolerance
+	};
+};

--- a/src/routes/ekspozycja/page.test.ts
+++ b/src/routes/ekspozycja/page.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, beforeAll, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Page from './+page.svelte';
+import type { CurrencyExposureReport } from '$lib/types/exposure';
+
+beforeAll(() => {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn()
+		}))
+	});
+});
+
+vi.mock('echarts', () => ({
+	init: vi.fn(() => ({ setOption: vi.fn(), resize: vi.fn(), dispose: vi.fn() }))
+}));
+
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+
+vi.mock('$app/stores', async () => {
+	const { readable } = await import('svelte/store');
+	return { page: readable({ url: new URL('http://localhost/ekspozycja') }) };
+});
+
+const report = (over: Partial<CurrencyExposureReport> = {}): CurrencyExposureReport => ({
+	currencies: [
+		{ currency: 'PLN', value_pln: 60000, percent: 60 },
+		{ currency: 'USD', value_pln: 40000, percent: 40 }
+	],
+	total_pln: 100000,
+	pln_pct: 60,
+	foreign_pct: 40,
+	snapshot_date: '2026-04-30',
+	...over
+});
+
+describe('Ekspozycja page', () => {
+	it('renders the heading and per-currency rows', () => {
+		render(Page, {
+			props: { data: { user: null, report: report(), targetPLNPct: null, tolerance: 5 } }
+		});
+		expect(screen.getByRole('heading', { name: 'Ekspozycja walutowa', level: 1 })).toBeTruthy();
+		expect(screen.getByText('PLN')).toBeTruthy();
+		expect(screen.getByText('USD')).toBeTruthy();
+	});
+
+	it('shows the empty-state when there are no currencies', () => {
+		render(Page, {
+			props: {
+				data: { user: null, report: report({ currencies: [] }), targetPLNPct: null, tolerance: 5 }
+			}
+		});
+		expect(screen.getByText(/Brak snapshotu lub aktywnych kont/)).toBeTruthy();
+	});
+
+	it('renders the drift band when a target is set', () => {
+		render(Page, {
+			props: {
+				data: {
+					user: null,
+					report: report({
+						drift: {
+							target_pln_pct: 50,
+							actual_pln_pct: 60,
+							drift_pln_pct: 10,
+							within_tolerance: false,
+							tolerance_pct: 5
+						}
+					}),
+					targetPLNPct: 50,
+					tolerance: 5
+				}
+			}
+		});
+		expect(screen.getByText(/Dryft względem celu 50% PLN/)).toBeTruthy();
+		expect(screen.getByText('+10.0 pp')).toBeTruthy();
+		expect(screen.getByText(/poza pasmem ±5 pp/)).toBeTruthy();
+	});
+
+	it('omits the drift band when no target is set', () => {
+		render(Page, {
+			props: { data: { user: null, report: report(), targetPLNPct: null, tolerance: 5 } }
+		});
+		expect(screen.queryByText(/Dryft względem celu/)).toBeNull();
+	});
+});


### PR DESCRIPTION
## Motivation

`/api/exposure/currency` (PLN vs USD/EUR/GBP/CHF, drift bands) was only surfaced as a small dashboard widget (#678).

## Implementation information

New standalone `/ekspozycja` page:
- Summary cards (PLN %, foreign %, portfolio total, snapshot date), a donut chart, and a per-currency table with share bars.
- Target PLN share + tolerance are URL-driven (query params), so the drift band is shareable and survives reloads; the load function validates ranges (0–100 target, non-negative tolerance) and only requests the drift band for a valid target.
- Added a `Globe` nav entry and shared `exposure.ts` wire types.

Scope note: `/api/exposure/currency` returns per-currency aggregates only — there is no per-holding attribution in the backend, so holdings-level attribution is out of scope here (would require a new endpoint). The done-when criteria (standalone page + drift bands + per-currency list) are met with the existing endpoint.

Closes #678

> Changelog: feat(exposure): dedicated currency exposure page