### PR TITLE
refactor(http): reuse json request decoder

### DIFF
--- a/backend-go/internal/allocation/handler.go
+++ b/backend-go/internal/allocation/handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -127,8 +126,7 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 // Create serves POST /api/allocation/targets.
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	var req createRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &req) {
 		return
 	}
 	if vErr := validateCreate(&req); vErr != nil {
@@ -156,8 +154,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	patch, vErr := buildUpdatePatch(raw)
@@ -190,8 +187,7 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 // every target for one owner scope. The payload's targets must sum to 100.
 func (h *Handler) Replace(w http.ResponseWriter, r *http.Request) {
 	var req replaceRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &req) {
 		return
 	}
 	if vErr := validateReplaceBatch(req.Targets); vErr != nil {

--- a/backend-go/internal/bonds/handler.go
+++ b/backend-go/internal/bonds/handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -328,8 +327,7 @@ func floatFromDecimal(d decimal.Decimal) float64 {
 // Create serves POST /api/bonds.
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	var req createRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &req) {
 		return
 	}
 	if vErr := validateCreate(&req); vErr != nil {
@@ -368,8 +366,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	patch, vErr := buildUpdatePatch(raw)

--- a/backend-go/internal/config/handler.go
+++ b/backend-go/internal/config/handler.go
@@ -1,9 +1,7 @@
 package config
 
 import (
-	"encoding/json"
 	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -130,8 +128,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 // Put serves PUT /api/config.
 func (h *Handler) Put(w http.ResponseWriter, r *http.Request) {
 	var req request
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &req) {
 		return
 	}
 	if vErr := req.validate(); vErr != nil {

--- a/backend-go/internal/cpi/handler.go
+++ b/backend-go/internal/cpi/handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -115,8 +114,7 @@ func (h *Handler) GetSeries(w http.ResponseWriter, r *http.Request) {
 // Adjust serves POST /api/cpi/adjust.
 func (h *Handler) Adjust(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	amount, vErr := requireFloat(raw, "amount")

--- a/backend-go/internal/equity_grants/handler.go
+++ b/backend-go/internal/equity_grants/handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"math"
 	"net/http"
@@ -281,8 +280,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 // Create serves POST /api/equity-grants.
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	req, vErr := buildCreateRequest(raw)
@@ -307,8 +305,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	patch, vErr := buildUpdatePatch(raw)

--- a/backend-go/internal/retirement/handler.go
+++ b/backend-go/internal/retirement/handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -269,8 +268,7 @@ func (h *Handler) UpsertLimit(w http.ResponseWriter, r *http.Request) {
 		ownerUserID = &n
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	req, vErr := buildLimitRequest(raw, h.now)
@@ -294,8 +292,7 @@ func (h *Handler) UpsertLimit(w http.ResponseWriter, r *http.Request) {
 // GeneratePPKContributions serves POST /api/retirement/ppk-contributions/generate.
 func (h *Handler) GeneratePPKContributions(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	req, vErr := buildGenerateRequest(raw, h.now)

--- a/backend-go/internal/salaries/handler.go
+++ b/backend-go/internal/salaries/handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -153,8 +152,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 // Create serves POST /api/salaries.
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	req, vErr := buildCreateRequest(raw, h.now)
@@ -190,8 +188,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	patch, vErr := buildUpdatePatch(raw, h.now)

--- a/backend-go/internal/simulations/handler.go
+++ b/backend-go/internal/simulations/handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"math"
 	"math/rand/v2"
@@ -89,8 +88,7 @@ type mortgageResponse struct {
 // MortgageVsInvest serves POST /api/simulations/mortgage-vs-invest.
 func (h *Handler) MortgageVsInvest(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	in, vErr := buildMortgageInputs(raw)
@@ -187,8 +185,7 @@ type wiborResponse struct {
 // WiborScenarios serves POST /api/simulations/wibor.
 func (h *Handler) WiborScenarios(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	in, vErr := buildWiborInputs(raw)
@@ -269,8 +266,7 @@ func (h *Handler) Prefill(w http.ResponseWriter, r *http.Request) {
 // Retirement serves POST /api/simulations/retirement.
 func (h *Handler) Retirement(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<18)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<18, &raw) {
 		return
 	}
 	in, vErr := buildSimulationInputs(raw)
@@ -323,8 +319,7 @@ type monteCarloAccountMixWire struct {
 // returns and reports the success rate plus 5/50/95 percentile bands.
 func (h *Handler) MonteCarlo(w http.ResponseWriter, r *http.Request) {
 	var in monteCarloInputsWire
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<18)).Decode(&in); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<18, &in) {
 		return
 	}
 	if in.CurrentAge <= 0 || in.LifeExpectancy <= in.CurrentAge {

--- a/backend-go/internal/snapshots/handler.go
+++ b/backend-go/internal/snapshots/handler.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -107,8 +106,7 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 // Create serves POST /api/snapshots.
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<20, &raw) {
 		return
 	}
 	req, vErr := buildCreateRequest(raw)
@@ -131,8 +129,7 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<20, &raw) {
 		return
 	}
 	patch, vErr := buildUpdatePatch(raw)

--- a/backend-go/internal/zus/handler.go
+++ b/backend-go/internal/zus/handler.go
@@ -2,7 +2,6 @@ package zus
 
 import (
 	"encoding/json"
-	"io"
 	"log/slog"
 	"net/http"
 	"sort"
@@ -100,8 +99,7 @@ type prefillResponse struct {
 // Calculate serves POST /api/zus/calculate.
 func (h *Handler) Calculate(w http.ResponseWriter, r *http.Request) {
 	raw := map[string]json.RawMessage{}
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&raw); err != nil {
-		httputil.WriteBodyValidationError(w, "body", "Invalid JSON body", err.Error())
+	if !httputil.DecodeJSON(w, r, 1<<16, &raw) {
 		return
 	}
 	req, vErr := buildInputs(raw, h.now)


### PR DESCRIPTION
## Summary
- Replace repeated limited JSON decoder blocks with httputil.DecodeJSON in handlers that already used the same Pydantic-shaped invalid JSON response
- Remove now-unused io imports from those handlers
- Leave auth, optional-body scenarios, and legacy empty-input raw body helpers unchanged because their response contracts differ

## Verification
- (cd backend-go && go test ./...)
- (cd backend-go && go vet ./...)
- git diff --check