### PR TITLE
refactor(validation): share required enum parsing

### DIFF
--- a/backend-go/internal/accounts/validation.go
+++ b/backend-go/internal/accounts/validation.go
@@ -34,13 +34,13 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Name = name
 
-	t, vErr := requireEnumString(raw, "type", validAccountTypes)
+	t, vErr := validation.RequiredEnumString(raw, "type", validAccountTypes)
 	if vErr != nil {
 		return r, vErr
 	}
 	r.Type = t
 
-	cat, vErr := requireEnumString(raw, "category", validCategories)
+	cat, vErr := validation.RequiredEnumString(raw, "category", validCategories)
 	if vErr != nil {
 		return r, vErr
 	}
@@ -64,7 +64,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.AccountWrapper = wrap
 
-	purpose, vErr := requireEnumString(raw, "purpose", validPurposes)
+	purpose, vErr := validation.RequiredEnumString(raw, "purpose", validPurposes)
 	if vErr != nil {
 		return r, vErr
 	}
@@ -262,21 +262,6 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 		return nil, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
 	}
 	return &n, nil
-}
-
-func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if _, ok := allowed[s]; !ok {
-		return "", &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
-	}
-	return s, nil
 }
 
 func optionalString(raw map[string]json.RawMessage, key, fallback string) (string, *httputil.ValidationError) {

--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -43,7 +43,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Currency = currency
 
-	r.Type, vErr = requireEnumString(raw, "type", validBonusTypes)
+	r.Type, vErr = validation.RequiredEnumString(raw, "type", validBonusTypes)
 	if vErr != nil {
 		return r, vErr
 	}
@@ -60,7 +60,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.OwnerUserID = ownerID
 
-	r.ContractType, vErr = requireEnumString(raw, "contract_type", validContractTypes)
+	r.ContractType, vErr = validation.RequiredEnumString(raw, "contract_type", validContractTypes)
 	if vErr != nil {
 		return r, vErr
 	}
@@ -218,21 +218,6 @@ func optionalCurrency(raw map[string]json.RawMessage, fallback string) (string, 
 	s = strings.ToUpper(strings.TrimSpace(s))
 	if _, ok := validCurrencies[s]; !ok {
 		return "", &httputil.ValidationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
-	}
-	return s, nil
-}
-
-func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if _, ok := allowed[s]; !ok {
-		return "", &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
 	}
 	return s, nil
 }

--- a/backend-go/internal/debts/validation.go
+++ b/backend-go/internal/debts/validation.go
@@ -34,7 +34,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Name = name
 
-	dt, vErr := requireEnumString(raw, "debt_type", validDebtTypes)
+	dt, vErr := validation.RequiredEnumString(raw, "debt_type", validDebtTypes)
 	if vErr != nil {
 		return r, vErr
 	}
@@ -158,21 +158,6 @@ func requireOwnerUserID(raw map[string]json.RawMessage) (*int, *httputil.Validat
 
 func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
 	return validation.RequiredTrimmedString(raw, key, "Field required", emptyMsg)
-}
-
-func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if _, ok := allowed[s]; !ok {
-		return "", &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
-	}
-	return s, nil
 }
 
 func requireDateNotFuture(raw map[string]json.RawMessage, key, msg string) (time.Time, *httputil.ValidationError) {

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -90,7 +90,7 @@ func requireGrantBasics(raw map[string]json.RawMessage, r *createRequest) *httpu
 	}
 	r.GrantDate = t
 
-	grantType, vErr := requireEnumString(raw, "type", validGrantTypes)
+	grantType, vErr := validation.RequiredEnumString(raw, "type", validGrantTypes)
 	if vErr != nil {
 		return vErr
 	}
@@ -147,7 +147,7 @@ func requireGrantVesting(raw map[string]json.RawMessage, r *createRequest) *http
 	}
 	r.VestTotalMonths = total
 
-	freq, vErr := requireEnumString(raw, "vest_frequency", validFrequencies)
+	freq, vErr := validation.RequiredEnumString(raw, "vest_frequency", validFrequencies)
 	if vErr != nil {
 		return vErr
 	}
@@ -383,21 +383,6 @@ func optionalNonNegativeInt(raw map[string]json.RawMessage, key, msg string, fal
 		return 0, &httputil.ValidationError{Field: key, Msg: msg}
 	}
 	return n, nil
-}
-
-func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if _, ok := allowed[s]; !ok {
-		return "", &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
-	}
-	return s, nil
 }
 
 func optionalEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}, fallback string) (string, *httputil.ValidationError) {

--- a/backend-go/internal/retirement/validation.go
+++ b/backend-go/internal/retirement/validation.go
@@ -33,7 +33,7 @@ func buildLimitRequest(raw map[string]json.RawMessage, now func() time.Time) (li
 	}
 	r.Year = year
 
-	wrap, vErr := requireEnumString(raw, "account_wrapper", validWrappers)
+	wrap, vErr := validation.RequiredEnumString(raw, "account_wrapper", validWrappers)
 	if vErr != nil {
 		return r, vErr
 	}
@@ -150,21 +150,6 @@ func requireIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httput
 		return nil, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
 	}
 	return &n, nil
