### PR TITLE
chore(perf): audit DB indexes + expose pool stats

### DIFF
--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
 	"github.com/Automaat/finance-buddy/backend-go/internal/db"
 	"github.com/Automaat/finance-buddy/backend-go/internal/holdings"
+	"github.com/Automaat/finance-buddy/backend-go/internal/metrics"
 	"github.com/Automaat/finance-buddy/backend-go/internal/quotes"
 	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
 	"github.com/Automaat/finance-buddy/backend-go/internal/scheduler"
@@ -112,6 +113,10 @@ func run() int {
 		defer pool.Close()
 		deps.Pool = pool
 
+		// Expose pgx pool health on /metrics so connection-pool waits
+		// (fb_db_pool_empty_acquire_total) are measurable before tuning MaxConns.
+		registerPoolMetrics(pool)
+
 		// CPI monthly-refresh scheduler — replaces the Python APScheduler job.
 		cpiStore := cpi.NewStore(pool)
 		sched := scheduler.NewCPIScheduler(cpiStore, cpi.NewGUSFetcher(), logger)
@@ -179,6 +184,22 @@ func run() int {
 		}
 	}
 	return 0
+}
+
+// registerPoolMetrics wires the pgx pool's live stats into /metrics so pool
+// saturation and waits (fb_db_pool_empty_acquire_total) are observable.
+func registerPoolMetrics(pool *pgxpool.Pool) {
+	metrics.RegisterPoolCollector(func() metrics.PoolStats {
+		s := pool.Stat()
+		return metrics.PoolStats{
+			Total:             s.TotalConns(),
+			Idle:              s.IdleConns(),
+			Acquired:          s.AcquiredConns(),
+			Max:               s.MaxConns(),
+			AcquireCount:      s.AcquireCount(),
+			EmptyAcquireCount: s.EmptyAcquireCount(),
+		}
+	})
 }
 
 // initDB opens the pool, applies the baseline schema, runs additive DDL

