### PR TITLE
feat(investments): XIRR returns dashboard view

### DIFF
--- a/src/routes/investments/+layout.svelte
+++ b/src/routes/investments/+layout.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { Briefcase, Coins } from 'lucide-svelte';
+	import { Briefcase, Coins, TrendingUp } from 'lucide-svelte';
 
 	let { children } = $props();
 
 	const tabs = [
 		{ href: '/investments/holdings', label: 'Akcje / ETF', icon: Briefcase },
-		{ href: '/investments/bonds', label: 'Obligacje', icon: Coins }
+		{ href: '/investments/bonds', label: 'Obligacje', icon: Coins },
+		{ href: '/investments/returns', label: 'Zwroty', icon: TrendingUp }
 	];
 
 	const activeTab = $derived(page.url.pathname);

--- a/src/routes/investments/returns/+page.svelte
+++ b/src/routes/investments/returns/+page.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import ContributionAdjustedReturns from '$lib/components/ContributionAdjustedReturns.svelte';
+	import type { PageData } from './$types';
+
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
+
+	type ScopeKind = 'all' | 'category' | 'wrapper' | 'account';
+
+	// Fixed scope presets (categories + wrappers); per-account options come from
+	// the loaded investment accounts. Selection is local state — the returns card
+	// re-fetches reactively on scope change, no page reload needed.
+	const PRESETS: { kind: ScopeKind; value?: string; label: string }[] = [
+		{ kind: 'all', label: 'Całość' },
+		{ kind: 'category', value: 'stock', label: 'Akcje' },
+		{ kind: 'category', value: 'etf', label: 'ETF' },
+		{ kind: 'category', value: 'bond', label: 'Obligacje' },
+		{ kind: 'category', value: 'fund', label: 'Fundusze' },
+		{ kind: 'wrapper', value: 'IKE', label: 'IKE' },
+		{ kind: 'wrapper', value: 'IKZE', label: 'IKZE' },
+		{ kind: 'wrapper', value: 'PPK', label: 'PPK' }
+	];
+
+	let selectedKind = $state<ScopeKind>('all');
+	let selectedValue = $state<string | undefined>(undefined);
+	let selectedAccountId = $state<number | undefined>(undefined);
+
+	function selectPreset(kind: ScopeKind, value?: string) {
+		selectedKind = kind;
+		selectedValue = value;
+		selectedAccountId = undefined;
+	}
+
+	function selectAccount(event: Event) {
+		const raw = (event.currentTarget as HTMLSelectElement).value;
+		if (raw === '') {
+			selectPreset('all');
+			return;
+		}
+		selectedKind = 'account';
+		selectedValue = undefined;
+		selectedAccountId = Number(raw);
+	}
+
+	const isPresetActive = (kind: ScopeKind, value?: string): boolean =>
+		selectedKind === kind && selectedValue === value && selectedAccountId === undefined;
+
+	const scope = $derived({
+		type: selectedKind,
+		value: selectedValue,
+		account_id: selectedAccountId
+	});
+
+	const scopeTitle = $derived.by(() => {
+		if (selectedKind === 'account') {
+			return data.accounts.find((a) => a.id === selectedAccountId)?.name ?? 'Konto';
+		}
+		return (
+			PRESETS.find((p) => p.kind === selectedKind && p.value === selectedValue)?.label ?? 'Zwroty'
+		);
+	});
+</script>
+
+<svelte:head>
+	<title>Zwroty - Finance Buddy</title>
+</svelte:head>
+
+<div class="space-y-4">
+	<div role="group" aria-label="Zakres zwrotów" class="flex flex-wrap gap-2">
+		{#each PRESETS as preset (preset.kind + (preset.value ?? ''))}
+			<button
+				type="button"
+				class="btn btn-sm {isPresetActive(preset.kind, preset.value)
+					? 'preset-filled-primary-500'
+					: 'preset-tonal-surface'}"
+				aria-pressed={isPresetActive(preset.kind, preset.value)}
+				onclick={() => selectPreset(preset.kind, preset.value)}
+			>
+				{preset.label}
+			</button>
+		{/each}
+
+		{#if data.accounts.length > 0}
+			<label class="label inline-flex items-center gap-2">
+				<span class="sr-only">Konto</span>
+				<select
+					class="select w-48"
+					value={selectedKind === 'account' ? String(selectedAccountId) : ''}
+					onchange={selectAccount}
+				>
+					<option value="">Pojedyncze konto…</option>
+					{#each data.accounts as account (account.id)}
+						<option value={String(account.id)}>{account.name}</option>
+					{/each}
+				</select>
+			</label>
+		{/if}
+	</div>
+
+	<ContributionAdjustedReturns {scope} title={scopeTitle} />
+</div>

--- a/src/routes/investments/returns/+page.ts
+++ b/src/routes/investments/returns/+page.ts
@@ -12,7 +12,11 @@ export interface ReturnsAccountOption {
 }
 
 // Investment accounts feed the per-account scope selector. Categories and
-// wrappers are fixed sets, so only the account list needs fetching.
+// wrappers are fixed sets, so only the account list needs fetching. An active
+// account counts as investment-capable if its category is an investment one OR
+// it carries a retirement wrapper (IKE/IKZE/PPK accounts may be categorized as
+// ppk/other yet still hold investments) — matching how the returns endpoint
+// scopes per-account.
 export const load: PageLoad = async ({ fetch }) => {
 	const apiUrl = resolveApiUrl();
 	const res = await fetch(`${apiUrl}/api/accounts`);
@@ -21,7 +25,9 @@ export const load: PageLoad = async ({ fetch }) => {
 	}
 	const data: { assets: ReturnsAccountOption[] } = await res.json();
 	const accounts = (data.assets ?? [])
-		.filter((a) => a.is_active && INVESTMENT_CATEGORIES.has(a.category))
+		.filter(
+			(a) => a.is_active && (INVESTMENT_CATEGORIES.has(a.category) || a.account_wrapper != null)
+		)
 		.sort((a, b) => a.name.localeCompare(b.name, 'pl'));
 	return { accounts };
 };

--- a/src/routes/investments/returns/+page.ts
+++ b/src/routes/investments/returns/+page.ts
@@ -1,0 +1,27 @@
+import { error } from '@sveltejs/kit';
+import { resolveApiUrl } from '$lib/api';
+import { INVESTMENT_CATEGORIES } from '$lib/constants';
+import type { PageLoad } from './$types';
+
+export interface ReturnsAccountOption {
+	id: number;
+	name: string;
+	category: string;
+	account_wrapper: string | null;
+	is_active: boolean;
+}
+
+// Investment accounts feed the per-account scope selector. Categories and
+// wrappers are fixed sets, so only the account list needs fetching.
+export const load: PageLoad = async ({ fetch }) => {
+	const apiUrl = resolveApiUrl();
+	const res = await fetch(`${apiUrl}/api/accounts`);
+	if (!res.ok) {
+		throw error(res.status, 'Nie udało się pobrać kont');
+	}
+	const data: { assets: ReturnsAccountOption[] } = await res.json();
+	const accounts = (data.assets ?? [])
+		.filter((a) => a.is_active && INVESTMENT_CATEGORIES.has(a.category))
+		.sort((a, b) => a.name.localeCompare(b.name, 'pl'));
+	return { accounts };
+};

--- a/src/routes/investments/returns/page.test.ts
+++ b/src/routes/investments/returns/page.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+
+vi.mock('$env/dynamic/public', () => ({
+	env: {
+		PUBLIC_API_URL_BROWSER: 'http://localhost:8000',
+		PUBLIC_API_URL: 'http://localhost:8000'
+	}
+}));
+
+import Page from './+page.svelte';
+import type { ReturnsAccountOption } from './+page.ts';
+
+const returnsPayload = {
+	scope: { type: 'all' },
+	period: 'all',
+	since: null,
+	as_of: '2026-05-24',
+	deposits: 10000,
+	withdrawals: 0,
+	net_contributed: 10000,
+	current_value: 12000,
+	valuation_change: 2000,
+	simple_roi_pct: 20,
+	money_weighted_pct: 15.5,
+	has_snapshot: true,
+	convergence_failed: false
+};
+
+const accounts: ReturnsAccountOption[] = [
+	{ id: 1, name: 'XTB IKE', category: 'stock', account_wrapper: 'IKE', is_active: true },
+	{ id: 2, name: 'mBank ETF', category: 'etf', account_wrapper: null, is_active: true }
+];
+
+describe('Returns page', () => {
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		fetchSpy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async () => new Response(JSON.stringify(returnsPayload)));
+	});
+
+	afterEach(() => {
+		fetchSpy.mockRestore();
+	});
+
+	it('renders the scope preset buttons and the returns card', async () => {
+		render(Page, { props: { data: { user: null, accounts } } });
+		expect(screen.getByRole('button', { name: 'Całość' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Akcje' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'IKE' })).toBeTruthy();
+		await waitFor(() => expect(screen.getByText('Zwrot (XIRR)')).toBeTruthy());
+	});
+
+	it('marks the selected preset as pressed and switches scope', async () => {
+		render(Page, { props: { data: { user: null, accounts } } });
+		const akcje = screen.getByRole('button', { name: 'Akcje' });
+		await fireEvent.click(akcje);
+		expect(akcje.getAttribute('aria-pressed')).toBe('true');
+		// fetch should be called with scope=category&value=stock
+		await waitFor(() => {
+			const calls = fetchSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+			expect(
+				calls.some((u: string) => u.includes('scope=category') && u.includes('value=stock'))
+			).toBe(true);
+		});
+	});
+
+	it('lists investment accounts in the per-account selector', () => {
+		render(Page, { props: { data: { user: null, accounts } } });
+		expect(screen.getByRole('option', { name: 'XTB IKE' })).toBeTruthy();
+		expect(screen.getByRole('option', { name: 'mBank ETF' })).toBeTruthy();
+	});
+
+	it('hides the account selector when there are no investment accounts', () => {
+		render(Page, { props: { data: { user: null, accounts: [] } } });
+		expect(screen.queryByText('Pojedyncze konto…')).toBeNull();
+	});
+});


### PR DESCRIPTION
## Motivation

`/api/investment/returns` (XIRR, contribution-adjusted, by scope/period) was only surfaced inside `/metryki` (#679).

## Implementation information

New `/investments/returns` tab in the unified investments view:
- Scope selector — całość / category (Akcje, ETF, Obligacje, Fundusze) / wrapper (IKE, IKZE, PPK) preset buttons, plus a per-account `<select>` populated from active investment accounts.
- Reuses the existing `ContributionAdjustedReturns` card, which already renders simple ROI vs XIRR (money-weighted) and 1m/3m/ytd/1y/all period switching — the page is a thin scope wrapper, no duplicated fetch/render logic.
- Added a "Zwroty" tab to the investments layout.

Closes #679

> Changelog: feat(investments): XIRR returns dashboard view