### PR TITLE
refactor(http): reuse path id parser

### DIFF
--- a/backend-go/internal/allocation/handler.go
+++ b/backend-go/internal/allocation/handler.go
@@ -7,9 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strconv"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
@@ -272,13 +270,7 @@ func (h *Handler) writeStoreError(w http.ResponseWriter, err error) {
 }
 
 func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
-	raw := chi.URLParam(r, "id")
-	id, err := strconv.Atoi(raw)
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "target_id", "must be an integer", raw)
-		return 0, false
-	}
-	return id, true
+	return httputil.PathIntField(w, r, "id", "target_id")
 }
 
 // HoldingsFromSnapshots is a default HoldingsProvider — pulls the latest

--- a/backend-go/internal/bonds/handler.go
+++ b/backend-go/internal/bonds/handler.go
@@ -6,12 +6,10 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/bondrates"
@@ -434,13 +432,7 @@ func (h *Handler) loadMonthlyYoY(ctx context.Context) map[cpi.YearMonth]decimal.
 }
 
 func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
-	raw := chi.URLParam(r, "id")
-	id, err := strconv.Atoi(raw)
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "bond_id", "must be an integer", raw)
-		return 0, false
-	}
-	return id, true
+	return httputil.PathIntField(w, r, "id", "bond_id")
 }
 
 // lookupResponse is the body of GET /api/bonds/lookup.

--- a/backend-go/internal/equity_grants/handler.go
+++ b/backend-go/internal/equity_grants/handler.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
 
 	companyvaluations "github.com/Automaat/finance-buddy/backend-go/internal/company_valuations"
@@ -360,11 +359,5 @@ func (h *Handler) writeStoreError(w http.ResponseWriter, err error, id int) {
 }
 
 func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
-	raw := chi.URLParam(r, "id")
-	id, err := strconv.Atoi(raw)
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "grant_id", "must be an integer", raw)
-		return 0, false
-	}
-	return id, true
+	return httputil.PathIntField(w, r, "id", "grant_id")
 }

--- a/backend-go/internal/salaries/handler.go
+++ b/backend-go/internal/salaries/handler.go
@@ -7,10 +7,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/shopspring/decimal"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/cpi"
@@ -337,13 +335,7 @@ func parseListFilter(q map[string][]string) (ListFilter, *httputil.ValidationErr
 }
 
 func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
-	raw := chi.URLParam(r, "id")
-	id, err := strconv.Atoi(raw)
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "salary_id", "must be an integer", raw)
-		return 0, false
-	}
-	return id, true
+	return httputil.PathIntField(w, r, "id", "salary_id")
 }
 
 func truncateDay(t time.Time) time.Time {

--- a/backend-go/internal/snapshots/handler.go
+++ b/backend-go/internal/snapshots/handler.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
 )
@@ -194,11 +192,5 @@ func setLiteral(ids []int) string {
 }
 
 func parseIDParam(w http.ResponseWriter, r *http.Request) (int, bool) {
-	raw := chi.URLParam(r, "id")
-	id, err := strconv.Atoi(raw)
-	if err != nil {
-		httputil.WriteBodyValidationError(w, "snapshot_id", "must be an integer", raw)
-		return 0, false
-	}
-	return id, true
+	return httputil.PathIntField(w, r, "id", "snapshot_id")
 }


### PR DESCRIPTION
## Summary
- Reuse httputil.PathIntField for allocation target, salary, bond, grant, and snapshot path IDs
- Remove duplicate chi URL param parsing from those handlers
- Leave positive-integer and query-param parsers unchanged because their validation wire shape differs

## Verification
- (cd backend-go && go test ./...)
- (cd backend-go && go vet ./...)
- (cd backend-go && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...)
- git diff --check