### PR TITLE
test(frontend): cover toast + MetricCard + Confirm

### DIFF
--- a/src/lib/components/Confirm.test.ts
+++ b/src/lib/components/Confirm.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Confirm from './Confirm.svelte';
+import { confirm, confirmDialog } from '$lib/stores/confirm.svelte';
+
+describe('Confirm', () => {
+	afterEach(() => {
+		if (confirmDialog.current && !confirmDialog.current.pending) confirmDialog.cancel();
+	});
+
+	it('renders nothing when there is no pending request', () => {
+		render(Confirm);
+		expect(screen.queryByText('Usuń pozycję')).toBeNull();
+	});
+
+	it('renders the title + message of an open request', () => {
+		render(Confirm);
+		const p = confirm({ title: 'Usuń pozycję', message: 'Na pewno?' });
+		return Promise.resolve().then(() => {
+			expect(screen.getByText('Usuń pozycję')).toBeTruthy();
+			expect(screen.getByText('Na pewno?')).toBeTruthy();
+			confirmDialog.cancel();
+			return p;
+		});
+	});
+
+	it('resolves true when the request is confirmed', async () => {
+		render(Confirm);
+		const p = confirm({ title: 't', message: 'm' });
+		confirmDialog.confirm();
+		await expect(p).resolves.toBe(true);
+	});
+});

--- a/src/lib/components/MetricCard.test.ts
+++ b/src/lib/components/MetricCard.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import MetricCard from './MetricCard.svelte';
+
+describe('MetricCard', () => {
+	it('renders label and formatted value with suffix', () => {
+		render(MetricCard, { props: { label: 'Wartość', value: 1234.5, decimals: 1, suffix: ' PLN' } });
+		expect(screen.getByText('Wartość')).toBeTruthy();
+		// pl-PL uses a comma decimal + a (non-breaking) space thousands sep;
+		// match loosely on the meaningful parts rather than the exact spacing.
+		expect(screen.getByText((text) => text.includes('234,5') && text.includes('PLN'))).toBeTruthy();
+	});
+
+	it('shows an em-dash for null/NaN', () => {
+		render(MetricCard, { props: { label: 'Brak', value: null } });
+		expect(screen.getByText('—')).toBeTruthy();
+	});
+
+	it('applies the colour class for the chosen colour', () => {
+		render(MetricCard, { props: { label: 'Zysk', value: 10, color: 'green' } });
+		const valueEl = screen.getByText('10');
+		expect(valueEl.className).toContain('text-success-600-400');
+	});
+});

--- a/src/lib/stores/toast.test.ts
+++ b/src/lib/stores/toast.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { toast } from './toast.svelte';
+
+describe('toast store', () => {
+	beforeEach(() => {
+		// Drain any leftover toasts between tests.
+		for (const t of [...toast.items]) toast.dismiss(t.id);
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('pushes error/success/info toasts with kind + message', () => {
+		const e = toast.error('boom');
+		const s = toast.success('yay');
+		const i = toast.info('fyi');
+		const kinds = toast.items.map((t) => `${t.kind}:${t.message}`);
+		expect(kinds).toEqual(['error:boom', 'success:yay', 'info:fyi']);
+		expect(new Set([e, s, i]).size).toBe(3); // unique ids
+	});
+
+	it('dismiss removes a toast by id', () => {
+		const id = toast.error('x');
+		expect(toast.items).toHaveLength(1);
+		toast.dismiss(id);
+		expect(toast.items).toHaveLength(0);
+	});
+
+	it('auto-dismisses after the duration', () => {
+		vi.useFakeTimers();
+		toast.success('temp', 1000);
+		expect(toast.items).toHaveLength(1);
+		vi.advanceTimersByTime(1000);
+		expect(toast.items).toHaveLength(0);
+	});
+
+	it('does not auto-dismiss when duration is 0', () => {
+		vi.useFakeTimers();
+		toast.info('sticky', 0);
+		vi.advanceTimersByTime(100000);
+		expect(toast.items).toHaveLength(1);
+	});
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,10 +19,10 @@ export default defineConfig({
 			// target — raise them as coverage improves so regressions can't
 			// slip past CI while the codebase already covers more.
 			thresholds: {
-				statements: 78,
-				branches: 57,
-				functions: 81,
-				lines: 79
+				statements: 79,
+				branches: 60,
+				functions: 82,
+				lines: 81
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation

Several Svelte components and the `toast` store had no tests (#688).

## Implementation information

- **`toast` store**: push (error/success/info) with kind+message+unique id, `dismiss` by id, auto-dismiss after duration (fake timers), and no-auto-dismiss when duration is 0.
- **MetricCard**: label + formatted value (+suffix), em-dash for null/NaN, colour-class mapping.
- **Confirm**: renders nothing without a pending request, renders the title+message of an open request, and resolves `true` on confirm.
- Ratcheted coverage thresholds toward the measured baseline: statements 78→79, branches 57→60, functions 81→82, lines 79→81 (current actuals 79.66 / 60.47 / 82.14 / 81.21).

Closes #688

> Changelog: test(frontend): cover toast + MetricCard + Confirm