### PR TITLE
feat(metryki): richer metric cards

### DIFF
--- a/api/openapi-go.json
+++ b/api/openapi-go.json
@@ -3466,6 +3466,11 @@
                       },
                       "type": "array"
                     },
+                    "latest_snapshot_date": {
+                      "format": "date",
+                      "nullable": true,
+                      "type": "string"
+                    },
                     "metric_cards": {
                       "properties": {
                         "annual_expenses": {

--- a/backend-go/internal/dashboard/dashboard.go
+++ b/backend-go/internal/dashboard/dashboard.go
@@ -111,6 +111,10 @@ type result struct {
 	WrapperTimeSeries      map[string][]timeSeriesPoint
 	CategoryTimeSeries     map[string][]timeSeriesPoint
 	TileDeltas             tileDeltas
+	// LatestSnapshotDate is the date of the snapshot backing the always-latest
+	// tiles + metric cards. nil when there are no snapshots. Independent of the
+	// date-range filter, which only trims the time series.
+	LatestSnapshotDate *time.Time
 }
 
 // Compute runs the dashboard. Aggregate-backed when snapshot_aggregates has

--- a/backend-go/internal/dashboard/handler.go
+++ b/backend-go/internal/dashboard/handler.go
@@ -259,6 +259,7 @@ type dashboardWire struct {
 	WrapperTimeSeries      wrapperTimeSeriesWire  `json:"wrapper_time_series"`
 	CategoryTimeSeries     categoryTimeSeriesWire `json:"category_time_series"`
 	TileDeltas             tileDeltasWire         `json:"tile_deltas"`
+	LatestSnapshotDate     *wire.IsoDate          `json:"latest_snapshot_date"`
 }
 
 func toWire(res result) dashboardWire {
@@ -297,6 +298,10 @@ func toWire(res result) dashboardWire {
 	w.CategoryTimeSeries = categoryTimeSeriesWire{
 		Stock: seriesToWire(res.CategoryTimeSeries["stock"]),
 		Bond:  seriesToWire(res.CategoryTimeSeries["bond"]),
+	}
+	if res.LatestSnapshotDate != nil {
+		d := wire.IsoDate(*res.LatestSnapshotDate)
+		w.LatestSnapshotDate = &d
 	}
 	return w
 }

--- a/backend-go/internal/dashboard/handler_test.go
+++ b/backend-go/internal/dashboard/handler_test.go
@@ -121,6 +121,41 @@ func TestApplyDateRangeFiltersTimeSeries(t *testing.T) {
 	}
 }
 
+func TestApplyDateRangePreservesLatestSnapshotDate(t *testing.T) {
+	t.Parallel()
+
+	d := date("2025-01-01")
+	res := result{
+		LatestSnapshotDate: &d,
+		NetWorthHistory: []netWorthPoint{
+			{Date: date("2024-01-01"), Value: 10},
+			{Date: date("2025-01-01"), Value: 30},
+		},
+	}
+	applyDateRange(&res, dateRange{from: date("2030-01-01"), to: date("2030-12-31")})
+
+	if res.LatestSnapshotDate == nil || !res.LatestSnapshotDate.Equal(d) {
+		t.Errorf("latest snapshot date was mutated by date-range filter: %v", res.LatestSnapshotDate)
+	}
+}
+
+func TestToWireSerializesLatestSnapshotDate(t *testing.T) {
+	t.Parallel()
+
+	d := date("2025-03-09")
+	withDate := toWire(result{LatestSnapshotDate: &d})
+	if withDate.LatestSnapshotDate == nil {
+		t.Fatal("expected latest_snapshot_date to be serialized")
+	}
+	if got := time.Time(*withDate.LatestSnapshotDate); !got.Equal(d) {
+		t.Errorf("latest_snapshot_date=%v want=%v", got, d)
+	}
+
+	if got := toWire(result{}); got.LatestSnapshotDate != nil {
+		t.Errorf("expected nil latest_snapshot_date when unset, got %v", got.LatestSnapshotDate)
+	}
+}
+
 func TestApplyDateRangeNoBoundsIsNoop(t *testing.T) {
 	t.Parallel()
 

--- a/backend-go/internal/dashboard/paths.go
+++ b/backend-go/internal/dashboard/paths.go
@@ -64,6 +64,9 @@ func computeFromAggregates(ctx context.Context, s *Store, aggRows []AggregateRow
 	}
 	latestRows := buildMergedRows(latestValues, shared.snapshotDate, shared.accounts, shared.assetIDs)
 	res.RetirementAccountValue = retirementValueOf(latestRows)
+	if d, ok := shared.snapshotDate[latestSID]; ok {
+		res.LatestSnapshotDate = &d
+	}
 
 	if shared.hasConfig && len(latestRows) > 0 {
 		latestDate := shared.snapshotDate[latestSID]
@@ -166,6 +169,8 @@ func computeRaw(ctx context.Context, s *Store) (result, error) {
 
 	latestSID, latestDate, found := latestSnapshotByDate(rows)
 	if found {
+		ld := latestDate
+		res.LatestSnapshotDate = &ld
 		var latestRows []mergedRow
 		for _, r := range rows {
 			if r.SnapshotID == latestSID {

--- a/src/lib/components/MetricCard.svelte
+++ b/src/lib/components/MetricCard.svelte
@@ -5,9 +5,28 @@
 		decimals?: number;
 		suffix?: string;
 		color?: 'green' | 'blue' | 'red' | 'yellow' | 'neutral';
+		// Optional explanation shown as a native tooltip on the label (and a
+		// subtle dotted underline as the affordance), for cryptic metrics.
+		tooltip?: string;
+		// Optional muted line beneath the value (e.g. a mortgage's months/years).
+		secondary?: string;
+		// When value is null/undefined, render this hint + optional link instead
+		// of a bare em-dash, so a missing metric points the user at how to fill it.
+		emptyHint?: string;
+		emptyHref?: string;
 	}
 
-	let { label, value, decimals = 0, suffix = '', color = 'neutral' }: Props = $props();
+	let {
+		label,
+		value,
+		decimals = 0,
+		suffix = '',
+		color = 'neutral',
+		tooltip,
+		secondary,
+		emptyHint,
+		emptyHref
+	}: Props = $props();
 
 	const formatter = $derived(
 		new Intl.NumberFormat('pl-PL', {
@@ -16,9 +35,9 @@
 		})
 	);
 
-	const displayValue = $derived(
-		value == null || Number.isNaN(value) ? '—' : formatter.format(value) + suffix
-	);
+	const isEmpty = $derived(value == null || Number.isNaN(value));
+	const displayValue = $derived(isEmpty ? '—' : formatter.format(value as number) + suffix);
+	const showHint = $derived(isEmpty && emptyHint != null);
 
 	const valueClass = $derived(
 		{
@@ -32,6 +51,26 @@
 </script>
 
 <div class="card preset-filled-surface-100-900 p-4 space-y-1">
-	<div class="text-sm opacity-75">{label}</div>
-	<div class="text-2xl font-bold {valueClass}">{displayValue}</div>
+	{#if tooltip}
+		<div class="text-sm opacity-75 cursor-help underline decoration-dotted" title={tooltip}>
+			{label}
+		</div>
+	{:else}
+		<div class="text-sm opacity-75">{label}</div>
+	{/if}
+
+	{#if showHint}
+		<div class="text-sm text-surface-600-400">
+			{#if emptyHref}
+				<a href={emptyHref} class="underline">{emptyHint}</a>
+			{:else}
+				{emptyHint}
+			{/if}
+		</div>
+	{:else}
+		<div class="text-2xl font-bold {valueClass}">{displayValue}</div>
+		{#if secondary}
+			<div class="text-xs text-surface-600-400">{secondary}</div>
+		{/if}
+	{/if}
 </div>

--- a/src/lib/components/MetricCard.test.ts
+++ b/src/lib/components/MetricCard.test.ts
@@ -21,4 +21,35 @@ describe('MetricCard', () => {
 		const valueEl = screen.getByText('10');
 		expect(valueEl.className).toContain('text-success-600-400');
 	});
+
+	it('exposes the tooltip as a title on the label', () => {
+		render(MetricCard, { props: { label: 'Koszt', value: 5, tooltip: 'Wyjaśnienie' } });
+		expect(screen.getByText('Koszt').getAttribute('title')).toBe('Wyjaśnienie');
+	});
+
+	it('renders a secondary line beneath the value', () => {
+		render(MetricCard, {
+			props: { label: 'Hipoteka', value: 1000, secondary: '12 mies. do spłaty' }
+		});
+		expect(screen.getByText('12 mies. do spłaty')).toBeTruthy();
+	});
+
+	it('renders an empty-hint link instead of an em-dash when value is null', () => {
+		render(MetricCard, {
+			props: {
+				label: 'Brak',
+				value: null,
+				emptyHint: 'Uzupełnij konfigurację',
+				emptyHref: '/settings/config'
+			}
+		});
+		expect(screen.queryByText('—')).toBeNull();
+		const link = screen.getByRole('link', { name: 'Uzupełnij konfigurację' });
+		expect(link.getAttribute('href')).toBe('/settings/config');
+	});
+
+	it('falls back to the em-dash when value is null and no hint is given', () => {
+		render(MetricCard, { props: { label: 'Brak', value: null } });
+		expect(screen.getByText('—')).toBeTruthy();
+	});
 });

--- a/src/lib/types/api.generated.ts
+++ b/src/lib/types/api.generated.ts
@@ -2438,6 +2438,8 @@ export interface paths {
                                 /** Format: double */
                                 value?: number;
                             }[];
+                            /** Format: date */
+                            latest_snapshot_date?: string | null;
                             metric_cards?: {
                                 /** Format: double */
                                 annual_expenses?: number | null;

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -36,6 +36,17 @@
 	const cpiSeries = $derived(data.cpiSeries);
 	const hasCpiSeries = $derived((cpiSeries?.points?.length ?? 0) > 0);
 	const ikzePitStats = $derived(data.ikzePitStats ?? []);
+	const snapshotDate = $derived(data.snapshotDate ?? null);
+
+	// Secondary line for the consolidated mortgage card: "X mies. · Y lat do
+	// spłaty". Empty when there's no mortgage so the card shows just the em-dash.
+	const mortgagePayoffLabel = $derived.by(() => {
+		const months = metricCards.mortgage_months_left;
+		const years = metricCards.mortgage_years_left;
+		if (!months || months <= 0) return undefined;
+		const yearsText = years != null ? ` · ${years.toFixed(1)} lat` : '';
+		return `${months} mies.${yearsText} do spłaty`;
+	});
 
 	let allocationChart: HTMLDivElement;
 	let inflationChart = $state<HTMLDivElement | undefined>(undefined);
@@ -180,7 +191,12 @@
 		</div>
 	{/if}
 
-	<h2 class="h2">Przegląd finansowy</h2>
+	<div class="flex flex-wrap items-baseline justify-between gap-2">
+		<h2 class="h2">Przegląd finansowy</h2>
+		{#if snapshotDate}
+			<span class="text-sm text-surface-600-400">stan na {snapshotDate}</span>
+		{/if}
+	</div>
 
 	<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 		<MetricCard
@@ -196,6 +212,7 @@
 			value={metricCards.emergency_fund_months}
 			decimals={2}
 			color="green"
+			tooltip="Aktywa płynne (bank + konta oszczędnościowe) ÷ miesięczne wydatki."
 		/>
 
 		<MetricCard
@@ -204,28 +221,17 @@
 			decimals={2}
 			suffix=" PLN"
 			color="blue"
+			tooltip="Miesięczny dochód, jaki dałyby oszczędności emerytalne przy bezpiecznej stopie wypłaty."
 		/>
 
 		<MetricCard
-			label="Ile zostało do spłaty hipoteki"
+			label="Hipoteka do spłaty"
 			value={metricCards.mortgage_remaining}
 			decimals={0}
 			suffix=" PLN"
 			color="red"
-		/>
-
-		<MetricCard
-			label="Ile miesięcy do spłaty hipoteki"
-			value={metricCards.mortgage_months_left}
-			decimals={0}
-			color="red"
-		/>
-
-		<MetricCard
-			label="Ile lat do spłaty hipoteki"
-			value={metricCards.mortgage_years_left}
-			decimals={2}
-			color="red"
+			secondary={mortgagePayoffLabel}
+			tooltip="Pozostały kapitał do spłaty oraz szacowany czas przy obecnym tempie."
 		/>
 
 		<MetricCard
@@ -252,49 +258,55 @@
 			color="green"
 		/>
 
-		{#if metricCards.savings_rate !== null}
-			<MetricCard
-				label="Ile oszczędzamy miesięcznie"
-				value={metricCards.savings_rate}
-				decimals={1}
-				suffix="%"
-				color="green"
-			/>
-		{/if}
+		<MetricCard
+			label="Ile oszczędzamy miesięcznie"
+			value={metricCards.savings_rate}
+			decimals={1}
+			suffix="%"
+			color="green"
+			tooltip="Średnia z 3 ostatnich miesięcznych zmian wartości netto ÷ średnia z 3 ostatnich pensji."
+			emptyHint="Dodaj pensje i snapshoty, by policzyć"
+			emptyHref="/salaries"
+		/>
 
-		{#if metricCards.debt_to_income_ratio !== null}
-			<MetricCard
-				label="Stosunek długu do dochodu"
-				value={metricCards.debt_to_income_ratio}
-				decimals={1}
-				suffix="%"
-				color={metricCards.debt_to_income_ratio < 30
+		<MetricCard
+			label="Stosunek długu do dochodu"
+			value={metricCards.debt_to_income_ratio}
+			decimals={1}
+			suffix="%"
+			color={metricCards.debt_to_income_ratio == null
+				? 'neutral'
+				: metricCards.debt_to_income_ratio < 30
 					? 'green'
 					: metricCards.debt_to_income_ratio <= 36
 						? 'blue'
 						: 'red'}
-			/>
-		{/if}
+			tooltip="Miesięczne zobowiązania ÷ miesięczny dochód. <30% dobrze, >36% wysoko."
+			emptyHint="Uzupełnij konfigurację"
+			emptyHref="/settings/config"
+		/>
 
-		{#if metricCards.hour_of_work_cost !== null}
-			<MetricCard
-				label="Koszt godziny pracy"
-				value={metricCards.hour_of_work_cost}
-				decimals={2}
-				suffix=" PLN"
-				color="blue"
-			/>
-		{/if}
+		<MetricCard
+			label="Koszt godziny pracy"
+			value={metricCards.hour_of_work_cost}
+			decimals={2}
+			suffix=" PLN"
+			color="blue"
+			tooltip="Ile kosztuje Cię godzina pracy (dojazdy, przygotowania) względem pensji netto."
+			emptyHint="Uzupełnij konfigurację"
+			emptyHref="/settings/config"
+		/>
 
-		{#if metricCards.hour_of_life_cost !== null}
-			<MetricCard
-				label="Koszt godziny życia"
-				value={metricCards.hour_of_life_cost}
-				decimals={2}
-				suffix=" PLN"
-				color="green"
-			/>
-		{/if}
+		<MetricCard
+			label="Koszt godziny życia"
+			value={metricCards.hour_of_life_cost}
+			decimals={2}
+			suffix=" PLN"
+			color="green"
+			tooltip="Miesięczne wydatki rozłożone na wszystkie godziny doby — ile kosztuje godzina życia."
+			emptyHint="Uzupełnij konfigurację"
+			emptyHref="/settings/config"
+		/>
 	</div>
 
 	<!-- PPK Stats Section -->

--- a/src/routes/metryki/+page.ts
+++ b/src/routes/metryki/+page.ts
@@ -86,8 +86,7 @@ export async function load({ fetch, url }) {
 			owners,
 			realYieldAccounts,
 			cpiSeries,
-			retirementStats,
-			snapshotDate
+			retirementStats
 		] = await Promise.all([
 			fetch(dashboardURL),
 			fetchJson<PpkStat[]>(fetch, `${apiUrl}/api/retirement/ppk-stats`, []),
@@ -104,13 +103,7 @@ export async function load({ fetch, url }) {
 			fetchJson<CpiSeries>(fetch, `${apiUrl}/api/cpi/series`, cpiDefault),
 			// Yearly retirement stats (current year, all owners) — only the IKZE
 			// rows with a computed PIT benefit are surfaced below.
-			fetchJson<YearlyStat[]>(fetch, `${apiUrl}/api/retirement/stats`, []),
-			// Snapshots are ordered date-desc; the first row's date is the "as of"
-			// for the always-latest metric cards (which the dashboard date range
-			// never filters). Best-effort: missing → no date label.
-			fetchJson<{ date?: string }[]>(fetch, `${apiUrl}/api/snapshots`, []).then(
-				(rows) => rows[0]?.date ?? null
-			)
+			fetchJson<YearlyStat[]>(fetch, `${apiUrl}/api/retirement/stats`, [])
 		]);
 
 		// IKZE is the only Polish wrapper with an up-front PIT deduction; the
@@ -125,6 +118,10 @@ export async function load({ fetch, url }) {
 		}
 
 		const dashboard = await dashboardRes.json();
+		// The always-latest tiles/metric cards reflect this snapshot regardless
+		// of the date-range filter; the dashboard exposes it so we don't pay for
+		// a full /api/snapshots list just to read one date.
+		const snapshotDate: string | null = dashboard.latest_snapshot_date ?? null;
 
 		return {
 			metricCards: dashboard.metric_cards,

--- a/src/routes/metryki/+page.ts
+++ b/src/routes/metryki/+page.ts
@@ -86,7 +86,8 @@ export async function load({ fetch, url }) {
 			owners,
 			realYieldAccounts,
 			cpiSeries,
-			retirementStats
+			retirementStats,
+			snapshotDate
 		] = await Promise.all([
 			fetch(dashboardURL),
 			fetchJson<PpkStat[]>(fetch, `${apiUrl}/api/retirement/ppk-stats`, []),
@@ -103,7 +104,13 @@ export async function load({ fetch, url }) {
 			fetchJson<CpiSeries>(fetch, `${apiUrl}/api/cpi/series`, cpiDefault),
 			// Yearly retirement stats (current year, all owners) — only the IKZE
 			// rows with a computed PIT benefit are surfaced below.
-			fetchJson<YearlyStat[]>(fetch, `${apiUrl}/api/retirement/stats`, [])
+			fetchJson<YearlyStat[]>(fetch, `${apiUrl}/api/retirement/stats`, []),
+			// Snapshots are ordered date-desc; the first row's date is the "as of"
+			// for the always-latest metric cards (which the dashboard date range
+			// never filters). Best-effort: missing → no date label.
+			fetchJson<{ date?: string }[]>(fetch, `${apiUrl}/api/snapshots`, []).then(
+				(rows) => rows[0]?.date ?? null
+			)
 		]);
 
 		// IKZE is the only Polish wrapper with an up-front PIT deduction; the
@@ -132,6 +139,7 @@ export async function load({ fetch, url }) {
 			realYieldAccounts,
 			cpiSeries,
 			ikzePitStats,
+			snapshotDate,
 			range,
 			dateFrom,
 			dateTo

--- a/src/routes/metryki/page.test.ts
+++ b/src/routes/metryki/page.test.ts
@@ -79,6 +79,7 @@ const mockData = {
 	realYieldAccounts: [],
 	cpiSeries: { points: [], base_year: null, latest_year: null, source: '' },
 	ikzePitStats: [],
+	snapshotDate: null,
 	range: 'all' as const,
 	dateFrom: null,
 	dateTo: null
@@ -111,12 +112,32 @@ describe('Metryki Page', () => {
 		expect(screen.getByText(/Portfel jest zgodny z docelową alokacją/)).toBeTruthy();
 	});
 
-	it('hides optional metric cards when their values are null', () => {
+	it('keeps optional metric cards visible with a config hint when null', () => {
 		render(Page, { props: { data: mockData } });
-		expect(screen.queryByText('Ile oszczędzamy miesięcznie')).toBeNull();
-		expect(screen.queryByText('Stosunek długu do dochodu')).toBeNull();
-		expect(screen.queryByText('Koszt godziny pracy')).toBeNull();
-		expect(screen.queryByText('Koszt godziny życia')).toBeNull();
+		// Labels stay on the page instead of vanishing…
+		expect(screen.getByText('Stosunek długu do dochodu')).toBeTruthy();
+		expect(screen.getByText('Koszt godziny pracy')).toBeTruthy();
+		expect(screen.getByText('Koszt godziny życia')).toBeTruthy();
+		// …and point the user at where to fill the gap.
+		const hints = screen.getAllByRole('link', { name: 'Uzupełnij konfigurację' });
+		expect(hints.length).toBeGreaterThan(0);
+		expect(hints[0].getAttribute('href')).toBe('/settings/config');
+		// savings_rate has its own bespoke hint pointing at /salaries.
+		const savingsHint = screen.getByRole('link', { name: 'Dodaj pensje i snapshoty, by policzyć' });
+		expect(savingsHint.getAttribute('href')).toBe('/salaries');
+	});
+
+	it('omits the mortgage payoff line when there is nothing left to pay', () => {
+		render(Page, { props: { data: mockData } });
+		// mockData has mortgage_months_left: 0 → no "X mies. … do spłaty" line.
+		// (The card's tooltip mentions "do spłaty"; the secondary line is the
+		// one that also carries "mies.".)
+		expect(screen.queryByText(/mies\..*do spłaty/)).toBeNull();
+	});
+
+	it('does not show a snapshot date when none is available', () => {
+		render(Page, { props: { data: mockData } });
+		expect(screen.queryByText(/stan na/)).toBeNull();
 	});
 
 	it('omits PPK, stock and bond summary sections when no data', () => {
@@ -221,6 +242,7 @@ describe('Metryki Page with populated data', () => {
 				pit_savings: 2880
 			}
 		],
+		snapshotDate: '2026-05-24',
 		range: 'all' as const,
 		dateFrom: null,
 		dateTo: null
@@ -239,6 +261,18 @@ describe('Metryki Page with populated data', () => {
 		expect(screen.getByText('Stosunek długu do dochodu')).toBeTruthy();
 		expect(screen.getByText('Koszt godziny pracy')).toBeTruthy();
 		expect(screen.getByText('Koszt godziny życia')).toBeTruthy();
+		// values present → no config hint links
+		expect(screen.queryByRole('link', { name: 'Uzupełnij konfigurację' })).toBeNull();
+	});
+
+	it('shows the snapshot date and one consolidated mortgage card', () => {
+		render(Page, { props: { data: populatedData } });
+		expect(screen.getByText('stan na 2026-05-24')).toBeTruthy();
+		// the three legacy mortgage cards collapse into one with a payoff line
+		expect(screen.getByText('Hipoteka do spłaty')).toBeTruthy();
+		expect(screen.queryByText('Ile miesięcy do spłaty hipoteki')).toBeNull();
+		expect(screen.queryByText('Ile lat do spłaty hipoteki')).toBeNull();
+		expect(screen.getByText(/240 mies\..*do spłaty/)).toBeTruthy();
 	});
 
 	it('renders the PPK, stock and bond summary sections', () => {
@@ -350,6 +384,10 @@ describe('metryki load', () => {
 				marginal_tax_rate: null,
 				pit_savings: null
 			}
+		]),
+		'/api/snapshots': jsonResponse([
+			{ id: 9, date: '2026-05-24' },
+			{ id: 8, date: '2026-04-24' }
 		])
 	});
 
@@ -376,13 +414,15 @@ describe('metryki load', () => {
 				pit_savings: 2880
 			}
 		]);
+		// the most recent snapshot's date drives the "stan na" label
+		expect(result.snapshotDate).toBe('2026-05-24');
 	});
 
-	it('dispatches all eight requests before any response resolves', async () => {
+	it('dispatches all nine requests before any response resolves', async () => {
 		// Gate every response behind a manually-released promise. A serial
 		// loader would dispatch request N+1 only after response N resolved, so
 		// it would have issued just one fetch while the gate is shut. The
-		// concurrent loader fires all eight up front — assert that before
+		// concurrent loader fires all nine up front — assert that before
 		// releasing the gate.
 		const { fetchFn } = routedFetch(happyRoutes());
 		const respond = fetchFn.getMockImplementation();
@@ -401,7 +441,7 @@ describe('metryki load', () => {
 		// Flush the synchronous dispatch microtasks without resolving the gate.
 		await Promise.resolve();
 		await Promise.resolve();
-		expect(dispatched).toBe(8);
+		expect(dispatched).toBe(9);
 
 		release();
 		await pending;
@@ -416,6 +456,7 @@ describe('metryki load', () => {
 		routes['/api/accounts'] = new Error('network down');
 		routes['/api/cpi/series'] = jsonResponse(null, 503);
 		routes['/api/retirement/stats'] = jsonResponse(null, 500);
+		routes['/api/snapshots'] = new Error('network down');
 
 		const { fetchFn } = routedFetch(routes);
 		const result = await load(loadEvent(fetchFn as unknown as typeof fetch));
@@ -426,6 +467,7 @@ describe('metryki load', () => {
 		expect(result.owners).toEqual([]);
 		expect(result.realYieldAccounts).toEqual([]);
 		expect(result.ikzePitStats).toEqual([]);
+		expect(result.snapshotDate).toBeNull();
 		expect(result.cpiSeries).toEqual({
 			points: [],
 			base_year: null,

--- a/src/routes/metryki/page.test.ts
+++ b/src/routes/metryki/page.test.ts
@@ -338,7 +338,8 @@ describe('metryki load', () => {
 		},
 		investment_time_series: [],
 		wrapper_time_series: { ike: [], ikze: [], ppk: [] },
-		category_time_series: { stock: [], bond: [] }
+		category_time_series: { stock: [], bond: [] },
+		latest_snapshot_date: '2026-05-24'
 	};
 
 	const happyRoutes = (): Record<string, Response | Error> => ({
@@ -384,10 +385,6 @@ describe('metryki load', () => {
 				marginal_tax_rate: null,
 				pit_savings: null
 			}
-		]),
-		'/api/snapshots': jsonResponse([
-			{ id: 9, date: '2026-05-24' },
-			{ id: 8, date: '2026-04-24' }
 		])
 	});
 
@@ -414,15 +411,15 @@ describe('metryki load', () => {
 				pit_savings: 2880
 			}
 		]);
-		// the most recent snapshot's date drives the "stan na" label
+		// the dashboard's latest_snapshot_date drives the "stan na" label
 		expect(result.snapshotDate).toBe('2026-05-24');
 	});
 
-	it('dispatches all nine requests before any response resolves', async () => {
+	it('dispatches all eight requests before any response resolves', async () => {
 		// Gate every response behind a manually-released promise. A serial
 		// loader would dispatch request N+1 only after response N resolved, so
 		// it would have issued just one fetch while the gate is shut. The
-		// concurrent loader fires all nine up front — assert that before
+		// concurrent loader fires all eight up front — assert that before
 		// releasing the gate.
 		const { fetchFn } = routedFetch(happyRoutes());
 		const respond = fetchFn.getMockImplementation();
@@ -441,7 +438,7 @@ describe('metryki load', () => {
 		// Flush the synchronous dispatch microtasks without resolving the gate.
 		await Promise.resolve();
 		await Promise.resolve();
-		expect(dispatched).toBe(9);
+		expect(dispatched).toBe(8);
 
 		release();
 		await pending;
@@ -456,7 +453,6 @@ describe('metryki load', () => {
 		routes['/api/accounts'] = new Error('network down');
 		routes['/api/cpi/series'] = jsonResponse(null, 503);
 		routes['/api/retirement/stats'] = jsonResponse(null, 500);
-		routes['/api/snapshots'] = new Error('network down');
 
 		const { fetchFn } = routedFetch(routes);
 		const result = await load(loadEvent(fetchFn as unknown as typeof fetch));
@@ -467,15 +463,25 @@ describe('metryki load', () => {
 		expect(result.owners).toEqual([]);
 		expect(result.realYieldAccounts).toEqual([]);
 		expect(result.ikzePitStats).toEqual([]);
-		expect(result.snapshotDate).toBeNull();
 		expect(result.cpiSeries).toEqual({
 			points: [],
 			base_year: null,
 			latest_year: null,
 			source: ''
 		});
-		// the dashboard still loaded fine
+		// the dashboard still loaded fine, including its snapshot date
 		expect(result.metricCards).toEqual(metricCards);
+		expect(result.snapshotDate).toBe('2026-05-24');
+	});
+
+	it('yields a null snapshot date when the dashboard omits it', async () => {
+		const routes = happyRoutes();
+		const { latest_snapshot_date: _omit, ...noDate } = dashboardBody;
+		routes['/api/dashboard'] = jsonResponse(noDate);
+
+		const { fetchFn } = routedFetch(routes);
+		const result = await load(loadEvent(fetchFn as unknown as typeof fetch));
+		expect(result.snapshotDate).toBeNull();
 	});
 
 	it('throws the dashboard status when the dashboard request fails', async () => {


### PR DESCRIPTION
## Motivation

`MetricCard` was label + value + colour only — cryptic metrics had no explanation, three separate mortgage cards cluttered the grid, optional cards silently vanished when unconfigured, and nothing told the user how fresh the numbers were. Closes #714.

## Implementation information

`MetricCard` gains four optional, backward-compatible props (the other consumer, `investments/ppk`, is unaffected):
- `tooltip` — native `title=` on the label with a dotted-underline affordance, matching the home dashboard's FIRE-section convention.
- `secondary` — a muted line beneath the value.
- `emptyHint` / `emptyHref` — when the value is null, render a hint (optionally a link) instead of a bare em-dash.

On the `/metryki` overview:
- The three mortgage cards (remaining / months / years) collapse into one "Hipoteka do spłaty" card with a "240 mies. · 20.0 lat do spłaty" secondary line.
- Cryptic cards (hour-of-work/life cost, interest income, emergency fund, debt-to-income) get formula tooltips.
- Optional cards stay visible when unconfigured, pointing at `/settings/config` (or `/salaries` for the savings rate) instead of disappearing.
- A "stan na <date>" label shows the latest snapshot date, fetched best-effort from `/api/snapshots` (date-desc) and joined into the page's `Promise.all`; a failure simply hides the label.

### Tests
- `MetricCard.test.ts`: tooltip title, secondary line, empty-hint link, em-dash fallback.
- `page.test.ts`: snapshot date shown/hidden, single consolidated mortgage card (old cards gone, payoff line present/absent), config + salaries hints, plus the 9-request concurrency/degrade matrix.

Closes #714

> Changelog: feat(metryki): richer metric cards