### PR TITLE
perf(frontend): chart reflow + abort mount fetches

### DIFF
--- a/src/lib/components/ContributionAdjustedReturns.svelte
+++ b/src/lib/components/ContributionAdjustedReturns.svelte
@@ -49,27 +49,32 @@
 		return params.toString();
 	}
 
-	async function load() {
+	async function load(signal: AbortSignal) {
 		loading = true;
 		try {
 			const apiUrl = resolveApiUrl();
-			const res = await fetch(`${apiUrl}/api/investment/returns?${buildQuery()}`);
+			const res = await fetch(`${apiUrl}/api/investment/returns?${buildQuery()}`, { signal });
 			if (!res.ok) throw new Error('Nie udało się pobrać zwrotów');
 			data = (await res.json()) as ReturnsResponse;
 		} catch (err) {
+			if (signal.aborted) return;
 			if (err instanceof Error) toast.error(err.message);
 			data = null;
 		} finally {
-			loading = false;
+			if (!signal.aborted) loading = false;
 		}
 	}
 
+	// Re-fetch on scope/period change; abort the prior request (and on destroy)
+	// so a stale response can't overwrite the current scope's data.
 	$effect(() => {
 		void period;
 		void scope.type;
 		void scope.value;
 		void scope.account_id;
-		load();
+		const controller = new AbortController();
+		void load(controller.signal);
+		return () => controller.abort();
 	});
 
 	function fmt(n: number): string {

--- a/src/lib/components/ContributionAdjustedReturns.svelte
+++ b/src/lib/components/ContributionAdjustedReturns.svelte
@@ -55,7 +55,12 @@
 			const apiUrl = resolveApiUrl();
 			const res = await fetch(`${apiUrl}/api/investment/returns?${buildQuery()}`, { signal });
 			if (!res.ok) throw new Error('Nie udało się pobrać zwrotów');
-			data = (await res.json()) as ReturnsResponse;
+			const body = (await res.json()) as ReturnsResponse;
+			// Guard the success path too: a response that arrives after this run
+			// was superseded (signal aborted) must not overwrite the newer scope's
+			// data, even if the fetch itself didn't reject on abort.
+			if (signal.aborted) return;
+			data = body;
 		} catch (err) {
 			if (signal.aborted) return;
 			if (err instanceof Error) toast.error(err.message);

--- a/src/lib/components/ContributionAdjustedReturns.test.ts
+++ b/src/lib/components/ContributionAdjustedReturns.test.ts
@@ -58,6 +58,35 @@ describe('ContributionAdjustedReturns', () => {
 		});
 	});
 