-}
-
-func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if _, ok := allowed[s]; !ok {
-		return "", &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
-	}
-	return s, nil
 }
 
 func requireIntRange(raw map[string]json.RawMessage, key string, lo, hi int, msg string) (int, *httputil.ValidationError) {

--- a/backend-go/internal/salaries/validation.go
+++ b/backend-go/internal/salaries/validation.go
@@ -41,7 +41,7 @@ func buildCreateRequest(raw map[string]json.RawMessage, now func() time.Time) (c
 	}
 	r.GrossAmount = amount
 
-	contract, vErr := requireEnumString(raw, "contract_type", validContractTypes)
+	contract, vErr := validation.RequiredEnumString(raw, "contract_type", validContractTypes)
 	if vErr != nil {
 		return r, vErr
 	}
@@ -182,19 +182,4 @@ func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (de
 		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: msg}
 	}
 	return d, nil
-}
-
-func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	s, err := validation.RawString(v)
-	if err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if _, ok := allowed[s]; !ok {
-		return "", &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
-	}
-	return s, nil
 }

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -106,6 +107,27 @@ func RequiredIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httpu
 		return nil, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
 	}
 	return &n, nil
+}
+
+// RequiredEnumString reads a required string field and checks it belongs to
+// the provided allowed set.
+func RequiredEnumString(
+	raw map[string]json.RawMessage,
+	key string,
+	allowed map[string]struct{},
+) (string, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
+	}
+	s, err := RawString(v)
+	if err != nil {
+		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return "", &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	return s, nil
 }
 
 // RequiredDecimal reads a required JSON number field. Quoted numeric strings

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -134,6 +134,46 @@ func TestRequiredIntOrNull(t *testing.T) {
 	requireValidation(t, vErr, "owner_user_id", "must be an integer")
 }
 
+func TestRequiredEnumString(t *testing.T) {
+	allowed := map[string]struct{}{"employment": {}, "b2b": {}}
+
+	got, vErr := RequiredEnumString(
+		map[string]json.RawMessage{"contract_type": json.RawMessage(`"employment"`)},
+		"contract_type",
+		allowed,
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != "employment" {
+		t.Fatalf("got = %q", got)
+	}
+
+	_, vErr = RequiredEnumString(map[string]json.RawMessage{}, "contract_type", allowed)
+	requireValidation(t, vErr, "contract_type", "Field required")
+
+	_, vErr = RequiredEnumString(
+		map[string]json.RawMessage{"contract_type": json.RawMessage(`null`)},
+		"contract_type",
+		allowed,
+	)
+	requireValidation(t, vErr, "contract_type", "Field required")
+
+	_, vErr = RequiredEnumString(
+		map[string]json.RawMessage{"contract_type": json.RawMessage(`7`)},
+		"contract_type",
+		allowed,
+	)
+	requireValidation(t, vErr, "contract_type", "must be a string")
+
+	_, vErr = RequiredEnumString(
+		map[string]json.RawMessage{"contract_type": json.RawMessage(`"mandate"`)},
+		"contract_type",
+		allowed,
+	)
+	requireValidation(t, vErr, "contract_type", `invalid value "mandate"`)
+}
+
 func TestRequiredDecimal(t *testing.T) {
 	got, vErr := RequiredDecimal(
 		map[string]json.RawMessage{"amount": json.RawMessage(`123.45`)},

--- a/backend-go/internal/zus/validation.go
+++ b/backend-go/internal/zus/validation.go
@@ -2,7 +2,6 @@ package zus
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
@@ -31,7 +30,7 @@ func buildInputs(raw map[string]json.RawMessage, now func() time.Time) (calculat
 	}
 	c.Inputs.BirthYear = c.BirthDate.Year()
 
-	c.Inputs.Gender, err = requireEnumString(raw, "gender", map[string]struct{}{"M": {}, "F": {}})
+	c.Inputs.Gender, err = validation.RequiredEnumString(raw, "gender", map[string]struct{}{"M": {}, "F": {}})
 	if err != nil {
 		return c, err
 	}
@@ -180,21 +179,6 @@ func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httput
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
 	}
 	return t, nil
-}
-
-func requireEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if _, ok := allowed[s]; !ok {
-		return "", &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
-	}
-	return s, nil
 }
 
 func requireNonNegativeFloat(raw map[string]json.RawMessage, key, msg string) (float64, *httputil.ValidationError) {


### PR DESCRIPTION
## Summary
- Add validation.RequiredEnumString for required raw JSON enum fields
- Replace duplicated required enum parsing in account, salary, bonus, debt, equity grant, retirement, and ZUS validators
- Cover shared enum parsing behavior in validation tests

## Checks
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check