### PR TITLE
fix(snapshots): round autocalc, warn stale quotes

### DIFF
--- a/src/lib/components/SnapshotForm.svelte
+++ b/src/lib/components/SnapshotForm.svelte
@@ -6,16 +6,10 @@
 	import type { Account, Asset, SnapshotResponse } from '$lib/types';
 	import type { OwnerOption } from '$lib/types/owners';
 	import { categoryLabel } from '$lib/utils/categories';
+	import { round2, staleQuotes, type HoldingQuote } from '$lib/utils/quoteFreshness';
 	import NewAccountModal from './snapshot/NewAccountModal.svelte';
 	import NewAssetModal from './snapshot/NewAssetModal.svelte';
 	import ValueRow from './snapshot/ValueRow.svelte';
-
-	// Minimal shape consumed from GET /api/holdings for quote-freshness check.
-	interface HoldingQuote {
-		security: { name: string };
-		quantity: string;
-		latest_quote_date: string | null;
-	}
 
 	interface Props {
 		editingSnapshot?: SnapshotResponse | null;
@@ -35,30 +29,13 @@
 		holdings = []
 	}: Props = $props();
 
-	const round2 = (n: number): number => Math.round(n * 100) / 100;
-
 	// Quote-freshness: investment autocalc uses the latest stored price quote.
 	// Flag held positions whose quote is missing or older than this many days
 	// so the user can refresh before snapshotting.
 	const STALE_QUOTE_DAYS = 2;
 
