### PR TITLE
test(backend): handler + negative bb-tests

### DIFF
--- a/backend-bb-tests/tests/test_validation_errors.py
+++ b/backend-bb-tests/tests/test_validation_errors.py
@@ -1,0 +1,99 @@
+"""Negative-path black-box coverage for mutating endpoints (issue #682).
+
+Every case asserts a 4xx (validation or not-found) and that the body is JSON.
+All requests are designed to fail before any write, so no @pytest.mark.mutates
+marker is needed.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+def _first_account_id(client: httpx.Client) -> int:
+    response = client.get("/api/accounts")
+    assert response.status_code == 200, response.text
+    assets = response.json().get("assets", [])
+    assert assets, "seed must provide at least one asset account"
+    return int(assets[0]["id"])
+
+
+MISSING_ID = 999_999_999
+
+
+def _assert_4xx_json(response: httpx.Response, *expected: int) -> None:
+    assert response.status_code in expected, f"{response.status_code}: {response.text}"
+    # Error bodies are always JSON (detail string or Pydantic-shaped list).
+    response.json()
+
+
+def test_create_account_invalid_returns_422(client: httpx.Client) -> None:
+    response = client.post(
+        "/api/accounts",
+        json={"name": "", "type": "asset", "category": "bank", "owner_user_id": 1},
+    )
+    _assert_4xx_json(response, 400, 422)
+
+
+def test_update_account_invalid_wrapper_returns_422(client: httpx.Client) -> None:
+    account_id = _first_account_id(client)
+    response = client.put(f"/api/accounts/{account_id}", json={"account_wrapper": "BOGUS"})
+    _assert_4xx_json(response, 400, 422)
+
+
+def test_update_missing_account_returns_404(client: httpx.Client) -> None:
+    response = client.put(f"/api/accounts/{MISSING_ID}", json={"name": "x"})
+    _assert_4xx_json(response, 404)
+
+
+def test_delete_missing_account_returns_404(client: httpx.Client) -> None:
+    response = client.delete(f"/api/accounts/{MISSING_ID}")
+    _assert_4xx_json(response, 404)
+
+
+def test_create_transaction_empty_body_returns_422(client: httpx.Client) -> None:
+    account_id = _first_account_id(client)
+    response = client.post(f"/api/accounts/{account_id}/transactions", json={})
+    _assert_4xx_json(response, 400, 422)
+
+
+def test_create_transaction_missing_account_returns_404(client: httpx.Client) -> None:
+    response = client.post(
+        f"/api/accounts/{MISSING_ID}/transactions",
+        json={"amount": 10, "date": "2026-01-01", "owner_user_id": 1},
+    )
+    _assert_4xx_json(response, 404)
+
+
+def test_delete_missing_transaction_returns_404(client: httpx.Client) -> None:
+    account_id = _first_account_id(client)
+    response = client.delete(f"/api/accounts/{account_id}/transactions/{MISSING_ID}")
+    _assert_4xx_json(response, 404)
+
+
+def test_create_snapshot_without_values_returns_422(client: httpx.Client) -> None:
+    response = client.post("/api/snapshots", json={"date": "2026-02-28", "notes": "x"})
+    _assert_4xx_json(response, 400, 422)
+
+
+def test_create_bond_invalid_type_returns_422(client: httpx.Client) -> None:
+    response = client.post(
+        "/api/bonds",
+        json={
+            "type": "ZZZ",
+            "series": "X",
+            "face_value": 100,
+            "purchase_date": "2026-01-01",
+            "first_year_rate": 5,
+            "margin": 1,
+        },
+    )
+    _assert_4xx_json(response, 400, 422)
+
+
+def test_get_missing_bond_returns_404(client: httpx.Client) -> None:
+    _assert_4xx_json(client.get(f"/api/bonds/{MISSING_ID}"), 404)
+
+
+def test_delete_missing_bond_returns_404(client: httpx.Client) -> None:
+    _assert_4xx_json(client.delete(f"/api/bonds/{MISSING_ID}"), 404)

--- a/backend-go/internal/bonds/handler_test.go
+++ b/backend-go/internal/bonds/handler_test.go
@@ -1,0 +1,106 @@
+package bonds
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
+)
+
+func validCreate() createRequest {
+	return createRequest{
+		Type:          "COI",
+		Series:        "COI0631",
+		FaceValue:     100,
+		PurchaseDate:  wire.IsoDate(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		FirstYearRate: 6.5,
+		Margin:        1.5,
+	}
+}
+
+func TestValidateCreateErrors(t *testing.T) {
+	cases := []struct {
+		name      string
+		mutate    func(*createRequest)
+		wantField string
+	}{
+		{"invalid type", func(r *createRequest) { r.Type = "ZZZ" }, "type"},
+		{"empty series", func(r *createRequest) { r.Series = "  " }, "series"},
+		{"zero face value", func(r *createRequest) { r.FaceValue = 0 }, "face_value"},
+		{"negative face value", func(r *createRequest) { r.FaceValue = -10 }, "face_value"},
+		{"zero purchase date", func(r *createRequest) { r.PurchaseDate = wire.IsoDate(time.Time{}) }, "purchase_date"},
+		{"rate out of range", func(r *createRequest) { r.FirstYearRate = 150 }, "first_year_rate"},
+		{"negative margin", func(r *createRequest) { r.Margin = -1 }, "margin"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := validCreate()
+			tc.mutate(&req)
+			vErr := validateCreate(&req)
+			if vErr == nil {
+				t.Fatalf("expected validation error for %s", tc.name)
+			}
+			if vErr.Field != tc.wantField {
+				t.Fatalf("field = %q, want %q", vErr.Field, tc.wantField)
+			}
+		})
+	}
+}
+
+func TestValidateCreateNormalizesType(t *testing.T) {
+	req := validCreate()
+	req.Type = " coi "
+	if vErr := validateCreate(&req); vErr != nil {
+		t.Fatalf("unexpected error: %+v", vErr)
+	}
+	if req.Type != "COI" {
+		t.Fatalf("type should be trimmed + upper-cased, got %q", req.Type)
+	}
+}
+
+func TestBuildUpdatePatchErrors(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		wantField string
+	}{
+		{"invalid type", `{"type":"ZZZ"}`, "type"},
+		{"empty series", `{"series":"  "}`, "series"},
+		{"zero face value", `{"face_value":0}`, "face_value"},
+		{"rate out of range", `{"first_year_rate":250}`, "first_year_rate"},
+		{"non-integer owner", `{"owner_user_id":"x"}`, "owner_user_id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var raw map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(tc.body), &raw); err != nil {
+				t.Fatalf("bad test JSON: %v", err)
+			}
+			_, vErr := buildUpdatePatch(raw)
+			if vErr == nil || vErr.Field != tc.wantField {
+				t.Fatalf("got %+v, want field %q", vErr, tc.wantField)
+			}
+		})
+	}
+}
+
+func TestParseIDParamInvalidWrites422(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/bonds/abc", http.NoBody)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "abc")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	if _, ok := parseIDParam(rec, req); ok {
+		t.Fatal("expected ok=false on non-integer id")
+	}
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+}

--- a/backend-go/internal/transactions/handler_test.go
+++ b/backend-go/internal/transactions/handler_test.go
@@ -1,0 +1,79 @@
+package transactions
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// rawBody turns a JSON object literal into the map[string]json.RawMessage the
+// validation builders consume.
+func rawBody(t *testing.T, obj string) map[string]json.RawMessage {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(obj), &raw); err != nil {
+		t.Fatalf("bad test JSON: %v", err)
+	}
+	return raw
+}
+
+func TestBuildCreateRequestValidationErrors(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		wantField string
+	}{
+		{"missing amount", `{"date":"2026-01-01","owner_user_id":1}`, "amount"},
+		{"zero amount", `{"amount":0,"date":"2026-01-01","owner_user_id":1}`, "amount"},
+		{"negative amount", `{"amount":-5,"date":"2026-01-01","owner_user_id":1}`, "amount"},
+		{"missing date", `{"amount":10,"owner_user_id":1}`, "date"},
+		{"bad date format", `{"amount":10,"date":"01-2026","owner_user_id":1}`, "date"},
+		{"missing owner field", `{"amount":10,"date":"2026-01-01"}`, "owner_user_id"},
+		{"non-integer owner", `{"amount":10,"date":"2026-01-01","owner_user_id":"x"}`, "owner_user_id"},
+		{"invalid transaction_type", `{"amount":10,"date":"2026-01-01","owner_user_id":1,"transaction_type":"nope"}`, "transaction_type"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, vErr := buildCreateRequest(rawBody(t, tc.body))
+			if vErr == nil {
+				t.Fatalf("expected validation error for %s", tc.name)
+			}
+			if vErr.Field != tc.wantField {
+				t.Fatalf("field = %q, want %q", vErr.Field, tc.wantField)
+			}
+		})
+	}
+}
+
+func TestBuildCreateRequestValidWithNullOwner(t *testing.T) {
+	// Explicit null owner ("Shared") is allowed and yields nil.
+	req, vErr := buildCreateRequest(rawBody(t, `{"amount":123.45,"date":"2026-01-01","owner_user_id":null}`))
+	if vErr != nil {
+		t.Fatalf("unexpected validation error: %+v", vErr)
+	}
+	if req.OwnerUserID != nil {
+		t.Fatalf("null owner should yield nil, got %v", *req.OwnerUserID)
+	}
+	if req.Amount.String() != "123.45" {
+		t.Fatalf("amount = %s, want 123.45", req.Amount.String())
+	}
+}
+
+func TestParseAccountIDInvalidWrites422(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/accounts/abc/transactions", http.NoBody)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("account_id", "abc")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	if _, ok := parseAccountID(rec, req); ok {
+		t.Fatal("expected ok=false on non-integer account_id")
+	}
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+}


### PR DESCRIPTION
## Motivation

Most Go handler packages had no `handler_test.go` and the black-box suite was mostly happy-path, leaving error/validation paths under-covered (#682).

## Implementation information

- **transactions**: handler unit tests for `buildCreateRequest` (missing/zero/negative amount, missing/bad date, missing/non-integer owner, invalid transaction_type), the null-owner happy path, and `parseAccountID` 422.
- **bonds**: handler unit tests for `validateCreate` (invalid type, empty series, non-positive face value, zero purchase date, out-of-range rate/margin), type normalization, `buildUpdatePatch` error cases, and `parseIDParam` 422.
- **bb-tests**: a consolidated `test_validation_errors.py` asserting 4xx shapes for the accounts / transactions / snapshots / bonds mutating endpoints (invalid bodies → 422, missing resources → 404).

accounts + snapshots already had handler/validation unit tests, so this fills the transactions + bonds gap plus the negative bb sweep.

Closes #682

> Changelog: test(backend): handler + negative bb-tests