### PR TITLE
refactor(frontend): centralized API client

### DIFF
--- a/src/lib/apiClient.test.ts
+++ b/src/lib/apiClient.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('$env/dynamic/public', () => ({
+	env: { PUBLIC_API_URL_BROWSER: 'http://localhost:8000', PUBLIC_API_URL: 'http://localhost:8000' }
+}));
+vi.mock('$app/environment', () => ({ browser: true }));
+
+import { api, ApiError } from './apiClient';
+
+describe('apiClient', () => {
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		fetchSpy = vi.spyOn(globalThis, 'fetch');
+	});
+	afterEach(() => {
+		fetchSpy.mockRestore();
+	});
+
+	it('GET parses JSON and hits the resolved base URL', async () => {
+		fetchSpy.mockResolvedValue(new Response(JSON.stringify({ ok: 1 }), { status: 200 }));
+		const out = await api.get<{ ok: number }>('/api/thing');
+		expect(out).toEqual({ ok: 1 });
+		expect(String(fetchSpy.mock.calls[0][0])).toBe('http://localhost:8000/api/thing');
+	});
+
+	it('appends query params, skipping null/undefined/empty', async () => {
+		fetchSpy.mockResolvedValue(new Response('[]', { status: 200 }));
+		await api.get('/api/x', { query: { a: 1, b: undefined, c: null, d: '', e: 'y' } });
+		const url = String(fetchSpy.mock.calls[0][0]);
+		expect(url).toContain('a=1');
+		expect(url).toContain('e=y');
+		expect(url).not.toContain('b=');
+		expect(url).not.toContain('c=');
+		expect(url).not.toContain('d=');
+	});
+
+	it('POST sends a JSON body + content-type', async () => {
+		fetchSpy.mockResolvedValue(new Response(JSON.stringify({ id: 1 }), { status: 201 }));
+		await api.post('/api/x', { name: 'a' });
+		const init = fetchSpy.mock.calls[0][1] as RequestInit;
+		expect(init.method).toBe('POST');
+		expect(init.body).toBe(JSON.stringify({ name: 'a' }));
+		expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+	});
+
+	it('DELETE returns undefined on 204 (no body parse)', async () => {
+		fetchSpy.mockResolvedValue(new Response(null, { status: 204 }));
+		await expect(api.del('/api/x/1')).resolves.toBeUndefined();
+	});
+
+	it('throws ApiError with string detail', async () => {
+		fetchSpy.mockResolvedValue(
+			new Response(JSON.stringify({ detail: 'Not found' }), { status: 404 })
+		);
+		await expect(api.get('/api/x')).rejects.toMatchObject({ status: 404, message: 'Not found' });
+		await expect(api.get('/api/x')).rejects.toBeInstanceOf(ApiError);
+	});
+
+	it('joins Pydantic-array detail messages', async () => {
+		fetchSpy.mockResolvedValue(
+			new Response(JSON.stringify({ detail: [{ msg: 'a bad' }, { msg: 'b bad' }] }), {
+				status: 422
+			})
+		);
+		await expect(api.post('/api/x', {})).rejects.toMatchObject({
+			status: 422,
+			message: 'a bad; b bad'
+		});
+	});
+
+	it('falls back to status text on a non-JSON error body', async () => {
+		fetchSpy.mockResolvedValue(
+			new Response('boom', { status: 500, statusText: 'Internal Server Error' })
+		);
+		await expect(api.get('/api/x')).rejects.toMatchObject({ status: 500 });
+	});
+});

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,0 +1,87 @@
+import { resolveApiUrl } from '$lib/api';
+
+// ApiError carries the HTTP status plus a human message extracted from the
+// backend's error body, so callers can branch on `status` (e.g. 404 vs 422)
+// while still having a ready-to-show `message`.
+export class ApiError extends Error {
+	readonly status: number;
+	constructor(status: number, message: string) {
+		super(message);
+		this.name = 'ApiError';
+		this.status = status;
+	}
+}
+
+type FetchFn = typeof globalThis.fetch;
+
+export interface ApiOptions {
+	// Pass SvelteKit's `fetch` from a load() so SSR cookies/relative URLs work;
+	// defaults to the global fetch for browser-side mutations.
+	fetch?: FetchFn;
+	// Query params appended to the path.
+	query?: Record<string, string | number | undefined | null>;
+	signal?: AbortSignal;
+}
+
+// extractDetail turns the backend's error body into a single message. The Go
+// backend emits either {"detail": "msg"} or a Pydantic-shaped
+// {"detail": [{"msg": "..."}]}; fall back to the status text otherwise.
+function extractDetail(body: unknown, fallback: string): string {
+	if (body && typeof body === 'object' && 'detail' in body) {
+		const detail = (body as { detail: unknown }).detail;
+		if (typeof detail === 'string' && detail) return detail;
+		if (Array.isArray(detail)) {
+			const msgs = detail
+				.map((d) =>
+					d && typeof d === 'object' && 'msg' in d ? String((d as { msg: unknown }).msg) : ''
+				)
+				.filter(Boolean);
+			if (msgs.length > 0) return msgs.join('; ');
+		}
+	}
+	return fallback;
+}
+
+function buildUrl(path: string, query?: ApiOptions['query']): string {
+	const base = resolveApiUrl();
+	if (!query) return `${base}${path}`;
+	const params = new URLSearchParams();
+	for (const [key, value] of Object.entries(query)) {
+		if (value !== undefined && value !== null && value !== '') {
+			params.set(key, String(value));
+		}
+	}
+	const qs = params.toString();
+	return qs ? `${base}${path}?${qs}` : `${base}${path}`;
+}
+
+async function request<T>(
+	method: string,
+	path: string,
+	body: unknown,
+	opts: ApiOptions = {}
+): Promise<T> {
+	const doFetch = opts.fetch ?? globalThis.fetch;
+	const init: RequestInit = { method, signal: opts.signal };
+	if (body !== undefined) {
+		init.headers = { 'Content-Type': 'application/json' };
+		init.body = JSON.stringify(body);
+	}
+	const res = await doFetch(buildUrl(path, opts.query), init);
+	if (!res.ok) {
+		const errBody = await res.json().catch(() => null);
+		throw new ApiError(res.status, extractDetail(errBody, res.statusText));
+	}
+	// 204 No Content (and empty bodies) have nothing to parse.
+	if (res.status === 204) return undefined as T;
+	const text = await res.text();
+	return (text ? JSON.parse(text) : undefined) as T;
+}
+
+export const api = {
+	get: <T>(path: string, opts?: ApiOptions) => request<T>('GET', path, undefined, opts),
+	post: <T>(path: string, body?: unknown, opts?: ApiOptions) =>
+		request<T>('POST', path, body, opts),
+	put: <T>(path: string, body?: unknown, opts?: ApiOptions) => request<T>('PUT', path, body, opts),
+	del: <T = void>(path: string, opts?: ApiOptions) => request<T>('DELETE', path, undefined, opts)
+};

