### PR TITLE
fix(frontend): responsive mobile tables + charts

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -76,3 +76,61 @@ body {
 	--nord14: #a3be8c;
 	--nord15: #b48ead;
 }
+
+/* Mobile card-stack for tables. Add the .table-cards class to a table's
+   wrapper; on narrow screens each row collapses into a label/value card so
+   wide tables stay readable without horizontal scrolling. Cells opt into a
+   label by setting data-label="…" on the <td>. */
+@media (max-width: 767px) {
+	.table-cards :is(table, tbody, tr, td) {
+		display: block;
+	}
+
+	.table-cards thead {
+		display: none;
+	}
+
+	.table-cards tr {
+		border: 1px solid var(--color-surface-300);
+		border-radius: var(--radius-3);
+		padding: var(--size-2) var(--size-3);
+		margin-block-end: var(--size-3);
+	}
+
+	.table-cards tr:last-child {
+		margin-block-end: 0;
+	}
+
+	.table-cards td {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: var(--size-4);
+		padding: var(--size-1) 0;
+		text-align: right;
+		white-space: normal;
+		border: 0;
+	}
+
+	.table-cards td[data-label]::before {
+		content: attr(data-label);
+		flex: 0 0 auto;
+		font-weight: var(--font-weight-6);
+		color: var(--color-text-2);
+		text-align: left;
+	}
+
+	/* Cells without a label (e.g. action buttons) group to the right edge
+	   instead of spreading across the card. */
+	.table-cards td:not([data-label]) {
+		justify-content: flex-end;
+		gap: var(--size-2);
+	}
+
+	/* Opt-in horizontal scroll for wide tables, mobile only — keeps desktop's
+	   page-level sticky header, which a permanent overflow container would
+	   capture. */
+	.table-scroll-mobile {
+		overflow-x: auto;
+	}
+}

--- a/src/lib/components/CurrencyExposureWidget.svelte
+++ b/src/lib/components/CurrencyExposureWidget.svelte
@@ -3,6 +3,8 @@
 	import { resolveApiUrl } from '$lib/api';
 	import { formatPLN } from '$lib/utils/format';
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
+	import { applyMobileChartTweaks } from '$lib/utils/charts/responsive';
+	import { isMobile } from '$lib/utils/viewport';
 	import { Globe } from 'lucide-svelte';
 
 	interface CurrencyBucket {
@@ -94,23 +96,31 @@
 			value: c.value_pln,
 			itemStyle: { color: c.currency === 'PLN' ? '#1e40af' : palette[i % palette.length] }
 		}));
-		handle.chart.setOption({
-			tooltip: {
-				trigger: 'item',
-				formatter: (p: { name: string; value: number; percent: number }) =>
-					`${p.name}<br/>${formatPLN(p.value)} (${p.percent.toFixed(1)}%)`
-			},
-			legend: { bottom: 0 },
-			series: [
+		handle.chart.setOption(
+			applyMobileChartTweaks(
 				{
-					type: 'pie',
-					radius: ['45%', '70%'],
-					avoidLabelOverlap: false,
-					label: { show: true, formatter: '{b}: {d}%' },
-					data
-				}
-			]
-		});
+					tooltip: {
+						trigger: 'item',
+						formatter: (params) => {
+							const p = Array.isArray(params) ? params[0] : params;
+							const pct = (p as { percent?: number }).percent ?? 0;
+							return `${p.name}<br/>${formatPLN(p.value as number)} (${pct.toFixed(1)}%)`;
+						}
+					},
+					legend: { bottom: 0 },
+					series: [
+						{
+							type: 'pie',
+							radius: ['45%', '70%'],
+							avoidLabelOverlap: false,
+							label: { show: true, formatter: '{b}: {d}%' },
+							data
+						}
+					]
+				},
+				$isMobile
+			)
+		);
 	});
 
 	function applyTarget() {

--- a/src/lib/components/DashboardCharts.svelte
+++ b/src/lib/components/DashboardCharts.svelte
@@ -76,11 +76,19 @@
 				return `${date}<br/>Wartość: ${value}`;
 			}
 		},
