### PR TITLE
feat(holdings): dividend income tracking

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -5627,6 +5627,24 @@
     },
     "/api/holdings/dividends": {
       "get": {
+        "parameters": [
+          {
+            "description": "Filter to one account.",
+            "in": "query",
+            "name": "account_id",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter to one security.",
+            "in": "query",
+            "name": "security_id",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -5682,6 +5700,36 @@
         ]
       },
       "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "account_id": {
+                    "type": "integer"
+                  },
+                  "currency": {
+                    "type": "string"
+                  },
+                  "gross_amount": {
+                    "type": "string"
+                  },
+                  "pay_date": {
+                    "type": "string"
+                  },
+                  "security_id": {
+                    "type": "integer"
+                  },
+                  "withholding_tax": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "201": {
             "content": {

--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -5625,6 +5625,133 @@
         ]
       }
     },
+    "/api/holdings/dividends": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "dividends": {
+                      "items": {
+                        "properties": {
+                          "account_id": {
+                            "type": "integer"
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "gross_amount": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "integer"
+                          },
+                          "net_amount": {
+                            "type": "string"
+                          },
+                          "pay_date": {
+                            "type": "string"
+                          },
+                          "security_id": {
+                            "type": "integer"
+                          },
+                          "withholding_tax": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List dividends (filterable by account_id/security_id)",
+        "tags": [
+          "holdings"
+        ]
+      },
+      "post": {
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account_id": {
+                      "type": "integer"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "currency": {
+                      "type": "string"
+                    },
+                    "gross_amount": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "net_amount": {
+                      "type": "string"
+                    },
+                    "pay_date": {
+                      "type": "string"
+                    },
+                    "security_id": {
+                      "type": "integer"
+                    },
+                    "withholding_tax": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "summary": "Record a dividend",
+        "tags": [
+          "holdings"
+        ]
+      }
+    },
+    "/api/holdings/dividends/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete a dividend",
+        "tags": [
+          "holdings"
+        ]
+      }
+    },
     "/api/holdings/lots": {
       "get": {
         "responses": {
@@ -6069,6 +6196,10 @@
                       "type": "number"
                     },
                     "deposits": {
+                      "format": "double",
+                      "type": "number"
+                    },
+                    "dividends_received_net": {
                       "format": "double",
                       "type": "number"
                     },

--- a/backend-bb-tests/tests/test_dividends.py
+++ b/backend-bb-tests/tests/test_dividends.py
@@ -20,7 +20,12 @@ def _create_security(client: httpx.Client, request: pytest.FixtureRequest) -> in
     symbol = f"DIV{abs(hash(request.node.name)) % 100000}"
     response = client.post(
         "/api/holdings/securities",
-        json={"symbol": symbol, "name": "Dividend Test Co", "asset_type": "stock", "currency": "PLN"},
+        json={
+            "symbol": symbol,
+            "name": "Dividend Test Co",
+            "asset_type": "stock",
+            "currency": "PLN",
+        },
     )
     assert response.status_code == 201, response.text
     return int(response.json()["id"])

--- a/backend-bb-tests/tests/test_dividends.py
+++ b/backend-bb-tests/tests/test_dividends.py
@@ -31,6 +31,7 @@ def _create_security(client: httpx.Client, request: pytest.FixtureRequest) -> in
     return int(response.json()["id"])
 
 
+@pytest.mark.mutates
 def test_dividend_crud_and_net(client: httpx.Client, request: pytest.FixtureRequest) -> None:
     account_id = _investment_account_id(client)
     security_id = _create_security(client, request)
@@ -67,6 +68,7 @@ def test_dividend_crud_and_net(client: httpx.Client, request: pytest.FixtureRequ
     assert all(d["id"] != dividend_id for d in gone.json()["dividends"])
 
 
+@pytest.mark.mutates
 def test_dividend_validation_rejects_tax_above_gross(
     client: httpx.Client, request: pytest.FixtureRequest
 ) -> None:
@@ -88,6 +90,7 @@ def test_dividend_validation_rejects_tax_above_gross(
         client.delete(f"/api/holdings/securities/{security_id}")
 
 
+@pytest.mark.mutates
 def test_returns_folds_dividend_income(
     client: httpx.Client, request: pytest.FixtureRequest
 ) -> None:

--- a/backend-bb-tests/tests/test_dividends.py
+++ b/backend-bb-tests/tests/test_dividends.py
@@ -1,0 +1,116 @@
+"""Black-box tests for /api/holdings/dividends — CRUD plus the dividend
+income folding into /api/investment/returns (issue #681)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+
+def _investment_account_id(client: httpx.Client) -> int:
+    response = client.get("/api/accounts")
+    assert response.status_code == 200, response.text
+    for account in response.json().get("assets", []):
+        if account.get("category") in ("stock", "etf", "bond", "fund"):
+            return int(account["id"])
+    raise AssertionError("no seeded investment account to attach a dividend to")
+
+
+def _create_security(client: httpx.Client, request: pytest.FixtureRequest) -> int:
+    symbol = f"DIV{abs(hash(request.node.name)) % 100000}"
+    response = client.post(
+        "/api/holdings/securities",
+        json={"symbol": symbol, "name": "Dividend Test Co", "asset_type": "stock", "currency": "PLN"},
+    )
+    assert response.status_code == 201, response.text
+    return int(response.json()["id"])
+
+
+def test_dividend_crud_and_net(client: httpx.Client, request: pytest.FixtureRequest) -> None:
+    account_id = _investment_account_id(client)
+    security_id = _create_security(client, request)
+    dividend_id: int | None = None
+    try:
+        created = client.post(
+            "/api/holdings/dividends",
+            json={
+                "account_id": account_id,
+                "security_id": security_id,
+                "pay_date": "2026-03-15",
+                "gross_amount": "100.00",
+                "withholding_tax": "19.00",
+            },
+        )
+        assert created.status_code == 201, created.text
+        body = created.json()
+        dividend_id = int(body["id"])
+        assert body["net_amount"] == "81.00"
+        assert body["gross_amount"] == "100.00"
+        assert body["withholding_tax"] == "19.00"
+
+        listed = client.get(f"/api/holdings/dividends?security_id={security_id}")
+        assert listed.status_code == 200, listed.text
+        ids = {d["id"] for d in listed.json()["dividends"]}
+        assert dividend_id in ids
+    finally:
+        if dividend_id is not None:
+            assert client.delete(f"/api/holdings/dividends/{dividend_id}").status_code == 204
+        client.delete(f"/api/holdings/securities/{security_id}")
+
+    gone = client.get(f"/api/holdings/dividends?security_id={security_id}")
+    assert gone.status_code == 200
+    assert all(d["id"] != dividend_id for d in gone.json()["dividends"])
+
+
+def test_dividend_validation_rejects_tax_above_gross(
+    client: httpx.Client, request: pytest.FixtureRequest
+) -> None:
+    account_id = _investment_account_id(client)
+    security_id = _create_security(client, request)
+    try:
+        response = client.post(
+            "/api/holdings/dividends",
+            json={
+                "account_id": account_id,
+                "security_id": security_id,
+                "pay_date": "2026-03-15",
+                "gross_amount": "50.00",
+                "withholding_tax": "60.00",
+            },
+        )
+        assert response.status_code == 422, response.text
+    finally:
+        client.delete(f"/api/holdings/securities/{security_id}")
+
+
+def test_returns_folds_dividend_income(
+    client: httpx.Client, request: pytest.FixtureRequest
+) -> None:
+    account_id = _investment_account_id(client)
+    security_id = _create_security(client, request)
+    dividend_id: int | None = None
+    try:
+        baseline = client.get(f"/api/investment/returns?scope=account&id={account_id}")
+        assert baseline.status_code == 200, baseline.text
+        base_net = baseline.json()["dividends_received_net"]
+
+        created = client.post(
+            "/api/holdings/dividends",
+            json={
+                "account_id": account_id,
+                "security_id": security_id,
+                "pay_date": "2026-01-15",
+                "gross_amount": "200.00",
+                "withholding_tax": "0.00",
+            },
+        )
+        assert created.status_code == 201, created.text
+        dividend_id = int(created.json()["id"])
+
+        after = client.get(f"/api/investment/returns?scope=account&id={account_id}")
+        assert after.status_code == 200, after.text
+        assert after.json()["dividends_received_net"] == pytest.approx(base_net + 200.0)
+    finally:
+        if dividend_id is not None:
+            client.delete(f"/api/holdings/dividends/{dividend_id}")
+        client.delete(f"/api/holdings/securities/{security_id}")

--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -235,6 +235,11 @@ func initDB(ctx context.Context, dsn string, logger *slog.Logger, adminUsername,
 		pool.Close()
 		return nil, 2
 	}
+	if err := holdings.NewStore(pool).EnsureDividendsSchema(ctx); err != nil {
+		logger.Error("ensure holding_dividends schema", "err", err)
+		pool.Close()
+		return nil, 2
+	}
 	return pool, 0
 }
 

--- a/backend-go/internal/holdings/dividends.go
+++ b/backend-go/internal/holdings/dividends.go
@@ -1,0 +1,131 @@
+package holdings
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/shopspring/decimal"
+)
+
+// ErrDividendNotFound is returned by DeleteDividend when no row matches.
+var ErrDividendNotFound = errors.New("dividend not found")
+
+// Dividend is one cash-dividend payout recorded against a security held in an
+// account: the gross amount and the withholding tax taken at source. Net (the
+// cash that actually landed) is gross − withholding.
+type Dividend struct {
+	ID             int
+	AccountID      int
+	SecurityID     int
+	PayDate        time.Time
+	GrossAmount    decimal.Decimal
+	WithholdingTax decimal.Decimal
+	Currency       string
+	CreatedAt      time.Time
+}
+
+// Net is the cash received after withholding.
+func (d Dividend) Net() decimal.Decimal { return d.GrossAmount.Sub(d.WithholdingTax) }
+
+// EnsureDividendsSchema creates the holding_dividends table + index if missing.
+// Idempotent so it can run on every startup — schema.sql only seeds empty
+// databases, so existing installs need the additive DDL here too (mirrors the
+// bonds / allocation EnsureSchema pattern).
+func (s *Store) EnsureDividendsSchema(ctx context.Context) error {
+	if _, err := s.pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS holding_dividends (
+			id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+			account_id integer NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+			security_id integer NOT NULL REFERENCES securities(id) ON DELETE RESTRICT,
+			pay_date date NOT NULL,
+			gross_amount numeric(15, 2) NOT NULL,
+			withholding_tax numeric(15, 2) NOT NULL DEFAULT 0,
+			currency varchar(3) NOT NULL DEFAULT 'PLN',
+			created_at timestamp without time zone NOT NULL DEFAULT (now() AT TIME ZONE 'utc')
+		)`); err != nil {
+		return fmt.Errorf("ensure holding_dividends table: %w", err)
+	}
+	if _, err := s.pool.Exec(ctx, `
+		CREATE INDEX IF NOT EXISTS ix_holding_dividends_acct_sec_date
+		ON holding_dividends (account_id, security_id, pay_date DESC)`); err != nil {
+		return fmt.Errorf("ensure holding_dividends index: %w", err)
+	}
+	return nil
+}
+
+const divCols = `id, account_id, security_id, pay_date, gross_amount, withholding_tax, currency, created_at`
+
+func scanDividend(row pgx.Row) (Dividend, error) {
+	var d Dividend
+	if err := row.Scan(&d.ID, &d.AccountID, &d.SecurityID, &d.PayDate,
+		&d.GrossAmount, &d.WithholdingTax, &d.Currency, &d.CreatedAt); err != nil {
+		return Dividend{}, err
+	}
+	return d, nil
+}
+
+// ListDividends returns dividends, newest pay-date first, optionally filtered
+// by account and/or security.
+func (s *Store) ListDividends(ctx context.Context, accountID, securityID *int) ([]Dividend, error) {
+	args := []any{}
+	where := ""
+	add := func(clause string, val any) {
+		args = append(args, val)
+		if where == "" {
+			where = fmt.Sprintf("WHERE %s$%d", clause, len(args))
+		} else {
+			where += fmt.Sprintf(" AND %s$%d", clause, len(args))
+		}
+	}
+	if accountID != nil {
+		add("account_id = ", *accountID)
+	}
+	if securityID != nil {
+		add("security_id = ", *securityID)
+	}
+	rows, err := s.pool.Query(ctx, `SELECT `+divCols+` FROM holding_dividends `+where+`
+		ORDER BY pay_date DESC, id DESC`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list dividends: %w", err)
+	}
+	defer rows.Close()
+	out := []Dividend{}
+	for rows.Next() {
+		d, err := scanDividend(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan dividend: %w", err)
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// CreateDividend inserts one dividend and returns the persisted row.
+func (s *Store) CreateDividend(ctx context.Context, d Dividend) (Dividend, error) {
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO holding_dividends (account_id, security_id, pay_date, gross_amount, withholding_tax, currency)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING `+divCols,
+		d.AccountID, d.SecurityID, d.PayDate, d.GrossAmount, d.WithholdingTax, d.Currency)
+	created, err := scanDividend(row)
+	if err != nil {
+		return Dividend{}, fmt.Errorf("create dividend: %w", err)
+	}
+	return created, nil
+}
+
+// DeleteDividend removes a dividend by id, returning ErrDividendNotFound when
+// no row matched.
+func (s *Store) DeleteDividend(ctx context.Context, id int) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM holding_dividends WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete dividend: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrDividendNotFound
+	}
+	return nil
+}

--- a/backend-go/internal/holdings/handler.go
+++ b/backend-go/internal/holdings/handler.go
@@ -458,6 +458,18 @@ type listDividendsResponse struct {
 	Dividends []dividendResponse `json:"dividends"`
 }
 
+// dividendCreateRequest documents the POST /api/holdings/dividends body for
+// OpenAPI generation. Decimal money fields ride as JSON strings to preserve
+// precision; withholding_tax and currency are optional (default 0 / "PLN").
+type dividendCreateRequest struct {
+	AccountID      int    `json:"account_id"`
+	SecurityID     int    `json:"security_id"`
+	PayDate        string `json:"pay_date"`
+	GrossAmount    string `json:"gross_amount"`
+	WithholdingTax string `json:"withholding_tax"`
+	Currency       string `json:"currency"`
+}
+
 func toDividend(d Dividend) dividendResponse {
 	return dividendResponse{
 		ID: d.ID, AccountID: d.AccountID, SecurityID: d.SecurityID,

--- a/backend-go/internal/holdings/handler.go
+++ b/backend-go/internal/holdings/handler.go
@@ -440,6 +440,111 @@ func toAccountPosition(p *AccountPosition) accountPositionResponse {
 	return resp
 }
 
+// --- dividend wire types ---
+
+type dividendResponse struct {
+	ID             int    `json:"id"`
+	AccountID      int    `json:"account_id"`
+	SecurityID     int    `json:"security_id"`
+	PayDate        string `json:"pay_date"`
+	GrossAmount    string `json:"gross_amount"`
+	WithholdingTax string `json:"withholding_tax"`
+	NetAmount      string `json:"net_amount"`
+	Currency       string `json:"currency"`
+	CreatedAt      string `json:"created_at"`
+}
+
+type listDividendsResponse struct {
+	Dividends []dividendResponse `json:"dividends"`
+}
+
+func toDividend(d Dividend) dividendResponse {
+	return dividendResponse{
+		ID: d.ID, AccountID: d.AccountID, SecurityID: d.SecurityID,
+		PayDate:        d.PayDate.UTC().Format("2006-01-02"),
+		GrossAmount:    d.GrossAmount.StringFixed(2),
+		WithholdingTax: d.WithholdingTax.StringFixed(2),
+		NetAmount:      d.Net().StringFixed(2),
+		Currency:       d.Currency,
+		CreatedAt:      d.CreatedAt.UTC().Format("2006-01-02T15:04:05.999999"),
+	}
+}
+
+// ListDividends serves GET /api/holdings/dividends?account_id=&security_id=.
+func (h *Handler) ListDividends(w http.ResponseWriter, r *http.Request) {
+	var accountID, securityID *int
+	if v := r.URL.Query().Get("account_id"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			httputil.WriteBodyValidationError(w, "account_id", "must be a positive integer", "")
+			return
+		}
+		accountID = &n
+	}
+	if v := r.URL.Query().Get("security_id"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			httputil.WriteBodyValidationError(w, "security_id", "must be a positive integer", "")
+			return
+		}
+		securityID = &n
+	}
+	rows, err := h.store.ListDividends(r.Context(), accountID, securityID)
+	if err != nil {
+		h.logger.Error("list dividends", "err", err)
+		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	out := make([]dividendResponse, 0, len(rows))
+	for _, d := range rows {
+		out = append(out, toDividend(d))
+	}
+	httputil.WriteJSON(w, http.StatusOK, listDividendsResponse{Dividends: out})
+}
+
+// CreateDividend serves POST /api/holdings/dividends.
+func (h *Handler) CreateDividend(w http.ResponseWriter, r *http.Request) {
+	raw, err := readBody(r)
+	if err != nil {
+		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", "")
+		return
+	}
+	div, vErr := buildDividendInput(raw)
+	if vErr != nil {
+		httputil.WriteBodyValidationError(w, vErr.Field, vErr.Msg, "")
+		return
+	}
+	created, err := h.store.CreateDividend(r.Context(), div)
+	if err != nil {
+		if pgErrorCode(err) == pgForeignKeyViolation {
+			httputil.WriteDetailError(w, http.StatusNotFound, "Referenced account or security not found")
+			return
+		}
+		h.logger.Error("create dividend", "err", err)
+		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	httputil.WriteJSON(w, http.StatusCreated, toDividend(created))
+}
+
+// DeleteDividend serves DELETE /api/holdings/dividends/{id}.
+func (h *Handler) DeleteDividend(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.DeleteDividend(r.Context(), id); err != nil {
+		if errors.Is(err, ErrDividendNotFound) {
+			httputil.WriteDetailError(w, http.StatusNotFound, "Dividend not found")
+			return
+		}
+		h.logger.Error("delete dividend", "err", err)
+		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // --- shared helpers ---
 
 func parseID(w http.ResponseWriter, r *http.Request) (int, bool) {

--- a/backend-go/internal/holdings/openapi.go
+++ b/backend-go/internal/holdings/openapi.go
@@ -17,8 +17,11 @@ var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/holdings/lots", Tag: "holdings", Summary: "List lots (filterable by account_id/security_id)", Response: listLotsResponse{}},
 	{Method: "POST", Path: "/api/holdings/lots", Tag: "holdings", Summary: "Create a lot", Status: http.StatusCreated, Response: lotResponse{}},
 	{Method: "DELETE", Path: "/api/holdings/lots/{id}", Tag: "holdings", Summary: "Delete a lot", Status: http.StatusNoContent},
-	{Method: "GET", Path: "/api/holdings/dividends", Tag: "holdings", Summary: "List dividends (filterable by account_id/security_id)", Response: listDividendsResponse{}},
-	{Method: "POST", Path: "/api/holdings/dividends", Tag: "holdings", Summary: "Record a dividend", Status: http.StatusCreated, Response: dividendResponse{}},
+	{Method: "GET", Path: "/api/holdings/dividends", Tag: "holdings", Summary: "List dividends (filterable by account_id/security_id)", Query: []apispec.QueryParam{
+		{Name: "account_id", Type: "integer", Description: "Filter to one account."},
+		{Name: "security_id", Type: "integer", Description: "Filter to one security."},
+	}, Response: listDividendsResponse{}},
+	{Method: "POST", Path: "/api/holdings/dividends", Tag: "holdings", Summary: "Record a dividend", Status: http.StatusCreated, Request: dividendCreateRequest{}, Response: dividendResponse{}},
 	{Method: "DELETE", Path: "/api/holdings/dividends/{id}", Tag: "holdings", Summary: "Delete a dividend", Status: http.StatusNoContent},
 	{Method: "POST", Path: "/api/holdings/refresh-quotes", Tag: "holdings", Summary: "Pull latest quotes from Stooq for all securities", Response: refreshQuotesResponse{}},
 }

--- a/backend-go/internal/holdings/openapi.go
+++ b/backend-go/internal/holdings/openapi.go
@@ -17,6 +17,9 @@ var APISpec = []apispec.Route{
 	{Method: "GET", Path: "/api/holdings/lots", Tag: "holdings", Summary: "List lots (filterable by account_id/security_id)", Response: listLotsResponse{}},
 	{Method: "POST", Path: "/api/holdings/lots", Tag: "holdings", Summary: "Create a lot", Status: http.StatusCreated, Response: lotResponse{}},
 	{Method: "DELETE", Path: "/api/holdings/lots/{id}", Tag: "holdings", Summary: "Delete a lot", Status: http.StatusNoContent},
+	{Method: "GET", Path: "/api/holdings/dividends", Tag: "holdings", Summary: "List dividends (filterable by account_id/security_id)", Response: listDividendsResponse{}},
+	{Method: "POST", Path: "/api/holdings/dividends", Tag: "holdings", Summary: "Record a dividend", Status: http.StatusCreated, Response: dividendResponse{}},
+	{Method: "DELETE", Path: "/api/holdings/dividends/{id}", Tag: "holdings", Summary: "Delete a dividend", Status: http.StatusNoContent},
 	{Method: "POST", Path: "/api/holdings/refresh-quotes", Tag: "holdings", Summary: "Pull latest quotes from Stooq for all securities", Response: refreshQuotesResponse{}},
 }
 

--- a/backend-go/internal/holdings/validation.go
+++ b/backend-go/internal/holdings/validation.go
@@ -172,6 +172,66 @@ func buildQuoteInput(raw map[string]json.RawMessage, securityID int) (PriceQuote
 	return q, nil
 }
 
+func buildDividendInput(raw map[string]json.RawMessage) (Dividend, *httputil.ValidationError) {
+	var d Dividend
+	d.Currency = "PLN"
+	if vErr := requireInt(raw, "account_id", &d.AccountID); vErr != nil {
+		return d, vErr
+	}
+	if d.AccountID <= 0 {
+		return d, &httputil.ValidationError{Field: "account_id", Msg: "must be positive"}
+	}
+	if vErr := requireInt(raw, "security_id", &d.SecurityID); vErr != nil {
+		return d, vErr
+	}
+	if d.SecurityID <= 0 {
+		return d, &httputil.ValidationError{Field: "security_id", Msg: "must be positive"}
+	}
+	dateStr, vErr := requireString2(raw, "pay_date")
+	if vErr != nil {
+		return d, vErr
+	}
+	parsed, derr := time.Parse("2006-01-02", dateStr)
+	if derr != nil {
+		return d, &httputil.ValidationError{Field: "pay_date", Msg: "must be YYYY-MM-DD"}
+	}
+	d.PayDate = parsed
+	gross, vErr := requireDecimal(raw, "gross_amount")
+	if vErr != nil {
+		return d, vErr
+	}
+	if gross.Sign() <= 0 {
+		return d, &httputil.ValidationError{Field: "gross_amount", Msg: "must be positive"}
+	}
+	d.GrossAmount = gross
+	if v, ok := raw["withholding_tax"]; ok && string(v) != "null" {
+		tax, terr := decimal.NewFromString(strings.Trim(string(v), `"`))
+		if terr != nil {
+			return d, &httputil.ValidationError{Field: "withholding_tax", Msg: "must be a number"}
+		}
+		if tax.Sign() < 0 {
+			return d, &httputil.ValidationError{Field: "withholding_tax", Msg: "must not be negative"}
+		}
+		if tax.GreaterThan(gross) {
+			return d, &httputil.ValidationError{Field: "withholding_tax", Msg: "must not exceed gross amount"}
+		}
+		d.WithholdingTax = tax
+	}
+	if v, ok := raw["currency"]; ok && string(v) != "null" {
+		var c string
+		if err := json.Unmarshal(v, &c); err != nil {
+			return d, &httputil.ValidationError{Field: "currency", Msg: "must be a string"}
+		}
+		if c = strings.TrimSpace(c); c != "" {
+			if len(c) != 3 {
+				return d, &httputil.ValidationError{Field: "currency", Msg: "must be 3 chars"}
+			}
+			d.Currency = strings.ToUpper(c)
+		}
+	}
+	return d, nil
+}
+
 func requireInt(raw map[string]json.RawMessage, key string, dest *int) *httputil.ValidationError {
 	v, ok := raw[key]
 	if !ok || string(v) == "null" {

--- a/backend-go/internal/investment/handler.go
+++ b/backend-go/internal/investment/handler.go
@@ -1,6 +1,7 @@
 package investment
 
 import (
+	"context"
 	"log/slog"
 	"math"
 	"net/http"
@@ -47,6 +48,7 @@ type returnsResponse struct {
 	ValuationChange   wire.PyFloat  `json:"valuation_change"`
 	SimpleROIPct      wire.PyFloat  `json:"simple_roi_pct"`
 	MoneyWeightedPct  *wire.PyFloat `json:"money_weighted_pct"`
+	DividendsNet      wire.PyFloat  `json:"dividends_received_net"`
 	HasSnapshot       bool          `json:"has_snapshot"`
 	ConvergenceFailed bool          `json:"convergence_failed"`
 }
@@ -104,26 +106,16 @@ func (h *Handler) Returns(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deposits, withdrawals := 0.0, 0.0
-	xirrFlows := make([]CashFlow, 0, len(flows)+2)
-	// Windowed periods need an opening balance so XIRR reflects the return
-	// over the period rather than treating pre-window value as free money.
-	// Inject the snapshot-as-of-since as a positive cash flow at `since`.
-	var openingValue float64
-	if window.Since != nil {
-		openValDec, _, hasOpen, err := h.store.LatestValueInScope(r.Context(), scope, *window.Since)
-		if err != nil {
-			h.logger.Error("returns: opening snapshot", "err", err)
-			httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
-			return
-		}
-		if hasOpen {
-			openingValue, _ = openValDec.Float64()
-			if openingValue > 0 {
-				xirrFlows = append(xirrFlows, CashFlow{Date: *window.Since, Amount: openingValue})
-			}
-		}
+	xirrFlows := make([]CashFlow, 0, len(flows)+4)
+	openingValue, openFlows, err := h.openingFlow(r.Context(), scope, window.Since)
+	if err != nil {
+		h.logger.Error("returns: opening snapshot", "err", err)
+		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
 	}
+	xirrFlows = append(xirrFlows, openFlows...)
+
+	deposits, withdrawals := 0.0, 0.0
 	for _, f := range flows {
 		amt, _ := f.Amount.Float64()
 		if amt >= 0 {
@@ -134,6 +126,18 @@ func (h *Handler) Returns(w http.ResponseWriter, r *http.Request) {
 		xirrFlows = append(xirrFlows, CashFlow{Date: f.Date, Amount: amt})
 	}
 	netContrib := deposits - withdrawals
+
+	// Dividends are income, not contributions: fold net cash in as negative
+	// XIRR flows (money returned to the investor) and add to the gain side of
+	// simple ROI, so real ETF/stock returns aren't understated.
+	dividendsNet, divFlows, err := h.dividendFlows(r.Context(), scope, PeriodWindow{Since: window.Since, AsOf: flowEnd})
+	if err != nil {
+		h.logger.Error("returns: dividends", "err", err)
+		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	xirrFlows = append(xirrFlows, divFlows...)
+
 	currentValue, _ := value.Float64()
 	// Valuation change is the difference between current value and what was
 	// put in over the window — current value minus (opening + net flows).
@@ -152,7 +156,8 @@ func (h *Handler) Returns(w http.ResponseWriter, r *http.Request) {
 		NetContributed:  wire.PyFloat(netContrib),
 		CurrentValue:    wire.PyFloat(currentValue),
 		ValuationChange: wire.PyFloat(valuationChange),
-		SimpleROIPct:    wire.PyFloat(math.Round(SimpleROI(openingValue+netContrib, currentValue)*10000) / 100),
+		SimpleROIPct:    wire.PyFloat(math.Round(SimpleROI(openingValue+netContrib, currentValue+dividendsNet)*10000) / 100),
+		DividendsNet:    wire.PyFloat(dividendsNet),
 		HasSnapshot:     hasSnap,
 	}
 	if window.Since != nil {
@@ -171,6 +176,45 @@ func (h *Handler) Returns(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	httputil.WriteJSON(w, http.StatusOK, resp)
+}
+
+// openingFlow injects the scope's value as-of the window start as a positive
+// XIRR flow so a windowed return reflects growth over the period rather than
+// treating pre-window value as free money. Returns the opening value (0 when
+// no window or no snapshot) and the flow(s) to prepend.
+func (h *Handler) openingFlow(ctx context.Context, scope ScopeFilter, since *time.Time) (float64, []CashFlow, error) {
+	if since == nil {
+		return 0, nil, nil
+	}
+	openValDec, _, hasOpen, err := h.store.LatestValueInScope(ctx, scope, *since)
+	if err != nil {
+		return 0, nil, err
+	}
+	if !hasOpen {
+		return 0, nil, nil
+	}
+	opening, _ := openValDec.Float64()
+	if opening <= 0 {
+		return opening, nil, nil
+	}
+	return opening, []CashFlow{{Date: *since, Amount: opening}}, nil
+}
+
+// dividendFlows returns total net dividend income in scope/window and the
+// matching negative XIRR flows (cash returned to the investor).
+func (h *Handler) dividendFlows(ctx context.Context, scope ScopeFilter, w PeriodWindow) (float64, []CashFlow, error) {
+	rows, err := h.store.ScopedDividends(ctx, scope, w)
+	if err != nil {
+		return 0, nil, err
+	}
+	net := 0.0
+	out := make([]CashFlow, 0, len(rows))
+	for _, d := range rows {
+		amt, _ := d.Amount.Float64()
+		net += amt
+		out = append(out, CashFlow{Date: d.Date, Amount: -amt})
+	}
+	return net, out, nil
 }
 
 func validPeriod(p string) bool {

--- a/backend-go/internal/investment/store.go
+++ b/backend-go/internal/investment/store.go
@@ -101,6 +101,59 @@ func (s *Store) ScopedFlows(ctx context.Context, scope ScopeFilter, w PeriodWind
 	return out, rows.Err()
 }
 
+// ScopedDividends pulls net dividend cash (gross − withholding) per pay-date
+// in scope between `since` and `asOf`, chronologically sorted. Net is reported
+// as a positive amount; the returns handler injects it as a negative XIRR flow
+// (cash returned to the investor), so dividends lift the money-weighted return
+// rather than being mistaken for new contributions.
+func (s *Store) ScopedDividends(ctx context.Context, scope ScopeFilter, w PeriodWindow) ([]TransactionDated, error) {
+	args := []any{w.AsOf}
+	clauses := []string{"a.is_active = true", "hd.pay_date <= $1"}
+	if w.Since != nil {
+		args = append(args, *w.Since)
+		clauses = append(clauses, fmt.Sprintf("hd.pay_date >= $%d", len(args)))
+	}
+	switch {
+	case scope.AccountID != nil:
+		args = append(args, *scope.AccountID)
+		clauses = append(clauses, fmt.Sprintf("a.id = $%d", len(args)))
+	case scope.Category != nil:
+		args = append(args, *scope.Category)
+		clauses = append(clauses, fmt.Sprintf("a.category = $%d", len(args)))
+	case scope.Wrapper != nil:
+		args = append(args, *scope.Wrapper)
+		clauses = append(clauses, fmt.Sprintf("a.account_wrapper = $%d", len(args)))
+	}
+	where := ""
+	for i, c := range clauses {
+		if i == 0 {
+			where = "WHERE " + c
+		} else {
+			where += " AND " + c
+		}
+	}
+	q := `
+		SELECT hd.pay_date, (hd.gross_amount - hd.withholding_tax)
+		FROM holding_dividends hd
+		JOIN accounts a ON a.id = hd.account_id
+		` + where + `
+		ORDER BY hd.pay_date ASC, hd.id ASC`
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("scoped dividends: %w", err)
+	}
+	defer rows.Close()
+	out := []TransactionDated{}
+	for rows.Next() {
+		var td TransactionDated
+		if err := rows.Scan(&td.Date, &td.Amount); err != nil {
+			return nil, fmt.Errorf("scan dividend flow: %w", err)
+		}
+		out = append(out, td)
+	}
+	return out, rows.Err()
+}
+
 // LatestValueInScope returns the sum of snapshot_values at the latest
 // snapshot date on or before `asOf` for accounts matching scope. Returns
 // (zero, false) when no qualifying snapshot exists.

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -271,6 +271,9 @@ func registerHoldingsRoutes(r chi.Router, stooqAPIKey string, pool *pgxpool.Pool
 	r.Get("/api/holdings/lots", hHandler.ListLots)
 	r.Post("/api/holdings/lots", hHandler.CreateLot)
 	r.Delete("/api/holdings/lots/{id}", hHandler.DeleteLot)
+	r.Get("/api/holdings/dividends", hHandler.ListDividends)
+	r.Post("/api/holdings/dividends", hHandler.CreateDividend)
+	r.Delete("/api/holdings/dividends/{id}", hHandler.DeleteDividend)
 
 	stooq := quotes.NewStooqFetcher(stooqAPIKey)
 	refresh := quotes.NewRefreshHandler(hStore, stooq, logger)

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -3612,7 +3612,12 @@ export interface paths {
         /** List dividends (filterable by account_id/security_id) */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    /** @description Filter to one account. */
+                    account_id?: number;
+                    /** @description Filter to one security. */
+                    security_id?: number;
+                };
                 header?: never;
                 path?: never;
                 cookie?: never;
@@ -3651,7 +3656,18 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody: {
+                content: {
+                    "application/json": {
+                        account_id?: number;
+                        currency?: string;
+                        gross_amount?: string;
+                        pay_date?: string;
+                        security_id?: number;
+                        withholding_tax?: string;
+                    };
+                };
+            };
             responses: {
                 /** @description Created */
                 201: {

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -3602,6 +3602,120 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/holdings/dividends": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List dividends (filterable by account_id/security_id) */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            dividends?: {
+                                account_id?: number;
+                                created_at?: string;
+                                currency?: string;
+                                gross_amount?: string;
+                                id?: number;
+                                net_amount?: string;
+                                pay_date?: string;
+                                security_id?: number;
+                                withholding_tax?: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Record a dividend */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            account_id?: number;
+                            created_at?: string;
+                            currency?: string;
+                            gross_amount?: string;
+                            id?: number;
+                            net_amount?: string;
+                            pay_date?: string;
+                            security_id?: number;
+                            withholding_tax?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/holdings/dividends/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a dividend */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/holdings/lots": {
         parameters: {
             query?: never;
@@ -4019,6 +4133,8 @@ export interface paths {
                             current_value?: number;
                             /** Format: double */
                             deposits?: number;
+                            /** Format: double */
+                            dividends_received_net?: number;
                             has_snapshot?: boolean;
                             /** Format: double */
                             money_weighted_pct?: number | null;

--- a/src/routes/investments/holdings/+page.svelte
+++ b/src/routes/investments/holdings/+page.svelte
@@ -6,10 +6,17 @@
 	import { confirm } from '$lib/stores/confirm.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import PIT38Report from '$lib/components/PIT38Report.svelte';
-	import { Plus, Trash2, BarChart, RefreshCw } from 'lucide-svelte';
+	import { Plus, Trash2, BarChart, RefreshCw, Coins } from 'lucide-svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
+
+	const securityLabel = (id: number): string => {
+		const s = data.securities.find((sec) => sec.id === id);
+		return s ? s.symbol : `#${id}`;
+	};
+	const accountLabel = (id: number): string =>
+		data.accounts.find((a) => a.id === id)?.name ?? `#${id}`;
 
 	const ASSET_TYPES = [
 		{ value: 'stock', label: 'Akcja' },
@@ -21,8 +28,19 @@
 	let securityModalOpen = $state(false);
 	let lotModalOpen = $state(false);
 	let quoteModalOpen = $state(false);
+	let dividendModalOpen = $state(false);
 	let saving = $state(false);
 	let refreshing = $state(false);
+
+	let dividendForm = $state(
+		untrack(() => ({
+			account_id: data.accounts[0]?.id ?? 0,
+			security_id: data.securities[0]?.id ?? 0,
+			pay_date: new Date().toISOString().slice(0, 10),
+			gross_amount: '0',
+			withholding_tax: '0'
+		}))
+	);
 
 	let securityForm = $state({
 		symbol: '',
@@ -89,6 +107,70 @@
 			price: '0'
 		};
 		quoteModalOpen = true;
+	}
+
+	function openDividendModal() {
+		if (data.accounts.length === 0) {
+			toast.error('Najpierw dodaj konto.');
+			return;
+		}
+		if (data.securities.length === 0) {
+			toast.error('Najpierw dodaj papier wartościowy.');
+			return;
+		}
+		dividendForm = {
+			account_id: data.accounts[0].id,
+			security_id: data.securities[0].id,
+			pay_date: new Date().toISOString().slice(0, 10),
+			gross_amount: '0',
+			withholding_tax: '0'
+		};
+		dividendModalOpen = true;
+	}
+
+	async function saveDividend() {
+		saving = true;
+		try {
+			const apiUrl = resolveApiUrl();
+			const res = await fetch(`${apiUrl}/api/holdings/dividends`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(dividendForm)
+			});
+			if (!res.ok) {
+				const d = await res.json().catch(() => ({ detail: res.statusText }));
+				throw new Error(d.detail ?? res.statusText);
+			}
+			dividendModalOpen = false;
+			toast.success('Dodano dywidendę');
+			await invalidateAll();
+		} catch (err) {
+			if (err instanceof Error) toast.error(err.message);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function deleteDividend(id: number) {
+		const ok = await confirm({
+			title: 'Usunąć dywidendę?',
+			message: 'Wpis dywidendy zostanie trwale usunięty.',
+			danger: true,
+			confirmText: 'Usuń'
+		});
+		if (!ok) return;
+		try {
+			const apiUrl = resolveApiUrl();
+			const res = await fetch(`${apiUrl}/api/holdings/dividends/${id}`, { method: 'DELETE' });
+			if (!res.ok) {
+				const d = await res.json().catch(() => ({ detail: res.statusText }));
+				throw new Error(d.detail ?? res.statusText);
+			}
+			toast.success('Usunięto');
+			await invalidateAll();
+		} catch (err) {
+			if (err instanceof Error) toast.error(err.message);
+		}
 	}
 
 	async function saveSecurity() {
@@ -217,6 +299,9 @@
 	);
 	const totalProfit = $derived(totalValue - totalPaid);
 	const profitPct = $derived(totalPaid > 0 ? (totalProfit / totalPaid) * 100 : 0);
+	const totalDividendsNet = $derived(
+		data.dividends.reduce((sum, d) => sum + Number(d.net_amount), 0)
+	);
 
 	function fmtPLN(n: number): string {
 		return (
@@ -284,6 +369,9 @@
 			</button>
 			<button type="button" class="btn preset-tonal-surface" onclick={openQuoteModal}>
 				<BarChart size={16} /><span>Notowanie</span>
+			</button>
+			<button type="button" class="btn preset-tonal-surface" onclick={openDividendModal}>
+				<Coins size={16} /><span>Dywidenda</span>
 			</button>
 			<button type="button" class="btn preset-filled-primary-500" onclick={openLotModal}>
 				<Plus size={16} /><span>Nowa transakcja</span>
@@ -510,6 +598,66 @@
 			</ul>
 		{/if}
 	</section>
+
+	<section class="card preset-filled-surface-100-900 p-4 space-y-3">
+		<header class="flex flex-wrap items-center justify-between gap-2">
+			<h2 class="h3 flex items-center gap-2"><Coins size={18} /> Dywidendy</h2>
+			{#if data.dividends.length > 0}
+				<span class="text-sm text-surface-700-300">
+					Netto łącznie: <span class="font-semibold text-success-500"
+						>{fmtPLN(totalDividendsNet)}</span
+					>
+				</span>
+			{/if}
+		</header>
+		{#if data.dividends.length === 0}
+			<p class="text-sm text-surface-700-300">
+				Brak zarejestrowanych dywidend. Dodaj wpłatę dywidendy, aby uwzględnić ją w zwrotach (XIRR).
+			</p>
+		{:else}
+			<div class="table-wrap">
+				<table class="table table-hover text-sm">
+					<thead>
+						<tr>
+							<th>Data wypłaty</th>
+							<th>Papier</th>
+							<th>Konto</th>
+							<th class="text-right">Brutto</th>
+							<th class="text-right">Podatek</th>
+							<th class="text-right">Netto</th>
+							<th></th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each data.dividends as d (d.id)}
+							<tr>
+								<td>{d.pay_date}</td>
+								<td class="font-semibold">{securityLabel(d.security_id)}</td>
+								<td class="text-surface-700-300">{accountLabel(d.account_id)}</td>
+								<td class="text-right">{fmt(d.gross_amount)} {d.currency}</td>
+								<td class="text-right text-surface-600-400"
+									>{fmt(d.withholding_tax)} {d.currency}</td
+								>
+								<td class="text-right font-semibold text-success-500"
+									>{fmt(d.net_amount)} {d.currency}</td
+								>
+								<td class="text-right">
+									<button
+										type="button"
+										class="btn-icon btn-icon-sm"
+										aria-label="Usuń dywidendę"
+										onclick={() => deleteDividend(d.id)}
+									>
+										<Trash2 size={14} />
+									</button>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	</section>
 </div>
 
 <Modal
@@ -626,6 +774,49 @@
 		</label>
 		<p class="text-xs text-surface-600-400">
 			Notowania na (papier, datę) są unikalne — kolejne wpisy dla tej samej daty nadpiszą cenę.
+		</p>
+	</div>
+</Modal>
+
+<Modal
+	open={dividendModalOpen}
+	title="Nowa dywidenda"
+	onCancel={() => (dividendModalOpen = false)}
+	onConfirm={saveDividend}
+	confirmDisabled={saving}
+	confirmText={saving ? 'Zapisywanie...' : 'Zapisz'}
+>
+	<div class="flex flex-col gap-3">
+		<label class="label">
+			<span class="text-sm font-semibold">Konto</span>
+			<select bind:value={dividendForm.account_id} class="select">
+				{#each data.accounts as a}
+					<option value={a.id}>{a.name}</option>
+				{/each}
+			</select>
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Papier</span>
+			<select bind:value={dividendForm.security_id} class="select">
+				{#each data.securities as s}
+					<option value={s.id}>{s.symbol} — {s.name}</option>
+				{/each}
+			</select>
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Data wypłaty</span>
+			<input type="date" bind:value={dividendForm.pay_date} class="input" />
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Kwota brutto</span>
+			<input type="text" bind:value={dividendForm.gross_amount} class="input" />
+		</label>
+		<label class="label">
+			<span class="text-sm font-semibold">Podatek u źródła</span>
+			<input type="text" bind:value={dividendForm.withholding_tax} class="input" />
+		</label>
+		<p class="text-xs text-surface-600-400">
+			Netto (brutto − podatek) liczy się jako dochód i podnosi zwrot money-weighted (XIRR).
 		</p>
 	</div>
 </Modal>

--- a/src/routes/investments/holdings/+page.ts
+++ b/src/routes/investments/holdings/+page.ts
@@ -53,6 +53,18 @@ export interface AccountOption {
 	name: string;
 }
 
+export interface DividendRow {
+	id: number;
+	account_id: number;
+	security_id: number;
+	pay_date: string;
+	gross_amount: string;
+	withholding_tax: string;
+	net_amount: string;
+	currency: string;
+	created_at: string;
+}
+
 interface AccountRow {
 	id: number;
 	name: string;
@@ -64,10 +76,11 @@ const INVESTMENT_CATEGORIES = new Set(['stock', 'bond', 'fund', 'etf']);
 
 export const load: PageLoad = async ({ fetch }) => {
 	const apiUrl = resolveApiUrl();
-	const [holdingsRes, securitiesRes, accountsRes] = await Promise.all([
+	const [holdingsRes, securitiesRes, accountsRes, dividendsRes] = await Promise.all([
 		fetch(`${apiUrl}/api/holdings`),
 		fetch(`${apiUrl}/api/holdings/securities`),
-		fetch(`${apiUrl}/api/accounts`)
+		fetch(`${apiUrl}/api/accounts`),
+		fetch(`${apiUrl}/api/holdings/dividends`)
 	]);
 	if (!holdingsRes.ok) throw error(holdingsRes.status, 'Failed to load holdings');
 	if (!securitiesRes.ok) throw error(securitiesRes.status, 'Failed to load securities');
@@ -81,9 +94,13 @@ export const load: PageLoad = async ({ fetch }) => {
 	const accounts = (accountsPayload.assets ?? [])
 		.filter((a) => a.is_active && INVESTMENT_CATEGORIES.has(a.category))
 		.map((a) => ({ id: a.id, name: a.name }));
+	const dividends = dividendsRes.ok
+		? ((await dividendsRes.json()) as { dividends: DividendRow[] }).dividends
+		: [];
 	return {
 		holdings: holdings.holdings,
 		securities: securities.securities,
-		accounts
+		accounts,
+		dividends
 	};
 };

--- a/src/routes/investments/holdings/+page.ts
+++ b/src/routes/investments/holdings/+page.ts
@@ -85,6 +85,7 @@ export const load: PageLoad = async ({ fetch }) => {
 	if (!holdingsRes.ok) throw error(holdingsRes.status, 'Failed to load holdings');
 	if (!securitiesRes.ok) throw error(securitiesRes.status, 'Failed to load securities');
 	if (!accountsRes.ok) throw error(accountsRes.status, 'Failed to load accounts');
+	if (!dividendsRes.ok) throw error(dividendsRes.status, 'Failed to load dividends');
 	const holdings = (await holdingsRes.json()) as { holdings: HoldingRow[] };
 	const securities = (await securitiesRes.json()) as { securities: SecurityRow[] };
 	const accountsPayload = (await accountsRes.json()) as {
@@ -94,9 +95,7 @@ export const load: PageLoad = async ({ fetch }) => {
 	const accounts = (accountsPayload.assets ?? [])
 		.filter((a) => a.is_active && INVESTMENT_CATEGORIES.has(a.category))
 		.map((a) => ({ id: a.id, name: a.name }));
-	const dividends = dividendsRes.ok
-		? ((await dividendsRes.json()) as { dividends: DividendRow[] }).dividends
-		: [];
+	const dividends = ((await dividendsRes.json()) as { dividends: DividendRow[] }).dividends;
 	return {
 		holdings: holdings.holdings,
 		securities: securities.securities,


### PR DESCRIPTION
## Motivation

Holdings tracked lots/cost-basis but had no dividend income flow, so real ETF/stock returns were understated (#681).

## Implementation information

**Ledger** — new `holding_dividends` table (account + security FKs, pay date, gross, withholding) created by an additive, idempotent `EnsureDividendsSchema` at startup (mirrors the bonds/allocation pattern). CRUD at `GET/POST /api/holdings/dividends` + `DELETE /api/holdings/dividends/{id}`; money kept as `decimal` throughout (net = gross − withholding), validation rejects negatives and tax > gross.

**Returns integration** — `/api/investment/returns` now folds scoped net dividends into the calc: as **negative** XIRR cash flows (income returned to the investor, per xirr.go's sign convention) and into the simple-ROI ending value, plus a new `dividends_received_net` response field. Dividends are scoped/windowed identically to transaction flows (capped at the valuation snapshot date). The `Returns` handler was refactored into `openingFlow` + `dividendFlows` helpers to stay within funlen.

**UI** — the holdings page gains a "Dywidendy" section (list + net total) and an add/delete modal.

Regenerated `api/openapi-go.json` and `src/lib/types/api.generated.ts`. Added bb-tests for CRUD, the net calc, tax>gross rejection, and the returns-folding.

> **Note:** folding net dividends into the ending value assumes account snapshot values reflect share market value, not dividend cash already sitting in the account — consistent with how holdings are valued here.

Closes #681

> Changelog: feat(holdings): dividend income tracking