### PR TITLE
refactor(validation): reuse required date parsing

### DIFF
--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -22,7 +22,7 @@ import (
 func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputil.ValidationError) {
 	var r createRequest
 
-	t, vErr := requireDate(raw, "date")
+	t, vErr := validation.RequiredDate(raw, "date")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -185,10 +185,6 @@ func patchEnums(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Valida
 
 func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
 	return validation.RequiredTrimmedString(raw, key, "Field required", emptyMsg)
-}
-
-func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
-	return validation.RequiredDate(raw, key)
 }
 
 func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {

--- a/backend-go/internal/company_valuations/validation.go
+++ b/backend-go/internal/company_valuations/validation.go
@@ -28,7 +28,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Company = company
 
-	t, vErr := requireDate(raw, "date")
+	t, vErr := validation.RequiredDate(raw, "date")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -184,10 +184,6 @@ func patchNumbers(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 
 func requireString(raw map[string]json.RawMessage, key, missingMsg, emptyMsg string) (string, *httputil.ValidationError) {
 	return validation.RequiredTrimmedString(raw, key, missingMsg, emptyMsg)
-}
-
-func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
-	return validation.RequiredDate(raw, key)
 }
 
 func optionalCurrency(raw map[string]json.RawMessage) (string, *httputil.ValidationError) {

--- a/backend-go/internal/cpi/handler.go
+++ b/backend-go/internal/cpi/handler.go
@@ -122,12 +122,12 @@ func (h *Handler) Adjust(w http.ResponseWriter, r *http.Request) {
 		httputil.WritePydanticError(w, vErr)
 		return
 	}
-	from, vErr := requireDate(raw, "from_date")
+	from, vErr := validation.RequiredDate(raw, "from_date")
 	if vErr != nil {
 		httputil.WritePydanticError(w, vErr)
 		return
 	}
-	to, vErr := requireDate(raw, "to_date")
+	to, vErr := validation.RequiredDate(raw, "to_date")
 	if vErr != nil {
 		httputil.WritePydanticError(w, vErr)
 		return
@@ -252,20 +252,4 @@ func requireFloat(raw map[string]json.RawMessage, key string) (float64, *httputi
 		return 0, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
 	return f, nil
-}
-
-func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	t, err := time.Parse("2006-01-02", s)
-	if err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
-	}
-	return t, nil
 }

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -84,7 +84,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 }
 
 func requireGrantBasics(raw map[string]json.RawMessage, r *createRequest) *httputil.ValidationError {
-	t, vErr := requireDate(raw, "grant_date")
+	t, vErr := validation.RequiredDate(raw, "grant_date")
 	if vErr != nil {
 		return vErr
 	}
@@ -129,7 +129,7 @@ func requireGrantBasics(raw map[string]json.RawMessage, r *createRequest) *httpu
 }
 
 func requireGrantVesting(raw map[string]json.RawMessage, r *createRequest) *httputil.ValidationError {
-	vsd, vErr := requireDate(raw, "vest_start_date")
+	vsd, vErr := validation.RequiredDate(raw, "vest_start_date")
 	if vErr != nil {
 		return vErr
 	}
@@ -337,22 +337,6 @@ func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string
 		return "", &httputil.ValidationError{Field: key, Msg: emptyMsg}
 	}
 	return s, nil
-}
-
-func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	t, err := time.Parse("2006-01-02", s)
-	if err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
-	}
-	return t, nil
 }
 
 func requirePositiveInt(raw map[string]json.RawMessage, key, msg string) (int, *httputil.ValidationError) {

--- a/backend-go/internal/salaries/validation.go
+++ b/backend-go/internal/salaries/validation.go
@@ -26,7 +26,7 @@ type createRequest struct {
 // fields surface "Field required" on missing.
 func buildCreateRequest(raw map[string]json.RawMessage, now func() time.Time) (createRequest, *httputil.ValidationError) {
 	var r createRequest
-	t, vErr := requireDate(raw, "date")
+	t, vErr := validation.RequiredDate(raw, "date")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -135,21 +135,6 @@ func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string
 		return "", &httputil.ValidationError{Field: key, Msg: emptyMsg}
 	}
 	return s, nil
-}
-
-func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	t, err := validation.RawDate(v)
-	if err != nil {
-		if validation.IsRawDateFormatError(err) {
-			return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
-		}
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	return t, nil
 }
 
 func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {

--- a/backend-go/internal/salaries/validation_test.go
+++ b/backend-go/internal/salaries/validation_test.go
@@ -167,9 +167,16 @@ func TestBuildUpdatePatchBlankCompany(t *testing.T) {
 	}
 }
 
-func TestRequireDateInvalid(t *testing.T) {
-	_, vErr := requireDate(rawJSON(t, map[string]any{"d": "31-01-2026"}), "d")
-	if vErr == nil || vErr.Field != "d" {
+func TestBuildCreateRequestInvalidDate(t *testing.T) {
+	raw := rawJSON(t, map[string]any{
+		"date":          "31-01-2026",
+		"gross_amount":  1000,
+		"contract_type": "UOP",
+		"company":       "Acme",
+		"owner_user_id": nil,
+	})
+	_, vErr := buildCreateRequest(raw, testNow)
+	if vErr == nil || vErr.Field != "date" {
 		t.Fatalf("expected error, got %+v", vErr)
 	}
 }

--- a/backend-go/internal/snapshots/validation.go
+++ b/backend-go/internal/snapshots/validation.go
@@ -17,7 +17,7 @@ type createRequest struct {
 
 func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputil.ValidationError) {
 	var r createRequest
-	t, vErr := requireDate(raw, "date")
+	t, vErr := validation.RequiredDate(raw, "date")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -133,22 +133,6 @@ func parseValueEntry(e map[string]json.RawMessage) (ValueInput, *httputil.Valida
 	}
 	v.Value = d
 	return v, nil
-}
-
-func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	t, err := time.Parse("2006-01-02", s)
-	if err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
-	}
-	return t, nil
 }
 
 func optionalInt(raw map[string]json.RawMessage, key string) (*int, *httputil.ValidationError) {

--- a/backend-go/internal/zus/validation.go
+++ b/backend-go/internal/zus/validation.go
@@ -24,7 +24,7 @@ func buildInputs(raw map[string]json.RawMessage, now func() time.Time) (calculat
 	if err != nil {
 		return c, err
 	}
-	c.BirthDate, err = requireDate(raw, "birth_date")
+	c.BirthDate, err = validation.RequiredDate(raw, "birth_date")
 	if err != nil {
 		return c, err
 	}
@@ -147,22 +147,6 @@ func validateAgeRelationship(birth time.Time, retirementAge int, now func() time
 }
 
 // --- helpers ---
-
-func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	t, err := time.Parse("2006-01-02", s)
-	if err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
-	}
-	return t, nil
-}
 
 func requireNonNegativeFloat(raw map[string]json.RawMessage, key, msg string) (float64, *httputil.ValidationError) {
 	v, ok := raw[key]


### PR DESCRIPTION
## Summary
- Replace duplicate required YYYY-MM-DD parsing with validation.RequiredDate
- Remove local required-date helpers from salary, bonus, company valuation, equity grant, snapshot, ZUS, and CPI validation paths
- Keep recurring validation untouched because its missing/null message is intentionally different

## Checks
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check