### PR TITLE
feat(metryki): surface hidden investment metrics

### DIFF
--- a/src/lib/components/ContributionAdjustedReturns.svelte
+++ b/src/lib/components/ContributionAdjustedReturns.svelte
@@ -20,7 +20,8 @@
 		valuation_change: number;
 		simple_roi_pct: number;
 		money_weighted_pct: number | null;
-		dividends_received_net: number;
+		// Optional: older snapshots / other callers may omit it; treat missing as 0.
+		dividends_received_net?: number | null;
 		has_snapshot: boolean;
 		convergence_failed: boolean;
 	}
@@ -161,14 +162,14 @@
 					{data.valuation_change >= 0 ? '+' : ''}{fmt(data.valuation_change)} PLN
 				</dd>
 			</div>
-			{#if data.dividends_received_net !== 0}
+			{#if (data.dividends_received_net ?? 0) !== 0}
 				<div class="flex items-baseline justify-between gap-3 py-2">
 					<dt class="text-xs text-surface-600-400 shrink-0">
 						Dywidendy (netto)
 						<span class="block text-[10px] opacity-70">w okresie, po podatku</span>
 					</dt>
 					<dd class="text-base font-semibold text-right tabular-nums text-success-500">
-						+{fmt(data.dividends_received_net)} PLN
+						+{fmt(data.dividends_received_net ?? 0)} PLN
 					</dd>
 				</div>
 			{/if}

--- a/src/lib/components/ContributionAdjustedReturns.svelte
+++ b/src/lib/components/ContributionAdjustedReturns.svelte
@@ -20,6 +20,7 @@
 		valuation_change: number;
 		simple_roi_pct: number;
 		money_weighted_pct: number | null;
+		dividends_received_net: number;
 		has_snapshot: boolean;
 		convergence_failed: boolean;
 	}
@@ -160,6 +161,17 @@
 					{data.valuation_change >= 0 ? '+' : ''}{fmt(data.valuation_change)} PLN
 				</dd>
 			</div>
+			{#if data.dividends_received_net !== 0}
+				<div class="flex items-baseline justify-between gap-3 py-2">
+					<dt class="text-xs text-surface-600-400 shrink-0">
+						Dywidendy (netto)
+						<span class="block text-[10px] opacity-70">w okresie, po podatku</span>
+					</dt>
+					<dd class="text-base font-semibold text-right tabular-nums text-success-500">
+						+{fmt(data.dividends_received_net)} PLN
+					</dd>
+				</div>
+			{/if}
 			<div class="flex items-baseline justify-between gap-3 py-2">
 				<dt class="text-xs text-surface-600-400 shrink-0">
 					Zwrot (XIRR)

--- a/src/lib/components/ContributionAdjustedReturns.test.ts
+++ b/src/lib/components/ContributionAdjustedReturns.test.ts
@@ -22,6 +22,7 @@ const successPayload = {
 	valuation_change: 2000,
 	simple_roi_pct: 20,
 	money_weighted_pct: 15.5,
+	dividends_received_net: 0,
 	has_snapshot: true,
 	convergence_failed: false
 };
@@ -95,6 +96,23 @@ describe('ContributionAdjustedReturns', () => {
 		await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
 		const lastCall = fetchSpy.mock.calls[fetchSpy.mock.calls.length - 1][0] as string;
 		expect(lastCall).toContain('period=1m');
+	});
+
+	it('hides the dividends row when none were received in the period', async () => {
+		render(ContributionAdjustedReturns, { props: { scope: { type: 'all' } } });
+		await waitFor(() => expect(screen.getByText('Wartość obecna')).toBeTruthy());
+		expect(screen.queryByText('Dywidendy (netto)')).toBeNull();
+	});
+
+	it('renders the net dividends row when the period paid dividends', async () => {
+		fetchSpy.mockImplementation(
+			async () => new Response(JSON.stringify({ ...successPayload, dividends_received_net: 150.5 }))
+		);
+		render(ContributionAdjustedReturns, { props: { scope: { type: 'all' } } });
+		await waitFor(() => {
+			expect(screen.getByText('Dywidendy (netto)')).toBeTruthy();
+			expect(screen.getByText((t) => /\+150,50\s*PLN/.test(t))).toBeTruthy();
+		});
 	});
 
 	it('shows convergence-failed copy when API reports it', async () => {

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -386,7 +386,7 @@
 
 				<MetricCard
 					label="IKZE - Krańcowa stawka PIT"
-					value={(pit.marginal_tax_rate ?? 0) * 100}
+					value={pit.marginal_tax_rate == null ? null : pit.marginal_tax_rate * 100}
 					decimals={0}
 					suffix="%"
 					color="blue"

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -35,6 +35,7 @@
 	const realYieldAccounts = $derived(data.realYieldAccounts ?? []);
 	const cpiSeries = $derived(data.cpiSeries);
 	const hasCpiSeries = $derived((cpiSeries?.points?.length ?? 0) > 0);
+	const ikzePitStats = $derived(data.ikzePitStats ?? []);
 
 	let allocationChart: HTMLDivElement;
 	let inflationChart = $state<HTMLDivElement | undefined>(undefined);
@@ -363,6 +364,45 @@
 		{/each}
 	{/if}
 
+	<!-- IKZE PIT Savings Section -->
+	{#if ikzePitStats.length > 0}
+		<h2 class="h2">Korzyść podatkowa IKZE ({ikzePitStats[0].year})</h2>
+		<p class="text-sm text-surface-600-400">
+			Wpłaty na IKZE odliczasz od podstawy opodatkowania. Szacunek na podstawie krańcowej stawki PIT
+			z ostatniej pensji.
+		</p>
+		{#each ikzePitStats as pit}
+			<h3 class="h4 font-semibold mt-4 mb-3">
+				{ownerName((data.owners ?? []) as OwnerOption[], pit.owner_user_id)}
+			</h3>
+			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+				<MetricCard
+					label="IKZE - Wpłacono w tym roku"
+					value={pit.total_contributed}
+					decimals={0}
+					suffix=" PLN"
+					color="blue"
+				/>
+
+				<MetricCard
+					label="IKZE - Krańcowa stawka PIT"
+					value={(pit.marginal_tax_rate ?? 0) * 100}
+					decimals={0}
+					suffix="%"
+					color="blue"
+				/>
+
+				<MetricCard
+					label="IKZE - Szacowana ulga PIT"
+					value={pit.pit_savings}
+					decimals={0}
+					suffix=" PLN"
+					color="green"
+				/>
+			</div>
+		{/each}
+	{/if}
+
 	<!-- Stock Stats Section -->
 	{#if data.stockStats}
 		<h2 class="h2">Podsumowanie Akcji</h2>
@@ -444,6 +484,9 @@
 		<ContributionAdjustedReturns scope={{ type: 'all' }} title="Gospodarstwo" />
 		<ContributionAdjustedReturns scope={{ type: 'category', value: 'stock' }} title="Akcje" />
 		<ContributionAdjustedReturns scope={{ type: 'category', value: 'bond' }} title="Obligacje" />
+		<ContributionAdjustedReturns scope={{ type: 'wrapper', value: 'IKE' }} title="IKE" />
+		<ContributionAdjustedReturns scope={{ type: 'wrapper', value: 'IKZE' }} title="IKZE" />
+		<ContributionAdjustedReturns scope={{ type: 'wrapper', value: 'PPK' }} title="PPK" />
 	</div>
 
 	<h2 class="h2">Realne zwroty (po inflacji)</h2>

--- a/src/routes/metryki/+page.ts
+++ b/src/routes/metryki/+page.ts
@@ -27,6 +27,17 @@ interface CategoryStat {
 	roi_percentage: number;
 }
 
+// YearlyStat mirrors a GET /api/retirement/stats row. Only IKZE rows carry the
+// PIT fields; the page renders those to surface the tax benefit of IKZE.
+export interface YearlyStat {
+	year: number;
+	account_wrapper: string;
+	owner_user_id: number | null;
+	total_contributed: number;
+	marginal_tax_rate: number | null;
+	pit_savings: number | null;
+}
+
 // fetchJson GETs a URL and returns its parsed body, or `fallback` on any
 // failure (non-OK status, network error, malformed JSON). Lets the page run
 // every best-effort request inside one Promise.all without a rejection from
@@ -67,22 +78,40 @@ export async function load({ fetch, url }) {
 			source: ''
 		};
 
-		const [dashboardRes, ppkStats, stockStats, bondStats, owners, realYieldAccounts, cpiSeries] =
-			await Promise.all([
-				fetch(dashboardURL),
-				fetchJson<PpkStat[]>(fetch, `${apiUrl}/api/retirement/ppk-stats`, []),
-				fetchJson<CategoryStat | null>(fetch, `${apiUrl}/api/investment/stock-stats`, null),
-				fetchJson<CategoryStat | null>(fetch, `${apiUrl}/api/investment/bond-stats`, null),
-				fetchJson<OwnerOption[]>(fetch, `${apiUrl}/api/users`, []),
-				// Accounts carry per-account real_yield_pct (post-Belka, post-CPI);
-				// the CPI series feeds the cumulative-inflation chart — both power
-				// the real-return section and degrade to empty on failure without
-				// taking down the page.
-				fetchJson<{ assets?: RealYieldAccount[] }>(fetch, `${apiUrl}/api/accounts`, {}).then(
-					(data) => (data.assets ?? []).filter((a: RealYieldAccount) => a.interest_rate_pct != null)
-				),
-				fetchJson<CpiSeries>(fetch, `${apiUrl}/api/cpi/series`, cpiDefault)
-			]);
+		const [
+			dashboardRes,
+			ppkStats,
+			stockStats,
+			bondStats,
+			owners,
+			realYieldAccounts,
+			cpiSeries,
+			retirementStats
+		] = await Promise.all([
+			fetch(dashboardURL),
+			fetchJson<PpkStat[]>(fetch, `${apiUrl}/api/retirement/ppk-stats`, []),
+			fetchJson<CategoryStat | null>(fetch, `${apiUrl}/api/investment/stock-stats`, null),
+			fetchJson<CategoryStat | null>(fetch, `${apiUrl}/api/investment/bond-stats`, null),
+			fetchJson<OwnerOption[]>(fetch, `${apiUrl}/api/users`, []),
+			// Accounts carry per-account real_yield_pct (post-Belka, post-CPI);
+			// the CPI series feeds the cumulative-inflation chart — both power
+			// the real-return section and degrade to empty on failure without
+			// taking down the page.
+			fetchJson<{ assets?: RealYieldAccount[] }>(fetch, `${apiUrl}/api/accounts`, {}).then((data) =>
+				(data.assets ?? []).filter((a: RealYieldAccount) => a.interest_rate_pct != null)
+			),
+			fetchJson<CpiSeries>(fetch, `${apiUrl}/api/cpi/series`, cpiDefault),
+			// Yearly retirement stats (current year, all owners) — only the IKZE
+			// rows with a computed PIT benefit are surfaced below.
+			fetchJson<YearlyStat[]>(fetch, `${apiUrl}/api/retirement/stats`, [])
+		]);
+
+		// IKZE is the only Polish wrapper with an up-front PIT deduction; the
+		// backend fills pit_savings on those rows when the owner has a salary on
+		// record. Surface just those so the tax benefit is visible.
+		const ikzePitStats = retirementStats.filter(
+			(s) => s.account_wrapper === 'IKZE' && s.pit_savings != null
+		);
 
 		if (!dashboardRes.ok) {
 			throw error(dashboardRes.status, 'Failed to load dashboard data');
@@ -102,6 +131,7 @@ export async function load({ fetch, url }) {
 			owners,
 			realYieldAccounts,
 			cpiSeries,
+			ikzePitStats,
 			range,
 			dateFrom,
 			dateTo

--- a/src/routes/metryki/page.test.ts
+++ b/src/routes/metryki/page.test.ts
@@ -78,6 +78,7 @@ const mockData = {
 	owners: [],
 	realYieldAccounts: [],
 	cpiSeries: { points: [], base_year: null, latest_year: null, source: '' },
+	ikzePitStats: [],
 	range: 'all' as const,
 	dateFrom: null,
 	dateTo: null
@@ -123,6 +124,11 @@ describe('Metryki Page', () => {
 		expect(screen.queryByRole('heading', { name: 'Podsumowanie PPK' })).toBeNull();
 		expect(screen.queryByRole('heading', { name: 'Podsumowanie Akcji' })).toBeNull();
 		expect(screen.queryByRole('heading', { name: 'Podsumowanie Obligacji' })).toBeNull();
+	});
+
+	it('omits the IKZE tax-benefit section when there are no PIT stats', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.queryByRole('heading', { name: /Korzyść podatkowa IKZE/ })).toBeNull();
 	});
 });
 
@@ -205,6 +211,16 @@ describe('Metryki Page with populated data', () => {
 			latest_year: 2024,
 			source: 'GUS'
 		},
+		ikzePitStats: [
+			{
+				year: 2024,
+				account_wrapper: 'IKZE',
+				owner_user_id: 1,
+				total_contributed: 9000,
+				marginal_tax_rate: 0.32,
+				pit_savings: 2880
+			}
+		],
 		range: 'all' as const,
 		dateFrom: null,
 		dateTo: null
@@ -228,9 +244,19 @@ describe('Metryki Page with populated data', () => {
 	it('renders the PPK, stock and bond summary sections', () => {
 		render(Page, { props: { data: populatedData } });
 		expect(screen.getByRole('heading', { name: 'Podsumowanie PPK' })).toBeTruthy();
-		expect(screen.getByRole('heading', { name: 'Marcin', level: 3 })).toBeTruthy();
+		// "Marcin" heads both the PPK and IKZE owner sub-sections.
+		expect(screen.getAllByRole('heading', { name: 'Marcin', level: 3 }).length).toBeGreaterThan(0);
 		expect(screen.getByRole('heading', { name: 'Podsumowanie Akcji' })).toBeTruthy();
 		expect(screen.getByRole('heading', { name: 'Podsumowanie Obligacji' })).toBeTruthy();
+	});
+
+	it('renders the IKZE tax-benefit section with its estimated PIT saving', () => {
+		render(Page, { props: { data: populatedData } });
+		expect(screen.getByRole('heading', { name: /Korzyść podatkowa IKZE/ })).toBeTruthy();
+		expect(screen.getByText('IKZE - Szacowana ulga PIT')).toBeTruthy();
+		// pit_savings 2880 → pl-PL formats with a narrow no-break space; match on
+		// the digits regardless of which whitespace separates the thousands.
+		expect(screen.getByText((text) => /2\s*880\s*PLN/.test(text))).toBeTruthy();
 	});
 });
 
@@ -298,7 +324,33 @@ describe('metryki load', () => {
 			base_year: 2022,
 			latest_year: 2024,
 			source: 'GUS'
-		})
+		}),
+		'/api/retirement/stats': jsonResponse([
+			{
+				year: 2024,
+				account_wrapper: 'IKE',
+				owner_user_id: 1,
+				total_contributed: 5000,
+				marginal_tax_rate: null,
+				pit_savings: null
+			},
+			{
+				year: 2024,
+				account_wrapper: 'IKZE',
+				owner_user_id: 1,
+				total_contributed: 9000,
+				marginal_tax_rate: 0.32,
+				pit_savings: 2880
+			},
+			{
+				year: 2024,
+				account_wrapper: 'IKZE',
+				owner_user_id: 2,
+				total_contributed: 0,
+				marginal_tax_rate: null,
+				pit_savings: null
+			}
+		])
 	});
 
 	it('maps every endpoint into the returned data shape', async () => {
@@ -313,13 +365,24 @@ describe('metryki load', () => {
 		// accounts without interest_rate_pct are filtered out
 		expect(result.realYieldAccounts).toEqual([{ id: 1, interest_rate_pct: 5 }]);
 		expect(result.cpiSeries.source).toBe('GUS');
+		// only IKZE rows with a non-null pit_savings survive the filter
+		expect(result.ikzePitStats).toEqual([
+			{
+				year: 2024,
+				account_wrapper: 'IKZE',
+				owner_user_id: 1,
+				total_contributed: 9000,
+				marginal_tax_rate: 0.32,
+				pit_savings: 2880
+			}
+		]);
 	});
 
-	it('dispatches all seven requests before any response resolves', async () => {
+	it('dispatches all eight requests before any response resolves', async () => {
 		// Gate every response behind a manually-released promise. A serial
 		// loader would dispatch request N+1 only after response N resolved, so
 		// it would have issued just one fetch while the gate is shut. The
-		// concurrent loader fires all seven up front — assert that before
+		// concurrent loader fires all eight up front — assert that before
 		// releasing the gate.
 		const { fetchFn } = routedFetch(happyRoutes());
 		const respond = fetchFn.getMockImplementation();
@@ -338,7 +401,7 @@ describe('metryki load', () => {
 		// Flush the synchronous dispatch microtasks without resolving the gate.
 		await Promise.resolve();
 		await Promise.resolve();
-		expect(dispatched).toBe(7);
+		expect(dispatched).toBe(8);
 
 		release();
 		await pending;
@@ -352,6 +415,7 @@ describe('metryki load', () => {
 		routes['/api/users'] = new Error('network down');
 		routes['/api/accounts'] = new Error('network down');
 		routes['/api/cpi/series'] = jsonResponse(null, 503);
+		routes['/api/retirement/stats'] = jsonResponse(null, 500);
 
 		const { fetchFn } = routedFetch(routes);
 		const result = await load(loadEvent(fetchFn as unknown as typeof fetch));
@@ -361,6 +425,7 @@ describe('metryki load', () => {
 		expect(result.bondStats).toBeNull();
 		expect(result.owners).toEqual([]);
 		expect(result.realYieldAccounts).toEqual([]);
+		expect(result.ikzePitStats).toEqual([]);
 		expect(result.cpiSeries).toEqual({
 			points: [],
 			base_year: null,


### PR DESCRIPTION
## Motivation

The `/metryki` page leaves several metrics the backend already computes invisible. Closing #713 surfaces the three highest-value ones.

## Implementation information

- **IKZE PIT tax benefit** — the loader now fetches `/api/retirement/stats` (current year, all owners) and keeps the IKZE rows that carry a computed `pit_savings`. A new section shows, per owner: contributions this year, marginal PIT rate, and the estimated deduction. This is the central reason to hold IKZE for Polish taxpayers and was previously backend-only.
- **Per-wrapper contribution-adjusted returns** — added `ContributionAdjustedReturns` cards for `scope=wrapper` IKE / IKZE / PPK alongside the existing household/stock/bond cards. The backend already supported the wrapper scope.
- **Net dividends** — the returns widget now renders a "Dywidendy (netto)" row from the existing `dividends_received_net` field, shown only when a period actually paid dividends.

All three reuse existing endpoints and components; no backend changes. The new `/api/retirement/stats` fetch joins the page's `Promise.all` and degrades to `[]` on failure, so a stats outage hides only the IKZE section.

### Tests
- Loader: IKZE filter (only IKZE rows with non-null `pit_savings` survive), 8-request concurrency, degrade-to-default for the new source.
- Page: IKZE section present/absent.
- Widget: dividends row present-when-nonzero / hidden-when-zero, plus a fixture fix that previously rendered a silent NaN row.

Closes #713

> Changelog: feat(metryki): surface hidden investment metrics