-		xAxis: { type: 'time' },
+		xAxis: {
+			type: 'time',
+			// hideOverlap drops colliding tick labels instead of smearing them
+			// together — critical on a narrow phone axis, especially with sparse
+			// data where ECharts otherwise stacks day/month labels on top of
+			// each other.
+			axisLabel: { hideOverlap: true }
+		},
 		yAxis: {
 			type: 'value',
 			axisLabel: { formatter: (value: number) => formatPLN(value) }
 		},
+		grid: { ...gridConfig, containLabel: true },
 		series: [
 			{
 				data: netWorthHistory.map((h) => [h.date, h.value]),
@@ -94,8 +102,7 @@
 				},
 				lineStyle: { color: chartAccent, width: 2 }
 			}
-		],
-		grid: gridConfig
+		]
 	});
 
 	const pieOption = $derived<EChartsOption>({
@@ -105,11 +112,20 @@
 			textStyle: { fontSize: titleFontSize }
 		},
 		tooltip: { trigger: 'item', formatter: '{b}: {c} PLN ({d}%)' },
+		// On a phone the radial callout labels collide and get clipped at the
+		// card edges, so swap them for a scrollable legend along the bottom.
+		legend: $isMobile
+			? { type: 'scroll', bottom: 0, left: 'center', textStyle: { fontSize: 11 } }
+			: undefined,
 		color: [...chartPalette],
 		series: [
 			{
 				type: 'pie',
 				radius: ['40%', '70%'],
+				center: $isMobile ? ['50%', '42%'] : ['50%', '50%'],
+				avoidLabelOverlap: true,
+				label: { show: !$isMobile },
+				labelLine: { show: !$isMobile },
 				data: allocation.map((a) => ({
 					name: `${a.category} (${ownerName(owners, a.owner_user_id)})`,
 					value: a.value
@@ -174,7 +190,7 @@
 				goto(`/snapshots/${step.snapshotId}/edit`);
 			}
 		});
-		waterfallChart.setOption(buildWaterfallOption(waterfallSliced));
+		waterfallChart.setOption(buildWaterfallOption(waterfallSliced, { isMobile: $isMobile }));
 	});
 </script>
 

--- a/src/lib/utils/charts/metryki.ts
+++ b/src/lib/utils/charts/metryki.ts
@@ -34,7 +34,10 @@ export interface TimeSeriesPoint {
 const formatPLN = (val: number): string =>
 	val.toLocaleString('pl-PL', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
 
-export function buildAllocationChartOption(byCategory: AllocationCategory[]): EChartsOption {
+export function buildAllocationChartOption(
+	byCategory: AllocationCategory[],
+	isMobile = false
+): EChartsOption {
 	const categories = byCategory.map((item) => item.category);
 	const currentValues = byCategory.map((item) => parseFloat(item.current_percentage.toFixed(1)));
 	const targetValues = byCategory.map((item) => parseFloat(item.target_percentage.toFixed(1)));
@@ -45,7 +48,7 @@ export function buildAllocationChartOption(byCategory: AllocationCategory[]): EC
 			text: 'Alokacja inwestycyjna: Obecna vs Docelowa',
 			left: 'center',
 			top: 10,
-			textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
+			textStyle: { color: '#2e3440', fontSize: isMobile ? 13 : 16, fontWeight: 'bold' }
 		},
 		tooltip: {
 			trigger: 'axis',
@@ -58,7 +61,7 @@ export function buildAllocationChartOption(byCategory: AllocationCategory[]): EC
 		legend: {
 			data: ['Obecna', 'Docelowa'],
 			bottom: 10,
-			textStyle: { color: '#2e3440', fontSize: 14 }
+			textStyle: { color: '#2e3440', fontSize: isMobile ? 11 : 14 }
 		},
 		grid: {
 			left: 60,
@@ -72,7 +75,7 @@ export function buildAllocationChartOption(byCategory: AllocationCategory[]): EC
 			data: categories,
 			axisLabel: {
 				color: '#2e3440',
-				fontSize: 14,
+				fontSize: isMobile ? 12 : 14,
 				fontWeight: 'bold',
 				formatter: function (value: string) {
 					return value.charAt(0).toUpperCase() + value.slice(1);
@@ -110,7 +113,7 @@ export function buildAllocationChartOption(byCategory: AllocationCategory[]): EC
 					distance: 5,
 					formatter: '{c}%',
 					color: '#2e3440',
-					fontSize: 14,
+					fontSize: isMobile ? 10 : 14,
 					fontWeight: 'bold'
 				}
 			},
@@ -126,7 +129,7 @@ export function buildAllocationChartOption(byCategory: AllocationCategory[]): EC
 					distance: 5,
 					formatter: '{c}%',
 					color: '#2e3440',
-					fontSize: 14,
+					fontSize: isMobile ? 10 : 14,
 					fontWeight: 'bold'
 				}
 			}
@@ -134,7 +137,10 @@ export function buildAllocationChartOption(byCategory: AllocationCategory[]): EC
 	};
 }
 
-export function buildWrapperChartOption(byWrapper: AllocationWrapper[]): EChartsOption {
+export function buildWrapperChartOption(
+	byWrapper: AllocationWrapper[],
+	isMobile = false
+): EChartsOption {
 	const wrapperData = byWrapper.map((item) => ({
 		name: item.wrapper,
 		value: item.value
@@ -146,7 +152,7 @@ export function buildWrapperChartOption(byWrapper: AllocationWrapper[]): ECharts
 			text: 'Podział według kont (IKE/IKZE/PPK)',
 			left: 'center',
 			top: 10,
-			textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
+			textStyle: { color: '#2e3440', fontSize: isMobile ? 13 : 16, fontWeight: 'bold' }
 		},
 		tooltip: {
 			trigger: 'item',
@@ -162,18 +168,25 @@ export function buildWrapperChartOption(byWrapper: AllocationWrapper[]): ECharts
 				return `${single.name}: ${value} PLN (${(single.percent ?? 0).toFixed(1)}%)`;
 			}
 		},
-		legend: {
-			orient: 'vertical',
-			left: 20,
-			top: 'middle',
-			textStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
-			itemGap: 15
-		},
+		legend: isMobile
+			? {
+					type: 'scroll',
+					bottom: 0,
+					left: 'center',
+					textStyle: { color: '#2e3440', fontSize: 11, fontWeight: 'bold' }
+				}
+			: {
+					orient: 'vertical',
+					left: 20,
+					top: 'middle',
+					textStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
+					itemGap: 15
+				},
 		series: [
 			{
 				type: 'pie',
 				radius: ['40%', '65%'],
-				center: ['50%', '50%'],
+				center: isMobile ? ['50%', '42%'] : ['50%', '50%'],
 				avoidLabelOverlap: true,
 				minShowLabelAngle: 1,
 				data: wrapperData,
@@ -191,7 +204,7 @@ export function buildWrapperChartOption(byWrapper: AllocationWrapper[]): ECharts
 					}
 				},
 				label: {
-					show: true,
+					show: !isMobile,
 					position: 'outside',
 					alignTo: 'edge',
 					margin: 20,
@@ -205,7 +218,7 @@ export function buildWrapperChartOption(byWrapper: AllocationWrapper[]): ECharts
 					overflow: 'none'
 				},
 				labelLine: {
-					show: true,
+					show: !isMobile,
 					length: 25,
 					length2: 20,
 					smooth: 0.2,

--- a/src/lib/utils/charts/responsive.test.ts
+++ b/src/lib/utils/charts/responsive.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import type { EChartsOption } from 'echarts';
+import { applyMobileChartTweaks } from './responsive';
+
+type TitleShape = { textStyle: { fontSize: number } };
+type PieShape = {
+	label: { show: boolean };
+	labelLine: { show: boolean };
+	avoidLabelOverlap: boolean;
+};
+
+describe('applyMobileChartTweaks', () => {
+	it('returns the option untouched when not mobile', () => {
+		const option: EChartsOption = { title: { text: 'X', textStyle: { fontSize: 16 } } };
+		expect(applyMobileChartTweaks(option, false)).toBe(option);
+		expect((option.title as TitleShape).textStyle.fontSize).toBe(16);
+	});
+
+	it('shrinks an oversized in-canvas title on mobile', () => {
+		const option: EChartsOption = { title: { text: 'Długi tytuł', textStyle: { fontSize: 18 } } };
+		applyMobileChartTweaks(option, true);
+		expect((option.title as TitleShape).textStyle.fontSize).toBe(13);
+	});
+
+	it('caps a title with no explicit font size', () => {
+		const option: EChartsOption = { title: { text: 'X' } };
+		applyMobileChartTweaks(option, true);
+		expect((option.title as TitleShape).textStyle.fontSize).toBe(13);
+	});
+
+	it('leaves an already-small title font as-is', () => {
+		const option: EChartsOption = { title: { text: 'X', textStyle: { fontSize: 11 } } };
+		applyMobileChartTweaks(option, true);
+		expect((option.title as TitleShape).textStyle.fontSize).toBe(11);
+	});
+
+	it('handles an array of titles', () => {
+		const option: EChartsOption = { title: [{ text: 'A', textStyle: { fontSize: 20 } }] };
+		applyMobileChartTweaks(option, true);
+		expect((option.title as TitleShape[])[0].textStyle.fontSize).toBe(13);
+	});
+
+	it('drops pie callout labels in favour of the legend on mobile', () => {
+		const option: EChartsOption = {
+			series: [{ type: 'pie', label: { show: true }, labelLine: { show: true }, data: [] }]
+		};
+		applyMobileChartTweaks(option, true);
+		const series = (option.series as PieShape[])[0];
+		expect(series.label.show).toBe(false);
+		expect(series.labelLine.show).toBe(false);
+		expect(series.avoidLabelOverlap).toBe(true);
+	});
+
+	it('handles a single (non-array) pie series', () => {
+		const option: EChartsOption = { series: { type: 'pie', label: { show: true }, data: [] } };
+		applyMobileChartTweaks(option, true);
+		expect((option.series as PieShape).label.show).toBe(false);
+	});
+
+	it('leaves non-pie series labels untouched', () => {
+		const option: EChartsOption = { series: [{ type: 'bar', label: { show: true }, data: [] }] };
+		applyMobileChartTweaks(option, true);
+		expect((option.series as { label: { show: boolean } }[])[0].label.show).toBe(true);
+	});
+});

--- a/src/lib/utils/charts/responsive.ts
+++ b/src/lib/utils/charts/responsive.ts
@@ -1,0 +1,31 @@
+import type { EChartsOption } from 'echarts';
+
+// Desktop-tuned chart options clip their in-canvas titles and let pie callout
+// labels collide on a phone-width canvas. applyMobileChartTweaks mutates the
+// option in place (builders hand back a fresh object on every call) so that on
+// a phone the title shrinks and donut/pie series drop their radial callouts in
+// favour of the legend. A no-op when isMobile is false.
+export function applyMobileChartTweaks(option: EChartsOption, isMobile: boolean): EChartsOption {
+	if (!isMobile) return option;
+
+	const titles = Array.isArray(option.title) ? option.title : option.title ? [option.title] : [];
+	for (const title of titles) {
+		const current = typeof title.textStyle?.fontSize === 'number' ? title.textStyle.fontSize : 16;
+		title.textStyle = { ...title.textStyle, fontSize: Math.min(current, 13) };
+	}
+
+	const series = Array.isArray(option.series)
+		? option.series
+		: option.series
+			? [option.series]
+			: [];
+	for (const item of series) {
+		if (item.type === 'pie') {
+			item.avoidLabelOverlap = true;
+			item.label = { ...item.label, show: false };
+			item.labelLine = { ...item.labelLine, show: false };
+		}
+	}
+
+	return option;
+}

--- a/src/lib/utils/charts/waterfall.ts
+++ b/src/lib/utils/charts/waterfall.ts
@@ -68,6 +68,7 @@ function formatMonth(dateISO: string): string {
 
 export interface WaterfallChartOptions {
 	maxMonths?: number; // crop to the most recent N steps (mobile = 6)
+	isMobile?: boolean; // shrink the in-canvas title so it doesn't clip on phones
 }
 
 // buildWaterfallOption renders a grouped bar chart: per month, an Asset Δ
@@ -110,7 +111,10 @@ export function buildWaterfallOption(
 	};
 
 	return {
-		title: { text: 'Wartość netto — wkład miesięczny' },
+		title: {
+			text: 'Wartość netto — wkład miesięczny',
+			textStyle: { fontSize: options.isMobile ? 13 : 16 }
+		},
 		tooltip: {
 			trigger: 'axis',
 			formatter: (params: TopLevelFormatterParams) => {

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -439,7 +439,7 @@
 
 {#snippet assetRow(account: Account)}
 	<tr>
-		<td class="font-medium">
+		<td class="font-medium" data-label="Nazwa">
 			{account.name}
 			{#if account.excluded_from_fire}
 				<span
@@ -450,10 +450,12 @@
 				</span>
 			{/if}
 		</td>
-		<td>{categoryLabels[account.category] || account.category}</td>
-		<td>{ownerName(owners, account.owner_user_id)}</td>
-		<td class="font-semibold text-primary-600-400">{formatPLN(account.current_value)}</td>
-		<td class="whitespace-nowrap">
+		<td data-label="Kategoria">{categoryLabels[account.category] || account.category}</td>
+		<td data-label="Właściciel">{ownerName(owners, account.owner_user_id)}</td>
+		<td class="font-semibold text-primary-600-400" data-label="Wartość">
+			{formatPLN(account.current_value)}
+		</td>
+		<td class="whitespace-nowrap" data-label="Realne %">
 			{#if account.real_yield_pct != null}
 				<span
 					class="font-semibold {realYieldColorClass(account.real_yield_pct)}"
@@ -503,10 +505,12 @@
 
 {#snippet liabilityRow(account: Account)}
 	<tr>
-		<td class="font-medium">{account.name}</td>
-		<td>{categoryLabels[account.category] || account.category}</td>
-		<td>{ownerName(owners, account.owner_user_id)}</td>
-		<td class="font-semibold text-error-600-400">{formatPLN(account.current_value)}</td>
+		<td class="font-medium" data-label="Nazwa">{account.name}</td>
+		<td data-label="Kategoria">{categoryLabels[account.category] || account.category}</td>
+		<td data-label="Właściciel">{ownerName(owners, account.owner_user_id)}</td>
+		<td class="font-semibold text-error-600-400" data-label="Wartość">
+			{formatPLN(account.current_value)}
+		</td>
 		<td class="text-right whitespace-nowrap">
 			<button
 				type="button"
@@ -600,13 +604,15 @@
 			{#if accounts.assets.length === 0}
 				<div class="text-center py-12 text-surface-700-300"><p>Brak aktywów</p></div>
 			{:else}
-				<SortableTable
-					columns={accountColumns}
-					items={accounts.assets}
-					row={assetRow}
-					paramName="sortA"
-					getKey={(a) => a.id}
-				/>
+				<div class="table-cards">
+					<SortableTable
+						columns={accountColumns}
+						items={accounts.assets}
+						row={assetRow}
+						paramName="sortA"
+						getKey={(a) => a.id}
+					/>
+				</div>
 			{/if}
 		</div>
 
@@ -617,13 +623,15 @@
 			{#if accounts.liabilities.length === 0}
 				<div class="text-center py-12 text-surface-700-300"><p>Brak pasywów</p></div>
 			{:else}
-				<SortableTable
-					columns={liabilityColumns}
-					items={accounts.liabilities}
-					row={liabilityRow}
-					paramName="sortL"
-					getKey={(a) => a.id}
-				/>
+				<div class="table-cards">
+					<SortableTable
+						columns={liabilityColumns}
+						items={accounts.liabilities}
+						row={liabilityRow}
+						paramName="sortL"
+						getKey={(a) => a.id}
+					/>
+				</div>
 			{/if}
 		</div>
 	</div>

--- a/src/routes/debts/+page.svelte
+++ b/src/routes/debts/+page.svelte
@@ -309,7 +309,7 @@
 				<p>Brak zobowiązań</p>
 			</div>
 		{:else}
-			<div class="table-wrap">
+			<div class="table-wrap table-cards">
 				<table class="table table-hover">
 					<thead>
 						<tr>
@@ -328,10 +328,12 @@
 					<tbody>
 						{#each data.debts as debt}
 							<tr>
-								<td>{debt.name}</td>
-								<td>{debtTypeLabels[debt.debt_type] || debt.debt_type}</td>
-								<td class="font-semibold">{formatPLN(debt.initial_amount)}</td>
-								<td class="font-semibold text-error-600-400">
+								<td data-label="Nazwa">{debt.name}</td>
+								<td data-label="Typ">{debtTypeLabels[debt.debt_type] || debt.debt_type}</td>
+								<td class="font-semibold" data-label="Kwota początkowa"
+									>{formatPLN(debt.initial_amount)}</td
+								>
+								<td class="font-semibold text-error-600-400" data-label="Pozostało">
 									{#if debt.latest_balance !== null}
 										<div>{formatPLN(debt.latest_balance)}</div>
 										{#if debt.latest_balance_date}
@@ -343,11 +345,13 @@
 										<span class="text-surface-700-300 italic">brak danych</span>
 									{/if}
 								</td>
-								<td class="font-semibold">{formatPLN(debt.total_paid)}</td>
-								<td class="font-semibold text-error-600-400">{formatPLN(debt.interest_paid)}</td>
-								<td>{debt.interest_rate}%</td>
-								<td>{formatDate(debt.start_date)}</td>
-								<td>{ownerName(owners, debt.account_owner_user_id)}</td>
+								<td class="font-semibold" data-label="Wpłacono">{formatPLN(debt.total_paid)}</td>
+								<td class="font-semibold text-error-600-400" data-label="Odsetki"
+									>{formatPLN(debt.interest_paid)}</td
+								>
+								<td data-label="Oprocentowanie">{debt.interest_rate}%</td>
+								<td data-label="Data">{formatDate(debt.start_date)}</td>
+								<td data-label="Właściciel">{ownerName(owners, debt.account_owner_user_id)}</td>
 								<td class="text-right whitespace-nowrap">
 									<button
 										type="button"

--- a/src/routes/investments/holdings/+page.svelte
+++ b/src/routes/investments/holdings/+page.svelte
@@ -356,7 +356,7 @@
 				na podstawie ręcznych notowań.
 			</p>
 		</div>
-		<div class="flex gap-2">
+		<div class="flex flex-wrap gap-2">
 			<button
 				type="button"
 				class="btn preset-tonal-surface"

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -12,6 +12,8 @@
 	} from '$lib/utils/charts/metryki';
 	import { buildCumulativeInflationChartOption } from '$lib/utils/charts/inflation';
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
+	import { applyMobileChartTweaks } from '$lib/utils/charts/responsive';
+	import { isMobile } from '$lib/utils/viewport';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
 	import ContributionAdjustedReturns from '$lib/components/ContributionAdjustedReturns.svelte';
 	import CurrencyExposureWidget from '$lib/components/CurrencyExposureWidget.svelte';
@@ -80,8 +82,12 @@
 	// Re-apply options whenever the underlying series change (reflow, no remount).
 	$effect(() => {
 		if (!chartsReady) return;
-		handles.allocation.chart.setOption(buildAllocationChartOption(allocationAnalysis.by_category));
-		handles.wrapper.chart.setOption(buildWrapperChartOption(allocationAnalysis.by_wrapper));
+		handles.allocation.chart.setOption(
+			buildAllocationChartOption(allocationAnalysis.by_category, $isMobile)
+		);
+		handles.wrapper.chart.setOption(
+			buildWrapperChartOption(allocationAnalysis.by_wrapper, $isMobile)
+		);
 		handles.investmentTrend.chart.setOption(buildInvestmentTrendChartOption(investmentTimeSeries));
 		handles.ike.chart.setOption(
 			buildWrapperTrendChartOption('IKE w czasie', wrapperTimeSeries.ike)
@@ -116,7 +122,9 @@
 			return;
 		}
 		if (!inflationHandle) inflationHandle = createChart(inflationChart);
-		inflationHandle.chart.setOption(buildCumulativeInflationChartOption(cpiSeries));
+		inflationHandle.chart.setOption(
+			applyMobileChartTweaks(buildCumulativeInflationChartOption(cpiSeries), $isMobile)
+		);
 	});
 </script>
 

--- a/src/routes/optimizer/+page.svelte
+++ b/src/routes/optimizer/+page.svelte
@@ -129,7 +129,7 @@
 			{#each ranked as r, idx (r.option)}
 				<li class="card preset-tonal-surface p-4 space-y-2 {r.available ? '' : 'opacity-60'}">
 					<header class="flex flex-wrap items-baseline justify-between gap-2">
-						<div class="flex items-baseline gap-3">
+						<div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
 							<span class="text-2xl font-bold">{idx + 1}.</span>
 							<span class="text-lg font-semibold">{r.name}</span>
 							{#if !r.available}

--- a/src/routes/settings/users/+page.svelte
+++ b/src/routes/settings/users/+page.svelte
@@ -157,7 +157,7 @@
 		</form>
 	</div>
 
-	<div class="card preset-filled-surface-50-950 p-5">
+	<div class="card preset-filled-surface-50-950 p-5 table-cards">
 		<table class="table">
 			<thead>
 				<tr>
@@ -172,17 +172,19 @@
 			<tbody>
 				{#each users as appUser (appUser.id)}
 					<tr>
-						<td>{appUser.username}</td>
-						<td>{fullName(appUser)}</td>
-						<td>{appUser.ppk_employee_rate ?? '—'} / {appUser.ppk_employer_rate ?? '—'}</td>
-						<td>
+						<td data-label="Użytkownik">{appUser.username}</td>
+						<td data-label="Imię i nazwisko">{fullName(appUser)}</td>
+						<td data-label="PPK">
+							{appUser.ppk_employee_rate ?? '—'} / {appUser.ppk_employer_rate ?? '—'}
+						</td>
+						<td data-label="Rola">
 							{#if appUser.is_admin}
 								<span class="badge preset-filled-primary-500">Administrator</span>
 							{:else}
 								<span class="badge preset-tonal-surface">Użytkownik</span>
 							{/if}
 						</td>
-						<td>{appUser.created_at.slice(0, 10)}</td>
+						<td data-label="Utworzono">{appUser.created_at.slice(0, 10)}</td>
 						<td>
 							<button
 								type="button"

--- a/src/routes/simulations/+page.svelte
+++ b/src/routes/simulations/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { onMount, untrack } from 'svelte';
 	import { resolveApiUrl } from '$lib/api';
+	import { applyMobileChartTweaks } from '$lib/utils/charts/responsive';
+	import { isMobile } from '$lib/utils/viewport';
 	import * as echarts from 'echarts';
 	import type { PageData } from './$types';
 	import {
@@ -410,7 +412,9 @@
 			return;
 		}
 
-		chart?.setOption(buildRetirementProjectionOption(results.simulations));
+		chart?.setOption(
+			applyMobileChartTweaks(buildRetirementProjectionOption(results.simulations), $isMobile)
+		);
 	});
 
 	// Render the wrapper-aggregate chart reactively: it only mounts after the
@@ -438,7 +442,12 @@
 			return;
 		}
 
-		wrapperChart?.setOption(buildRetirementByWrapperOption(results.simulations, MILESTONE_AGES));
+		wrapperChart?.setOption(
+			applyMobileChartTweaks(
+				buildRetirementByWrapperOption(results.simulations, MILESTONE_AGES),
+				$isMobile
+			)
+		);
 	});
 
 	onMount(() => {

--- a/src/routes/simulations/mortgage/+page.svelte
+++ b/src/routes/simulations/mortgage/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { onMount, tick, untrack } from 'svelte';
 	import { resolveApiUrl } from '$lib/api';
+	import { applyMobileChartTweaks } from '$lib/utils/charts/responsive';
+	import { isMobile } from '$lib/utils/viewport';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
@@ -203,7 +205,7 @@
 			]
 		};
 
-		chart?.setOption(option);
+		chart?.setOption(applyMobileChartTweaks(option, $isMobile));
 	}
 
 	onMount(() => {

--- a/src/routes/simulations/wibor/+page.svelte
+++ b/src/routes/simulations/wibor/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { onMount, tick } from 'svelte';
 	import { resolveApiUrl } from '$lib/api';
+	import { applyMobileChartTweaks } from '$lib/utils/charts/responsive';
+	import { isMobile } from '$lib/utils/viewport';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
@@ -123,7 +125,7 @@
 			},
 			series
 		};
-		chart?.setOption(option);
+		chart?.setOption(applyMobileChartTweaks(option, $isMobile));
 	}
 
 	function formatCurrency(value: number): string {
@@ -165,7 +167,7 @@
 				<Info size={20} />
 			</summary>
 			<div
-				class="absolute left-0 z-20 mt-2 w-80 sm:w-96 card preset-filled-surface-100-900 p-3 text-sm shadow-xl"
+				class="fixed inset-x-3 z-20 mt-2 card preset-filled-surface-100-900 p-3 text-sm shadow-xl sm:absolute sm:inset-x-auto sm:left-0 sm:w-96"
 			>
 				<p>
 					<strong>WIBOR</strong> (Warsaw Interbank Offered Rate) to średnia stawka, po jakiej banki pożyczają

--- a/src/routes/simulations/zus/+page.svelte
+++ b/src/routes/simulations/zus/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { onMount, tick, untrack } from 'svelte';
 	import { resolveApiUrl } from '$lib/api';
+	import { applyMobileChartTweaks } from '$lib/utils/charts/responsive';
+	import { isMobile } from '$lib/utils/viewport';
 	import * as echarts from 'echarts';
 	import type { EChartsOption } from 'echarts';
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
@@ -192,7 +194,7 @@
 			]
 		};
 
-		chart?.setOption(option);
+		chart?.setOption(applyMobileChartTweaks(option, $isMobile));
 	}
 
 	onMount(() => {

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -258,12 +258,14 @@
 				<p>Brak transakcji</p>
 			</div>
 		{:else}
-			<SortableTable
-				columns={transactionColumns}
-				items={data.transactions.transactions}
-				row={transactionRow}
-				getKey={(t) => t.id}
-			/>
+			<div class="table-scroll-mobile">
+				<SortableTable
+					columns={transactionColumns}
+					items={data.transactions.transactions}
+					row={transactionRow}
+					getKey={(t) => t.id}
+				/>
+			</div>
 		{/if}
 	</div>
 </div>


### PR DESCRIPTION
## Motivation

On iPhone, wide tables were cut off with no way to scroll — the global
`html, body { overflow-x: hidden }` clips overflow rather than scrolling
it — and ECharts diagrams clipped or collided on a phone-width canvas:
net-worth line labels smeared together, donut callout labels were cut at
the card edge, and the metryki bar/donut titles overran the viewport.
Reported as "text being cut" and "unreadable diagrams" on a real iPhone.

> Changelog: fix(frontend): responsive mobile tables + charts

## Implementation information

Tables (hybrid approach):
- Card-stack on mobile for **accounts**, **settings/users**, **debts** via a
  new `.table-cards` utility in `app.css` — rows collapse to label/value
  cards keyed off `data-label` on each cell.
- Mobile-only horizontal-scroll wrapper for **transactions** and **holdings**
  so the page no longer overflows, while desktop keeps its page-sticky
  header. The holdings action-button row now wraps.

Charts:
- `hideOverlap` + `containLabel` on the net-worth line chart.
- Pie/donut radial callouts swapped for a scrollable bottom legend on
  mobile (dashboard allocation + currency exposure).
- New shared `applyMobileChartTweaks()` helper (`charts/responsive.ts`)
  shrinks oversized in-canvas titles and drops colliding pie callouts;
  applied to the simulation/calculator and inflation charts. The metryki
  allocation bar + account donut take an `isMobile` flag directly.

Misc: `/optimizer` heading row wraps; `/simulations/wibor` info popover is
constrained to the viewport on mobile.

## Supporting documentation

Verified in Chrome mobile emulation at **375 / 393 / 430 px**: zero
horizontal overflow on all 21 routes (was accounts 257px, holdings 249px,
settings/users 163px, optimizer 21px); charts readable with no clipped
titles or colliding labels.

Quality gates: oxlint, prettier, svelte-check (0 errors), 619 vitest tests,
coverage thresholds met.

FYI (not in this PR): prod `/ekspozycja` and `/investments/returns` error on
the released image but work on `main` — needs a deploy.