### PR TITLE
refactor(frontend): dedupe labels + alloc check

### DIFF
--- a/src/lib/components/RealYieldsTable.svelte
+++ b/src/lib/components/RealYieldsTable.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { formatPercent, formatSignedPercent } from '$lib/utils/format';
+	import { categoryLabel } from '$lib/utils/categories';
 
 	// Minimal shape of the /api/accounts rows this table needs. real_yield_pct
 	// is populated server-side only for interest-bearing accounts (post-Belka,
@@ -19,19 +20,6 @@
 	}
 
 	let { accounts }: Props = $props();
-
-	const CATEGORY_LABELS: Record<string, string> = {
-		bank: 'Konto bankowe',
-		saving_account: 'Oszczędności',
-		bond: 'Obligacje',
-		stock: 'Akcje',
-		ppk: 'PPK',
-		fund: 'Fundusz',
-		etf: 'ETF'
-	};
-
-	const categoryLabel = (category: string): string =>
-		CATEGORY_LABELS[category] ?? category.charAt(0).toUpperCase() + category.slice(1);
 
 	const rows = $derived(
 		accounts

--- a/src/lib/components/SnapshotForm.svelte
+++ b/src/lib/components/SnapshotForm.svelte
@@ -5,6 +5,7 @@
 	import { Wallet, Umbrella, TrendingUp, Home, CreditCard } from 'lucide-svelte';
 	import type { Account, Asset, SnapshotResponse } from '$lib/types';
 	import type { OwnerOption } from '$lib/types/owners';
+	import { categoryLabel } from '$lib/utils/categories';
 	import NewAccountModal from './snapshot/NewAccountModal.svelte';
 	import NewAssetModal from './snapshot/NewAssetModal.svelte';
 	import ValueRow from './snapshot/ValueRow.svelte';
@@ -381,28 +382,12 @@
 		}
 	}
 
