### PR TITLE
perf(metryki): parallelize page data fetches

### DIFF
--- a/src/routes/metryki/+page.ts
+++ b/src/routes/metryki/+page.ts
@@ -1,8 +1,46 @@
-import { error } from '@sveltejs/kit';
+import { error, isHttpError } from '@sveltejs/kit';
 import { resolveApiUrl } from '$lib/api';
 import { resolveRangeParams } from '$lib/utils/dateRange';
 import type { CpiSeries } from '$lib/types/cpi';
+import type { OwnerOption } from '$lib/types/owners';
 import type { RealYieldAccount } from '$lib/components/RealYieldsTable.svelte';
+
+// PpkStat / CategoryStat mirror GET /api/retirement/ppk-stats and
+// /api/investment/{stock,bond}-stats — the subset the page renders. Declared
+// here (not reused from $lib/types/retirement, whose PPKStats keys on a legacy
+// `owner` string) so PageData keeps the owner_user_id shape +page.svelte reads.
+interface PpkStat {
+	owner_user_id: number | null;
+	total_value: number;
+	employee_contributed: number;
+	employer_contributed: number;
+	government_contributed: number;
+	total_contributed: number;
+	returns: number;
+	roi_percentage: number;
+}
+
+interface CategoryStat {
+	total_value: number;
+	total_contributed: number;
+	returns: number;
+	roi_percentage: number;
+}
+
+// fetchJson GETs a URL and returns its parsed body, or `fallback` on any
+// failure (non-OK status, network error, malformed JSON). Lets the page run
+// every best-effort request inside one Promise.all without a rejection from
+// one source tearing down the batch. The explicit return type keeps the
+// fallback from narrowing T to `never[]`/`null` at each call site.
+async function fetchJson<T>(fetchFn: typeof fetch, url: string, fallback: T): Promise<T> {
+	try {
+		const res = await fetchFn(url);
+		if (!res.ok) return fallback;
+		return (await res.json()) as T;
+	} catch {
+		return fallback;
+	}
+}
 
 export async function load({ fetch, url }) {
 	try {
@@ -16,65 +54,41 @@ export async function load({ fetch, url }) {
 			? `${apiUrl}/api/dashboard?${dashboardQS.toString()}`
 			: `${apiUrl}/api/dashboard`;
 
-		const dashboardRes = await fetch(dashboardURL);
+		// Fire every request concurrently — only the dashboard fetch gates the
+		// page, so there's no reason to serialize the rest. Wall-clock load
+		// collapses from the sum of 7 round-trips to the slowest single one.
+		// Each fetch is wrapped so a network rejection can't reject the batch:
+		// the dashboard's HTTP-status check is enforced explicitly below, and
+		// every other source keeps its current degrade-to-default semantics.
+		const cpiDefault: CpiSeries = {
+			points: [],
+			base_year: null,
+			latest_year: null,
+			source: ''
+		};
+
+		const [dashboardRes, ppkStats, stockStats, bondStats, owners, realYieldAccounts, cpiSeries] =
+			await Promise.all([
+				fetch(dashboardURL),
+				fetchJson<PpkStat[]>(fetch, `${apiUrl}/api/retirement/ppk-stats`, []),
+				fetchJson<CategoryStat | null>(fetch, `${apiUrl}/api/investment/stock-stats`, null),
+				fetchJson<CategoryStat | null>(fetch, `${apiUrl}/api/investment/bond-stats`, null),
+				fetchJson<OwnerOption[]>(fetch, `${apiUrl}/api/users`, []),
+				// Accounts carry per-account real_yield_pct (post-Belka, post-CPI);
+				// the CPI series feeds the cumulative-inflation chart — both power
+				// the real-return section and degrade to empty on failure without
+				// taking down the page.
+				fetchJson<{ assets?: RealYieldAccount[] }>(fetch, `${apiUrl}/api/accounts`, {}).then(
+					(data) => (data.assets ?? []).filter((a: RealYieldAccount) => a.interest_rate_pct != null)
+				),
+				fetchJson<CpiSeries>(fetch, `${apiUrl}/api/cpi/series`, cpiDefault)
+			]);
 
 		if (!dashboardRes.ok) {
 			throw error(dashboardRes.status, 'Failed to load dashboard data');
 		}
 
 		const dashboard = await dashboardRes.json();
-
-		// Fetch PPK stats
-		const ppkStatsRes = await fetch(`${apiUrl}/api/retirement/ppk-stats`);
-		let ppkStats = [];
-		if (ppkStatsRes.ok) {
-			ppkStats = await ppkStatsRes.json();
-		}
-
-		// Fetch stock stats
-		const stockStatsRes = await fetch(`${apiUrl}/api/investment/stock-stats`);
-		let stockStats = null;
-		if (stockStatsRes.ok) {
-			stockStats = await stockStatsRes.json();
-		}
-
-		// Fetch bond stats
-		const bondStatsRes = await fetch(`${apiUrl}/api/investment/bond-stats`);
-		let bondStats = null;
-		if (bondStatsRes.ok) {
-			bondStats = await bondStatsRes.json();
-		}
-
-		// Fetch owners for owner_user_id resolution
-		const ownersRes = await fetch(`${apiUrl}/api/users`);
-		const owners = ownersRes.ok ? await ownersRes.json() : [];
-
-		// Accounts carry per-account real_yield_pct (post-Belka, post-CPI) and
-		// the CPI series feeds the cumulative-inflation chart — both power the
-		// real-return section. These are best-effort: a failure (network or
-		// malformed JSON) degrades only that section to empty, never the whole
-		// metrics page, so they get their own try/catch.
-		let realYieldAccounts: RealYieldAccount[] = [];
-		let cpiSeries: CpiSeries = { points: [], base_year: null, latest_year: null, source: '' };
-		try {
-			const accountsRes = await fetch(`${apiUrl}/api/accounts`);
-			if (accountsRes.ok) {
-				const accountsData = await accountsRes.json();
-				realYieldAccounts = (accountsData.assets ?? []).filter(
-					(a: RealYieldAccount) => a.interest_rate_pct != null
-				);
-			}
-		} catch {
-			realYieldAccounts = [];
-		}
-		try {
-			const cpiSeriesRes = await fetch(`${apiUrl}/api/cpi/series`);
-			if (cpiSeriesRes.ok) {
-				cpiSeries = await cpiSeriesRes.json();
-			}
-		} catch {
-			// keep the empty default
-		}
 
 		return {
 			metricCards: dashboard.metric_cards,
@@ -93,7 +107,7 @@ export async function load({ fetch, url }) {
 			dateTo
 		};
 	} catch (err) {
-		if (err instanceof Error && 'status' in err) {
+		if (isHttpError(err)) {
 			throw err;
 		}
 		throw error(500, 'Failed to load metrics data');

--- a/src/routes/metryki/page.test.ts
+++ b/src/routes/metryki/page.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeAll, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import Page from './+page.svelte';
+import { load } from './+page';
 
 beforeAll(() => {
 	Object.defineProperty(window, 'matchMedia', {
@@ -230,5 +231,153 @@ describe('Metryki Page with populated data', () => {
 		expect(screen.getByRole('heading', { name: 'Marcin', level: 3 })).toBeTruthy();
 		expect(screen.getByRole('heading', { name: 'Podsumowanie Akcji' })).toBeTruthy();
 		expect(screen.getByRole('heading', { name: 'Podsumowanie Obligacji' })).toBeTruthy();
+	});
+});
+
+// jsonResponse fakes the slice of the Fetch Response that the loader reads:
+// `ok`, `status`, and `json()`. `ok` derives from status like the platform.
+function jsonResponse(body: unknown, status = 200): Response {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		json: async () => body
+	} as Response;
+}
+
+// routedFetch returns a fetch stub that answers each endpoint from `routes`,
+// recording call order so concurrency can be asserted. A route value may be a
+// Response or a thrown error (to simulate a network failure).
+function routedFetch(routes: Record<string, Response | Error>) {
+	const calls: string[] = [];
+	const fetchFn = vi.fn(async (input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input.toString();
+		calls.push(url);
+		const key = Object.keys(routes).find((k) => url.includes(k));
+		const route = key ? routes[key] : undefined;
+		if (route instanceof Error) throw route;
+		if (route) return route;
+		return jsonResponse({}, 404);
+	});
+	return { fetchFn, calls };
+}
+
+const loadEvent = (fetchFn: typeof fetch) =>
+	({
+		fetch: fetchFn,
+		url: new URL('http://localhost/metryki')
+	}) as unknown as Parameters<typeof load>[0];
+
+describe('metryki load', () => {
+	const dashboardBody = {
+		metric_cards: metricCards,
+		allocation_analysis: {
+			by_category: [],
+			by_wrapper: [],
+			rebalancing: [],
+			total_investment_value: 0
+		},
+		investment_time_series: [],
+		wrapper_time_series: { ike: [], ikze: [], ppk: [] },
+		category_time_series: { stock: [], bond: [] }
+	};
+
+	const happyRoutes = (): Record<string, Response | Error> => ({
+		'/api/dashboard': jsonResponse(dashboardBody),
+		'/api/retirement/ppk-stats': jsonResponse([{ owner_user_id: 1 }]),
+		'/api/investment/stock-stats': jsonResponse({ total_value: 1 }),
+		'/api/investment/bond-stats': jsonResponse({ total_value: 2 }),
+		'/api/users': jsonResponse([{ id: 1, name: 'Marcin' }]),
+		'/api/accounts': jsonResponse({
+			assets: [
+				{ id: 1, interest_rate_pct: 5 },
+				{ id: 2, interest_rate_pct: null }
+			]
+		}),
+		'/api/cpi/series': jsonResponse({
+			points: [{ year: 2024 }],
+			base_year: 2022,
+			latest_year: 2024,
+			source: 'GUS'
+		})
+	});
+
+	it('maps every endpoint into the returned data shape', async () => {
+		const { fetchFn } = routedFetch(happyRoutes());
+		const result = await load(loadEvent(fetchFn as unknown as typeof fetch));
+
+		expect(result.metricCards).toEqual(metricCards);
+		expect(result.ppkStats).toEqual([{ owner_user_id: 1 }]);
+		expect(result.stockStats).toEqual({ total_value: 1 });
+		expect(result.bondStats).toEqual({ total_value: 2 });
+		expect(result.owners).toEqual([{ id: 1, name: 'Marcin' }]);
+		// accounts without interest_rate_pct are filtered out
+		expect(result.realYieldAccounts).toEqual([{ id: 1, interest_rate_pct: 5 }]);
+		expect(result.cpiSeries.source).toBe('GUS');
+	});
+
+	it('dispatches all seven requests before any response resolves', async () => {
+		// Gate every response behind a manually-released promise. A serial
+		// loader would dispatch request N+1 only after response N resolved, so
+		// it would have issued just one fetch while the gate is shut. The
+		// concurrent loader fires all seven up front — assert that before
+		// releasing the gate.
+		const { fetchFn } = routedFetch(happyRoutes());
+		const respond = fetchFn.getMockImplementation();
+		if (!respond) throw new Error('expected a mock implementation');
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => (release = resolve));
+		// Count dispatches in the wrapper, BEFORE the gate, so the tally reflects
+		// requests issued — not responses delivered (which the gate withholds).
+		let dispatched = 0;
+		fetchFn.mockImplementation((input: string | URL | Request) => {
+			dispatched += 1;
+			return gate.then(() => respond(input));
+		});
+
+		const pending = load(loadEvent(fetchFn as unknown as typeof fetch));
+		// Flush the synchronous dispatch microtasks without resolving the gate.
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(dispatched).toBe(7);
+
+		release();
+		await pending;
+	});
+
+	it('degrades every best-effort source to its default without failing the page', async () => {
+		const routes = happyRoutes();
+		routes['/api/retirement/ppk-stats'] = jsonResponse(null, 500);
+		routes['/api/investment/stock-stats'] = new Error('network down');
+		routes['/api/investment/bond-stats'] = jsonResponse(null, 500);
+		routes['/api/users'] = new Error('network down');
+		routes['/api/accounts'] = new Error('network down');
+		routes['/api/cpi/series'] = jsonResponse(null, 503);
+
+		const { fetchFn } = routedFetch(routes);
+		const result = await load(loadEvent(fetchFn as unknown as typeof fetch));
+
+		expect(result.ppkStats).toEqual([]);
+		expect(result.stockStats).toBeNull();
+		expect(result.bondStats).toBeNull();
+		expect(result.owners).toEqual([]);
+		expect(result.realYieldAccounts).toEqual([]);
+		expect(result.cpiSeries).toEqual({
+			points: [],
+			base_year: null,
+			latest_year: null,
+			source: ''
+		});
+		// the dashboard still loaded fine
+		expect(result.metricCards).toEqual(metricCards);
+	});
+
+	it('throws the dashboard status when the dashboard request fails', async () => {
+		const routes = happyRoutes();
+		routes['/api/dashboard'] = jsonResponse(null, 502);
+
+		const { fetchFn } = routedFetch(routes);
+		await expect(load(loadEvent(fetchFn as unknown as typeof fetch))).rejects.toMatchObject({
+			status: 502
+		});
 	});
 });


### PR DESCRIPTION
## Motivation

The `/metryki` loader (`src/routes/metryki/+page.ts`) issued **7 sequential** `await fetch` calls — dashboard, ppk-stats, stock-stats, bond-stats, users, accounts, cpi/series — each blocking the next. Wall-clock load time was the *sum* of all 7 round-trips even though only the dashboard fetch gates the others.

## Implementation information

- All 7 requests now fire concurrently inside one `Promise.all`; the loader awaits once. Wall-clock collapses to the slowest single round-trip.
- A small `fetchJson<T>` helper wraps each best-effort source so a non-OK status or network rejection degrades to the prior default instead of rejecting the batch. Semantics per endpoint are unchanged: only the dashboard fetch can fail the page; ppk/stock/bond/owners/accounts/cpi all degrade to `[]` / `null` / empty exactly as before.
- Adopted `isHttpError` (matching `routes/+page.ts`) so a failing dashboard surfaces its real HTTP status instead of being masked as a generic 500.
- Added `load`-level tests: data-shape mapping, a gated concurrency test that fails against a serial implementation, full degrade-to-default matrix, and dashboard-status propagation.

Full `{#await}`/Skeleton streaming is deliberately **out of scope** — it needs the chart sections extracted into child components (the 9 charts are created in the page's own `onMount` against `bind:this` divs that must exist at first paint). That extraction is tracked under the IA / chart-refactor subissues.

Closes #712

> Changelog: perf(metryki): parallelize page data fetches