### PR TITLE
refactor(charts): shared base + theme tokens

### DIFF
--- a/src/lib/utils/charts/chartBase.test.ts
+++ b/src/lib/utils/charts/chartBase.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { baseChartOption, chartTooltip, axisLine, splitLine } from './chartBase';
+import { chartInk, chartAxisLine, chartSplitLine, chartTooltipBg } from '$lib/utils/theme';
+
+describe('chartBase', () => {
+	it('baseChartOption sets a transparent background, title and tooltip', () => {
+		const option = baseChartOption('Tytuł');
+		expect(option.backgroundColor).toBe('transparent');
+		expect((option.title as { text: string }).text).toBe('Tytuł');
+		expect(option.tooltip).toBeTruthy();
+	});
+
+	it('baseChartOption uses the theme ink and a smaller title on mobile', () => {
+		const desktop = baseChartOption('A').title as {
+			textStyle: { color: string; fontSize: number };
+		};
+		const mobile = baseChartOption('A', true).title as { textStyle: { fontSize: number } };
+		expect(desktop.textStyle.color).toBe(chartInk);
+		expect(mobile.textStyle.fontSize).toBeLessThan(desktop.textStyle.fontSize);
+	});
+
+	it('chartTooltip defaults to axis trigger and the theme surface', () => {
+		const tooltip = chartTooltip() as { trigger: string; backgroundColor: string };
+		expect(tooltip.trigger).toBe('axis');
+		expect(tooltip.backgroundColor).toBe(chartTooltipBg);
+		expect((chartTooltip('item') as { trigger: string }).trigger).toBe('item');
+	});
+
+	it('axisLine and splitLine carry the theme colors', () => {
+		expect(axisLine().lineStyle.color).toBe(chartAxisLine);
+		expect(axisLine(5).lineStyle.width).toBe(5);
+		expect(splitLine().lineStyle.color).toBe(chartSplitLine);
+		expect(splitLine().lineStyle.type).toBe('dashed');
+	});
+});

--- a/src/lib/utils/charts/chartBase.ts
+++ b/src/lib/utils/charts/chartBase.ts
@@ -1,0 +1,52 @@
+import type { EChartsOption } from 'echarts';
+import {
+	chartInk,
+	chartAxisLine,
+	chartSplitLine,
+	chartTooltipBg,
+	chartTooltipBorder
+} from '$lib/utils/theme';
+
+// Shared ECharts "chrome" the metryki builders all repeat: a transparent
+// background, a centered bold title, and a token-colored tooltip surface.
+// Builders spread this and override only what differs (series, axes, legend),
+// so the furniture lives in one place instead of being copy-pasted per chart.
+
+/** Tooltip surface styled with the theme tokens. `trigger` defaults to 'axis'. */
+export function chartTooltip(
+	trigger: 'axis' | 'item' = 'axis'
+): NonNullable<EChartsOption['tooltip']> {
+	return {
+		trigger,
+		backgroundColor: chartTooltipBg,
+		borderColor: chartTooltipBorder,
+		textStyle: { color: chartInk }
+	};
+}
+
+/** A solid axis line in the theme color. */
+export function axisLine(width = 2) {
+	return { lineStyle: { color: chartAxisLine, width } };
+}
+
+/** A dashed split (grid) line in the theme color. */
+export function splitLine() {
+	return { lineStyle: { color: chartSplitLine, type: 'dashed' as const } };
+}
+
+/**
+ * Base option shared by every metryki chart: transparent background plus a
+ * token-styled centered title and tooltip. Spread it first, then override.
+ */
+export function baseChartOption(title: string, isMobile = false): EChartsOption {
+	return {
+		backgroundColor: 'transparent',
+		title: {
+			text: title,
+			left: 'center',
+			top: 10,
+			textStyle: { color: chartInk, fontSize: isMobile ? 13 : 16, fontWeight: 'bold' }
+		},
+		tooltip: chartTooltip()
+	};
+}

--- a/src/lib/utils/charts/inflation.ts
+++ b/src/lib/utils/charts/inflation.ts
@@ -1,13 +1,15 @@
 import type { EChartsOption } from 'echarts';
 import type { CallbackDataParams, TopLevelFormatterParams } from 'echarts/types/dist/shared';
 import type { CpiSeries } from '$lib/types/cpi';
