### PR TITLE
refactor(frontend): CRUD form-state composable

### DIFF
--- a/src/lib/stores/crudForm.svelte.ts
+++ b/src/lib/stores/crudForm.svelte.ts
@@ -1,0 +1,52 @@
+// CrudForm is the shared reactive state for a create/edit form on a CRUD page:
+// open/close, the item being edited, a saving flag, and an error string. Each
+// page (or each independent form on a page — holdings has several) owns its own
+// instance, so this is a class factory rather than a singleton store.
+//
+// `submit` wraps the saving/try-catch/close bookkeeping that every page
+// otherwise re-implements. It returns true on success (and closes the form) and
+// false on failure, leaving `error` populated so the caller can render it inline
+// or raise a toast.
+export class CrudForm<T = unknown> {
+	open = $state(false);
+	editing = $state<T | null>(null);
+	saving = $state(false);
+	error = $state('');
+
+	get isEditing(): boolean {
+		return this.editing !== null;
+	}
+
+	openCreate(): void {
+		this.editing = null;
+		this.error = '';
+		this.open = true;
+	}
+
+	openEdit(item: T): void {
+		this.editing = item;
+		this.error = '';
+		this.open = true;
+	}
+
+	close(): void {
+		this.open = false;
+		this.editing = null;
+		this.error = '';
+	}
+
+	async submit(action: () => Promise<void>): Promise<boolean> {
+		this.saving = true;
+		this.error = '';
+		try {
+			await action();
+			this.close();
+			return true;
+		} catch (err) {
+			this.error = err instanceof Error ? err.message : String(err);
+			return false;
+		} finally {
+			this.saving = false;
+		}
+	}
+}

--- a/src/lib/stores/crudForm.test.ts
+++ b/src/lib/stores/crudForm.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { CrudForm } from './crudForm.svelte';
+
+interface Item {
+	id: number;
+	name: string;
+}
+
+describe('CrudForm', () => {
+	it('starts closed and not editing', () => {
+		const form = new CrudForm<Item>();
+		expect(form.open).toBe(false);
+		expect(form.editing).toBeNull();
+		expect(form.isEditing).toBe(false);
+		expect(form.saving).toBe(false);
+		expect(form.error).toBe('');
+	});
+
+	it('openCreate opens without an editing target', () => {
+		const form = new CrudForm<Item>();
+		form.error = 'stale';
+		form.openCreate();
+		expect(form.open).toBe(true);
+		expect(form.editing).toBeNull();
+		expect(form.isEditing).toBe(false);
+		expect(form.error).toBe('');
+	});
+
+	it('openEdit opens with the item', () => {
+		const form = new CrudForm<Item>();
+		const item = { id: 1, name: 'x' };
+		form.openEdit(item);
+		expect(form.open).toBe(true);
+		expect(form.editing).toEqual(item);
+		expect(form.isEditing).toBe(true);
+	});
+
+	it('close resets open/editing/error', () => {
+		const form = new CrudForm<Item>();
+		form.openEdit({ id: 1, name: 'x' });
+		form.error = 'boom';
+		form.close();
+		expect(form.open).toBe(false);
+		expect(form.editing).toBeNull();
+		expect(form.error).toBe('');
+	});
+
+	it('submit closes and returns true on success', async () => {
+		const form = new CrudForm<Item>();
+		form.openCreate();
+		let ran = false;
+		const ok = await form.submit(async () => {
+			ran = true;
+		});
+		expect(ran).toBe(true);
+		expect(ok).toBe(true);
+		expect(form.open).toBe(false);
+		expect(form.saving).toBe(false);
+		expect(form.error).toBe('');
+	});
+
+	it('submit keeps the form open and records the error on failure', async () => {
+		const form = new CrudForm<Item>();
+		form.openCreate();
+		const ok = await form.submit(async () => {
+			throw new Error('nope');
+		});
+		expect(ok).toBe(false);
+		expect(form.open).toBe(true);
+		expect(form.saving).toBe(false);
+		expect(form.error).toBe('nope');
+	});
+
+	it('submit clears a prior error before re-running', async () => {
+		const form = new CrudForm<Item>();
+		form.openCreate();
+		await form.submit(async () => {
+			throw new Error('first');
+		});
+		expect(form.error).toBe('first');
+		await form.submit(async () => {});
+		expect(form.error).toBe('');
+	});
+});