+	it('aborted first response cannot overwrite the newer period data', async () => {
+		// Hold the first (period=all) request open; the second (period=1m)
+		// resolves immediately. The period change aborts the first, so when the
+		// first finally resolves with stale data it must be ignored.
+		let resolveFirst: (r: Response) => void = () => {};
+		const firstPromise = new Promise<Response>((res) => {
+			resolveFirst = res;
+		});
+		let call = 0;
+		fetchSpy.mockImplementation((() => {
+			call += 1;
+			if (call === 1) return firstPromise;
+			return Promise.resolve(new Response(JSON.stringify(successPayload)));
+		}) as typeof fetch);
+
+		render(ContributionAdjustedReturns, { props: { scope: { type: 'all' } } });
+		// Switch period → aborts the first request, issues the second.
+		await fireEvent.click(screen.getByRole('tab', { name: '1M' }));
+		await waitFor(() => expect(screen.getByText('Wartość obecna')).toBeTruthy());
+
+		// Late stale resolution of the aborted first request.
+		resolveFirst(new Response(JSON.stringify({ ...successPayload, current_value: 99999 })));
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// The stale 99 999 value must never reach the DOM.
+		expect(screen.queryByText(/99[\s ]?999/)).toBeNull();
+	});
+
 	it('re-fetches when period changes', async () => {
 		render(ContributionAdjustedReturns, { props: { scope: { type: 'all' } } });
 		await waitFor(() => expect(fetchSpy).toHaveBeenCalled());

--- a/src/lib/components/CurrencyExposureWidget.svelte
+++ b/src/lib/components/CurrencyExposureWidget.svelte
@@ -35,8 +35,14 @@
 	let error = $state('');
 	let container: HTMLDivElement | undefined = $state();
 	let handle: ChartHandle | null = null;
+	// Cancels an in-flight request when a new one starts or the component is
+	// destroyed, so a late response can't write state onto an unmounted widget.
+	let inFlight: AbortController | null = null;
 
 	async function load() {
+		inFlight?.abort();
+		const controller = new AbortController();
+		inFlight = controller;
 		loading = true;
 		error = '';
 		try {
@@ -48,17 +54,21 @@
 			}
 			const qs = params.toString();
 			const url = `${apiUrl}/api/exposure/currency${qs ? `?${qs}` : ''}`;
-			const res = await fetch(url);
+			const res = await fetch(url, { signal: controller.signal });
 			if (!res.ok) throw new Error(`Pobranie ekspozycji nieudane: ${res.statusText}`);
 			report = await res.json();
 		} catch (err) {
+			if (controller.signal.aborted) return;
 			if (err instanceof Error) error = err.message;
 		} finally {
-			loading = false;
+			if (!controller.signal.aborted) loading = false;
 		}
 	}
 
-	onMount(load);
+	onMount(() => {
+		void load();
+		return () => inFlight?.abort();
+	});
 
 	const palette = [
 		'#3b82f6',

--- a/src/routes/investments/bonds/+page.svelte
+++ b/src/routes/investments/bonds/+page.svelte
@@ -200,18 +200,23 @@
 		if (id === null) return;
 		ytmLoading = true;
 		ytmError = '';
-		fetch(`${apiUrl}/api/bonds/${id}/ytm`)
+		// Abort the in-flight YTM fetch when the selected bond changes or the
+		// component unmounts, so a stale projection can't land on the chart.
+		const controller = new AbortController();
+		fetch(`${apiUrl}/api/bonds/${id}/ytm`, { signal: controller.signal })
 			.then(async (r) => {
 				if (!r.ok) throw new Error('Nie udało się załadować projekcji YTM');
 				const body = await r.json();
 				ytm = body.points as YTMPoint[];
 			})
 			.catch((err) => {
+				if (controller.signal.aborted) return;
 				ytmError = err instanceof Error ? err.message : 'Nieznany błąd';
 			})
 			.finally(() => {
-				ytmLoading = false;
+				if (!controller.signal.aborted) ytmLoading = false;
 			});
+		return () => controller.abort();
 	});
 
 	onMount(() => {

--- a/src/routes/investments/bonds/+page.svelte
+++ b/src/routes/investments/bonds/+page.svelte
@@ -197,7 +197,13 @@
 
 	$effect(() => {
 		const id = selectedBondId;
-		if (id === null) return;
+		if (id === null) {
+			// No bond selected (e.g. the last one was deleted): clear the loading
+			// flag so the prior request's aborted finally — which skips it —
+			// can't leave the YTM panel stuck on "loading".
+			ytmLoading = false;
+			return;
+		}
 		ytmLoading = true;
 		ytmError = '';
 		// Abort the in-flight YTM fetch when the selected bond changes or the

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { EChartsOption } from 'echarts';
+	import { onMount } from 'svelte';
 	import MetricCard from '$lib/components/MetricCard.svelte';
 	import DateRangePicker from '$lib/components/DateRangePicker.svelte';
 	import { TrendingUp, CheckCircle2, Lightbulb } from 'lucide-svelte';
@@ -45,40 +45,78 @@
 	let bondChart: HTMLDivElement;
 	let yearlyRoiChart: HTMLDivElement;
 
-	$effect(() => {
-		// Re-mount every chart whenever the underlying series change (e.g.
-		// after the date-range picker triggers a load() refresh).
-		const handles: ChartHandle[] = [];
+	// Chart instances are created once (the divs are always rendered) and kept;
+	// a date-range refresh only re-applies options via setOption, so ECharts
+	// reflows the existing canvas instead of disposing + recreating the fleet.
+	let handles: Record<string, ChartHandle> = {};
+	let chartsReady = $state(false);
+	let inflationHandle: ChartHandle | undefined;
 
-		const mount = (el: HTMLDivElement, option: EChartsOption) => {
-			const handle = createChart(el);
-			handle.chart.setOption(option);
-			handles.push(handle);
+	onMount(() => {
+		handles = {
+			allocation: createChart(allocationChart),
+			wrapper: createChart(wrapperChart),
+			investmentTrend: createChart(investmentTrendChart),
+			ike: createChart(ikeChart),
+			ikze: createChart(ikzeChart),
+			ppk: createChart(ppkChart),
+			stock: createChart(stockChart),
+			bond: createChart(bondChart),
+			yearlyRoi: createChart(yearlyRoiChart)
 		};
+		chartsReady = true;
+		return () => {
+			for (const handle of Object.values(handles)) handle.dispose();
+			handles = {};
+			chartsReady = false;
+			// The inflation chart has its own effect-driven lifecycle, but its
+			// ref doesn't reliably flip to undefined on whole-component teardown,
+			// so dispose it here too to avoid leaking the instance + observer.
+			inflationHandle?.dispose();
+			inflationHandle = undefined;
+		};
+	});
 
-		mount(allocationChart, buildAllocationChartOption(allocationAnalysis.by_category));
-		mount(wrapperChart, buildWrapperChartOption(allocationAnalysis.by_wrapper));
-		mount(investmentTrendChart, buildInvestmentTrendChartOption(investmentTimeSeries));
-		mount(ikeChart, buildWrapperTrendChartOption('IKE w czasie', wrapperTimeSeries.ike));
-		mount(ikzeChart, buildWrapperTrendChartOption('IKZE w czasie', wrapperTimeSeries.ikze));
-		mount(ppkChart, buildWrapperTrendChartOption('PPK w czasie', wrapperTimeSeries.ppk));
-		mount(stockChart, buildWrapperTrendChartOption('Akcje w czasie', categoryTimeSeries.stock));
-		mount(bondChart, buildWrapperTrendChartOption('Obligacje w czasie', categoryTimeSeries.bond));
-		mount(
-			yearlyRoiChart,
+	// Re-apply options whenever the underlying series change (reflow, no remount).
+	$effect(() => {
+		if (!chartsReady) return;
+		handles.allocation.chart.setOption(buildAllocationChartOption(allocationAnalysis.by_category));
+		handles.wrapper.chart.setOption(buildWrapperChartOption(allocationAnalysis.by_wrapper));
+		handles.investmentTrend.chart.setOption(buildInvestmentTrendChartOption(investmentTimeSeries));
+		handles.ike.chart.setOption(
+			buildWrapperTrendChartOption('IKE w czasie', wrapperTimeSeries.ike)
+		);
+		handles.ikze.chart.setOption(
+			buildWrapperTrendChartOption('IKZE w czasie', wrapperTimeSeries.ikze)
+		);
+		handles.ppk.chart.setOption(
+			buildWrapperTrendChartOption('PPK w czasie', wrapperTimeSeries.ppk)
+		);
+		handles.stock.chart.setOption(
+			buildWrapperTrendChartOption('Akcje w czasie', categoryTimeSeries.stock)
+		);
+		handles.bond.chart.setOption(
+			buildWrapperTrendChartOption('Obligacje w czasie', categoryTimeSeries.bond)
+		);
+		handles.yearlyRoi.chart.setOption(
 			buildYearlyRoiChartOption(
 				categoryTimeSeries.stock,
 				categoryTimeSeries.bond,
 				wrapperTimeSeries.ppk
 			)
 		);
-		if (hasCpiSeries && inflationChart) {
-			mount(inflationChart, buildCumulativeInflationChartOption(cpiSeries));
-		}
+	});
 
-		return () => {
-			for (const handle of handles) handle.dispose();
-		};
+	// The inflation chart's container is conditional, so it has its own
+	// create-once / dispose-when-gone lifecycle keyed on the ref + data.
+	$effect(() => {
+		if (!hasCpiSeries || !inflationChart) {
+			inflationHandle?.dispose();
+			inflationHandle = undefined;
+			return;
+		}
+		if (!inflationHandle) inflationHandle = createChart(inflationChart);
+		inflationHandle.chart.setOption(buildCumulativeInflationChartOption(cpiSeries));
 	});
 </script>
 


### PR DESCRIPTION
## Motivation

ECharts instances on the metryki page were disposed + recreated on every data refresh instead of reflowed, and several mount/effect fetches had no cancellation, so a late response could write state onto an unmounted view (#687).

## Implementation information

- **Chart reflow (metryki)**: the 9 always-present charts are now created once in `onMount` (kept in a `handles` record, gated by a `chartsReady` flag) and a separate `$effect` re-applies options via `setOption` when the series change — ECharts reflows the existing canvas instead of recreating the fleet on each date-range change. The conditional inflation chart keeps its own create-once / dispose-when-gone effect, and is also disposed in the `onMount` teardown so it can't leak on navigation-away.
- **AbortController** on the mount/effect fetches in `CurrencyExposureWidget` (onMount load), `ContributionAdjustedReturns` (per-run effect fetch), and the bonds **YTM** effect: each aborts the prior/in-flight request on dep-change or destroy and ignores aborted responses, preventing stale-write races and unmounted-component state updates.

Closes #687

> Changelog: perf(frontend): chart reflow + abort mount fetches