### PR TITLE
feat(retirement): PPK tab + auto-generate on 13th

### DIFF
--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/metrics"
 	"github.com/Automaat/finance-buddy/backend-go/internal/quotes"
 	"github.com/Automaat/finance-buddy/backend-go/internal/recurring"
+	"github.com/Automaat/finance-buddy/backend-go/internal/retirement"
 	"github.com/Automaat/finance-buddy/backend-go/internal/scheduler"
 	"github.com/Automaat/finance-buddy/backend-go/internal/server"
 )
@@ -145,6 +146,11 @@ func run() int {
 		stooq := quotes.NewStooqFetcher(cfg.StooqAPIKey)
 		quotesSched := quotes.NewScheduler(hStore, stooq, logger)
 		go quotesSched.Run(ctx)
+
+		// Monthly PPK contribution generator — fires on the 13th for every
+		// owner with a UOP salary + configured PPK rates + active PPK account.
+		ppkSched := retirement.NewPPKScheduler(retirement.NewStore(pool), logger)
+		go ppkSched.Run(ctx)
 	} else {
 		logger.Warn("no DB config (DATABASE_URL or PGHOST) — DB-backed endpoints will 404")
 	}

--- a/backend-go/internal/retirement/generate.go
+++ b/backend-go/internal/retirement/generate.go
@@ -1,0 +1,85 @@
+package retirement
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// contractTypeUOP is the salary contract type ("umowa o pracę") PPK generation
+// requires — only employment contracts mint contributions, manual or auto.
+const contractTypeUOP = "UOP"
+
+// ErrNotUOP marks an owner whose latest salary record isn't an employment
+// contract, so PPK contributions must not be generated.
+var ErrNotUOP = errors.New("salary contract type is not UOP")
+
+// GenerateOptions carries the optional government-subsidy opt-ins.
+type GenerateOptions struct {
+	IncludeWelcome bool
+	IncludeAnnual  bool
+}
+
+// GenerateOutcome reports the computed amounts and the insert result, for the
+// caller to render or log.
+type GenerateOutcome struct {
+	Gross       decimal.Decimal
+	EmployeeAmt decimal.Decimal
+	EmployerAmt decimal.Decimal
+	Subsidy     SubsidyConfig
+	Result      PPKContributionResult
+}
+
+// GeneratePPK runs the contribution-generation flow for one owner and month:
+// latest UOP salary -> PPK rates -> amounts -> active PPK account -> idempotent
+// insert. It returns sentinel errors (ErrNoSalary, ErrNotUOP, ErrUserNotFound,
+// ErrNoPPKAccount, ErrContributionsExist) for the caller to map. Shared by the
+// HTTP handler and the monthly scheduler.
+func GeneratePPK(ctx context.Context, store *Store, ownerUserID *int, month, year int, opts GenerateOptions) (GenerateOutcome, error) {
+	out := GenerateOutcome{}
+	firstDay := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC)
+	gross, contractType, err := store.CurrentSalaryRecordFor(ctx, ownerUserID, firstDay)
+	if err != nil {
+		return out, err
+	}
+	if contractType != contractTypeUOP {
+		return out, ErrNotUOP
+	}
+	employeeRate, employerRate, err := store.UserPPKRates(ctx, ownerUserID)
+	if err != nil {
+		return out, err
+	}
+	employeeAmt, employerAmt := computePPKContributionAmounts(gross, employeeRate, employerRate)
+	accountID, err := store.ActivePPKAccountForOwner(ctx, ownerUserID)
+	if err != nil {
+		return out, err
+	}
+	lastDay := time.Date(year, time.Month(month)+1, 0, 0, 0, 0, 0, time.UTC)
+	subsidy := SubsidyFor(year)
+	contrib := PPKContribution{
+		AccountID:   accountID,
+		EmployeeAmt: employeeAmt,
+		EmployerAmt: employerAmt,
+		Date:        lastDay,
+		OwnerUserID: ownerUserID,
+	}
+	if opts.IncludeWelcome {
+		contrib.WelcomeAmt = subsidy.WelcomeAmount
+	}
+	if opts.IncludeAnnual {
+		contrib.AnnualAmt = subsidy.AnnualAmount
+	}
+	result, err := store.InsertPPKContributions(ctx, contrib)
+	if err != nil {
+		return out, err
+	}
+	return GenerateOutcome{
+		Gross:       gross,
+		EmployeeAmt: employeeAmt,
+		EmployerAmt: employerAmt,
+		Subsidy:     subsidy,
+		Result:      result,
+	}, nil
+}