--- a/src/routes/goals/+page.svelte
+++ b/src/routes/goals/+page.svelte
@@ -4,6 +4,7 @@
 	import { Target, Plus, Pencil, Trash2, CheckCircle2, Calendar } from 'lucide-svelte';
 	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
+	import { CrudForm } from '$lib/stores/crudForm.svelte';
 	import type { Goal, AccountOption } from './+page';
 	import type { PageData } from './$types';
 
@@ -20,12 +21,9 @@
 	const totalCount = $derived(data.total_count as number);
 	const completedCount = $derived(data.completed_count as number);
 
-	let showForm = $state(false);
-	let editingGoal: Goal | null = $state(null);
+	const goalForm = new CrudForm<Goal>();
 	let showDeleteModal = $state(false);
 	let goalToDelete: number | null = $state(null);
-	let error = $state('');
-	let saving = $state(false);
 
 	const categoryLabels: Record<string, string> = {
 		bank: 'Konto bankowe',
@@ -57,46 +55,40 @@
 	let formData = $state(emptyForm());
 
 	$effect(() => {
-		if (editingGoal) {
+		const editing = goalForm.editing;
+		if (editing) {
 			formData = {
-				name: editingGoal.name,
-				target_amount: editingGoal.target_amount,
-				target_date: editingGoal.target_date,
-				current_amount: editingGoal.current_amount,
-				monthly_contribution: editingGoal.monthly_contribution,
-				is_completed: editingGoal.is_completed,
-				account_id: editingGoal.account_id,
-				category: editingGoal.category
+				name: editing.name,
+				target_amount: editing.target_amount,
+				target_date: editing.target_date,
+				current_amount: editing.current_amount,
+				monthly_contribution: editing.monthly_contribution,
+				is_completed: editing.is_completed,
+				account_id: editing.account_id,
+				category: editing.category
 			};
-		} else if (showForm) {
+		} else if (goalForm.open) {
 			formData = emptyForm();
 		}
 	});
 
 	function startCreate() {
-		editingGoal = null;
-		showForm = true;
+		goalForm.openCreate();
 	}
 
 	function startEdit(goal: Goal) {
-		editingGoal = goal;
-		showForm = true;
+		goalForm.openEdit(goal);
 	}
 
 	function cancelForm() {
-		showForm = false;
-		editingGoal = null;
-		error = '';
+		goalForm.close();
 	}
 
 	async function handleSubmit() {
-		error = '';
-		saving = true;
-		try {
-			const endpoint = editingGoal
-				? `${apiUrl}/api/goals/${editingGoal.id}`
-				: `${apiUrl}/api/goals`;
-			const method = editingGoal ? 'PUT' : 'POST';
+		const editing = goalForm.editing;
+		await goalForm.submit(async () => {
+			const endpoint = editing ? `${apiUrl}/api/goals/${editing.id}` : `${apiUrl}/api/goals`;
+			const method = editing ? 'PUT' : 'POST';
 			const response = await fetch(endpoint, {
 				method,
 				headers: { 'Content-Type': 'application/json' },
@@ -107,12 +99,7 @@
 				throw new Error(errorData.detail || 'Nie udało się zapisać celu');
 			}
 			await invalidateAll();
-			cancelForm();
-		} catch (err) {
-			if (err instanceof Error) error = err.message;
-		} finally {
-			saving = false;
-		}
+		});
 	}
 
 	function handleDelete(goalId: number) {
@@ -132,7 +119,7 @@
 			if (!response.ok) throw new Error('Nie udało się usunąć celu');
 			await invalidateAll();
 		} catch (err) {
-			if (err instanceof Error) error = err.message;
+			if (err instanceof Error) goalForm.error = err.message;
 		} finally {
 			showDeleteModal = false;
 			goalToDelete = null;
@@ -177,8 +164,8 @@
 		</button>
 	</header>
 
-	{#if error}
-		<div class="card preset-tonal-error-500 p-3 text-sm" role="alert">{error}</div>
+	{#if goalForm.error}
+		<div class="card preset-tonal-error-500 p-3 text-sm" role="alert">{goalForm.error}</div>
 	{/if}
 
 	{#if goals.length === 0}
@@ -279,10 +266,10 @@
 </div>
 
 <Modal
-	open={showForm}
-	title={editingGoal ? 'Edytuj cel' : 'Nowy cel'}
-	confirmText={saving ? 'Zapisywanie...' : 'Zapisz'}
-	confirmDisabled={saving || !formData.name || formData.target_amount <= 0}
+	open={goalForm.open}
+	title={goalForm.isEditing ? 'Edytuj cel' : 'Nowy cel'}
+	confirmText={goalForm.saving ? 'Zapisywanie...' : 'Zapisz'}
+	confirmDisabled={goalForm.saving || !formData.name || formData.target_amount <= 0}
 	onConfirm={handleSubmit}
 	onCancel={cancelForm}
 >
@@ -352,8 +339,8 @@
 			<input type="checkbox" class="checkbox" bind:checked={formData.is_completed} />
 			<span>Cel ukończony</span>
 		</label>
-		{#if error}
-			<div class="card preset-tonal-error-500 p-2 text-sm" role="alert">{error}</div>
+		{#if goalForm.error}
+			<div class="card preset-tonal-error-500 p-2 text-sm" role="alert">{goalForm.error}</div>
 		{/if}
 	</form>
 </Modal>

--- a/src/routes/investments/bonds/+page.svelte
+++ b/src/routes/investments/bonds/+page.svelte
@@ -10,6 +10,7 @@
 	import { Banknote, Pencil, Plus, Trash2, TrendingUp } from 'lucide-svelte';
 	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
+	import { CrudForm } from '$lib/stores/crudForm.svelte';
 	import { ownerName } from '$lib/types/owners';
 	import type { TreasuryBond } from './+page';
 	import type { PageData } from './$types';
@@ -45,10 +46,7 @@
 		}
 	}
 
-	let showForm = $state(false);
-	let editingBond: TreasuryBond | null = $state(null);
-	let saving = $state(false);
-	let formError = $state('');
+	const bondForm = new CrudForm<TreasuryBond>();
 	let lookingUp = $state(false);
 	let showDeleteModal = $state(false);
 	let bondToDelete: number | null = $state(null);
@@ -77,8 +75,6 @@
 	});
 
 	function startCreate() {
-		editingBond = null;
-		formError = '';
 		formData = {
 			type: 'EDO',
 			series: '',
@@ -88,12 +84,10 @@
 			account_id: null,
 			...defaultsForType('EDO')
 		};
-		showForm = true;
+		bondForm.openCreate();
 	}
 
 	function startEdit(bond: TreasuryBond) {
-		editingBond = bond;
-		formError = '';
 		formData = {
 			type: bond.type,
 			series: bond.series,
@@ -105,25 +99,23 @@
 			margin: bond.margin,
 			capitalize: bond.capitalize
 		};
-		showForm = true;
+		bondForm.openEdit(bond);
 	}
 
 	function cancelForm() {
-		showForm = false;
-		editingBond = null;
-		formError = '';
+		bondForm.close();
 	}
 
 	function applyTypeDefaults() {
 		// Only refresh rate defaults when creating; editing preserves the
 		// user-entered values that match the bond's actual coupon.
-		if (editingBond) return;
+		if (bondForm.isEditing) return;
 		const d = defaultsForType(formData.type);
 		formData = { ...formData, ...d };
 	}
 
 	async function lookupRate() {
-		formError = '';
+		bondForm.error = '';
 		lookingUp = true;
 		try {
 			const params = new URLSearchParams({ type: formData.type, series: formData.series });
@@ -139,20 +131,17 @@
 				margin: body.margin
 			};
 		} catch (err) {
-			if (err instanceof Error) formError = `Pobieranie stopy: ${err.message}`;
+			if (err instanceof Error) bondForm.error = `Pobieranie stopy: ${err.message}`;
 		} finally {
 			lookingUp = false;
 		}
 	}
 
 	async function handleSubmit() {
-		formError = '';
-		saving = true;
-		try {
-			const endpoint = editingBond
-				? `${apiUrl}/api/bonds/${editingBond.id}`
-				: `${apiUrl}/api/bonds`;
-			const method = editingBond ? 'PUT' : 'POST';
+		const editing = bondForm.editing;
+		await bondForm.submit(async () => {
+			const endpoint = editing ? `${apiUrl}/api/bonds/${editing.id}` : `${apiUrl}/api/bonds`;
+			const method = editing ? 'PUT' : 'POST';
 			const response = await fetch(endpoint, {
 				method,
 				headers: { 'Content-Type': 'application/json' },
@@ -166,12 +155,7 @@
 				throw new Error(detail);
 			}
 			await invalidateAll();
-			cancelForm();
-		} catch (err) {
-			if (err instanceof Error) formError = err.message;
-		} finally {
-			saving = false;
-		}
+		});
 	}
 
 	function handleDelete(bondId: number) {
@@ -189,7 +173,7 @@
 			if (!response.ok) throw new Error('Nie udało się usunąć obligacji');
 			await invalidateAll();
 		} catch (err) {
-			if (err instanceof Error) formError = err.message;
+			if (err instanceof Error) bondForm.error = err.message;
 		} finally {
 			showDeleteModal = false;
 			bondToDelete = null;
@@ -342,11 +326,11 @@
 </div>
 
 <div class="space-y-4">
-	{#if showForm}
+	{#if bondForm.open}
 		<div class="card preset-filled-surface-100-900 p-4 space-y-4">
 			<header>
 				<h3 class="h3 flex items-center gap-2">
-					{#if editingBond}
+					{#if bondForm.isEditing}
 						<Pencil size={20} /> Edytuj obligację
 					{:else}
 						<Plus size={20} /> Nowa obligacja
@@ -360,8 +344,8 @@
 					handleSubmit();
 				}}
 			>
-				{#if formError}
-					<div class="card preset-filled-error-500 p-3 text-sm">{formError}</div>
+				{#if bondForm.error}
+					<div class="card preset-filled-error-500 p-3 text-sm">{bondForm.error}</div>
 				{/if}
 
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -470,10 +454,14 @@
 						type="button"
 						class="btn preset-tonal-surface"
 						onclick={cancelForm}
-						disabled={saving}>Anuluj</button
+						disabled={bondForm.saving}>Anuluj</button
 					>
-					<button type="submit" class="btn preset-filled-primary-500" disabled={saving}>
-						{saving ? 'Zapisywanie...' : editingBond ? 'Zapisz zmiany' : 'Dodaj obligację'}
+					<button type="submit" class="btn preset-filled-primary-500" disabled={bondForm.saving}>
+						{bondForm.saving
+							? 'Zapisywanie...'
+							: bondForm.isEditing
+								? 'Zapisz zmiany'
+								: 'Dodaj obligację'}
 					</button>
 				</div>
 			</form>

--- a/src/routes/investments/holdings/+page.svelte
+++ b/src/routes/investments/holdings/+page.svelte
@@ -7,6 +7,7 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import PIT38Report from '$lib/components/PIT38Report.svelte';
 	import { Plus, Trash2, BarChart, RefreshCw, Coins } from 'lucide-svelte';
+	import { CrudForm } from '$lib/stores/crudForm.svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
@@ -25,11 +26,10 @@
 		{ value: 'fund', label: 'Fundusz' }
 	];
 
-	let securityModalOpen = $state(false);
-	let lotModalOpen = $state(false);
-	let quoteModalOpen = $state(false);
-	let dividendModalOpen = $state(false);
-	let saving = $state(false);
+	const securityCrud = new CrudForm();
+	const lotCrud = new CrudForm();
+	const quoteCrud = new CrudForm();
+	const dividendCrud = new CrudForm();
 	let refreshing = $state(false);
 
 	let dividendForm = $state(
@@ -70,9 +70,21 @@
 		}))
 	);
 
+	// saveVia wraps a create through a CrudForm (saving/error/close bookkeeping)
+	// and surfaces the outcome as a toast — holdings reports via toast rather
+	// than inline error.
+	async function saveVia(form: CrudForm, action: () => Promise<void>, successMsg: string) {
+		const ok = await form.submit(action);
+		if (ok) {
+			toast.success(successMsg);
+		} else {
+			toast.error(form.error);
+		}
+	}
+
 	function openSecurityModal() {
 		securityForm = { symbol: '', isin: '', name: '', asset_type: 'stock', currency: 'PLN' };
-		securityModalOpen = true;
+		securityCrud.openCreate();
 	}
 
 	function openLotModal() {
@@ -93,7 +105,7 @@
 			fee: '0',
 			date: new Date().toISOString().slice(0, 10)
 		};
-		lotModalOpen = true;
+		lotCrud.openCreate();
 	}
 
 	function openQuoteModal() {
@@ -106,7 +118,7 @@
 			date: new Date().toISOString().slice(0, 10),
 			price: '0'
 		};
-		quoteModalOpen = true;
+		quoteCrud.openCreate();
 	}
 
 	function openDividendModal() {
@@ -125,30 +137,27 @@
 			gross_amount: '0',
 			withholding_tax: '0'
 		};
-		dividendModalOpen = true;
+		dividendCrud.openCreate();
 	}
 
 	async function saveDividend() {
-		saving = true;
-		try {
-			const apiUrl = resolveApiUrl();
-			const res = await fetch(`${apiUrl}/api/holdings/dividends`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(dividendForm)
-			});
-			if (!res.ok) {
-				const d = await res.json().catch(() => ({ detail: res.statusText }));
-				throw new Error(d.detail ?? res.statusText);
-			}
-			dividendModalOpen = false;
-			toast.success('Dodano dywidendę');
-			await invalidateAll();
-		} catch (err) {
-			if (err instanceof Error) toast.error(err.message);
-		} finally {
-			saving = false;
-		}
+		const apiUrl = resolveApiUrl();
+		await saveVia(
+			dividendCrud,
+			async () => {
+				const res = await fetch(`${apiUrl}/api/holdings/dividends`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify(dividendForm)
+				});
+				if (!res.ok) {
+					const d = await res.json().catch(() => ({ detail: res.statusText }));
+					throw new Error(d.detail ?? res.statusText);
+				}
+				await invalidateAll();
+			},
+			'Dodano dywidendę'
+		);
 	}
 
 	async function deleteDividend(id: number) {
@@ -174,78 +183,72 @@
 	}
 
 	async function saveSecurity() {
-		saving = true;
-		try {
-			const apiUrl = resolveApiUrl();
-			const res = await fetch(`${apiUrl}/api/holdings/securities`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					symbol: securityForm.symbol,
-					isin: securityForm.isin || null,
-					name: securityForm.name,
-					asset_type: securityForm.asset_type,
-					currency: securityForm.currency
-				})
-			});
-			if (!res.ok) {
-				const d = await res.json().catch(() => ({ detail: res.statusText }));
-				throw new Error(d.detail ?? res.statusText);
-			}
-			securityModalOpen = false;
-			toast.success('Dodano papier wartościowy');
-			await invalidateAll();
-		} catch (err) {
-			if (err instanceof Error) toast.error(err.message);
-		} finally {
-			saving = false;
-		}
+		const apiUrl = resolveApiUrl();
+		await saveVia(
+			securityCrud,
+			async () => {
+				const res = await fetch(`${apiUrl}/api/holdings/securities`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						symbol: securityForm.symbol,
+						isin: securityForm.isin || null,
+						name: securityForm.name,
+						asset_type: securityForm.asset_type,
+						currency: securityForm.currency
+					})
+				});
+				if (!res.ok) {
+					const d = await res.json().catch(() => ({ detail: res.statusText }));
+					throw new Error(d.detail ?? res.statusText);
+				}
+				await invalidateAll();
+			},
+			'Dodano papier wartościowy'
+		);
 	}
 
 	async function saveLot() {
-		saving = true;
-		try {
-			const apiUrl = resolveApiUrl();
-			const res = await fetch(`${apiUrl}/api/holdings/lots`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(lotForm)
-			});
-			if (!res.ok) {
-				const d = await res.json().catch(() => ({ detail: res.statusText }));
-				throw new Error(d.detail ?? res.statusText);
-			}
-			lotModalOpen = false;
-			toast.success('Dodano transakcję');
-			await invalidateAll();
-		} catch (err) {
-			if (err instanceof Error) toast.error(err.message);
-		} finally {
-			saving = false;
-		}
+		const apiUrl = resolveApiUrl();
+		await saveVia(
+			lotCrud,
+			async () => {
+				const res = await fetch(`${apiUrl}/api/holdings/lots`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify(lotForm)
+				});
+				if (!res.ok) {
+					const d = await res.json().catch(() => ({ detail: res.statusText }));
+					throw new Error(d.detail ?? res.statusText);
+				}
+				await invalidateAll();
+			},
+			'Dodano transakcję'
+		);
 	}
 
 	async function saveQuote() {
-		saving = true;
-		try {
-			const apiUrl = resolveApiUrl();
-			const res = await fetch(`${apiUrl}/api/holdings/securities/${quoteForm.security_id}/quotes`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ date: quoteForm.date, price: quoteForm.price })
-			});
-			if (!res.ok) {
-				const d = await res.json().catch(() => ({ detail: res.statusText }));
-				throw new Error(d.detail ?? res.statusText);
-			}
-			quoteModalOpen = false;
-			toast.success('Zapisano notowanie');
-			await invalidateAll();
-		} catch (err) {
-			if (err instanceof Error) toast.error(err.message);
-		} finally {
-			saving = false;
-		}
+		const apiUrl = resolveApiUrl();
+		await saveVia(
+			quoteCrud,
+			async () => {
+				const res = await fetch(
+					`${apiUrl}/api/holdings/securities/${quoteForm.security_id}/quotes`,
+					{
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json' },
+						body: JSON.stringify({ date: quoteForm.date, price: quoteForm.price })
+					}
+				);
+				if (!res.ok) {
+					const d = await res.json().catch(() => ({ detail: res.statusText }));
+					throw new Error(d.detail ?? res.statusText);
+				}
+				await invalidateAll();
+			},
+			'Zapisano notowanie'
+		);
 	}
 
 	async function deleteSecurity(s: { id: number; symbol: string }) {
@@ -661,12 +664,12 @@
 </div>
 
 <Modal
-	open={securityModalOpen}
+	open={securityCrud.open}
 	title="Nowy papier wartościowy"
-	onCancel={() => (securityModalOpen = false)}
+	onCancel={() => securityCrud.close()}
 	onConfirm={saveSecurity}
-	confirmDisabled={saving}
-	confirmText={saving ? 'Zapisywanie...' : 'Zapisz'}
+	confirmDisabled={securityCrud.saving}
+	confirmText={securityCrud.saving ? 'Zapisywanie...' : 'Zapisz'}
 >
 	<div class="flex flex-col gap-3">
 		<label class="label">
@@ -697,12 +700,12 @@
 </Modal>
 
 <Modal
-	open={lotModalOpen}
+	open={lotCrud.open}
 	title="Nowa transakcja"
-	onCancel={() => (lotModalOpen = false)}
+	onCancel={() => lotCrud.close()}
 	onConfirm={saveLot}
-	confirmDisabled={saving}
-	confirmText={saving ? 'Zapisywanie...' : 'Zapisz'}
+	confirmDisabled={lotCrud.saving}
+	confirmText={lotCrud.saving ? 'Zapisywanie...' : 'Zapisz'}
 >
 	<div class="flex flex-col gap-3">
 		<label class="label">
@@ -748,12 +751,12 @@
 </Modal>
 
 <Modal
-	open={quoteModalOpen}
+	open={quoteCrud.open}
 	title="Nowe notowanie"
-	onCancel={() => (quoteModalOpen = false)}
+	onCancel={() => quoteCrud.close()}
 	onConfirm={saveQuote}
-	confirmDisabled={saving}
-	confirmText={saving ? 'Zapisywanie...' : 'Zapisz'}
+	confirmDisabled={quoteCrud.saving}
+	confirmText={quoteCrud.saving ? 'Zapisywanie...' : 'Zapisz'}
 >
 	<div class="flex flex-col gap-3">
 		<label class="label">
@@ -779,12 +782,12 @@
 </Modal>
 
 <Modal
-	open={dividendModalOpen}
+	open={dividendCrud.open}
 	title="Nowa dywidenda"
-	onCancel={() => (dividendModalOpen = false)}
+	onCancel={() => dividendCrud.close()}
 	onConfirm={saveDividend}
-	confirmDisabled={saving}
-	confirmText={saving ? 'Zapisywanie...' : 'Zapisz'}
+	confirmDisabled={dividendCrud.saving}
+	confirmText={dividendCrud.saving ? 'Zapisywanie...' : 'Zapisz'}
 >
 	<div class="flex flex-col gap-3">
 		<label class="label">

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -7,6 +7,7 @@
 	import { goto, invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
 	import { confirm } from '$lib/stores/confirm.svelte';
+	import { CrudForm } from '$lib/stores/crudForm.svelte';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
 	import { untrack } from 'svelte';
 	import type { Transaction } from '$lib/types/transactions';
@@ -41,24 +42,20 @@
 	let filterDateFrom = $state(untrack(() => data.filters.date_from || ''));
 	let filterDateTo = $state(untrack(() => data.filters.date_to || ''));
 
-	let showNewTransactionModal = $state(false);
+	const txForm = new CrudForm();
 	let newTransactionData = $state({
 		account_id: '',
 		amount: 0,
 		date: new Date().toISOString().split('T')[0],
 		owner_user_id: untrack(() => defaultOwnerUserId)
 	});
-	let transactionError = $state('');
-	let savingTransaction = $state(false);
 
-	let showPPKGenerateModal = $state(false);
+	const ppkForm = new CrudForm();
 	let ppkGenerateData = $state({
 		owner: untrack(() => defaultOwnerName),
 		month: new Date().getMonth() + 1,
 		year: new Date().getFullYear()
 	});
-	let ppkGenerateError = $state('');
-	let ppkGenerating = $state(false);
 
 	function applyFilters() {
 		const params = new URLSearchParams();
@@ -111,13 +108,11 @@
 			date: new Date().toISOString().split('T')[0],
 			owner_user_id: defaultOwnerUserId
 		};
-		transactionError = '';
-		showNewTransactionModal = true;
+		txForm.openCreate();
 	}
 
 	function closeNewTransactionModal() {
-		showNewTransactionModal = false;
-		transactionError = '';
+		txForm.close();
 	}
 
 	function openPPKGenerateModal() {
@@ -126,57 +121,38 @@
 			month: new Date().getMonth() + 1,
 			year: new Date().getFullYear()
 		};
-		ppkGenerateError = '';
-		showPPKGenerateModal = true;
+		ppkForm.openCreate();
 	}
 
 	function closePPKGenerateModal() {
-		showPPKGenerateModal = false;
-		ppkGenerateError = '';
+		ppkForm.close();
 	}
 
 	async function generatePPKContributions() {
 		if (!ppkGenerateData.owner) {
-			ppkGenerateError = 'Wybierz właściciela';
+			ppkForm.error = 'Wybierz właściciela';
 			return;
 		}
-
-		ppkGenerateError = '';
-		ppkGenerating = true;
-
-		try {
+		await ppkForm.submit(async () => {
 			const response = await fetch(`${apiUrl}/api/retirement/ppk-contributions/generate`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify(ppkGenerateData)
 			});
-
 			if (!response.ok) {
 				const errorData = await response.json();
 				throw new Error(errorData.detail || 'Nie udało się wygenerować wpłat PPK');
 			}
-
 			await invalidateAll();
-			closePPKGenerateModal();
-		} catch (err) {
-			if (err instanceof Error) {
-				ppkGenerateError = err.message;
-			}
-		} finally {
-			ppkGenerating = false;
-		}
+		});
 	}
 
 	async function createTransaction() {
 		if (!newTransactionData.account_id) {
-			transactionError = 'Wybierz konto';
+			txForm.error = 'Wybierz konto';
 			return;
 		}
-
-		transactionError = '';
-		savingTransaction = true;
-
-		try {
+		await txForm.submit(async () => {
 			const response = await fetch(
 				`${apiUrl}/api/accounts/${newTransactionData.account_id}/transactions`,
 				{
@@ -189,21 +165,12 @@
 					})
 				}
 			);
-
 			if (!response.ok) {
 				const errorData = await response.json();
 				throw new Error(errorData.detail || 'Failed to create transaction');
 			}
-
 			await invalidateAll();
-			closeNewTransactionModal();
-		} catch (err) {
-			if (err instanceof Error) {
-				transactionError = err.message;
-			}
-		} finally {
-			savingTransaction = false;
-		}
+		});
 	}
 </script>
 