--- a/backend-go/docs/db-perf-audit.md
+++ b/backend-go/docs/db-perf-audit.md
@@ -1,0 +1,64 @@
+# DB index & pool-sizing audit (issue #690)
+
+Verifies index coverage on the hot read paths and the pgx pool size. Conclusion
+up front: **no index or `MaxConns` change is warranted at the current and
+projected data scale** — the gap that exists is on a table small enough that a
+sequential scan is sub-millisecond. Pool waits are now observable so the sizing
+decision can be revisited with evidence rather than guesswork.
+
+## Data scale (single household)
+
+| Table             | Approx rows                          | Growth          |
+| ----------------- | ------------------------------------ | --------------- |
+| `accounts`        | ~10–20 (active)                      | flat            |
+| `snapshots`       | ~12/year → dozens                    | +12/year        |
+| `snapshot_values` | accounts × snapshots → low hundreds  | +~15/month      |
+| `transactions`    | low thousands                        | slow            |
+| `lots`            | tens–hundreds                        | slow            |
+
+These are tiny by Postgres standards: a seq scan of a few hundred rows is far
+cheaper than the planner would even consider an index for.
+
+## Hot queries → index coverage
+
+| Query (file)                                                   | Filter / join / sort                         | Covering index                                  |
+| -------------------------------------------------------------- | -------------------------------------------- | ----------------------------------------------- |
+| accounts list (`accounts/store.go`)                            | `WHERE is_active ORDER BY id`                | PK on `id`; `is_active` filter on a ~15-row table — seq scan optimal |
+| transactions list / scoped flows (`transactions`, `investment`)| `account_id`, `date` range                   | `ix_transactions_account_id_date (account_id, date)` ✓ |
+| latest snapshot value in scope (`investment`, `dashboard`)     | `snapshot_values JOIN snapshots`, scope by `account_id`, `GROUP BY account_id` | `uix_snapshot_account (snapshot_id, account_id)` — serves the FK join + the post-join account filter ✓ |
+| snapshot detail (`snapshots/store.go`)                         | `snapshot_values.snapshot_id = s.id`         | `uix_snapshot_account` / `uix_snapshot_asset` (leading `snapshot_id`) ✓ |
+| aggregate recompute (`aggregates/store.go`)                    | `snapshot_values WHERE account_id = $1` / `WHERE asset_id = $1` | `asset_id`: `ix_snapshot_values_asset_id` ✓. `account_id`: see gap below |
+| lots by security / account (`holdings`)                        | `security_id, date` / `account_id`           | `ix_lots_security_date`, `ix_lots_account` ✓     |
+| dashboard hot path (`dashboard/store.go`)                      | reads pre-computed `snapshot_aggregates`     | `ix_snapshot_aggregates_month`; PK lookups ✓     |
+
+## The one gap (not acted on, by design)
+
+`snapshot_values` has no index **leading** with `account_id`. The existing
+`uix_snapshot_account` leads with `snapshot_id`, so a standalone
+`WHERE account_id = $1` (accounts real-yield latest value; aggregate-recompute
+`SELECT DISTINCT snapshot_id`) cannot use it and seq-scans.
+
+Not added, because the issue's rule is "add missing indexes only if confirmed":
+on a few-hundred-row table the seq scan is sub-millisecond and the planner would
+ignore the index anyway. **Revisit if `snapshot_values` reaches tens of
+thousands of rows** (many accounts or multi-decade history), at which point:
+
+```sql
+CREATE INDEX ix_snapshot_values_account ON snapshot_values (account_id);
+```
+
+## Pool sizing
+
+`db.New` sets `MaxConns = 10`, `MaxConnIdleTime = 5m`, `HealthCheckPeriod = 1m`.
+For a single-household app behind one frontend, concurrent in-flight queries are
+in the low single digits, so 10 is comfortable. The issue's rule is "raise
+`MaxConns` only if pool waits observed" — to make that measurable rather than a
+guess, `/metrics` now exposes the pgx pool stats (issue #690):
+
+- `fb_db_pool_empty_acquire_total` — **the pool-waits signal**: increments each
+  time an acquire had to wait for a free connection. Flat at 0 ⇒ pool is not a
+  bottleneck.
+- `fb_db_pool_acquired_conns` / `fb_db_pool_total_conns` / `fb_db_pool_max_conns`
+  — saturation headroom.
+
+Raise `MaxConns` only once `fb_db_pool_empty_acquire_total` is observed climbing.

--- a/backend-go/docs/db-perf-audit.md
+++ b/backend-go/docs/db-perf-audit.md
@@ -8,28 +8,28 @@ decision can be revisited with evidence rather than guesswork.
 
 ## Data scale (single household)
 
-| Table             | Approx rows                          | Growth          |
-| ----------------- | ------------------------------------ | --------------- |
-| `accounts`        | ~10–20 (active)                      | flat            |
-| `snapshots`       | ~12/year → dozens                    | +12/year        |
-| `snapshot_values` | accounts × snapshots → low hundreds  | +~15/month      |
-| `transactions`    | low thousands                        | slow            |
-| `lots`            | tens–hundreds                        | slow            |
+| Table             | Approx rows                         | Growth     |
+| ----------------- | ----------------------------------- | ---------- |
+| `accounts`        | ~10–20 (active)                     | flat       |
+| `snapshots`       | ~12/year → dozens                   | +12/year   |
+| `snapshot_values` | accounts × snapshots → low hundreds | +~15/month |
+| `transactions`    | low thousands                       | slow       |
+| `lots`            | tens–hundreds                       | slow       |
 
 These are tiny by Postgres standards: a seq scan of a few hundred rows is far
 cheaper than the planner would even consider an index for.
 
 ## Hot queries → index coverage
 
-| Query (file)                                                   | Filter / join / sort                         | Covering index                                  |
-| -------------------------------------------------------------- | -------------------------------------------- | ----------------------------------------------- |
-| accounts list (`accounts/store.go`)                            | `WHERE is_active ORDER BY id`                | PK on `id`; `is_active` filter on a ~15-row table — seq scan optimal |
-| transactions list / scoped flows (`transactions`, `investment`)| `account_id`, `date` range                   | `ix_transactions_account_id_date (account_id, date)` ✓ |
-| latest snapshot value in scope (`investment`, `dashboard`)     | `snapshot_values JOIN snapshots`, scope by `account_id`, `GROUP BY account_id` | `uix_snapshot_account (snapshot_id, account_id)` — serves the FK join + the post-join account filter ✓ |
-| snapshot detail (`snapshots/store.go`)                         | `snapshot_values.snapshot_id = s.id`         | `uix_snapshot_account` / `uix_snapshot_asset` (leading `snapshot_id`) ✓ |
-| aggregate recompute (`aggregates/store.go`)                    | `snapshot_values WHERE account_id = $1` / `WHERE asset_id = $1` | `asset_id`: `ix_snapshot_values_asset_id` ✓. `account_id`: see gap below |
-| lots by security / account (`holdings`)                        | `security_id, date` / `account_id`           | `ix_lots_security_date`, `ix_lots_account` ✓     |
-| dashboard hot path (`dashboard/store.go`)                      | reads pre-computed `snapshot_aggregates`     | `ix_snapshot_aggregates_month`; PK lookups ✓     |
+| Query (file)                                                    | Filter / join / sort                                                           | Covering index                                                                                         |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| accounts list (`accounts/store.go`)                             | `WHERE is_active ORDER BY id`                                                  | PK on `id`; `is_active` filter on a ~15-row table — seq scan optimal                                   |
+| transactions list / scoped flows (`transactions`, `investment`) | `account_id`, `date` range                                                     | `ix_transactions_account_id_date (account_id, date)` ✓                                                 |
+| latest snapshot value in scope (`investment`, `dashboard`)      | `snapshot_values JOIN snapshots`, scope by `account_id`, `GROUP BY account_id` | `uix_snapshot_account (snapshot_id, account_id)` — serves the FK join + the post-join account filter ✓ |
+| snapshot detail (`snapshots/store.go`)                          | `snapshot_values.snapshot_id = s.id`                                           | `uix_snapshot_account` / `uix_snapshot_asset` (leading `snapshot_id`) ✓                                |
+| aggregate recompute (`aggregates/store.go`)                     | `snapshot_values WHERE account_id = $1` / `WHERE asset_id = $1`                | `asset_id`: `ix_snapshot_values_asset_id` ✓. `account_id`: see gap below                               |
+| lots by security / account (`holdings`)                         | `security_id, date` / `account_id`                                             | `ix_lots_security_date`, `ix_lots_account` ✓                                                           |
+| dashboard hot path (`dashboard/store.go`)                       | reads pre-computed `snapshot_aggregates`                                       | `ix_snapshot_aggregates_month`; PK lookups ✓                                                           |
 
 ## The one gap (not acted on, by design)
 

--- a/backend-go/internal/metrics/metrics.go
+++ b/backend-go/internal/metrics/metrics.go
@@ -51,6 +51,59 @@ func Handler() http.Handler {
 	return promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 }
 
+// PoolStats is the snapshot of pgx pool health the collector exposes. Kept as
+// a plain struct so this package doesn't import pgx — the caller adapts
+// pool.Stat() into it.
+type PoolStats struct {
+	Total             int32
+	Idle              int32
+	Acquired          int32
+	Max               int32
+	AcquireCount      int64
+	EmptyAcquireCount int64
+}
+
+// RegisterPoolCollector wires a pgx pool's live stats into /metrics. snapshot
+// is called on each scrape (pool.Stat() is cheap). EmptyAcquire is the "pool
+// waits" signal: a growing value is the evidence needed before raising
+// MaxConns. Call once at startup when a pool exists.
+func RegisterPoolCollector(snapshot func() PoolStats) {
+	registry.MustRegister(&poolCollector{snapshot: snapshot})
+}
+
+type poolCollector struct {
+	snapshot func() PoolStats
+}
+
+var (
+	poolTotalDesc = prometheus.NewDesc("fb_db_pool_total_conns", "Open connections in the pgx pool.", nil, nil)
+	poolIdleDesc  = prometheus.NewDesc("fb_db_pool_idle_conns", "Idle connections in the pgx pool.", nil, nil)
+	poolAcqDesc   = prometheus.NewDesc("fb_db_pool_acquired_conns", "Currently in-use connections.", nil, nil)
+	poolMaxDesc   = prometheus.NewDesc("fb_db_pool_max_conns", "Configured max connections.", nil, nil)
+	poolAcqTotal  = prometheus.NewDesc("fb_db_pool_acquire_total", "Cumulative successful acquires.", nil, nil)
+	poolEmptyDesc = prometheus.NewDesc("fb_db_pool_empty_acquire_total",
+		"Cumulative acquires that had to wait for a connection (pool was empty).", nil, nil)
+)
+
+func (c *poolCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- poolTotalDesc
+	ch <- poolIdleDesc
+	ch <- poolAcqDesc
+	ch <- poolMaxDesc
+	ch <- poolAcqTotal
+	ch <- poolEmptyDesc
+}
+
+func (c *poolCollector) Collect(ch chan<- prometheus.Metric) {
+	s := c.snapshot()
+	ch <- prometheus.MustNewConstMetric(poolTotalDesc, prometheus.GaugeValue, float64(s.Total))
+	ch <- prometheus.MustNewConstMetric(poolIdleDesc, prometheus.GaugeValue, float64(s.Idle))
+	ch <- prometheus.MustNewConstMetric(poolAcqDesc, prometheus.GaugeValue, float64(s.Acquired))
+	ch <- prometheus.MustNewConstMetric(poolMaxDesc, prometheus.GaugeValue, float64(s.Max))
+	ch <- prometheus.MustNewConstMetric(poolAcqTotal, prometheus.CounterValue, float64(s.AcquireCount))
+	ch <- prometheus.MustNewConstMetric(poolEmptyDesc, prometheus.CounterValue, float64(s.EmptyAcquireCount))
+}
+
 // ObserveRequest records one served request. route is the chi route pattern
 // (not the raw path) so cardinality stays bounded.
 func ObserveRequest(method, route string, status int, dur time.Duration) {

--- a/backend-go/internal/metrics/metrics_test.go
+++ b/backend-go/internal/metrics/metrics_test.go
@@ -61,3 +61,21 @@ func TestObserveRequestEmptyRouteFallsBack(t *testing.T) {
 		t.Fatalf("empty route should be recorded as unmatched")
 	}
 }
+
+func TestPoolCollectorExposesStats(t *testing.T) {
+	RegisterPoolCollector(func() PoolStats {
+		return PoolStats{Total: 4, Idle: 3, Acquired: 1, Max: 10, AcquireCount: 42, EmptyAcquireCount: 7}
+	})
+	body := scrape(t)
+	for _, want := range []string{
+		"fb_db_pool_max_conns 10",
+		"fb_db_pool_total_conns 4",
+		"fb_db_pool_acquired_conns 1",
+		"fb_db_pool_empty_acquire_total 7",
+		"fb_db_pool_acquire_total 42",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in /metrics output:\n%s", want, body)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

Index coverage on hot paths and pool sizing (`MaxConns=10`) were unverified (#690).

## Implementation information

Investigation, with two concrete outcomes:

- **Index audit** (`backend-go/docs/db-perf-audit.md`): mapped the hot read paths (accounts, transactions, snapshots, dashboard, investment returns, lots) to their covering indexes. All are either index-covered (`ix_transactions_account_id_date`, `uix_snapshot_account`, `ix_lots_*`, …) or hit tiny tables (accounts ~15, snapshots ~dozens, snapshot_values ~hundreds) where a seq scan is sub-ms. **No index added** — per the issue's "only if confirmed" rule. The one leading-`account_id` gap on `snapshot_values` is documented with the exact index to add *if* the table ever grows to tens of thousands of rows.
- **Pool sizing made measurable**: `/metrics` now exposes pgx pool stats (`fb_db_pool_total_conns`, `…_acquired_conns`, `…_max_conns`, `…_acquire_total`, and the key `fb_db_pool_empty_acquire_total` "waits" counter). `MaxConns=10` is kept; the doc says to raise it only once empty-acquires are observed climbing — turning the issue's criterion into a real signal.

Unit test for the pool collector.

Closes #690

> Changelog: chore(perf): audit DB indexes + expose pool stats