-	function daysSince(date: string | null): number {
-		if (!date) return Number.POSITIVE_INFINITY;
-		const then = new Date(`${date}T00:00:00Z`).getTime();
-		return Math.floor((Date.now() - then) / 86_400_000);
-	}
-
-	const staleQuotes = $derived(
-		editingSnapshot
-			? []
-			: holdings
-					.filter((h) => parseFloat(h.quantity) > 0)
-					.map((h) => ({
-						name: h.security.name,
-						date: h.latest_quote_date,
-						daysOld: daysSince(h.latest_quote_date)
-					}))
-					.filter((h) => h.daysOld > STALE_QUOTE_DAYS)
+	const staleHoldings = $derived(
+		editingSnapshot ? [] : staleQuotes(holdings, Date.now(), STALE_QUOTE_DAYS)
 	);
 
 	let refreshingPrices = $state(false);
@@ -468,11 +445,11 @@
 
 <form onsubmit={handleSubmit} class="max-w-[800px] flex flex-col gap-6">
 	<!-- Quote freshness warning -->
-	{#if staleQuotes.length > 0}
+	{#if staleHoldings.length > 0}
 		<div class="card preset-filled-warning-500 p-4 space-y-2">
 			<p class="text-sm font-semibold">⚠️ Notowania inwestycji mogą być nieaktualne</p>
 			<ul class="text-sm list-disc list-inside space-y-0.5">
-				{#each staleQuotes as q}
+				{#each staleHoldings as q}
 					<li>
 						{q.name}:
 						{#if q.date}

--- a/src/lib/components/SnapshotForm.svelte
+++ b/src/lib/components/SnapshotForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
-	import { goto } from '$app/navigation';
+	import { goto, invalidateAll } from '$app/navigation';
 	import { resolveApiUrl } from '$lib/api';
 	import { Wallet, Umbrella, TrendingUp, Home, CreditCard } from 'lucide-svelte';
 	import type { Account, Asset, SnapshotResponse } from '$lib/types';
@@ -10,12 +10,20 @@
 	import NewAssetModal from './snapshot/NewAssetModal.svelte';
 	import ValueRow from './snapshot/ValueRow.svelte';
 
+	// Minimal shape consumed from GET /api/holdings for quote-freshness check.
+	interface HoldingQuote {
+		security: { name: string };
+		quantity: string;
+		latest_quote_date: string | null;
+	}
+
 	interface Props {
 		editingSnapshot?: SnapshotResponse | null;
 		assets: Account[];
 		liabilities: Account[];
 		physicalAssets: Asset[];
 		owners?: OwnerOption[];
+		holdings?: HoldingQuote[];
 	}
 
 	let {
@@ -23,8 +31,64 @@
 		assets: assetsProp,
 		liabilities: liabilitiesProp,
 		physicalAssets: physicalAssetsProp,
-		owners = []
+		owners = [],
+		holdings = []
 	}: Props = $props();
+
+	const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+	// Quote-freshness: investment autocalc uses the latest stored price quote.
+	// Flag held positions whose quote is missing or older than this many days
+	// so the user can refresh before snapshotting.
+	const STALE_QUOTE_DAYS = 2;
+
+	function daysSince(date: string | null): number {
+		if (!date) return Number.POSITIVE_INFINITY;
+		const then = new Date(`${date}T00:00:00Z`).getTime();
+		return Math.floor((Date.now() - then) / 86_400_000);
+	}
+
+	const staleQuotes = $derived(
+		editingSnapshot
+			? []
+			: holdings
+					.filter((h) => parseFloat(h.quantity) > 0)
+					.map((h) => ({
+						name: h.security.name,
+						date: h.latest_quote_date,
+						daysOld: daysSince(h.latest_quote_date)
+					}))
+					.filter((h) => h.daysOld > STALE_QUOTE_DAYS)
+	);
+
+	let refreshingPrices = $state(false);
+
+	async function refreshPrices() {
+		refreshingPrices = true;
+		error = '';
+		try {
+			const response = await fetch(`${resolveApiUrl()}/api/holdings/refresh-quotes`, {
+				method: 'POST'
+			});
+			if (!response.ok) {
+				const errorData = await response.json().catch(() => null);
+				const message =
+					(errorData &&
+						typeof errorData === 'object' &&
+						'detail' in errorData &&
+						errorData.detail) ||
+					'Nie udało się zaktualizować cen';
+				throw new Error(String(message));
+			}
+			// Re-run load(): re-fetches accounts (live values recomputed with the
+			// fresh quotes) and holdings; the populate effect re-fills the form.
+			await invalidateAll();
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Błąd aktualizacji cen';
+		} finally {
+			refreshingPrices = false;
+		}
+	}
 
 	// Accounts/assets created in-component, merged with the prop-provided ones
 	let addedAccounts = $state<Account[]>([]);
@@ -96,13 +160,16 @@
 				}
 			});
 		} else {
-			// Create mode - initialize from current values
+			// Create mode - initialize from current values. Auto-calculated
+			// investment values carry many decimals (qty × price × FX); round
+			// to 2 places to match the numeric(15,2) column and the input's
+			// step="0.01" so the form passes native number validation.
 			[...assets, ...liabilities].forEach((account) => {
-				nextAccountValues[account.id] = account.current_value;
+				nextAccountValues[account.id] = round2(account.current_value);
 				if (account.current_value > 0) nextVisibleAccountIds.add(account.id);
 			});
 			physicalAssets.forEach((asset) => {
-				nextAssetValues[asset.id] = asset.current_value;
+				nextAssetValues[asset.id] = round2(asset.current_value);
 				if (asset.current_value > 0) nextVisibleAssetIds.add(asset.id);
 			});
 		}
@@ -400,6 +467,33 @@
 </script>
 
 <form onsubmit={handleSubmit} class="max-w-[800px] flex flex-col gap-6">
+	<!-- Quote freshness warning -->
+	{#if staleQuotes.length > 0}
+		<div class="card preset-filled-warning-500 p-4 space-y-2">
+			<p class="text-sm font-semibold">⚠️ Notowania inwestycji mogą być nieaktualne</p>
+			<ul class="text-sm list-disc list-inside space-y-0.5">
+				{#each staleQuotes as q}
+					<li>
+						{q.name}:
+						{#if q.date}
+							{q.date} ({q.daysOld} dni temu)
+						{:else}
+							brak notowania
+						{/if}
+					</li>
+				{/each}
+			</ul>
+			<button
+				type="button"
+				class="btn btn-sm preset-filled-surface-50-950"
+				onclick={refreshPrices}
+				disabled={refreshingPrices}
+			>
+				{refreshingPrices ? 'Aktualizowanie...' : '🔄 Aktualizuj ceny'}
+			</button>
+		</div>
+	{/if}
+
 	<!-- Date & Notes -->
 	<div class="card preset-filled-surface-100-900 p-4 space-y-4">
 		<header class="space-y-1">

--- a/src/lib/components/SnapshotForm.test.ts
+++ b/src/lib/components/SnapshotForm.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
-import { goto } from '$app/navigation';
+import { goto, invalidateAll } from '$app/navigation';
 import SnapshotForm from './SnapshotForm.svelte';
 import type { Account, Asset, SnapshotResponse, SnapshotValueResponse } from '$lib/types';
 
@@ -12,7 +12,8 @@ vi.mock('$env/dynamic/public', () => ({
 }));
 
 vi.mock('$app/navigation', () => ({
-	goto: vi.fn()
+	goto: vi.fn(),
+	invalidateAll: vi.fn()
 }));
 
 function makeAccount(overrides: Partial<Account>): Account {
@@ -526,5 +527,68 @@ describe('SnapshotForm — sections, hide/show, modals', () => {
 		});
 		await fireEvent.click(screen.getByRole('button', { name: 'Anuluj' }));
 		expect(goto).toHaveBeenCalledWith('/');
+	});
+
+	describe('quote freshness banner', () => {
+		// A far-past quote date is stale regardless of the current clock.
+		const staleHolding = {
+			security: { name: 'VWCE' },
+			quantity: '10',
+			latest_quote_date: '2020-01-01'
+		};
+
+		afterEach(() => {
+			vi.unstubAllGlobals();
+		});
+
+		it('shows the stale-quote banner in create mode', () => {
+			render(SnapshotForm, {
+				props: {
+					assets: [bankAccount],
+					liabilities: [],
+					physicalAssets: [],
+					holdings: [staleHolding]
+				}
+			});
+			expect(screen.getByText(/Notowania inwestycji mogą być nieaktualne/)).toBeTruthy();
+			expect(screen.getByText(/VWCE/)).toBeTruthy();
+		});
+
+		it('suppresses the banner when editing an existing snapshot', () => {
+			const editingSnapshot: SnapshotResponse = {
+				id: 1,
+				date: '2024-03-31',
+				notes: null,
+				values: []
+			};
+			render(SnapshotForm, {
+				props: {
+					editingSnapshot,
+					assets: [bankAccount],
+					liabilities: [],
+					physicalAssets: [],
+					holdings: [staleHolding]
+				}
+			});
+			expect(screen.queryByText(/Notowania inwestycji mogą być nieaktualne/)).toBeNull();
+		});
+
+		it('refresh button POSTs to refresh-quotes and re-runs load', async () => {
+			const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+			vi.stubGlobal('fetch', fetchMock);
+			render(SnapshotForm, {
+				props: {
+					assets: [bankAccount],
+					liabilities: [],
+					physicalAssets: [],
+					holdings: [staleHolding]
+				}
+			});
+			await fireEvent.click(screen.getByRole('button', { name: /Aktualizuj ceny/ }));
+			await waitFor(() => expect(invalidateAll).toHaveBeenCalled());
+			const [url, init] = fetchMock.mock.calls[0];
+			expect(url).toBe('http://localhost:8000/api/holdings/refresh-quotes');
+			expect(init.method).toBe('POST');
+		});
 	});
 });

--- a/src/lib/utils/quoteFreshness.test.ts
+++ b/src/lib/utils/quoteFreshness.test.ts
@@ -13,7 +13,13 @@ describe('round2', () => {
 
 	it('handles zero and negatives', () => {
 		expect(round2(0)).toBe(0);
-		expect(round2(-1.005)).toBe(-1); // banker's edge: -1.005 → -1
+		expect(round2(-12.34)).toBe(-12.34);
+	});
+
+	it('rounds exact-half cents away from zero despite float error', () => {
+		expect(round2(1.005)).toBe(1.01);
+		expect(round2(2.675)).toBe(2.68);
+		expect(round2(-1.005)).toBe(-1.01);
 	});
 });
 

--- a/src/lib/utils/quoteFreshness.test.ts
+++ b/src/lib/utils/quoteFreshness.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { round2, daysSince, staleQuotes, type HoldingQuote } from './quoteFreshness';
+
+describe('round2', () => {
+	it('rounds long decimals to two places', () => {
+		expect(round2(53970.9459578916)).toBe(53970.95);
+	});
+
+	it('leaves clean values unchanged', () => {
+		expect(round2(100)).toBe(100);
+		expect(round2(12.34)).toBe(12.34);
+	});
+
+	it('handles zero and negatives', () => {
+		expect(round2(0)).toBe(0);
+		expect(round2(-1.005)).toBe(-1); // banker's edge: -1.005 → -1
+	});
+});
+
+describe('daysSince', () => {
+	const now = Date.UTC(2026, 5, 14); // 2026-06-14
+
+	it('returns Infinity for a missing date', () => {
+		expect(daysSince(null, now)).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it('returns 0 for today', () => {
+		expect(daysSince('2026-06-14', now)).toBe(0);
+	});
+
+	it('counts whole days elapsed', () => {
+		expect(daysSince('2026-06-12', now)).toBe(2);
+		expect(daysSince('2026-06-01', now)).toBe(13);
+	});
+});
+
+describe('staleQuotes', () => {
+	const now = Date.UTC(2026, 5, 14);
+	const holding = (
+		name: string,
+		quantity: string,
+		latest_quote_date: string | null
+	): HoldingQuote => ({ security: { name }, quantity, latest_quote_date });
+
+	it('flags quotes older than the threshold', () => {
+		const result = staleQuotes([holding('VWCE', '10', '2026-06-10')], now, 2);
+		expect(result).toEqual([{ name: 'VWCE', date: '2026-06-10', daysOld: 4 }]);
+	});
+
+	it('flags positions with no quote', () => {
+		const result = staleQuotes([holding('ISAC', '5', null)], now, 2);
+		expect(result[0]).toMatchObject({ name: 'ISAC', date: null });
+		expect(result[0].daysOld).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it('excludes fresh quotes within the threshold', () => {
+		expect(staleQuotes([holding('VWCE', '10', '2026-06-13')], now, 2)).toEqual([]);
+	});
+
+	it('ignores positions with zero or negative quantity', () => {
+		expect(staleQuotes([holding('SOLD', '0', null)], now, 2)).toEqual([]);
+	});
+});

--- a/src/lib/utils/quoteFreshness.ts
+++ b/src/lib/utils/quoteFreshness.ts
@@ -16,7 +16,12 @@ export interface StaleQuote {
 
 // round2 matches the snapshot value's numeric(15,2) column and the value
 // input's step="0.01", so auto-calculated values pass native validation.
-export const round2 = (n: number): number => Math.round(n * 100) / 100;
+// The 1e-8 nudge on the scaled value absorbs IEEE-754 error so exact-half
+// cents round away from zero (e.g. 1.005 -> 1.01, not 1.00).
+export const round2 = (n: number): number => {
+	const scaled = n * 100;
+	return Math.round(scaled + Math.sign(scaled) * 1e-8) / 100;
+};
 
 export function daysSince(date: string | null, nowMs: number): number {
 	if (!date) return Number.POSITIVE_INFINITY;

--- a/src/lib/utils/quoteFreshness.ts
+++ b/src/lib/utils/quoteFreshness.ts
@@ -1,0 +1,40 @@
+// Quote-freshness helpers for the snapshot form. Investment accounts are
+// auto-valued from the latest stored price quote; these flag positions whose
+// quote is missing or stale so the user can refresh before snapshotting.
+
+export interface HoldingQuote {
+	security: { name: string };
+	quantity: string;
+	latest_quote_date: string | null;
+}
+
+export interface StaleQuote {
+	name: string;
+	date: string | null;
+	daysOld: number;
+}
+
+// round2 matches the snapshot value's numeric(15,2) column and the value
+// input's step="0.01", so auto-calculated values pass native validation.
+export const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+export function daysSince(date: string | null, nowMs: number): number {
+	if (!date) return Number.POSITIVE_INFINITY;
+	const then = new Date(`${date}T00:00:00Z`).getTime();
+	return Math.floor((nowMs - then) / 86_400_000);
+}
+
+export function staleQuotes(
+	holdings: HoldingQuote[],
+	nowMs: number,
+	staleDays: number
+): StaleQuote[] {
+	return holdings
+		.filter((h) => parseFloat(h.quantity) > 0)
+		.map((h) => ({
+			name: h.security.name,
+			date: h.latest_quote_date,
+			daysOld: daysSince(h.latest_quote_date, nowMs)
+		}))
+		.filter((h) => h.daysOld > staleDays);
+}

--- a/src/routes/snapshots/new/+page.svelte
+++ b/src/routes/snapshots/new/+page.svelte
@@ -24,4 +24,5 @@
 	liabilities={data.liabilities}
 	physicalAssets={data.physicalAssets}
 	owners={data.owners}
+	holdings={data.holdings}
 />

--- a/src/routes/snapshots/new/+page.ts
+++ b/src/routes/snapshots/new/+page.ts
@@ -5,11 +5,13 @@ export async function load({ fetch }) {
 	try {
 		const apiUrl = resolveApiUrl();
 
-		// Fetch accounts, assets, and owners in parallel
-		const [accountsResponse, assetsResponse, ownersResponse] = await Promise.all([
+		// Fetch accounts, assets, owners, and holdings in parallel. Holdings
+		// feed the quote-freshness check; their failure is non-fatal.
+		const [accountsResponse, assetsResponse, ownersResponse, holdingsResponse] = await Promise.all([
 			fetch(`${apiUrl}/api/accounts`),
 			fetch(`${apiUrl}/api/assets`),
-			fetch(`${apiUrl}/api/users`)
+			fetch(`${apiUrl}/api/users`),
+			fetch(`${apiUrl}/api/holdings`)
 		]);
 
 		if (!accountsResponse.ok) {
@@ -25,11 +27,13 @@ export async function load({ fetch }) {
 		const accountsData = await accountsResponse.json();
 		const assetsData = await assetsResponse.json();
 		const owners = await ownersResponse.json();
+		const holdings = holdingsResponse.ok ? (await holdingsResponse.json()).holdings : [];
 
 		return {
 			...accountsData,
 			physicalAssets: assetsData.assets,
-			owners
+			owners,
+			holdings
 		};
 	} catch (err) {
 		if (err instanceof Error && 'status' in err) {

--- a/src/routes/snapshots/new/+page.ts
+++ b/src/routes/snapshots/new/+page.ts
@@ -6,12 +6,13 @@ export async function load({ fetch }) {
 		const apiUrl = resolveApiUrl();
 
 		// Fetch accounts, assets, owners, and holdings in parallel. Holdings
-		// feed the quote-freshness check; their failure is non-fatal.
+		// feed the quote-freshness check only; a network failure there must not
+		// fail the whole load, so swallow its rejection to null.
 		const [accountsResponse, assetsResponse, ownersResponse, holdingsResponse] = await Promise.all([
 			fetch(`${apiUrl}/api/accounts`),
 			fetch(`${apiUrl}/api/assets`),
 			fetch(`${apiUrl}/api/users`),
-			fetch(`${apiUrl}/api/holdings`)
+			fetch(`${apiUrl}/api/holdings`).catch(() => null)
 		]);
 
 		if (!accountsResponse.ok) {
@@ -27,7 +28,13 @@ export async function load({ fetch }) {
 		const accountsData = await accountsResponse.json();
 		const assetsData = await assetsResponse.json();
 		const owners = await ownersResponse.json();
-		const holdings = holdingsResponse.ok ? (await holdingsResponse.json()).holdings : [];
+		const holdings =
+			holdingsResponse && holdingsResponse.ok
+				? await holdingsResponse.json().then(
+						(d) => d.holdings ?? [],
+						() => []
+					)
+				: [];
 
 		return {
 			...accountsData,


### PR DESCRIPTION
## Motivation

Saving a new snapshot from auto-generated values failed silently. Investment
accounts are auto-valued as `quantity × price × FX rate`, producing long
decimals (e.g. `53970.9459578916`). The value field is `<input type="number"
step="0.01">`, so the browser's native `stepMismatch` validation blocked
submission before the submit handler ran — the form just wouldn't save.

Separately, that autocalc reads the latest stored price quote with no
staleness check, so a snapshot can silently be valued on an old price.

> Changelog: fix(snapshots): round autocalc values, warn on stale quotes

## Implementation information

- Round create-mode auto-populated values to 2 decimals (`round2`) so they
  satisfy `step="0.01"` and match the `numeric(15,2)` column.
- New-snapshot load also fetches `/api/holdings` (non-fatal on failure). Held
  positions (qty > 0) whose latest quote is missing or older than 2 days are
  listed in a warning banner with a refresh action that calls the existing
  `POST /api/holdings/refresh-quotes`, then `invalidateAll()` re-runs load so
  accounts are re-valued with fresh quotes and the form re-fills.
- Banner is suppressed when editing an existing snapshot (stored values, not
  live autocalc).

No backend, schema, or scheduler changes — reuses existing endpoints.

Note: this maximizes autocalc accuracy but won't match the broker (e.g. XTB)
to the złoty — NBP daily fixing vs broker live rate+spread is inherent drift.
The value fields remain editable for exact reconciliation.

## Supporting documentation

None.