--- a/src/routes/goals/+page.svelte
+++ b/src/routes/goals/+page.svelte
@@ -2,7 +2,7 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import { formatPLN, formatDate } from '$lib/utils/format';
 	import { Target, Plus, Pencil, Trash2, CheckCircle2, Calendar } from 'lucide-svelte';
-	import { resolveApiUrl } from '$lib/api';
+	import { api } from '$lib/apiClient';
 	import { invalidateAll } from '$app/navigation';
 	import { CrudForm } from '$lib/stores/crudForm.svelte';
 	import type { Goal, AccountOption } from './+page';
@@ -13,8 +13,6 @@
 	}
 
 	let { data }: Props = $props();
-
-	const apiUrl = resolveApiUrl();
 
 	const goals = $derived(data.goals as Goal[]);
 	const accounts = $derived(data.accounts as AccountOption[]);
@@ -87,16 +85,10 @@
 	async function handleSubmit() {
 		const editing = goalForm.editing;
 		await goalForm.submit(async () => {
-			const endpoint = editing ? `${apiUrl}/api/goals/${editing.id}` : `${apiUrl}/api/goals`;
-			const method = editing ? 'PUT' : 'POST';
-			const response = await fetch(endpoint, {
-				method,
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(formData)
-			});
-			if (!response.ok) {
-				const errorData = await response.json();
-				throw new Error(errorData.detail || 'Nie udało się zapisać celu');
+			if (editing) {
+				await api.put(`/api/goals/${editing.id}`, formData);
+			} else {
+				await api.post('/api/goals', formData);
 			}
 			await invalidateAll();
 		});
@@ -115,8 +107,7 @@
 	async function confirmDelete() {
 		if (!goalToDelete) return;
 		try {
-			const response = await fetch(`${apiUrl}/api/goals/${goalToDelete}`, { method: 'DELETE' });
-			if (!response.ok) throw new Error('Nie udało się usunąć celu');
+			await api.del(`/api/goals/${goalToDelete}`);
 			await invalidateAll();
 		} catch (err) {
 			if (err instanceof Error) goalForm.error = err.message;

--- a/src/routes/goals/+page.ts
+++ b/src/routes/goals/+page.ts
@@ -31,17 +31,23 @@ export interface AccountOption {
 }
 
 export const load: PageLoad = async ({ fetch }) => {
-	let goalsData: GoalsListResponse;
 	try {
-		goalsData = await api.get<GoalsListResponse>('/api/goals', { fetch });
+		// Fetch in parallel; accounts are best-effort (the picker degrades to
+		// empty rather than failing the page).
+		const [goalsData, accounts] = await Promise.all([
+			api.get<GoalsListResponse>('/api/goals', { fetch }),
+			api
+				.get<{ assets: AccountOption[]; liabilities: AccountOption[] }>('/api/accounts', { fetch })
+				.then((d) => [...d.assets, ...d.liabilities])
+				.catch(() => [] as AccountOption[])
+		]);
+		return { ...goalsData, accounts };
 	} catch (err) {
-		throw error(err instanceof ApiError ? err.status : 500, 'Failed to load goals');
+		// A backend failure maps to its status; anything else (e.g. the
+		// resolveApiUrl misconfig HttpError) rethrows with its actionable message.
+		if (err instanceof ApiError) {
+			throw error(err.status, 'Failed to load goals');
+		}
+		throw err;
 	}
-	// Accounts are best-effort: the picker degrades to empty rather than
-	// failing the whole page.
-	const accounts = await api
-		.get<{ assets: AccountOption[]; liabilities: AccountOption[] }>('/api/accounts', { fetch })
-		.then((d) => [...d.assets, ...d.liabilities])
-		.catch(() => [] as AccountOption[]);
-	return { ...goalsData, accounts };
 };

--- a/src/routes/goals/+page.ts
+++ b/src/routes/goals/+page.ts
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { resolveApiUrl } from '$lib/api';
+import { api, ApiError } from '$lib/apiClient';
 import type { PageLoad } from './$types';
 
 export interface Goal {
@@ -31,22 +31,17 @@ export interface AccountOption {
 }
 
 export const load: PageLoad = async ({ fetch }) => {
-	const apiUrl = resolveApiUrl();
-	const [goalsResponse, accountsResponse] = await Promise.all([
-		fetch(`${apiUrl}/api/goals`),
-		fetch(`${apiUrl}/api/accounts`)
-	]);
-	if (!goalsResponse.ok) {
-		throw error(goalsResponse.status, 'Failed to load goals');
+	let goalsData: GoalsListResponse;
+	try {
+		goalsData = await api.get<GoalsListResponse>('/api/goals', { fetch });
+	} catch (err) {
+		throw error(err instanceof ApiError ? err.status : 500, 'Failed to load goals');
 	}
-	const goalsData: GoalsListResponse = await goalsResponse.json();
-	const accounts: AccountOption[] = accountsResponse.ok
-		? await accountsResponse
-				.json()
-				.then((d: { assets: AccountOption[]; liabilities: AccountOption[] }) => [
-					...d.assets,
-					...d.liabilities
-				])
-		: [];
+	// Accounts are best-effort: the picker degrades to empty rather than
+	// failing the whole page.
+	const accounts = await api
+		.get<{ assets: AccountOption[]; liabilities: AccountOption[] }>('/api/accounts', { fetch })
+		.then((d) => [...d.assets, ...d.liabilities])
+		.catch(() => [] as AccountOption[]);
 	return { ...goalsData, accounts };
 };

--- a/src/routes/investments/bonds/+page.svelte
+++ b/src/routes/investments/bonds/+page.svelte
@@ -9,6 +9,7 @@
 	import { createChart } from '$lib/utils/charts/lifecycle';
 	import { Banknote, Pencil, Plus, Trash2, TrendingUp } from 'lucide-svelte';
 	import { resolveApiUrl } from '$lib/api';
+	import { api } from '$lib/apiClient';
 	import { invalidateAll } from '$app/navigation';
 	import { CrudForm } from '$lib/stores/crudForm.svelte';
 	import { ownerName } from '$lib/types/owners';
@@ -118,13 +119,9 @@
 		bondForm.error = '';
 		lookingUp = true;
 		try {
-			const params = new URLSearchParams({ type: formData.type, series: formData.series });
-			const res = await fetch(`${apiUrl}/api/bonds/lookup?${params}`);
-			if (!res.ok) {
-				const d = await res.json().catch(() => ({ detail: res.statusText }));
-				throw new Error(d.detail ?? res.statusText);
-			}
-			const body = (await res.json()) as { first_year_rate: number; margin: number };
+			const body = await api.get<{ first_year_rate: number; margin: number }>('/api/bonds/lookup', {
+				query: { type: formData.type, series: formData.series }
+			});
 			formData = {
 				...formData,
 				first_year_rate: body.first_year_rate,
@@ -140,19 +137,10 @@
 	async function handleSubmit() {
 		const editing = bondForm.editing;
 		await bondForm.submit(async () => {
-			const endpoint = editing ? `${apiUrl}/api/bonds/${editing.id}` : `${apiUrl}/api/bonds`;
-			const method = editing ? 'PUT' : 'POST';
-			const response = await fetch(endpoint, {
-				method,
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(formData)
-			});
-			if (!response.ok) {
-				const body = await response.json();
-				const detail = Array.isArray(body.detail)
-					? body.detail.map((d: { msg: string }) => d.msg).join('; ')
-					: (body.detail ?? 'Nie udało się zapisać obligacji');
-				throw new Error(detail);
+			if (editing) {
+				await api.put(`/api/bonds/${editing.id}`, formData);
+			} else {
+				await api.post('/api/bonds', formData);
 			}
 			await invalidateAll();
 		});
@@ -169,8 +157,7 @@
 	async function confirmDelete() {
 		if (!bondToDelete) return;
 		try {
-			const response = await fetch(`${apiUrl}/api/bonds/${bondToDelete}`, { method: 'DELETE' });
-			if (!response.ok) throw new Error('Nie udało się usunąć obligacji');
+			await api.del(`/api/bonds/${bondToDelete}`);
 			await invalidateAll();
 		} catch (err) {
 			if (err instanceof Error) bondForm.error = err.message;

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -3,7 +3,7 @@
 	import SortableTable, { type SortableColumn } from '$lib/components/SortableTable.svelte';
 	import { formatPLN } from '$lib/utils/format';
 	import { Plus, Landmark, Search, BarChart3, Trash2 } from 'lucide-svelte';
-	import { resolveApiUrl } from '$lib/api';
+	import { api } from '$lib/apiClient';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
 	import { confirm } from '$lib/stores/confirm.svelte';
@@ -19,7 +19,6 @@
 
 	let { data }: Props = $props();
 
-	const apiUrl = resolveApiUrl();
 	const owners = $derived(data.owners as OwnerOption[]);
 	const defaultOwnerUserId = $derived(owners.length > 0 ? owners[0].id : null);
 	const defaultOwnerName = $derived(owners.length > 0 ? owners[0].name : '');
@@ -85,15 +84,7 @@
 		if (!ok) return;
 
 		try {
-			const response = await fetch(
-				`${apiUrl}/api/accounts/${accountId}/transactions/${transactionId}`,
-				{ method: 'DELETE' }
-			);
-
-			if (!response.ok) {
-				throw new Error('Failed to delete transaction');
-			}
-
+			await api.del(`/api/accounts/${accountId}/transactions/${transactionId}`);
 			await invalidateAll();
 		} catch (err) {
 			console.error('Failed to delete transaction:', err);
@@ -134,15 +125,7 @@
 			return;
 		}
 		await ppkForm.submit(async () => {
-			const response = await fetch(`${apiUrl}/api/retirement/ppk-contributions/generate`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(ppkGenerateData)
-			});
-			if (!response.ok) {
-				const errorData = await response.json();
-				throw new Error(errorData.detail || 'Nie udało się wygenerować wpłat PPK');
-			}
+			await api.post('/api/retirement/ppk-contributions/generate', ppkGenerateData);
 			await invalidateAll();
 		});
 	}
@@ -153,22 +136,11 @@
 			return;
 		}
 		await txForm.submit(async () => {
-			const response = await fetch(
-				`${apiUrl}/api/accounts/${newTransactionData.account_id}/transactions`,
-				{
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({
-						amount: newTransactionData.amount,
-						date: newTransactionData.date,
-						owner_user_id: newTransactionData.owner_user_id
-					})
-				}
-			);
-			if (!response.ok) {
-				const errorData = await response.json();
-				throw new Error(errorData.detail || 'Failed to create transaction');
-			}
+			await api.post(`/api/accounts/${newTransactionData.account_id}/transactions`, {
+				amount: newTransactionData.amount,
+				date: newTransactionData.date,
+				owner_user_id: newTransactionData.owner_user_id
+			});
 			await invalidateAll();
 		});
 	}


### PR DESCRIPTION
## Motivation

~59 scattered `fetch` calls each hand-rolled URL resolution, JSON parsing, and error/`detail` extraction (#685).

## Implementation information

- New `src/lib/apiClient.ts`: a thin typed `api.get/post/put/del` over `resolveApiUrl` that builds the URL (+ query params), sends JSON, returns parsed JSON (or `undefined` for 204), and on failure throws a typed `ApiError { status, message }` with the backend's `detail` extracted (handles both `{detail: "msg"}` and the Pydantic-shaped `{detail: [{msg}]}`). Accepts `opts.fetch` so `load()` passes SvelteKit's fetch (SSR base URL + cookies).
- Adopted in **goals** (load + create/edit/delete), **bonds** (lookup + create/edit/delete), and **transactions** (create / PPK-generate / delete), replacing hand-rolled fetch + detail parsing. `ApiError.message` flows straight into the existing `CrudForm.error` / toast paths.
- Incremental: the bonds YTM-chart fetch (bespoke shaping) is left as a raw fetch for now.
- Unit tests for the client (URL/query build, JSON, 204, string + array detail, statusText fallback).

Closes #685

> Changelog: refactor(frontend): centralized API client