--- a/backend-go/internal/retirement/handler.go
+++ b/backend-go/internal/retirement/handler.go
@@ -303,68 +303,42 @@ func (h *Handler) GeneratePPKContributions(w http.ResponseWriter, r *http.Reques
 		httputil.WritePydanticError(w, vErr)
 		return
 	}
-	firstDay := time.Date(req.Year, time.Month(req.Month), 1, 0, 0, 0, 0, time.UTC)
-	gross, err := h.store.CurrentSalaryFor(r.Context(), req.OwnerUserID, firstDay)
+	outcome, err := GeneratePPK(r.Context(), h.store, req.OwnerUserID, req.Month, req.Year,
+		GenerateOptions{IncludeWelcome: req.IncludeWelcome, IncludeAnnual: req.IncludeAnnual})
 	if err != nil {
-		if errors.Is(err, ErrNoSalary) {
-			httputil.WriteDetailError(w, http.StatusBadRequest,
-				fmt.Sprintf("No salary record found for user %s in %d/%d",
-					ownerLabel(req.OwnerUserID), req.Month, req.Year))
-			return
-		}
-		h.logger.Error("ppk salary", "err", err)
-		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
+		h.writeGenerateError(w, req, err)
 		return
 	}
-	employeeRate, employerRate, err := h.store.UserPPKRates(r.Context(), req.OwnerUserID)
-	if err != nil {
-		if errors.Is(err, ErrUserNotFound) {
-			httputil.WriteDetailError(w, http.StatusNotFound,
-				fmt.Sprintf("User %s not found", ownerLabel(req.OwnerUserID)))
-			return
-		}
-		h.logger.Error("ppk rates", "err", err)
+	httputil.WriteJSON(w, http.StatusOK, computePPKGenerateResponse(
+		req, outcome.Gross, outcome.EmployeeAmt, outcome.EmployerAmt, outcome.Subsidy, outcome.Result))
+}
+
+// writeGenerateError maps GeneratePPK sentinel errors to HTTP responses.
+func (h *Handler) writeGenerateError(w http.ResponseWriter, req generateRequest, err error) {
+	switch {
+	case errors.Is(err, ErrNoSalary):
+		httputil.WriteDetailError(w, http.StatusBadRequest,
+			fmt.Sprintf("No salary record found for user %s in %d/%d",
+				ownerLabel(req.OwnerUserID), req.Month, req.Year))
+	case errors.Is(err, ErrNotUOP):
+		httputil.WriteDetailError(w, http.StatusBadRequest,
+			fmt.Sprintf("PPK contributions require a UOP (employment) salary for user %s",
+				ownerLabel(req.OwnerUserID)))
+	case errors.Is(err, ErrUserNotFound):
+		httputil.WriteDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("User %s not found", ownerLabel(req.OwnerUserID)))
+	case errors.Is(err, ErrNoPPKAccount):
+		httputil.WriteDetailError(w, http.StatusNotFound,
+			fmt.Sprintf("No active PPK account found for user %s. "+
+				"Mark one PPK account as receiving contributions.",
+				ownerLabel(req.OwnerUserID)))
+	case errors.Is(err, ErrContributionsExist):
+		httputil.WriteDetailError(w, http.StatusConflict,
+			fmt.Sprintf("Contributions already exist for %d/%d", req.Month, req.Year))
+	default:
+		h.logger.Error("generate ppk contributions", "err", err)
 		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
-		return
 	}