@@ -330,12 +297,12 @@
 </div>
 
 <Modal
-	open={showNewTransactionModal}
+	open={txForm.open}
 	title="Nowa Transakcja"
 	onConfirm={createTransaction}
 	onCancel={closeNewTransactionModal}
-	confirmText={savingTransaction ? 'Zapisywanie...' : 'Dodaj transakcję'}
-	confirmDisabled={savingTransaction}
+	confirmText={txForm.saving ? 'Zapisywanie...' : 'Dodaj transakcję'}
+	confirmDisabled={txForm.saving}
 >
 	<form
 		onsubmit={(event) => {
@@ -344,8 +311,8 @@
 		}}
 		class="space-y-4"
 	>
-		{#if transactionError}
-			<div class="card preset-filled-error-500 p-3 text-sm">{transactionError}</div>
+		{#if txForm.error}
+			<div class="card preset-filled-error-500 p-3 text-sm">{txForm.error}</div>
 		{/if}
 
 		<label class="label">
@@ -395,12 +362,12 @@
 </Modal>
 
 <Modal
-	open={showPPKGenerateModal}
+	open={ppkForm.open}
 	title="Generuj wpłaty PPK"
 	onConfirm={generatePPKContributions}
 	onCancel={closePPKGenerateModal}
-	confirmText={ppkGenerating ? 'Generowanie...' : 'Generuj'}
-	confirmDisabled={ppkGenerating}
+	confirmText={ppkForm.saving ? 'Generowanie...' : 'Generuj'}
+	confirmDisabled={ppkForm.saving}
 >
 	<form
 		onsubmit={(event) => {
@@ -409,8 +376,8 @@
 		}}
 		class="space-y-4"
 	>
-		{#if ppkGenerateError}
-			<div class="card preset-filled-error-500 p-3 text-sm">{ppkGenerateError}</div>
+		{#if ppkForm.error}
+			<div class="card preset-filled-error-500 p-3 text-sm">{ppkForm.error}</div>
 		{/if}
 
 		<label class="label">


### PR DESCRIPTION
## Motivation

The `{saving, error, showForm/modalOpen, editing}` pattern + the saving/try-catch/close boilerplate was reimplemented in 10+ pages/modals (#684).

## Implementation information

- New `CrudForm` class (`src/lib/stores/crudForm.svelte.ts`): `open`/`editing`/`saving`/`error` runes state, `openCreate`/`openEdit`/`close`/`isEditing`, and a `submit(action)` wrapper that sets `saving`, clears `error`, runs the action, then closes + returns `true` on success or stores the message + returns `false` on failure. One instance per form/stream (class factory, not a singleton).
- Adopted in **goals** (modal + edit), **bonds** (inline card + `lookingUp`), **transactions** (two independent modal streams), and **holdings** (four create-only streams via a `saveVia` helper that toasts the outcome). Per-page error UX (inline banner vs toast) is preserved.
- Behavior-equivalent; as a side effect holdings no longer shares one `saving` flag across its four modals (each has its own).
- Unit test for `CrudForm` (open/edit/close/submit success+failure+error-reset).

Closes #684

> Changelog: refactor(frontend): CRUD form-state composable