### PR TITLE
fix(salaries): line to today only for current co

### DIFF
--- a/src/lib/utils/salaries.test.ts
+++ b/src/lib/utils/salaries.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { formatPctSigned, formatPlnSigned, isNonNegative, isoDateLocal } from './salaries';
+import {
+	formatPctSigned,
+	formatPlnSigned,
+	groupSalariesByCompany,
+	isNonNegative,
+	isoDateLocal
+} from './salaries';
 
 describe('isNonNegative', () => {
 	it('treats null as zero', () => {
@@ -69,5 +75,58 @@ describe('isoDateLocal', () => {
 	});
 	it('survives end-of-month rollover', () => {
 		expect(isoDateLocal(new Date(2025, 1, 28, 23, 59, 0))).toBe('2025-02-28');
+	});
+});
+
+describe('groupSalariesByCompany', () => {
+	const today = '2026-05-31';
+
+	it('extends only the current company to today', () => {
+		const map = groupSalariesByCompany(
+			[
+				{ company: 'Old Co', date: '2022-01-01', amount: 8000 },
+				{ company: 'Old Co', date: '2023-01-01', amount: 9000 },
+				{ company: 'Current Co', date: '2024-06-01', amount: 20000 },
+				{ company: 'Current Co', date: '2025-06-01', amount: 25000 }
+			],
+			today
+		);
+		expect(map.get('Old Co')).toEqual([
+			['2022-01-01', 8000],
+			['2023-01-01', 9000]
+		]);
+		expect(map.get('Current Co')).toEqual([
+			['2024-06-01', 20000],
+			['2025-06-01', 25000],
+			[today, 25000]
+		]);
+	});
+
+	it('sorts each company ascending by date before carry-forward', () => {
+		const map = groupSalariesByCompany(
+			[
+				{ company: 'Acme', date: '2025-06-01', amount: 12000 },
+				{ company: 'Acme', date: '2024-06-01', amount: 10000 }
+			],
+			today
+		);
+		expect(map.get('Acme')).toEqual([
+			['2024-06-01', 10000],
+			['2025-06-01', 12000],
+			[today, 12000]
+		]);
+	});
+
+	it('labels blank company names', () => {
+		const map = groupSalariesByCompany(
+			[{ company: '  ', date: '2025-01-01', amount: 5000 }],
+			today
+		);
+		expect([...map.keys()]).toEqual(['Nieokreślona firma']);
+	});
+
+	it('does not duplicate the today point when last record is already today', () => {
+		const map = groupSalariesByCompany([{ company: 'Acme', date: today, amount: 5000 }], today);
+		expect(map.get('Acme')).toEqual([[today, 5000]]);
 	});
 });

--- a/src/lib/utils/salaries.ts
+++ b/src/lib/utils/salaries.ts
@@ -39,3 +39,38 @@ function pad2(n: number): string {
 export function isoDateLocal(d: Date): string {
 	return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
 }
+
+// Groups [date, amount] salary points by company, sorted ascending by date.
+// Only the current company — the one holding the globally most recent record —
+// gets its last salary carried forward to `todayIso`, so it renders as a flat
+// line up to now. Old employers stay anchored to their last known date instead
+// of misleadingly extending to today.
+export function groupSalariesByCompany(
+	records: Array<{ company: string | null; date: string; amount: number }>,
+	todayIso: string
+): Map<string, Array<[string, number]>> {
+	const companyMap = new Map<string, Array<[string, number]>>();
+	for (const r of records) {
+		const companyName = (r.company ?? '').trim() || 'Nieokreślona firma';
+		if (!companyMap.has(companyName)) companyMap.set(companyName, []);
+		companyMap.get(companyName)!.push([r.date, r.amount]);
+	}
+
+	let currentCompany: string | null = null;
+	let currentCompanyLastDate = '';
+	companyMap.forEach((rows, company) => {
+		rows.sort((a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime());
+		const lastDate = rows[rows.length - 1]?.[0] ?? '';
+		if (lastDate > currentCompanyLastDate) {
+			currentCompanyLastDate = lastDate;
+			currentCompany = company;
+		}
+	});
+	if (currentCompany !== null) {
+		const rows = companyMap.get(currentCompany)!;
+		const last = rows[rows.length - 1];
+		if (last && last[0] < todayIso) rows.push([todayIso, last[1]]);
+	}
+
+	return companyMap;
+}

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -1110,13 +1110,26 @@
 		const todayDate = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 		const todayIso = isoDateLocal(todayDate);
 
-		companyMap.forEach((rows) => {
+		// The current company is the one holding the globally most recent
+		// salary record. Only its line extends to today — old employers stay
+		// anchored to their last known salary date.
+		let currentCompany: string | null = null;
+		let currentCompanyLastDate = '';
+		companyMap.forEach((rows, company) => {
 			rows.sort((a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime());
-			// Carry the most recent salary forward to today so a single-record
-			// series still renders as a flat line instead of a lone dot.
+			const lastDate = rows[rows.length - 1]?.[0] ?? '';
+			if (lastDate > currentCompanyLastDate) {
+				currentCompanyLastDate = lastDate;
+				currentCompany = company;
+			}
+		});
+		if (currentCompany !== null) {
+			const rows = companyMap.get(currentCompany)!;
+			// Carry the most recent salary forward to today so the current
+			// company renders as a flat line up to now instead of a lone dot.
 			const last = rows[rows.length - 1];
 			if (last && last[0] < todayIso) rows.push([todayIso, last[1]]);
-		});
+		}
 		const cpiLookup = buildCpiLookup(cpiSeries);
 		const hasCpi = cpiLookup !== null;
 

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -11,6 +11,7 @@
 	import {
 		formatPctSigned,
 		formatPlnSigned,
+		groupSalariesByCompany,
 		isNonNegative,
 		isoDateLocal
 	} from '$lib/utils/salaries';
@@ -1096,40 +1097,20 @@
 	};
 
 	function buildSeries(): LineSeries[] {
-		const companyMap = new Map<string, Array<[string, number]>>();
-
-		visibleSalaryRecords.forEach((r) => {
-			const companyName = (r.company ?? '').trim() || 'Nieokreślona firma';
-			if (!companyMap.has(companyName)) companyMap.set(companyName, []);
-			companyMap.get(companyName)!.push([r.date, r.gross_amount]);
-		});
-
 		const colors = ['#5E81AC', '#88C0D0', '#A3BE8C', '#EBCB8B', '#D08770', '#B48EAD', '#BF616A'];
 		// Date-only `today` matches the backend (which is also date-only).
 		const now = new Date();
 		const todayDate = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 		const todayIso = isoDateLocal(todayDate);
 
-		// The current company is the one holding the globally most recent
-		// salary record. Only its line extends to today — old employers stay
-		// anchored to their last known salary date.
-		let currentCompany: string | null = null;
-		let currentCompanyLastDate = '';
-		companyMap.forEach((rows, company) => {
-			rows.sort((a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime());
-			const lastDate = rows[rows.length - 1]?.[0] ?? '';
-			if (lastDate > currentCompanyLastDate) {
-				currentCompanyLastDate = lastDate;
-				currentCompany = company;
-			}
-		});
-		if (currentCompany !== null) {
-			const rows = companyMap.get(currentCompany)!;
-			// Carry the most recent salary forward to today so the current
-			// company renders as a flat line up to now instead of a lone dot.
-			const last = rows[rows.length - 1];
-			if (last && last[0] < todayIso) rows.push([todayIso, last[1]]);
-		}
+		const companyMap = groupSalariesByCompany(
+			visibleSalaryRecords.map((r) => ({
+				company: r.company,
+				date: r.date,
+				amount: r.gross_amount
+			})),
+			todayIso
+		);
 		const cpiLookup = buildCpiLookup(cpiSeries);
 		const hasCpi = cpiLookup !== null;
 


### PR DESCRIPTION
## Motivation

Salary progression chart carried each company's last salary forward to today, so old employers (e.g. Allegro, Sabre) rendered as flat lines reaching the present — making them look still-active. Only the current company should connect to today as a single line.

> Changelog: fix(salaries): extend only current company line to today

## Implementation information

`buildSeries()` in `src/routes/salaries/+page.svelte`: instead of extending every company series, determine the current company as the one holding the globally most recent salary record and extend only that series to today. Old employers now stop at their last actual record. Real-value and inflation-tracked series inherit the same data, so they stay consistent.

## Supporting documentation

None.