-	employeeAmt, employerAmt := computePPKContributionAmounts(gross, employeeRate, employerRate)
-	accountID, err := h.store.ActivePPKAccountForOwner(r.Context(), req.OwnerUserID)
-	if err != nil {
-		if errors.Is(err, ErrNoPPKAccount) {
-			httputil.WriteDetailError(w, http.StatusNotFound,
-				fmt.Sprintf("No active PPK account found for user %s. "+
-					"Mark one PPK account as receiving contributions.",
-					ownerLabel(req.OwnerUserID)))
-			return
-		}
-		h.logger.Error("ppk account", "err", err)
-		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
-		return
-	}
-	lastDay := time.Date(req.Year, time.Month(req.Month)+1, 0, 0, 0, 0, 0, time.UTC)
-	subsidy := SubsidyFor(req.Year)
-	contrib := PPKContribution{
-		AccountID: accountID, EmployeeAmt: employeeAmt, EmployerAmt: employerAmt,
-		Date: lastDay, OwnerUserID: req.OwnerUserID,
-	}
-	if req.IncludeWelcome {
-		contrib.WelcomeAmt = subsidy.WelcomeAmount
-	}
-	if req.IncludeAnnual {
-		contrib.AnnualAmt = subsidy.AnnualAmount
-	}
-	result, err := h.store.InsertPPKContributions(r.Context(), contrib)
-	if err != nil {
-		if errors.Is(err, ErrContributionsExist) {
-			httputil.WriteDetailError(w, http.StatusConflict,
-				fmt.Sprintf("Contributions already exist for %d/%d", req.Month, req.Year))
-			return
-		}
-		h.logger.Error("insert ppk contributions", "err", err)
-		httputil.WriteDetailError(w, http.StatusInternalServerError, "Internal Server Error")
-		return
-	}
-	httputil.WriteJSON(w, http.StatusOK, computePPKGenerateResponse(req, gross, employeeAmt, employerAmt, subsidy, result))
 }
 
 // errBadOwnerParam marks a non-integer owner_user_id query value.

--- a/backend-go/internal/retirement/ppk_scheduler.go
+++ b/backend-go/internal/retirement/ppk_scheduler.go
@@ -1,0 +1,109 @@
+package retirement
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/metrics"
+)
+
+const (
+	ppkRunDay  = 13
+	ppkRunHour = 4
+)
+
+// PPKScheduler auto-generates the current month's PPK contributions for every
+// eligible owner on the 13th of each month (04:00 Europe/Warsaw). Eligibility
+// = a UOP salary on record + configured PPK rates + an active PPK account;
+// owners failing any check are skipped. Generation is idempotent via the
+// store's per-month dedup, so a restart after the 13th re-runs harmlessly.
+// Single instance, mirrors the CPI/recurring schedulers.
+type PPKScheduler struct {
+	store  *Store
+	logger *slog.Logger
+	now    func() time.Time
+	loc    *time.Location
+}
+
+// NewPPKScheduler wires the scheduler. Falls back to UTC if the Europe/Warsaw
+// zone isn't available (missing tzdata).
+func NewPPKScheduler(store *Store, logger *slog.Logger) *PPKScheduler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	loc, err := time.LoadLocation("Europe/Warsaw")
+	if err != nil {
+		logger.Warn("ppk scheduler: Europe/Warsaw tz unavailable, using UTC", "err", err)
+		loc = time.UTC
+	}
+	return &PPKScheduler{store: store, logger: logger, now: time.Now, loc: loc}
+}
+
+// nextPPKRun returns the next 13th-of-month at ppkRunHour in from's location.
+func nextPPKRun(from time.Time) time.Time {
+	candidate := time.Date(from.Year(), from.Month(), ppkRunDay, ppkRunHour, 0, 0, 0, from.Location())
+	if candidate.After(from) {
+		return candidate
+	}
+	return time.Date(from.Year(), from.Month()+1, ppkRunDay, ppkRunHour, 0, 0, 0, from.Location())
+}
+
+// Run does a startup catch-up (when this month's 13th has already passed) then
+// loops firing on each 13th until ctx is canceled.
+func (s *PPKScheduler) Run(ctx context.Context) {
+	now := s.now().In(s.loc)
+	scheduled := time.Date(now.Year(), now.Month(), ppkRunDay, ppkRunHour, 0, 0, 0, s.loc)
+	if !now.Before(scheduled) {
+		s.logger.Info("ppk scheduler: catch-up pass at startup")
+		s.generateMonth(ctx, int(now.Month()), now.Year())
+	}
+	for {
+		now := s.now().In(s.loc)
+		next := nextPPKRun(now)
+		s.logger.Info("ppk scheduler: next run", "at", next.Format(time.RFC3339))
+		timer := time.NewTimer(max(next.Sub(now), 0))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			s.logger.Info("ppk scheduler: stopped")
+			return
+		case <-timer.C:
+			run := s.now().In(s.loc)
+			s.generateMonth(ctx, int(run.Month()), run.Year())
+		}
+	}
+}
+
+// generateMonth mints contributions for the given month/year for every named
+// owner, skipping the ineligible. Idempotent across reruns.
+func (s *PPKScheduler) generateMonth(ctx context.Context, month, year int) {
+	ids, err := s.store.UserIDs(ctx)
+	if err != nil {
+		s.logger.Warn("ppk scheduler: list users failed", "err", err)
+		metrics.SchedulerRun("ppk", "error")
+		return
+	}
+	created := 0
+	for i := range ids {
+		owner := ids[i]
+		_, err := GeneratePPK(ctx, s.store, &owner, month, year, GenerateOptions{})
+		switch {
+		case err == nil:
+			created++
+			s.logger.Info("ppk scheduler: generated",
+				"owner", owner, "month", month, "year", year)
+		case errors.Is(err, ErrContributionsExist):
+			// Already minted this month — idempotent skip.
+		case errors.Is(err, ErrNotUOP), errors.Is(err, ErrNoSalary),
+			errors.Is(err, ErrNoPPKAccount), errors.Is(err, ErrUserNotFound):
+			s.logger.Debug("ppk scheduler: owner not eligible", "owner", owner, "reason", err)
+		default:
+			s.logger.Error("ppk scheduler: generate failed", "owner", owner, "err", err)
+		}
+	}
+	s.logger.Info("ppk scheduler: month pass complete",
+		"month", month, "year", year, "created", created)
+	metrics.SchedulerRun("ppk", "success")
+}