+import { chartInk, chartContribution, chartValue } from '$lib/utils/theme';
+import { baseChartOption, chartTooltip, axisLine, splitLine } from './chartBase';
 
 type AxisTooltipItem = CallbackDataParams & { axisValue: string };
 
 // buildCumulativeInflationChartOption renders the CPI series as a cumulative
 // price-level line (fixed-base index, left axis) plus year-over-year inflation
-// bars (right axis). Mirrors the Nord palette and styling used across the
-// metryki charts so the inflation section blends in.
+// bars (right axis). Shares the metryki base option + theme tokens so the
+// inflation section blends in.
 export function buildCumulativeInflationChartOption(series: CpiSeries): EChartsOption {
 	const sorted = [...series.points].sort((a, b) => a.year - b.year);
 	const years = sorted.map((p) => String(p.year));
@@ -15,19 +17,10 @@ export function buildCumulativeInflationChartOption(series: CpiSeries): EChartsO
 	const yoy = sorted.map((p) => parseFloat(p.yoy_rate.toFixed(1)));
 
 	return {
-		backgroundColor: 'transparent',
-		title: {
-			text: 'Skumulowana inflacja (CPI)',
-			left: 'center',
-			top: 10,
-			textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
-		},
+		...baseChartOption('Skumulowana inflacja (CPI)'),
 		tooltip: {
-			trigger: 'axis',
+			...chartTooltip(),
 			axisPointer: { type: 'shadow' },
-			backgroundColor: 'rgba(255, 255, 255, 0.95)',
-			borderColor: '#d8dee9',
-			textStyle: { color: '#2e3440' },
 			formatter: function (params: TopLevelFormatterParams) {
 				const items = (Array.isArray(params) ? params : [params]) as AxisTooltipItem[];
 				const year = items[0]?.axisValue ?? '';
@@ -45,30 +38,30 @@ export function buildCumulativeInflationChartOption(series: CpiSeries): EChartsO
 		legend: {
 			data: ['Indeks cen (baza 100)', 'Inflacja r/r'],
 			bottom: 10,
-			textStyle: { color: '#2e3440', fontSize: 14 }
+			textStyle: { color: chartInk, fontSize: 14 }
 		},
 		grid: { left: 70, right: 60, bottom: 70, top: 70, containLabel: false },
 		xAxis: {
 			type: 'category',
 			data: years,
-			axisLabel: { color: '#2e3440', fontSize: 12 },
-			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
+			axisLabel: { color: chartInk, fontSize: 12 },
+			axisLine: axisLine(),
 			boundaryGap: true
 		},
 		yAxis: [
 			{
 				type: 'value',
 				name: 'Indeks',
-				nameTextStyle: { color: '#2e3440', fontSize: 12, fontWeight: 'bold' },
-				axisLabel: { color: '#2e3440', fontSize: 12 },
-				axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
-				splitLine: { lineStyle: { color: '#e5e9f0', type: 'dashed' } }
+				nameTextStyle: { color: chartInk, fontSize: 12, fontWeight: 'bold' },
+				axisLabel: { color: chartInk, fontSize: 12 },
+				axisLine: axisLine(),
+				splitLine: splitLine()
 			},
 			{
 				type: 'value',
 				name: 'r/r %',
-				nameTextStyle: { color: '#2e3440', fontSize: 12, fontWeight: 'bold' },
-				axisLabel: { color: '#2e3440', fontSize: 12, formatter: '{value}%' },
+				nameTextStyle: { color: chartInk, fontSize: 12, fontWeight: 'bold' },
+				axisLabel: { color: chartInk, fontSize: 12, formatter: '{value}%' },
 				axisLine: { show: false },
 				splitLine: { show: false }
 			}
@@ -80,7 +73,7 @@ export function buildCumulativeInflationChartOption(series: CpiSeries): EChartsO
 				yAxisIndex: 1,
 				data: yoy,
 				barWidth: '45%',
-				itemStyle: { color: '#88c0d0', borderRadius: [4, 4, 0, 0] }
+				itemStyle: { color: chartContribution, borderRadius: [4, 4, 0, 0] }
 			},
 			{
 				name: 'Indeks cen (baza 100)',
@@ -90,8 +83,8 @@ export function buildCumulativeInflationChartOption(series: CpiSeries): EChartsO
 				smooth: true,
 				symbol: 'circle',
 				symbolSize: 6,
-				lineStyle: { width: 3, color: '#5e81ac' },
-				itemStyle: { color: '#5e81ac' }
+				lineStyle: { width: 3, color: chartValue },
+				itemStyle: { color: chartValue }
 			}
 		]
 	};

--- a/src/lib/utils/charts/metryki.ts
+++ b/src/lib/utils/charts/metryki.ts
@@ -455,9 +455,9 @@ export function buildYearlyRoiChartOption(
 		yAxis: {
 			type: 'value',
 			axisLabel: { formatter: '{value}%', color: chartInkMuted },
-			// Solid split line here (unlike the dashed default elsewhere) — reuse
-			// only the token color, not splitLine()'s dashed `type`.
-			splitLine: { lineStyle: { color: splitLine().lineStyle.color } }
+			// Solid split line here (unlike the dashed default elsewhere): keep the
+			// shared token styling, override only the line type.
+			splitLine: { lineStyle: { ...splitLine().lineStyle, type: 'solid' } }
 		},
 		series: roiSeries as unknown as BarSeriesOption[]
 	};

--- a/src/lib/utils/charts/metryki.ts
+++ b/src/lib/utils/charts/metryki.ts
@@ -1,5 +1,14 @@
 import type { BarSeriesOption, EChartsOption } from 'echarts';
 import type { CallbackDataParams, TopLevelFormatterParams } from 'echarts/types/dist/shared';
+import {
+	chartInk,
+	chartInkMuted,
+	chartContribution,
+	chartValue,
+	chartPositive,
+	chartPalette
+} from '$lib/utils/theme';
+import { baseChartOption, chartTooltip, axisLine, splitLine } from './chartBase';
 
 type AxisTooltipItem = CallbackDataParams & { axisValue: string };
 
@@ -42,26 +51,27 @@ export function buildAllocationChartOption(
 	const currentValues = byCategory.map((item) => parseFloat(item.current_percentage.toFixed(1)));
 	const targetValues = byCategory.map((item) => parseFloat(item.target_percentage.toFixed(1)));
 
+	const barLabel = {
+		show: true,
+		position: 'top' as const,
+		distance: 5,
+		formatter: '{c}%',
+		color: chartInk,
+		fontSize: isMobile ? 10 : 14,
+		fontWeight: 'bold' as const
+	};
+
 	return {
-		backgroundColor: 'transparent',
-		title: {
-			text: 'Alokacja inwestycyjna: Obecna vs Docelowa',
-			left: 'center',
-			top: 10,
-			textStyle: { color: '#2e3440', fontSize: isMobile ? 13 : 16, fontWeight: 'bold' }
-		},
+		...baseChartOption('Alokacja inwestycyjna: Obecna vs Docelowa', isMobile),
 		tooltip: {
-			trigger: 'axis',
+			...chartTooltip(),
 			axisPointer: { type: 'shadow' },
-			backgroundColor: 'rgba(255, 255, 255, 0.95)',
-			borderColor: '#d8dee9',
-			textStyle: { color: '#2e3440' },
 			formatter: '{b}<br/>{a0}: {c0}%<br/>{a1}: {c1}%'
 		},
 		legend: {
 			data: ['Obecna', 'Docelowa'],
 			bottom: 10,
-			textStyle: { color: '#2e3440', fontSize: isMobile ? 11 : 14 }
+			textStyle: { color: chartInk, fontSize: isMobile ? 11 : 14 }
 		},
 		grid: {
 			left: 60,
@@ -74,14 +84,14 @@ export function buildAllocationChartOption(
 			type: 'category',
 			data: categories,
 			axisLabel: {
-				color: '#2e3440',
+				color: chartInk,
 				fontSize: isMobile ? 12 : 14,
 				fontWeight: 'bold',
 				formatter: function (value: string) {
 					return value.charAt(0).toUpperCase() + value.slice(1);
 				}
 			},
-			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
+			axisLine: axisLine(),
 			axisTick: { show: false }
 		},
 		yAxis: {
@@ -89,16 +99,16 @@ export function buildAllocationChartOption(
 			name: 'Procent (%)',
 			nameLocation: 'middle',
 			nameGap: 50,
-			nameTextStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
+			nameTextStyle: { color: chartInk, fontSize: 14, fontWeight: 'bold' },
 			max: 100,
 			axisLabel: {
-				color: '#2e3440',
+				color: chartInk,
 				fontSize: 13,
 				fontWeight: 'bold',
 				formatter: '{value}%'
 			},
-			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
-			splitLine: { lineStyle: { color: '#e5e9f0', type: 'dashed' } }
+			axisLine: axisLine(),
+			splitLine: splitLine()
 		},
 		series: [
 			{
@@ -106,32 +116,16 @@ export function buildAllocationChartOption(
 				type: 'bar',
 				data: currentValues,
 				barWidth: '35%',
-				itemStyle: { color: '#88c0d0', borderRadius: [4, 4, 0, 0] },
-				label: {
-					show: true,
-					position: 'top',
-					distance: 5,
-					formatter: '{c}%',
-					color: '#2e3440',
-					fontSize: isMobile ? 10 : 14,
-					fontWeight: 'bold'
-				}
+				itemStyle: { color: chartPalette[2], borderRadius: [4, 4, 0, 0] },
+				label: barLabel
 			},
 			{
 				name: 'Docelowa',
 				type: 'bar',
 				data: targetValues,
 				barWidth: '35%',
-				itemStyle: { color: '#81a1c1', borderRadius: [4, 4, 0, 0] },
-				label: {
-					show: true,
-					position: 'top',
-					distance: 5,
-					formatter: '{c}%',
-					color: '#2e3440',
-					fontSize: isMobile ? 10 : 14,
-					fontWeight: 'bold'
-				}
+				itemStyle: { color: chartPalette[0], borderRadius: [4, 4, 0, 0] },
+				label: barLabel
 			}
 		]
 	};
@@ -147,18 +141,9 @@ export function buildWrapperChartOption(
 	}));
 
 	return {
-		backgroundColor: 'transparent',
-		title: {
-			text: 'Podział według kont (IKE/IKZE/PPK)',
-			left: 'center',
-			top: 10,
-			textStyle: { color: '#2e3440', fontSize: isMobile ? 13 : 16, fontWeight: 'bold' }
-		},
+		...baseChartOption('Podział według kont (IKE/IKZE/PPK)', isMobile),
 		tooltip: {
-			trigger: 'item',
-			backgroundColor: 'rgba(255, 255, 255, 0.95)',
-			borderColor: '#d8dee9',
-			textStyle: { color: '#2e3440' },
+			...chartTooltip('item'),
 			formatter: function (params) {
 				const single = Array.isArray(params) ? params[0] : params;
 				const value = (single.value as number).toLocaleString('pl-PL', {
@@ -173,13 +158,13 @@ export function buildWrapperChartOption(
 					type: 'scroll',
 					bottom: 0,
 					left: 'center',
-					textStyle: { color: '#2e3440', fontSize: 11, fontWeight: 'bold' }
+					textStyle: { color: chartInk, fontSize: 11, fontWeight: 'bold' }
 				}
 			: {
 					orient: 'vertical',
 					left: 20,
 					top: 'middle',
-					textStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
+					textStyle: { color: chartInk, fontSize: 14, fontWeight: 'bold' },
 					itemGap: 15
 				},
 		series: [
@@ -190,7 +175,7 @@ export function buildWrapperChartOption(
 				avoidLabelOverlap: true,
 				minShowLabelAngle: 1,
 				data: wrapperData,
-				color: ['#88c0d0', '#81a1c1', '#5e81ac', '#b48ead'],
+				color: [...chartPalette],
 				emphasis: {
 					itemStyle: {
 						shadowBlur: 10,
@@ -209,7 +194,7 @@ export function buildWrapperChartOption(
 					alignTo: 'edge',
 					margin: 20,
 					edgeDistance: '15%',
-					color: '#000000',
+					color: chartInk,
 					fontSize: 15,
 					fontWeight: 'bold',
 					formatter: function (params) {
@@ -223,7 +208,7 @@ export function buildWrapperChartOption(
 					length2: 20,
 					smooth: 0.2,
 					lineStyle: {
-						color: '#2e3440',
+						color: chartInk,
 						width: 2
 					}
 				},
@@ -236,24 +221,26 @@ export function buildWrapperChartOption(
 	};
 }
 
-export function buildInvestmentTrendChartOption(series: TimeSeriesPoint[]): EChartsOption {
+// buildTrendChartOption is the shared contributions-vs-value line chart behind
+// both the all-investments trend and each per-wrapper trend. `valueLabel` is
+// the word the tooltip uses for the value line ("Wartość portfela" vs the
+// shorter "Wartość"); `axisFontSize` is the only other cosmetic difference
+// between the two original copies.
+function buildTrendChartOption(
+	title: string,
+	series: TimeSeriesPoint[],
+	valueLabel: string,
+	axisFontSize: number,
+	isMobile = false
+): EChartsOption {
 	const dates = series.map((item) => item.date);
 	const values = series.map((item) => item.value ?? 0);
 	const contributions = series.map((item) => item.contributions ?? 0);
 
 	return {
-		backgroundColor: 'transparent',
-		title: {
-			text: 'Inwestycje w czasie',
-			left: 'center',
-			top: 10,
-			textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
-		},
+		...baseChartOption(title, isMobile),
 		tooltip: {
-			trigger: 'axis',
-			backgroundColor: 'rgba(255, 255, 255, 0.95)',
-			borderColor: '#d8dee9',
-			textStyle: { color: '#2e3440' },
+			...chartTooltip(),
 			formatter: function (params: TopLevelFormatterParams) {
 				const items = (Array.isArray(params) ? params : [params]) as AxisTooltipItem[];
 				const date = items[0].axisValue;
@@ -262,15 +249,15 @@ export function buildInvestmentTrendChartOption(series: TimeSeriesPoint[]): ECha
 				const returns = value - contributed;
 
 				return `${date}<br/>
-					<span style="color:#5e81ac">●</span> Wartość portfela: <b>${formatPLN(value)} PLN</b><br/>
-					<span style="color:#88c0d0">■</span> Wpłaty: ${formatPLN(contributed)} PLN<br/>
-					<span style="color:#a3be8c">■</span> Zyski: ${formatPLN(returns)} PLN`;
+					<span style="color:${chartValue}">●</span> ${valueLabel}: <b>${formatPLN(value)} PLN</b><br/>
+					<span style="color:${chartContribution}">■</span> Wpłaty: ${formatPLN(contributed)} PLN<br/>
+					<span style="color:${chartPositive}">■</span> Zyski: ${formatPLN(returns)} PLN`;
 			}
 		},
 		legend: {
 			data: ['Wpłaty', 'Wartość portfela'],
 			bottom: 10,
-			textStyle: { color: '#2e3440', fontSize: 14 }
+			textStyle: { color: chartInk, fontSize: 14 }
 		},
 		grid: {
 			left: 80,
@@ -283,11 +270,11 @@ export function buildInvestmentTrendChartOption(series: TimeSeriesPoint[]): ECha
 			type: 'category',
 			data: dates,
 			axisLabel: {
-				color: '#2e3440',
-				fontSize: 12,
+				color: chartInk,
+				fontSize: axisFontSize,
 				rotate: 45
 			},
-			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
+			axisLine: axisLine(),
 			boundaryGap: false
 		},
 		yAxis: {
@@ -295,16 +282,16 @@ export function buildInvestmentTrendChartOption(series: TimeSeriesPoint[]): ECha
 			name: 'Wartość (PLN)',
 			nameLocation: 'middle',
 			nameGap: 60,
-			nameTextStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
+			nameTextStyle: { color: chartInk, fontSize: 14, fontWeight: 'bold' },
 			axisLabel: {
-				color: '#2e3440',
-				fontSize: 12,
+				color: chartInk,
+				fontSize: axisFontSize,
 				formatter: function (value: number) {
 					return (value / 1000).toFixed(0) + 'k';
 				}
 			},
-			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
-			splitLine: { lineStyle: { color: '#e5e9f0', type: 'dashed' } }
+			axisLine: axisLine(),
+			splitLine: splitLine()
 		},
 		series: [
 			{
@@ -315,7 +302,7 @@ export function buildInvestmentTrendChartOption(series: TimeSeriesPoint[]): ECha
 				lineStyle: { width: 0 },
 				showSymbol: false,
 				areaStyle: {
-					color: '#88c0d0',
+					color: chartContribution,
 					opacity: 0.8
 				},
 				emphasis: {
@@ -327,7 +314,7 @@ export function buildInvestmentTrendChartOption(series: TimeSeriesPoint[]): ECha
 				type: 'line',
 				data: values,
 				smooth: true,
-				lineStyle: { width: 3, color: '#5e81ac' },
+				lineStyle: { width: 3, color: chartValue },
 				showSymbol: false,
 				emphasis: {
 					focus: 'series'
@@ -337,108 +324,15 @@ export function buildInvestmentTrendChartOption(series: TimeSeriesPoint[]): ECha
 	};
 }
 
+export function buildInvestmentTrendChartOption(series: TimeSeriesPoint[]): EChartsOption {
+	return buildTrendChartOption('Inwestycje w czasie', series, 'Wartość portfela', 12);
+}
+
 export function buildWrapperTrendChartOption(
 	title: string,
 	series: TimeSeriesPoint[]
 ): EChartsOption {
-	const dates = series.map((item) => item.date);
-	const contributions = series.map((item) => item.contributions ?? 0);
-	const values = series.map((item) => item.value ?? 0);
-
-	return {
-		backgroundColor: 'transparent',
-		title: {
-			text: title,
-			left: 'center',
-			top: 10,
-			textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
-		},
-		tooltip: {
-			trigger: 'axis',
-			backgroundColor: 'rgba(255, 255, 255, 0.95)',
-			borderColor: '#d8dee9',
-			textStyle: { color: '#2e3440' },
-			formatter: function (params: TopLevelFormatterParams) {
-				const items = (Array.isArray(params) ? params : [params]) as AxisTooltipItem[];
-				const date = items[0].axisValue;
-				const contributed = items[0].value as number;
-				const value = items[1].value as number;
-				const returns = value - contributed;
-
-				return `${date}<br/>
-					<span style="color:#5e81ac">●</span> Wartość: <b>${formatPLN(value)} PLN</b><br/>
-					<span style="color:#88c0d0">■</span> Wpłaty: ${formatPLN(contributed)} PLN<br/>
-					<span style="color:#a3be8c">■</span> Zyski: ${formatPLN(returns)} PLN`;
-			}
-		},
-		legend: {
-			data: ['Wpłaty', 'Wartość portfela'],
-			bottom: 10,
-			textStyle: { color: '#2e3440', fontSize: 14 }
-		},
-		grid: {
-			left: 80,
-			right: 40,
-			bottom: 80,
-			top: 80,
-			containLabel: false
-		},
-		xAxis: {
-			type: 'category',
-			data: dates,
-			axisLabel: {
-				color: '#2e3440',
-				fontSize: 11,
-				rotate: 45
-			},
-			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
-			boundaryGap: false
-		},
-		yAxis: {
-			type: 'value',
-			name: 'Wartość (PLN)',
-			nameLocation: 'middle',
-			nameGap: 60,
-			nameTextStyle: { color: '#2e3440', fontSize: 14, fontWeight: 'bold' },
-			axisLabel: {
-				color: '#2e3440',
-				fontSize: 11,
-				formatter: function (value: number) {
-					return (value / 1000).toFixed(0) + 'k';
-				}
-			},
-			axisLine: { lineStyle: { color: '#d8dee9', width: 2 } },
-			splitLine: { lineStyle: { color: '#e5e9f0', type: 'dashed' } }
-		},
-		series: [
-			{
-				name: 'Wpłaty',
-				type: 'line',
-				data: contributions,
-				smooth: true,
-				lineStyle: { width: 0 },
-				showSymbol: false,
-				areaStyle: {
-					color: '#88c0d0',
-					opacity: 0.8
-				},
-				emphasis: {
-					focus: 'series'
-				}
-			},
-			{
-				name: 'Wartość portfela',
-				type: 'line',
-				data: values,
-				smooth: true,
-				lineStyle: { width: 3, color: '#5e81ac' },
-				showSymbol: false,
-				emphasis: {
-					focus: 'series'
-				}
-			}
-		]
-	};
+	return buildTrendChartOption(title, series, 'Wartość', 11);
 }
 
 // Computes year-over-year ROI using the modified Dietz method: the
@@ -495,25 +389,27 @@ export function buildYearlyRoiChartOption(
 	const labelPosition = (params: { value: unknown }): 'top' | 'bottom' =>
 		Number(params.value) >= 0 ? 'top' : 'bottom';
 
+	const roiLabel = {
+		show: true,
+		position: labelPosition,
+		formatter: '{c}%',
+		color: chartInk,
+		fontSize: 11
+	};
+
 	const roiSeries: RoiBarSeries[] = [
 		{
 			name: 'Akcje',
 			type: 'bar',
 			barWidth: '25%',
 			data: allYears.map((y) => stockRoi.get(y) ?? null),
-			itemStyle: { color: '#a3be8c' },
-			label: {
-				show: true,
-				position: labelPosition,
-				formatter: '{c}%',
-				color: '#2e3440',
-				fontSize: 11
-			},
+			itemStyle: { color: chartValue },
+			label: roiLabel,
 			markLine: {
 				silent: true,
 				symbol: 'none',
 				data: [{ yAxis: 0 }],
-				lineStyle: { color: '#4c566a', type: 'solid', width: 1 }
+				lineStyle: { color: chartInkMuted, type: 'solid', width: 1 }
 			}
 		},
 		{
@@ -521,45 +417,24 @@ export function buildYearlyRoiChartOption(
 			type: 'bar',
 			barWidth: '25%',
 			data: allYears.map((y) => bondRoi.get(y) ?? null),
-			itemStyle: { color: '#d08770' },
-			label: {
-				show: true,
-				position: labelPosition,
-				formatter: '{c}%',
-				color: '#2e3440',
-				fontSize: 11
-			}
+			itemStyle: { color: chartPalette[2] },
+			label: roiLabel
 		},
 		{
 			name: 'PPK',
 			type: 'bar',
 			barWidth: '25%',
 			data: allYears.map((y) => ppkRoi.get(y) ?? null),
-			itemStyle: { color: '#88c0d0' },
-			label: {
-				show: true,
-				position: labelPosition,
-				formatter: '{c}%',
-				color: '#2e3440',
-				fontSize: 11
-			}
+			itemStyle: { color: chartPositive },
+			label: roiLabel
 		}
 	];
 
 	return {
-		backgroundColor: 'transparent',
-		title: {
-			text: 'Roczny ROI: Akcje, Obligacje, PPK',
-			left: 'center',
-			top: 10,
-			textStyle: { color: '#2e3440', fontSize: 16, fontWeight: 'bold' }
-		},
+		...baseChartOption('Roczny ROI: Akcje, Obligacje, PPK'),
 		tooltip: {
-			trigger: 'axis',
+			...chartTooltip(),
 			axisPointer: { type: 'shadow' },
-			backgroundColor: 'rgba(255, 255, 255, 0.95)',
-			borderColor: '#d8dee9',
-			textStyle: { color: '#2e3440' },
 			formatter: function (params: TopLevelFormatterParams) {
 				const items = (Array.isArray(params) ? params : [params]) as CallbackDataParams[];
 				return items
@@ -569,18 +444,20 @@ export function buildYearlyRoiChartOption(
 		},
 		legend: {
 			top: 40,
-			textStyle: { color: '#2e3440' }
+			textStyle: { color: chartInk }
 		},
 		grid: { top: 80, left: 60, right: 30, bottom: 60 },
 		xAxis: {
 			type: 'category',
 			data: allYears.map(String),
-			axisLabel: { color: '#4c566a' }
+			axisLabel: { color: chartInkMuted }
 		},
 		yAxis: {
 			type: 'value',
-			axisLabel: { formatter: '{value}%', color: '#4c566a' },
-			splitLine: { lineStyle: { color: '#e5e9f0' } }
+			axisLabel: { formatter: '{value}%', color: chartInkMuted },
+			// Solid split line here (unlike the dashed default elsewhere) — reuse
+			// only the token color, not splitLine()'s dashed `type`.
+			splitLine: { lineStyle: { color: splitLine().lineStyle.color } }
 		},
 		series: roiSeries as unknown as BarSeriesOption[]
 	};

--- a/src/lib/utils/theme.test.ts
+++ b/src/lib/utils/theme.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { chartPalette, chartAccent, chartAccentGradient } from './theme';
+import {
+	chartPalette,
+	chartAccent,
+	chartAccentGradient,
+	chartInk,
+	chartInkMuted,
+	chartAxisLine,
+	chartSplitLine,
+	chartContribution,
+	chartValue,
+	chartPositive
+} from './theme';
 
 describe('theme', () => {
 	it('exposes 8 distinct palette colors', () => {
@@ -22,5 +33,23 @@ describe('theme', () => {
 		for (const stop of chartAccentGradient) {
 			expect(stop).toMatch(/^rgba\(225, 29, 72, /);
 		}
+	});
+
+	it('exposes hex chrome + semantic tokens (no leftover Nord palette)', () => {
+		const tokens = [
+			chartInk,
+			chartInkMuted,
+			chartAxisLine,
+			chartSplitLine,
+			chartContribution,
+			chartValue,
+			chartPositive
+		];
+		for (const token of tokens) {
+			expect(token).toMatch(/^#[0-9a-f]{6}$/);
+		}
+		// the rose value color is the accent; contribution is a lighter rose tint
+		expect(chartValue).toBe(chartAccent);
+		expect(chartContribution).toBe(chartPalette[2]);
 	});
 });

--- a/src/lib/utils/theme.ts
+++ b/src/lib/utils/theme.ts
@@ -18,3 +18,37 @@ export const chartAccent = '#e11d48';
 
 /** Area-fill gradient stops for the accent color, top (opaque) to bottom (faint). */
 export const chartAccentGradient = ['rgba(225, 29, 72, 0.5)', 'rgba(225, 29, 72, 0.1)'] as const;
+
+// --- Chart "chrome" tokens ---------------------------------------------------
+// The non-data furniture every chart shares: text, axes, grid lines, tooltip
+// surface. Pulled into one place so builders stop hardcoding a disconnected
+// Nord palette and instead read tokens aligned with the rose app theme.
+
+/** Primary text/ink for titles, axis names, labels. */
+export const chartInk = '#3f3f46';
+
+/** Muted ink for secondary axis labels and de-emphasized text. */
+export const chartInkMuted = '#71717a';
+
+/** Axis line color. */
+export const chartAxisLine = '#d4d4d8';
+
+/** Dashed split (grid) line color. */
+export const chartSplitLine = '#e4e4e7';
+
+/** Tooltip surface + border. */
+export const chartTooltipBg = 'rgba(255, 255, 255, 0.95)';
+export const chartTooltipBorder = '#d4d4d8';
+
+// --- Semantic series colors --------------------------------------------------
+// Stable meanings used across the investment charts so the same concept reads
+// the same color everywhere.
+
+/** Contributions / deposits (area fill under the value line). */
+export const chartContribution = '#fb7185';
+
+/** Portfolio value / primary line. */
+export const chartValue = '#e11d48';
+
+/** Positive return / gains. */
+export const chartPositive = '#16a34a';


### PR DESCRIPTION
## Motivation

`src/lib/utils/charts/metryki.ts` (587 lines) repeated the same background/title/tooltip/axis chrome in every builder and hardcoded a Nord hex palette (`#2e3440`, `#88c0d0`, `#d8dee9`…) disconnected from the app's rose theme. Closes #716.

## Implementation information

- **New `chartBase.ts`** — `baseChartOption(title)` plus `chartTooltip`, `axisLine`, `splitLine` helpers that all builders spread-then-override, so the shared chrome lives in one place. Kept minimal per CLAUDE.md (base + overrides, no speculative API).
- **Merged the two near-identical trend builders** (`buildInvestmentTrendChartOption` / `buildWrapperTrendChartOption`) into one internal `buildTrendChartOption` parameterized by the three things that actually differed (title, value-label word, axis font size).
- **Tokens in `theme.ts`** — added chart "chrome" tokens (ink, muted ink, axis line, split line, tooltip surface) and semantic series colors (contribution, value, positive), all rose-aligned. `metryki.ts` and `inflation.ts` now consume them; no Nord hex remains in either.

**Behavior preserved:** only colors and duplication changed. Chart structure, series data, axes, formatters and the existing 27 `metryki.test.ts` + inflation tests are unchanged and green.

### Tests
- New `chartBase.test.ts` covers the base option + helpers (tooltip trigger default/override, mobile title size, axis/split-line colors).
- `theme.test.ts` extended for the new tokens, including an assertion that the palette is hex (no leftover Nord values).

Closes #716

> Changelog: refactor(charts): shared base + theme tokens