-	const categoryLabels: Record<string, string> = {
-		bank: 'Konto bankowe',
-		saving_account: 'Konto oszczędnościowe',
-		stock: 'Akcje',
-		bond: 'Obligacje',
-		fund: 'Fundusz',
-		etf: 'ETF',
-		gold: 'Złoto',
-		ppk: 'PPK',
-		real_estate: 'Nieruchomości',
-		vehicle: 'Pojazd',
-		other: 'Inne',
-		mortgage: 'Hipoteka',
-		installment: 'Raty'
-	};
-
 	function accountMeta(account: Account): string {
-		return `(${categoryLabels[account.category] || account.category})`;
+		return `(${categoryLabel(account.category)})`;
 	}
 
 	function liabilityMeta(account: Account): string {
-		return `(${categoryLabels[account.category]})`;
+		return `(${categoryLabel(account.category)})`;
 	}
 
 	function closeNewAccountModal() {
@@ -472,7 +457,7 @@
 								>
 									{account.name}
 									<span class="text-surface-600-400 font-normal ml-1"
-										>({categoryLabels[account.category] || account.category})</span
+										>({categoryLabel(account.category)})</span
 									>
 								</button>
 							{/each}
@@ -583,7 +568,7 @@
 								>
 									{account.name}
 									<span class="text-surface-600-400 font-normal ml-1"
-										>({categoryLabels[account.category] || account.category})</span
+										>({categoryLabel(account.category)})</span
 									>
 								</button>
 							{/each}
@@ -643,7 +628,7 @@
 								>
 									{account.name}
 									<span class="text-surface-600-400 font-normal ml-1"
-										>({categoryLabels[account.category] || account.category})</span
+										>({categoryLabel(account.category)})</span
 									>
 								</button>
 							{/each}
@@ -711,7 +696,7 @@
 									>
 										{account.name}
 										<span class="text-surface-600-400 font-normal ml-1"
-											>({categoryLabels[account.category]})</span
+											>({categoryLabel(account.category)})</span
 										>
 									</button>
 								{/each}

--- a/src/lib/utils/allocation.test.ts
+++ b/src/lib/utils/allocation.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { sumsToHundred } from './allocation';
+
+describe('sumsToHundred', () => {
+	it('is true for exactly 100', () => {
+		expect(sumsToHundred(100)).toBe(true);
+	});
+
+	it('absorbs float drift within the default tolerance', () => {
+		expect(sumsToHundred(100.005)).toBe(true);
+		expect(sumsToHundred(99.995)).toBe(true);
+	});
+
+	it('rejects values outside tolerance', () => {
+		expect(sumsToHundred(99)).toBe(false);
+		expect(sumsToHundred(100.5)).toBe(false);
+	});
+
+	it('supports an exact (zero-tolerance) match', () => {
+		expect(sumsToHundred(100, 0)).toBe(true);
+		expect(sumsToHundred(100.01, 0)).toBe(false);
+	});
+});

--- a/src/lib/utils/allocation.ts
+++ b/src/lib/utils/allocation.ts
@@ -1,0 +1,10 @@
+// sumsToHundred reports whether a set of allocation percentages adds up to
+// 100 within tolerance. Shared by the config page (market allocation, exact)
+// and the allocation-targets page (per-category targets, float-tolerant) so
+// the "must total 100%" rule lives in one place.
+//
+// tolerance defaults to 0.01 (a hundredth of a percent) to absorb float drift
+// from summing decimals; pass 0 for an exact integer match.
+export function sumsToHundred(total: number, tolerance = 0.01): boolean {
+	return Math.abs(total - 100) <= tolerance;
+}

--- a/src/lib/utils/categories.test.ts
+++ b/src/lib/utils/categories.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { CATEGORY_LABELS, categoryLabel } from './categories';
+
+describe('categoryLabel', () => {
+	it('maps known categories to Polish labels', () => {
+		expect(categoryLabel('bank')).toBe('Konto bankowe');
+		expect(categoryLabel('saving_account')).toBe('Konto oszczędnościowe');
+		expect(categoryLabel('stock')).toBe('Akcje');
+		expect(categoryLabel('real_estate')).toBe('Nieruchomość');
+	});
+
+	it('capitalizes the raw key for unknown categories', () => {
+		expect(categoryLabel('crypto')).toBe('Crypto');
+	});
+
+	it('exposes the canonical map', () => {
+		expect(CATEGORY_LABELS.etf).toBe('ETF');
+		expect(Object.keys(CATEGORY_LABELS)).toContain('installment');
+	});
+});

--- a/src/lib/utils/categories.ts
+++ b/src/lib/utils/categories.ts
@@ -1,0 +1,25 @@
+// Canonical Polish labels for account/asset categories. Single source of
+// truth — goals, holdings, snapshot forms etc. import this instead of each
+// re-declaring its own map (which had drifted, e.g. "Oszczędności" vs
+// "Konto oszczędnościowe").
+export const CATEGORY_LABELS: Record<string, string> = {
+	bank: 'Konto bankowe',
+	saving_account: 'Konto oszczędnościowe',
+	stock: 'Akcje',
+	bond: 'Obligacje',
+	gold: 'Złoto',
+	real_estate: 'Nieruchomość',
+	ppk: 'PPK',
+	fund: 'Fundusz',
+	etf: 'ETF',
+	vehicle: 'Pojazd',
+	mortgage: 'Hipoteka',
+	installment: 'Raty',
+	other: 'Inne'
+};
+
+// categoryLabel returns the Polish label for a category key, falling back to a
+// capitalized form of the raw key for anything not in the map.
+export function categoryLabel(category: string): string {
+	return CATEGORY_LABELS[category] ?? category.charAt(0).toUpperCase() + category.slice(1);
+}

--- a/src/routes/goals/+page.svelte
+++ b/src/routes/goals/+page.svelte
@@ -5,6 +5,7 @@
 	import { api } from '$lib/apiClient';
 	import { invalidateAll } from '$app/navigation';
 	import { CrudForm } from '$lib/stores/crudForm.svelte';
+	import { CATEGORY_LABELS, categoryLabel } from '$lib/utils/categories';
 	import type { Goal, AccountOption } from './+page';
 	import type { PageData } from './$types';
 
@@ -22,22 +23,6 @@
 	const goalForm = new CrudForm<Goal>();
 	let showDeleteModal = $state(false);
 	let goalToDelete: number | null = $state(null);
-
-	const categoryLabels: Record<string, string> = {
-		bank: 'Konto bankowe',
-		saving_account: 'Konto oszczędnościowe',
-		stock: 'Akcje',
-		bond: 'Obligacje',
-		gold: 'Złoto',
-		real_estate: 'Nieruchomość',
-		ppk: 'PPK',
-		fund: 'Fundusz',
-		etf: 'ETF',
-		vehicle: 'Pojazd',
-		mortgage: 'Hipoteka',
-		installment: 'Raty',
-		other: 'Inne'
-	};
 
 	const emptyForm = () => ({
 		name: '',
@@ -246,7 +231,7 @@
 						{#if goal.category}
 							<div class="col-span-2">
 								<span class="text-surface-700-300">Kategoria</span>
-								<p class="font-semibold">{categoryLabels[goal.category] ?? goal.category}</p>
+								<p class="font-semibold">{categoryLabel(goal.category)}</p>
 							</div>
 						{/if}
 					</div>
@@ -321,7 +306,7 @@
 			<span>Kategoria (opcjonalnie)</span>
 			<select class="select" bind:value={formData.category}>
 				<option value={null}>—</option>
-				{#each Object.entries(categoryLabels) as [value, label] (value)}
+				{#each Object.entries(CATEGORY_LABELS) as [value, label] (value)}
 					<option {value}>{label}</option>
 				{/each}
 			</select>

--- a/src/routes/settings/allocation/+page.svelte
+++ b/src/routes/settings/allocation/+page.svelte
@@ -3,6 +3,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import { toast } from '$lib/stores/toast.svelte';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
+	import { sumsToHundred } from '$lib/utils/allocation';
 	import type { PageData } from './$types';
 
 	interface Target {
@@ -51,7 +52,7 @@
 	});
 
 	const draftSum = $derived(draft.reduce((acc, row) => acc + (Number(row.target_pct) || 0), 0));
-	const sumOk = $derived(Math.abs(draftSum - 100) < 0.01 || draft.length === 0);
+	const sumOk = $derived(draft.length === 0 || sumsToHundred(draftSum));
 
 	function addRow(): void {
 		const used = new Set(draft.map((d) => d.category));

--- a/src/routes/settings/config/+page.svelte
+++ b/src/routes/settings/config/+page.svelte
@@ -17,6 +17,7 @@
 	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
 	import { untrack } from 'svelte';
+	import { sumsToHundred } from '$lib/utils/allocation';
 	import type { PageData } from './$types';
 
 	interface Props {
@@ -115,7 +116,7 @@
 	const marketSum = $derived(
 		allocationStocks + allocationBonds + allocationGold + allocationCommodities
 	);
-	const isValidAllocation = $derived(marketSum === 100);
+	const isValidAllocation = $derived(sumsToHundred(marketSum, 0));
 
 	const currentAge = $derived(
 		birthDate


### PR DESCRIPTION
## Motivation

`categoryLabels` maps were duplicated across pages/components and the "must total 100%" allocation math was duplicated between the config and allocation-targets pages (#686).

## Implementation information

- **`$lib/utils/categories`** — one canonical `CATEGORY_LABELS` map + `categoryLabel(key)` (capitalizes unknown keys). Adopted in goals, `RealYieldsTable`, and `SnapshotForm`, removing their local maps. This also unifies labels that had drifted ('Oszczędności' → 'Konto oszczędnościowe', 'Nieruchomości' → 'Nieruchomość').
- **`$lib/utils/allocation`** — one `sumsToHundred(total, tolerance=0.01)` validator, reused by the config page (market allocation, exact via `tolerance: 0`) and the allocation-targets page (float-tolerant).
- Unit tests for both utils; full frontend suite (600 tests) green.

Closes #686

> Changelog: refactor(frontend): dedupe labels + alloc check