--- a/backend-go/internal/retirement/ppk_scheduler_test.go
+++ b/backend-go/internal/retirement/ppk_scheduler_test.go
@@ -1,0 +1,72 @@
+package retirement
+
+import (
+	"testing"
+	"time"
+)
+
+func mustParsePPK(t *testing.T, value string) time.Time {
+	t.Helper()
+	got, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("parse %q: %v", value, err)
+	}
+	return got
+}
+
+func TestNextPPKRun_BeforeThirteenth(t *testing.T) {
+	from := mustParsePPK(t, "2025-06-10T12:00:00+02:00")
+	got := nextPPKRun(from)
+	want := time.Date(2025, 6, 13, 4, 0, 0, 0, from.Location())
+	if !got.Equal(want) {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+func TestNextPPKRun_SameDayBeforeFour(t *testing.T) {
+	from := mustParsePPK(t, "2025-06-13T03:00:00+02:00")
+	got := nextPPKRun(from)
+	want := time.Date(2025, 6, 13, 4, 0, 0, 0, from.Location())
+	if !got.Equal(want) {
+		t.Errorf("want today 04:00, got %v", got)
+	}
+}
+
+func TestNextPPKRun_SameDayExactlyFourRollsToNextMonth(t *testing.T) {
+	from := mustParsePPK(t, "2025-06-13T04:00:00+02:00")
+	got := nextPPKRun(from)
+	want := time.Date(2025, 7, 13, 4, 0, 0, 0, from.Location())
+	if !got.Equal(want) {
+		t.Errorf("want next month, got %v", got)
+	}
+}
+
+func TestNextPPKRun_AfterThirteenthGoesToNextMonth(t *testing.T) {
+	from := mustParsePPK(t, "2025-06-20T09:30:00+02:00")
+	got := nextPPKRun(from)
+	want := time.Date(2025, 7, 13, 4, 0, 0, 0, from.Location())
+	if !got.Equal(want) {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+func TestNextPPKRun_DecemberRollsToNextYear(t *testing.T) {
+	from := mustParsePPK(t, "2025-12-20T09:30:00+01:00")
+	got := nextPPKRun(from)
+	want := time.Date(2026, 1, 13, 4, 0, 0, 0, from.Location())
+	if !got.Equal(want) {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+func TestNextPPKRun_PreservesLocation(t *testing.T) {
+	warsaw, err := time.LoadLocation("Europe/Warsaw")
+	if err != nil {
+		t.Skip("Europe/Warsaw tz unavailable")
+	}
+	from := time.Date(2025, 7, 10, 12, 0, 0, 0, warsaw)
+	got := nextPPKRun(from)
+	if got.Location() != warsaw {
+		t.Errorf("location: want Europe/Warsaw, got %v", got.Location())
+	}
+}

--- a/backend-go/internal/retirement/store.go
+++ b/backend-go/internal/retirement/store.go
@@ -285,6 +285,24 @@ func (s *Store) CurrentSalaryFor(ctx context.Context, ownerUserID *int, asOfDate
 	return v, nil
 }
 
+// CurrentSalaryRecordFor returns the latest active gross_amount and its
+// contract_type on/before asOfDate for one owner_user_id. PPK generation uses
+// it to gate on UOP (employment) contracts.
+func (s *Store) CurrentSalaryRecordFor(ctx context.Context, ownerUserID *int, asOfDate time.Time) (decimal.Decimal, string, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT gross_amount, contract_type FROM salary_records
+		WHERE owner_user_id IS NOT DISTINCT FROM $1 AND is_active = true AND date <= $2
+		ORDER BY date DESC LIMIT 1`,
+		ownerUserID, asOfDate,
+	)
+	var v decimal.Decimal
+	var contractType string
+	if err := row.Scan(&v, &contractType); err != nil {
+		return decimal.Zero, "", dbutil.MapErr(err, ErrNoSalary, "current salary")
+	}
+	return v, contractType, nil
+}
+
 // UserPPKRates returns (employee_rate, employer_rate) percentages from the
 // users table or ErrUserNotFound. A user with NULL PPK rates yields zero
 // rates (treated as "configured but not contributing").

--- a/src/routes/investments/+layout.svelte
+++ b/src/routes/investments/+layout.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { Briefcase, Coins, TrendingUp } from 'lucide-svelte';
+	import { Briefcase, Coins, PiggyBank, TrendingUp } from 'lucide-svelte';
 
 	let { children } = $props();
 
 	const tabs = [
 		{ href: '/investments/holdings', label: 'Akcje / ETF', icon: Briefcase },
 		{ href: '/investments/bonds', label: 'Obligacje', icon: Coins },
+		{ href: '/investments/ppk', label: 'PPK', icon: PiggyBank },
 		{ href: '/investments/returns', label: 'Zwroty', icon: TrendingUp }
 	];
 

--- a/src/routes/investments/ppk/+page.svelte
+++ b/src/routes/investments/ppk/+page.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+	import MetricCard from '$lib/components/MetricCard.svelte';
+	import { formatPLN } from '$lib/utils/format';
+	import { ownerName } from '$lib/types/owners';
+	import { PiggyBank, Wallet } from 'lucide-svelte';
+	import type { PageData } from './$types';
+
+	interface Props {
+		data: PageData;
+	}
+	let { data }: Props = $props();
+
+	// Household-wide rollup across every owner's PPK summary. ROI is recomputed
+	// from the summed totals rather than averaged, so it stays contribution-
+	// weighted.
+	const totalContributed = $derived(data.stats.reduce((s, p) => s + p.total_contributed, 0));
+	const totalValue = $derived(data.stats.reduce((s, p) => s + p.total_value, 0));
+	const totalReturns = $derived(data.stats.reduce((s, p) => s + p.returns, 0));
+	const roiPct = $derived(totalContributed > 0 ? (totalReturns / totalContributed) * 100 : 0);
+	const activeAccounts = $derived(data.accounts.filter((a) => a.is_active).length);
+</script>
+
+<svelte:head>
+	<title>PPK | Finansowa Forteca</title>
+</svelte:head>
+
+<div class="space-y-1 mb-6">
+	<h1 class="h2">PPK</h1>
+	<p class="text-surface-700-300 text-sm">
+		Pracownicze Plany Kapitałowe — wpłaty pracownika, pracodawcy i dopłaty państwa.
+	</p>
+</div>
+
+{#if data.stats.length === 0}
+	<div class="card preset-filled-surface-100-900 p-4">
+		<div class="text-center py-12 text-surface-700-300">
+			<p>Brak danych PPK</p>
+			<p class="text-sm mt-1">Dodaj konto z opakowaniem PPK i wpłaty, aby zobaczyć podsumowanie.</p>
+		</div>
+	</div>
+{:else}
+	<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+		<div class="card preset-filled-surface-100-900 p-4 space-y-1">
+			<header class="text-sm text-surface-700-300">Wpłacono</header>
+			<div class="text-2xl font-bold">{formatPLN(totalContributed)}</div>
+		</div>
+		<div class="card preset-filled-surface-100-900 p-4 space-y-1">
+			<header class="text-sm text-surface-700-300">Wartość bieżąca</header>
+			<div class="text-2xl font-bold text-primary-600-400">{formatPLN(totalValue)}</div>
+		</div>
+		<div class="card preset-filled-surface-100-900 p-4 space-y-1">
+			<header class="text-sm text-surface-700-300">Zysk</header>
+			<div class="text-2xl font-bold {totalReturns >= 0 ? 'text-success-500' : 'text-error-500'}">
+				{totalReturns >= 0 ? '+' : ''}{formatPLN(totalReturns)}
+			</div>
+			<div class="text-xs text-surface-600-400">
+				{totalReturns >= 0 ? '+' : ''}{roiPct.toFixed(2)}%
+			</div>
+		</div>
+		<div class="card preset-filled-surface-100-900 p-4 space-y-1">
+			<header class="text-sm text-surface-700-300">Liczba kont</header>
+			<div class="text-2xl font-bold">{activeAccounts}</div>
+		</div>
+	</div>
+
+	<div class="space-y-6">
+		{#each data.stats as stat (stat.owner_user_id)}
+			<div class="card preset-filled-surface-100-900 p-4 space-y-4">
+				<header>
+					<h3 class="h3 flex items-center gap-2">
+						<PiggyBank size={20} />
+						{ownerName(data.owners, stat.owner_user_id)}
+					</h3>
+				</header>
+				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+					<MetricCard
+						label="Wartość całkowita"
+						value={stat.total_value}
+						decimals={0}
+						suffix=" PLN"
+						color="green"
+					/>
+					<MetricCard
+						label="Wpłaty pracownika"
+						value={stat.employee_contributed}
+						decimals={0}
+						suffix=" PLN"
+						color="blue"
+					/>
+					<MetricCard
+						label="Wpłaty pracodawcy"
+						value={stat.employer_contributed}
+						decimals={0}
+						suffix=" PLN"
+						color="blue"
+					/>
+					<MetricCard
+						label="Dopłaty państwa"
+						value={stat.government_contributed}
+						decimals={0}
+						suffix=" PLN"
+						color="blue"
+					/>
+					<MetricCard
+						label="Łącznie wpłacone"
+						value={stat.total_contributed}
+						decimals={0}
+						suffix=" PLN"
+						color="blue"
+					/>
+					<MetricCard
+						label="Zyski z inwestycji"
+						value={stat.returns}
+						decimals={0}
+						suffix=" PLN"
+						color={stat.returns >= 0 ? 'green' : 'red'}
+					/>
+					<MetricCard
+						label="ROI"
+						value={stat.roi_percentage}
+						decimals={2}
+						suffix="%"
+						color={stat.roi_percentage >= 0 ? 'green' : 'red'}
+					/>
+				</div>
+			</div>
+		{/each}
+
+		<div class="card preset-filled-surface-100-900 p-4 space-y-4">
+			<header>
+				<h3 class="h3 flex items-center gap-2"><Wallet size={20} /> Konta PPK</h3>
+			</header>
+
+			{#if data.accounts.length === 0}
+				<div class="text-center py-12 text-surface-700-300">
+					<p>Brak kont PPK</p>
+				</div>
+			{:else}
+				<div class="table-wrap">
+					<table class="table table-hover">
+						<thead>
+							<tr>
+								<th>Konto</th>
+								<th>Właściciel</th>
+								<th>Status</th>
+								<th class="text-right">Wartość bieżąca</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each data.accounts as account (account.id)}
+								<tr>
+									<td class="font-medium">{account.name}</td>
+									<td>{ownerName(data.owners, account.owner_user_id)}</td>
+									<td class="text-xs text-surface-700-300">
+										{account.is_active ? 'Aktywne' : 'Nieaktywne'}
+									</td>
+									<td class="text-right font-semibold text-primary-600-400">
+										{formatPLN(account.current_value)}
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/src/routes/investments/ppk/+page.ts
+++ b/src/routes/investments/ppk/+page.ts
@@ -1,0 +1,68 @@
+import { error } from '@sveltejs/kit';
+import { resolveApiUrl } from '$lib/api';
+import type { OwnerOption } from '$lib/types/owners';
+import type { PageLoad } from './$types';
+
+// Per-owner PPK summary as served by GET /api/retirement/ppk-stats.
+export interface PPKStat {
+	owner_user_id: number | null;
+	total_value: number;
+	employee_contributed: number;
+	employer_contributed: number;
+	government_contributed: number;
+	total_contributed: number;
+	returns: number;
+	roi_percentage: number;
+}
+
+// A single PPK-wrapped account, surfaced from GET /api/accounts.
+export interface PPKAccount {
+	id: number;
+	name: string;
+	owner_user_id: number | null;
+	is_active: boolean;
+	current_value: number;
+}
+
+export const load: PageLoad = async ({ fetch }) => {
+	try {
+		const apiUrl = resolveApiUrl();
+		const [statsRes, ownersRes, accountsRes] = await Promise.all([
+			fetch(`${apiUrl}/api/retirement/ppk-stats`),
+			fetch(`${apiUrl}/api/users`),
+			fetch(`${apiUrl}/api/accounts`)
+		]);
+		if (!statsRes.ok) {
+			throw error(statsRes.status, 'Nie udało się pobrać danych PPK');
+		}
+		const stats: PPKStat[] = await statsRes.json();
+		const owners: OwnerOption[] = ownersRes.ok ? await ownersRes.json() : [];
+
+		let accounts: PPKAccount[] = [];
+		if (accountsRes.ok) {
+			const payload = await accountsRes.json();
+			accounts = (payload.assets ?? [])
+				.filter((a: { account_wrapper: string | null }) => a.account_wrapper === 'PPK')
+				.map(
+					(a: {
+						id: number;
+						name: string;
+						owner_user_id: number | null;
+						is_active: boolean;
+						current_value: number;
+					}) => ({
+						id: a.id,
+						name: a.name,
+						owner_user_id: a.owner_user_id,
+						is_active: a.is_active,
+						current_value: a.current_value
+					})
+				);
+		}
+
+		return { stats, owners, accounts };
+	} catch (err) {
+		if (err instanceof Error && 'status' in err) throw err;
+		throw error(500, 'Nie udało się pobrać danych PPK');
+	}
+};


### PR DESCRIPTION
## Motivation

Track PPK (Pracownicze Plany Kapitałowe) on the investments page and stop
hand-generating monthly contributions. PPK data already existed via
`/api/retirement/ppk-stats`, and contribution generation existed only as a
manual button — nothing fired it on a schedule.

> Changelog: feat(retirement): auto-generate monthly PPK contributions

## Implementation information

**PPK tab** (`/investments/ppk`) — read-only, mirrors the Obligacje tab:
- aggregate tiles (Wpłacono / Wartość bieżąca / Zysk + ROI% / Liczba kont)
- per-owner contribution breakdown via `MetricCard` (reusing the `/metryki`
  cards)
- PPK accounts table sourced from `/api/accounts` filtered to
  `account_wrapper = 'PPK'`
- new tab entry in `investments/+layout.svelte` (PiggyBank icon)

**Auto-generation** — new `retirement.PPKScheduler`:
- fires on the **13th @ 04:00 Europe/Warsaw**, single-instance, modeled on the
  CPI/recurring schedulers
- generates the **current month** for every eligible owner: a `UOP`
  (umowa o pracę) salary on record + configured PPK rates + an active PPK
  account
- excludes government subsidies (welcome/annual stay manual)
- idempotent via the store's per-month dedup; startup catch-up when the
  month's 13th already passed
- wired in `cmd/api/main.go`

**Shared flow** — extracted the 6-step generation into `GeneratePPK`, now used
by both the manual endpoint and the scheduler. Both enforce the UOP rule via a
new `ErrNotUOP` sentinel (→ 400 on the manual endpoint). Added
`Store.CurrentSalaryRecordFor` to read the salary's `contract_type`.

## Supporting documentation

Tests: `nextPPKRun` unit tests; `go test ./...` and the retirement black-box
suite (13 passed) green. Seed salaries are all `UOP`, so the manual endpoint's
new UOP gate doesn't regress existing tests.