### PR TITLE
refactor(validation): reuse positive decimal parsing

### DIFF
--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shopspring/decimal"
-
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
@@ -31,7 +29,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Date = t
 
-	amount, vErr := requirePositiveDecimal(raw, "amount", "Amount must be greater than 0")
+	amount, vErr := validation.RequiredPositiveDecimal(raw, "amount", "Field required", "Amount must be greater than 0")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -185,21 +183,6 @@ func patchEnums(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Valida
 
 func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
 	return validation.RequiredTrimmedString(raw, key, "Field required", emptyMsg)
-}
-
-func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	d, err := validation.RawDecimal(v)
-	if err != nil {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
-	}
-	if !d.IsPositive() {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	return d, nil
 }
 
 func optionalCurrency(raw map[string]json.RawMessage, fallback string) (string, *httputil.ValidationError) {

--- a/backend-go/internal/debts/validation.go
+++ b/backend-go/internal/debts/validation.go
@@ -46,7 +46,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.StartDate = sd
 
-	ia, vErr := requirePositiveDecimal(raw, "initial_amount", "Initial amount must be greater than 0")
+	ia, vErr := validation.RequiredPositiveDecimal(raw, "initial_amount", "Field required", "Initial amount must be greater than 0")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -169,21 +169,6 @@ func requireDateNotFuture(raw map[string]json.RawMessage, key, msg string) (time
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: msg}
 	}
 	return t, nil
-}
-
-func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	d, err := validation.RawDecimal(v)
-	if err != nil {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
-	}
-	if !d.IsPositive() {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	return d, nil
 }
 
 func requireNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {

--- a/backend-go/internal/retirement/validation.go
+++ b/backend-go/internal/retirement/validation.go
@@ -45,7 +45,7 @@ func buildLimitRequest(raw map[string]json.RawMessage, now func() time.Time) (li
 	}
 	r.OwnerUserID = owner
 
-	amt, vErr := requirePositiveDecimal(raw, "limit_amount", "Limit amount must be greater than 0")
+	amt, vErr := validation.RequiredPositiveDecimal(raw, "limit_amount", "Field required", "Limit amount must be greater than 0")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -148,19 +148,4 @@ func requireIntRange(raw map[string]json.RawMessage, key string, lo, hi int, msg
 		return 0, &httputil.ValidationError{Field: key, Msg: msg}
 	}
 	return n, nil
-}
-
-func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	d, err := validation.RawDecimal(v)
-	if err != nil {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
-	}
-	if !d.IsPositive() {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	return d, nil
 }

--- a/backend-go/internal/salaries/validation.go
+++ b/backend-go/internal/salaries/validation.go
@@ -35,7 +35,7 @@ func buildCreateRequest(raw map[string]json.RawMessage, now func() time.Time) (c
 	}
 	r.Date = t
 
-	amount, vErr := requirePositiveDecimal(raw, "gross_amount", "Gross amount must be greater than 0")
+	amount, vErr := validation.RequiredPositiveDecimal(raw, "gross_amount", "Field required", "Gross amount must be greater than 0")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -135,19 +135,4 @@ func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string
 		return "", &httputil.ValidationError{Field: key, Msg: emptyMsg}
 	}
 	return s, nil
-}
-
-func requirePositiveDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	d, err := validation.RawDecimal(v)
-	if err != nil {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
-	}
-	if !d.IsPositive() {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	return d, nil
 }


### PR DESCRIPTION
## Summary
- replace duplicate required positive decimal helpers with validation.RequiredPositiveDecimal
- keep create validation messages unchanged for salary, bonus event, debt, and retirement limit amount fields
- leave optional patch parsing and non-negative decimal validation local because their semantics differ

## Verification
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check