### PR TITLE
refactor(validation): centralize decimal parsing

### DIFF
--- a/backend-go/internal/holdings/validation.go
+++ b/backend-go/internal/holdings/validation.go
@@ -117,7 +117,7 @@ func buildLotInput(raw map[string]json.RawMessage) (Lot, *httputil.ValidationErr
 		return l, &httputil.ValidationError{Field: "price", Msg: "must not be negative"}
 	}
 	l.Price = price
-	if fee, vErr := validation.OptionalDecimal(raw, "fee"); vErr != nil {
+	if fee, vErr := validation.OptionalDecimalStringOrNumber(raw, "fee"); vErr != nil {
 		return l, vErr
 	} else if fee != nil {
 		if fee.Sign() < 0 {
@@ -203,7 +203,7 @@ func buildDividendInput(raw map[string]json.RawMessage) (Dividend, *httputil.Val
 		return d, &httputil.ValidationError{Field: "gross_amount", Msg: "must be positive"}
 	}
 	d.GrossAmount = gross
-	if tax, vErr := validation.OptionalDecimal(raw, "withholding_tax"); vErr != nil {
+	if tax, vErr := validation.OptionalDecimalStringOrNumber(raw, "withholding_tax"); vErr != nil {
 		return d, vErr
 	} else if tax != nil {
 		if tax.Sign() < 0 {
@@ -263,5 +263,5 @@ func requireString2(raw map[string]json.RawMessage, key string) (string, *httput
 }
 
 func requireDecimal(raw map[string]json.RawMessage, key string) (decimal.Decimal, *httputil.ValidationError) {
-	return validation.RequiredDecimal(raw, key, "required")
+	return validation.RequiredDecimalStringOrNumber(raw, key, "required")
 }

--- a/backend-go/internal/holdings/validation.go
+++ b/backend-go/internal/holdings/validation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 func buildSecurityInput(raw map[string]json.RawMessage) (Security, *httputil.ValidationError) {
@@ -116,15 +117,13 @@ func buildLotInput(raw map[string]json.RawMessage) (Lot, *httputil.ValidationErr
 		return l, &httputil.ValidationError{Field: "price", Msg: "must not be negative"}
 	}
 	l.Price = price
-	if v, ok := raw["fee"]; ok && string(v) != "null" {
-		fee, ferr := decimal.NewFromString(strings.Trim(string(v), `"`))
-		if ferr != nil {
-			return l, &httputil.ValidationError{Field: "fee", Msg: "must be a number"}
-		}
+	if fee, vErr := validation.OptionalDecimal(raw, "fee"); vErr != nil {
+		return l, vErr
+	} else if fee != nil {
 		if fee.Sign() < 0 {
 			return l, &httputil.ValidationError{Field: "fee", Msg: "must not be negative"}
 		}
-		l.Fee = fee
+		l.Fee = *fee
 	}
 	dateStr, vErr := requireString2(raw, "date")
 	if vErr != nil {
@@ -204,18 +203,16 @@ func buildDividendInput(raw map[string]json.RawMessage) (Dividend, *httputil.Val
 		return d, &httputil.ValidationError{Field: "gross_amount", Msg: "must be positive"}
 	}
 	d.GrossAmount = gross
-	if v, ok := raw["withholding_tax"]; ok && string(v) != "null" {
-		tax, terr := decimal.NewFromString(strings.Trim(string(v), `"`))
-		if terr != nil {
-			return d, &httputil.ValidationError{Field: "withholding_tax", Msg: "must be a number"}
-		}
+	if tax, vErr := validation.OptionalDecimal(raw, "withholding_tax"); vErr != nil {
+		return d, vErr
+	} else if tax != nil {
 		if tax.Sign() < 0 {
 			return d, &httputil.ValidationError{Field: "withholding_tax", Msg: "must not be negative"}
 		}
 		if tax.GreaterThan(gross) {
 			return d, &httputil.ValidationError{Field: "withholding_tax", Msg: "must not exceed gross amount"}
 		}
-		d.WithholdingTax = tax
+		d.WithholdingTax = *tax
 	}
 	if v, ok := raw["currency"]; ok && string(v) != "null" {
 		var c string
@@ -266,13 +263,5 @@ func requireString2(raw map[string]json.RawMessage, key string) (string, *httput
 }
 
 func requireDecimal(raw map[string]json.RawMessage, key string) (decimal.Decimal, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || string(v) == "null" {
-		return decimal.Zero, &httputil.ValidationError{Field: key, Msg: "required"}
-	}
-	d, err := decimal.NewFromString(strings.Trim(string(v), `"`))
-	if err != nil {
-		return decimal.Zero, &httputil.ValidationError{Field: key, Msg: "must be a number"}
-	}
-	return d, nil
+	return validation.RequiredDecimal(raw, key, "required")
 }

--- a/backend-go/internal/holdings/validation_test.go
+++ b/backend-go/internal/holdings/validation_test.go
@@ -1,0 +1,60 @@
+package holdings
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+)
+
+func TestBuildLotInputRejectsQuotedRequiredDecimal(t *testing.T) {
+	raw := map[string]json.RawMessage{
+		"account_id":  json.RawMessage(`1`),
+		"security_id": json.RawMessage(`2`),
+		"side":        json.RawMessage(`"buy"`),
+		"quantity":    json.RawMessage(`"10.5"`),
+		"price":       json.RawMessage(`100`),
+		"date":        json.RawMessage(`"2026-01-02"`),
+	}
+
+	_, vErr := buildLotInput(raw)
+	assertValidation(t, vErr, "quantity", "must be a number")
+}
+
+func TestBuildLotInputRejectsQuotedOptionalDecimal(t *testing.T) {
+	raw := map[string]json.RawMessage{
+		"account_id":  json.RawMessage(`1`),
+		"security_id": json.RawMessage(`2`),
+		"side":        json.RawMessage(`"buy"`),
+		"quantity":    json.RawMessage(`10.5`),
+		"price":       json.RawMessage(`100`),
+		"fee":         json.RawMessage(`"1.25"`),
+		"date":        json.RawMessage(`"2026-01-02"`),
+	}
+
+	_, vErr := buildLotInput(raw)
+	assertValidation(t, vErr, "fee", "must be a number")
+}
+
+func TestBuildDividendInputRejectsQuotedOptionalDecimal(t *testing.T) {
+	raw := map[string]json.RawMessage{
+		"account_id":      json.RawMessage(`1`),
+		"security_id":     json.RawMessage(`2`),
+		"pay_date":        json.RawMessage(`"2026-01-02"`),
+		"gross_amount":    json.RawMessage(`100`),
+		"withholding_tax": json.RawMessage(`"15"`),
+	}
+
+	_, vErr := buildDividendInput(raw)
+	assertValidation(t, vErr, "withholding_tax", "must be a number")
+}
+
+func assertValidation(t *testing.T, got *httputil.ValidationError, field, msg string) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("vErr is nil")
+	}
+	if got.Field != field || got.Msg != msg {
+		t.Fatalf("vErr = %#v, want field=%q msg=%q", got, field, msg)
+	}
+}

--- a/backend-go/internal/holdings/validation_test.go
+++ b/backend-go/internal/holdings/validation_test.go
@@ -4,49 +4,47 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 )
 
-func TestBuildLotInputRejectsQuotedRequiredDecimal(t *testing.T) {
+func TestBuildLotInputAcceptsQuotedDecimals(t *testing.T) {
 	raw := map[string]json.RawMessage{
 		"account_id":  json.RawMessage(`1`),
 		"security_id": json.RawMessage(`2`),
 		"side":        json.RawMessage(`"buy"`),
 		"quantity":    json.RawMessage(`"10.5"`),
-		"price":       json.RawMessage(`100`),
-		"date":        json.RawMessage(`"2026-01-02"`),
-	}
-
-	_, vErr := buildLotInput(raw)
-	assertValidation(t, vErr, "quantity", "must be a number")
-}
-
-func TestBuildLotInputRejectsQuotedOptionalDecimal(t *testing.T) {
-	raw := map[string]json.RawMessage{
-		"account_id":  json.RawMessage(`1`),
-		"security_id": json.RawMessage(`2`),
-		"side":        json.RawMessage(`"buy"`),
-		"quantity":    json.RawMessage(`10.5`),
-		"price":       json.RawMessage(`100`),
+		"price":       json.RawMessage(`"100"`),
 		"fee":         json.RawMessage(`"1.25"`),
 		"date":        json.RawMessage(`"2026-01-02"`),
 	}
 
-	_, vErr := buildLotInput(raw)
-	assertValidation(t, vErr, "fee", "must be a number")
+	got, vErr := buildLotInput(raw)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	assertDecimal(t, got.Quantity, "10.5")
+	assertDecimal(t, got.Price, "100")
+	assertDecimal(t, got.Fee, "1.25")
 }
 
-func TestBuildDividendInputRejectsQuotedOptionalDecimal(t *testing.T) {
+func TestBuildDividendInputAcceptsQuotedDecimals(t *testing.T) {
 	raw := map[string]json.RawMessage{
 		"account_id":      json.RawMessage(`1`),
 		"security_id":     json.RawMessage(`2`),
 		"pay_date":        json.RawMessage(`"2026-01-02"`),
-		"gross_amount":    json.RawMessage(`100`),
+		"gross_amount":    json.RawMessage(`"100"`),
 		"withholding_tax": json.RawMessage(`"15"`),
 	}
 
-	_, vErr := buildDividendInput(raw)
-	assertValidation(t, vErr, "withholding_tax", "must be a number")
+	got, vErr := buildDividendInput(raw)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	assertDecimal(t, got.GrossAmount, "100")
+	assertDecimal(t, got.WithholdingTax, "15")
+	assertDecimal(t, got.Net(), "85")
 }
 
 func assertValidation(t *testing.T, got *httputil.ValidationError, field, msg string) {
@@ -56,5 +54,13 @@ func assertValidation(t *testing.T, got *httputil.ValidationError, field, msg st
 	}
 	if got.Field != field || got.Msg != msg {
 		t.Fatalf("vErr = %#v, want field=%q msg=%q", got, field, msg)
+	}
+}
+
+func assertDecimal(t *testing.T, got decimal.Decimal, want string) {
+	t.Helper()
+	wantDecimal := decimal.RequireFromString(want)
+	if !got.Equal(wantDecimal) {
+		t.Fatalf("got = %s, want %s", got, wantDecimal)
 	}
 }

--- a/backend-go/internal/holdings/validation_test.go
+++ b/backend-go/internal/holdings/validation_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/shopspring/decimal"
-
-	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 )
 
 func TestBuildLotInputAcceptsQuotedDecimals(t *testing.T) {
@@ -45,16 +43,6 @@ func TestBuildDividendInputAcceptsQuotedDecimals(t *testing.T) {
 	assertDecimal(t, got.GrossAmount, "100")
 	assertDecimal(t, got.WithholdingTax, "15")
 	assertDecimal(t, got.Net(), "85")
-}
-
-func assertValidation(t *testing.T, got *httputil.ValidationError, field, msg string) {
-	t.Helper()
-	if got == nil {
-		t.Fatal("vErr is nil")
-	}
-	if got.Field != field || got.Msg != msg {
-		t.Fatalf("vErr = %#v, want field=%q msg=%q", got, field, msg)
-	}
 }
 
 func assertDecimal(t *testing.T, got decimal.Decimal, want string) {

--- a/backend-go/internal/recurring/validation.go
+++ b/backend-go/internal/recurring/validation.go
@@ -157,7 +157,7 @@ func requireString(raw map[string]json.RawMessage, key string, dest *string) *ht
 }
 
 func requireDecimal(raw map[string]json.RawMessage, key string) (decimal.Decimal, *httputil.ValidationError) {
-	return validation.RequiredDecimal(raw, key, "required")
+	return validation.RequiredDecimalStringOrNumber(raw, key, "required")
 }
 
 func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {

--- a/backend-go/internal/recurring/validation.go
+++ b/backend-go/internal/recurring/validation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 func buildInput(raw map[string]json.RawMessage) (CreateInput, *httputil.ValidationError) {
@@ -156,17 +157,7 @@ func requireString(raw map[string]json.RawMessage, key string, dest *string) *ht
 }
 
 func requireDecimal(raw map[string]json.RawMessage, key string) (decimal.Decimal, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || string(v) == "null" {
-		return decimal.Zero, &httputil.ValidationError{Field: key, Msg: "required"}
-	}
-	// Parse from JSON bytes to preserve precision per CLAUDE.md guidance.
-	s := strings.Trim(string(v), `"`)
-	d, err := decimal.NewFromString(s)
-	if err != nil {
-		return decimal.Zero, &httputil.ValidationError{Field: key, Msg: "must be a number"}
-	}
-	return d, nil
+	return validation.RequiredDecimal(raw, key, "required")
 }
 
 func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {

--- a/backend-go/internal/recurring/validation_test.go
+++ b/backend-go/internal/recurring/validation_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/shopspring/decimal"
-
-	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 )
 
 func TestBuildInputAcceptsQuotedAmount(t *testing.T) {
@@ -24,15 +22,5 @@ func TestBuildInputAcceptsQuotedAmount(t *testing.T) {
 	want := decimal.RequireFromString("1000.00")
 	if !got.Amount.Equal(want) {
 		t.Fatalf("got = %s, want %s", got.Amount, want)
-	}
-}
-
-func assertValidation(t *testing.T, got *httputil.ValidationError, field, msg string) {
-	t.Helper()
-	if got == nil {
-		t.Fatal("vErr is nil")
-	}
-	if got.Field != field || got.Msg != msg {
-		t.Fatalf("vErr = %#v, want field=%q msg=%q", got, field, msg)
 	}
 }

--- a/backend-go/internal/recurring/validation_test.go
+++ b/backend-go/internal/recurring/validation_test.go
@@ -1,0 +1,30 @@
+package recurring
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+)
+
+func TestBuildInputRejectsQuotedAmount(t *testing.T) {
+	raw := map[string]json.RawMessage{
+		"account_id": json.RawMessage(`1`),
+		"amount":     json.RawMessage(`"1000.00"`),
+		"frequency":  json.RawMessage(`"monthly"`),
+		"start_date": json.RawMessage(`"2026-01-01"`),
+	}
+
+	_, vErr := buildInput(raw)
+	assertValidation(t, vErr, "amount", "must be a number")
+}
+
+func assertValidation(t *testing.T, got *httputil.ValidationError, field, msg string) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("vErr is nil")
+	}
+	if got.Field != field || got.Msg != msg {
+		t.Fatalf("vErr = %#v, want field=%q msg=%q", got, field, msg)
+	}
+}

--- a/backend-go/internal/recurring/validation_test.go
+++ b/backend-go/internal/recurring/validation_test.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 )
 
-func TestBuildInputRejectsQuotedAmount(t *testing.T) {
+func TestBuildInputAcceptsQuotedAmount(t *testing.T) {
 	raw := map[string]json.RawMessage{
 		"account_id": json.RawMessage(`1`),
 		"amount":     json.RawMessage(`"1000.00"`),
@@ -15,8 +17,14 @@ func TestBuildInputRejectsQuotedAmount(t *testing.T) {
 		"start_date": json.RawMessage(`"2026-01-01"`),
 	}
 
-	_, vErr := buildInput(raw)
-	assertValidation(t, vErr, "amount", "must be a number")
+	got, vErr := buildInput(raw)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	want := decimal.RequireFromString("1000.00")
+	if !got.Amount.Equal(want) {
+		t.Fatalf("got = %s, want %s", got.Amount, want)
+	}
 }
 
 func assertValidation(t *testing.T, got *httputil.ValidationError, field, msg string) {

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 )
 
@@ -82,4 +84,39 @@ func RequiredIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httpu
 		return nil, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
 	}
 	return &n, nil
+}
+
+// RequiredDecimal reads a required JSON number field. Quoted numeric strings
+// are rejected to preserve the backend's pydantic-compatible wire contract.
+func RequiredDecimal(
+	raw map[string]json.RawMessage,
+	key string,
+	missingMsg string,
+) (decimal.Decimal, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return decimal.Zero, &httputil.ValidationError{Field: key, Msg: missingMsg}
+	}
+	d, err := RawDecimal(v)
+	if err != nil {
+		return decimal.Zero, &httputil.ValidationError{Field: key, Msg: "must be a number"}
+	}
+	return d, nil
+}
+
+// OptionalDecimal reads an optional JSON number field. Missing and explicit
+// null are treated the same; quoted numeric strings are rejected.
+func OptionalDecimal(
+	raw map[string]json.RawMessage,
+	key string,
+) (*decimal.Decimal, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return nil, nil
+	}
+	d, err := RawDecimal(v)
+	if err != nil {
+		return nil, &httputil.ValidationError{Field: key, Msg: "must be a number"}
+	}
+	return &d, nil
 }

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -120,3 +120,39 @@ func OptionalDecimal(
 	}
 	return &d, nil
 }
+
+// RequiredDecimalStringOrNumber reads a required decimal field that may arrive
+// as a JSON number or quoted numeric string. This preserves compatibility for
+// endpoints backed by string-valued frontend form controls.
+func RequiredDecimalStringOrNumber(
+	raw map[string]json.RawMessage,
+	key string,
+	missingMsg string,
+) (decimal.Decimal, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return decimal.Zero, &httputil.ValidationError{Field: key, Msg: missingMsg}
+	}
+	d, err := RawDecimalStringOrNumber(v)
+	if err != nil {
+		return decimal.Zero, &httputil.ValidationError{Field: key, Msg: "must be a number"}
+	}
+	return d, nil
+}
+
+// OptionalDecimalStringOrNumber reads an optional decimal field that may
+// arrive as a JSON number or quoted numeric string.
+func OptionalDecimalStringOrNumber(
+	raw map[string]json.RawMessage,
+	key string,
+) (*decimal.Decimal, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return nil, nil
+	}
+	d, err := RawDecimalStringOrNumber(v)
+	if err != nil {
+		return nil, &httputil.ValidationError{Field: key, Msg: "must be a number"}
+	}
+	return &d, nil
+}

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -153,6 +153,51 @@ func TestOptionalDecimal(t *testing.T) {
 	requireValidation(t, vErr, "fee", "must be a number")
 }
 
+func TestRequiredDecimalStringOrNumber(t *testing.T) {
+	got, vErr := RequiredDecimalStringOrNumber(
+		map[string]json.RawMessage{"amount": json.RawMessage(`"123.45"`)},
+		"amount",
+		"required",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if !got.Equal(decimal.RequireFromString("123.45")) {
+		t.Fatalf("got = %s", got)
+	}
+
+	_, vErr = RequiredDecimalStringOrNumber(map[string]json.RawMessage{}, "amount", "required")
+	requireValidation(t, vErr, "amount", "required")
+
+	_, vErr = RequiredDecimalStringOrNumber(
+		map[string]json.RawMessage{"amount": json.RawMessage(`"abc"`)},
+		"amount",
+		"required",
+	)
+	requireValidation(t, vErr, "amount", "must be a number")
+}
+
+func TestOptionalDecimalStringOrNumber(t *testing.T) {
+	got, vErr := OptionalDecimalStringOrNumber(
+		map[string]json.RawMessage{"fee": json.RawMessage(`"1.25"`)},
+		"fee",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || !got.Equal(decimal.RequireFromString("1.25")) {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalDecimalStringOrNumber(map[string]json.RawMessage{}, "fee")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalDecimalStringOrNumber(map[string]json.RawMessage{"fee": json.RawMessage(`"abc"`)}, "fee")
+	requireValidation(t, vErr, "fee", "must be a number")
+}
+
 func requireValidation(t *testing.T, got *httputil.ValidationError, field, msg string) {
 	t.Helper()
 	if got == nil {

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 )
 
@@ -99,6 +101,56 @@ func TestRequiredIntOrNull(t *testing.T) {
 
 	_, vErr = RequiredIntOrNull(map[string]json.RawMessage{"owner_user_id": json.RawMessage(`"7"`)}, "owner_user_id")
 	requireValidation(t, vErr, "owner_user_id", "must be an integer")
+}
+
+func TestRequiredDecimal(t *testing.T) {
+	got, vErr := RequiredDecimal(
+		map[string]json.RawMessage{"amount": json.RawMessage(`123.45`)},
+		"amount",
+		"required",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if !got.Equal(decimal.RequireFromString("123.45")) {
+		t.Fatalf("got = %s", got)
+	}
+
+	_, vErr = RequiredDecimal(map[string]json.RawMessage{}, "amount", "required")
+	requireValidation(t, vErr, "amount", "required")
+
+	_, vErr = RequiredDecimal(
+		map[string]json.RawMessage{"amount": json.RawMessage(`"123.45"`)},
+		"amount",
+		"required",
+	)
+	requireValidation(t, vErr, "amount", "must be a number")
+}
+
+func TestOptionalDecimal(t *testing.T) {
+	got, vErr := OptionalDecimal(
+		map[string]json.RawMessage{"fee": json.RawMessage(`1.25`)},
+		"fee",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || !got.Equal(decimal.RequireFromString("1.25")) {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalDecimal(map[string]json.RawMessage{}, "fee")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalDecimal(map[string]json.RawMessage{"fee": json.RawMessage(`null`)}, "fee")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalDecimal(map[string]json.RawMessage{"fee": json.RawMessage(`"1.25"`)}, "fee")
+	requireValidation(t, vErr, "fee", "must be a number")
 }
 
 func requireValidation(t *testing.T, got *httputil.ValidationError, field, msg string) {

--- a/backend-go/internal/validation/raw.go
+++ b/backend-go/internal/validation/raw.go
@@ -67,11 +67,20 @@ func RawInt(v json.RawMessage) (int, error) {
 	return n, nil
 }
 
-// RawDecimal decodes a JSON *number* as a decimal.Decimal. Quoted
-// strings ("123.45") are rejected on purpose — callers map the error
-// into a "must be a number" validation message, matching the Python
-// pydantic behavior the bb-tests pin. Numeric values stay exact —
-// never round-trip through float64.
+// RawDecimal decodes a JSON number as a decimal.Decimal. Quoted strings are
+// rejected on purpose. Numeric values stay exact — never round-trip through
+// float64.
 func RawDecimal(v json.RawMessage) (decimal.Decimal, error) {
 	return decimal.NewFromString(string(bytes.TrimSpace(v)))
+}
+
+// RawDecimalStringOrNumber decodes either a JSON number or a quoted numeric
+// string as a decimal.Decimal. Use this only for endpoints whose existing API
+// contract accepts form-bound frontend values as strings.
+func RawDecimalStringOrNumber(v json.RawMessage) (decimal.Decimal, error) {
+	s, err := RawString(v)
+	if err == nil {
+		return decimal.NewFromString(strings.TrimSpace(s))
+	}
+	return RawDecimal(v)
 }

--- a/backend-go/internal/validation/raw_test.go
+++ b/backend-go/internal/validation/raw_test.go
@@ -96,9 +96,35 @@ func TestRawDecimal(t *testing.T) {
 }
 
 func TestRawDecimalRejectsQuotedString(t *testing.T) {
-	// Quoted strings are NOT accepted — callers translate the error
-	// into "must be a number" to match pydantic's behavior.
 	if _, err := RawDecimal(json.RawMessage(`"123.45"`)); err == nil {
 		t.Fatal("expected error for quoted decimal")
+	}
+}
+
+func TestRawDecimalStringOrNumber(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  json.RawMessage
+		want decimal.Decimal
+	}{
+		{name: "number", raw: json.RawMessage(`123.45`), want: decimal.RequireFromString("123.45")},
+		{name: "string", raw: json.RawMessage(`"123.45"`), want: decimal.RequireFromString("123.45")},
+		{name: "trimmed string", raw: json.RawMessage(`"  1.5  "`), want: decimal.RequireFromString("1.5")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := RawDecimalStringOrNumber(tc.raw)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if !got.Equal(tc.want) {
+				t.Fatalf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+
+	if _, err := RawDecimalStringOrNumber(json.RawMessage(`"abc"`)); err == nil {
+		t.Fatal("expected error for non-numeric string")
 	}
 }


### PR DESCRIPTION
## Summary
- add shared validation helpers for required and optional decimal JSON fields
- migrate holdings and recurring validation to reject quoted numeric strings consistently
- add regression tests for shared helpers and migrated domain validators

## Tests
- go test ./...
- go vet ./...
- git diff --check