### PR TITLE
refactor(validation): reuse trimmed string parsing

### DIFF
--- a/backend-go/internal/accounts/validation.go
+++ b/backend-go/internal/accounts/validation.go
@@ -28,7 +28,7 @@ type createRequest struct {
 // buildCreateRequest validates the POST body.
 func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputil.ValidationError) {
 	var r createRequest
-	name, vErr := requireString(raw, "name", "Name cannot be empty")
+	name, vErr := validation.RequiredTrimmedString(raw, "name", "Field required", "Name cannot be empty")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -230,22 +230,6 @@ func parseInterestRate(v json.RawMessage) (decimal.Decimal, *httputil.Validation
 }
 
 // --- helpers ---
-
-func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return "", &httputil.ValidationError{Field: key, Msg: emptyMsg}
-	}
-	return s, nil
-}
 
 func optionalString(raw map[string]json.RawMessage, key, fallback string) (string, *httputil.ValidationError) {
 	v, ok := raw[key]

--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -46,7 +46,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 		return r, vErr
 	}
 
-	company, vErr := requireString(raw, "company", "Company cannot be empty")
+	company, vErr := validation.RequiredTrimmedString(raw, "company", "Field required", "Company cannot be empty")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -180,10 +180,6 @@ func patchEnums(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Valida
 }
 
 // --- shared decoders ---
-
-func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
-	return validation.RequiredTrimmedString(raw, key, "Field required", emptyMsg)
-}
 
 func optionalCurrency(raw map[string]json.RawMessage, fallback string) (string, *httputil.ValidationError) {
 	v, ok := raw["currency"]

--- a/backend-go/internal/company_valuations/validation.go
+++ b/backend-go/internal/company_valuations/validation.go
@@ -22,7 +22,7 @@ import (
 func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputil.ValidationError) {
 	var r createRequest
 
-	company, vErr := requireString(raw, "company", "Field required", "Company cannot be empty")
+	company, vErr := validation.RequiredTrimmedString(raw, "company", "Field required", "Company cannot be empty")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -66,7 +66,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 		return r, vErr
 	}
 
-	source, vErr := requireString(raw, "source", "Field required", "Source cannot be empty")
+	source, vErr := validation.RequiredTrimmedString(raw, "source", "Field required", "Source cannot be empty")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -181,10 +181,6 @@ func patchNumbers(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 }
 
 // --- shared decoders ---
-
-func requireString(raw map[string]json.RawMessage, key, missingMsg, emptyMsg string) (string, *httputil.ValidationError) {
-	return validation.RequiredTrimmedString(raw, key, missingMsg, emptyMsg)
-}
 
 func optionalCurrency(raw map[string]json.RawMessage) (string, *httputil.ValidationError) {
 	v, ok := raw["currency"]

--- a/backend-go/internal/debts/validation.go
+++ b/backend-go/internal/debts/validation.go
@@ -28,7 +28,7 @@ type createRequest struct {
 
 func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputil.ValidationError) {
 	var r createRequest
-	name, vErr := requireString(raw, "name", "Name cannot be empty")
+	name, vErr := validation.RequiredTrimmedString(raw, "name", "Field required", "Name cannot be empty")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -154,10 +154,6 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 
 func requireOwnerUserID(raw map[string]json.RawMessage) (*int, *httputil.ValidationError) {
 	return validation.RequiredIntOrNull(raw, "owner_user_id")
-}
-
-func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
-	return validation.RequiredTrimmedString(raw, key, "Field required", emptyMsg)
 }
 
 func requireDateNotFuture(raw map[string]json.RawMessage, key, msg string) (time.Time, *httputil.ValidationError) {

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -96,7 +96,7 @@ func requireGrantBasics(raw map[string]json.RawMessage, r *createRequest) *httpu
 	}
 	r.Type = grantType
 
-	company, vErr := requireString(raw, "company", "Company cannot be empty")
+	company, vErr := validation.RequiredTrimmedString(raw, "company", "Field required", "Company cannot be empty")
 	if vErr != nil {
 		return vErr
 	}
@@ -322,22 +322,6 @@ func patchSchedule(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Val
 }
 
 // --- shared decoders ---
-
-func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return "", &httputil.ValidationError{Field: key, Msg: emptyMsg}
-	}
-	return s, nil
-}
 
 func requirePositiveInt(raw map[string]json.RawMessage, key, msg string) (int, *httputil.ValidationError) {
 	v, ok := raw[key]

--- a/backend-go/internal/salaries/validation.go
+++ b/backend-go/internal/salaries/validation.go
@@ -47,7 +47,7 @@ func buildCreateRequest(raw map[string]json.RawMessage, now func() time.Time) (c
 	}
 	r.ContractType = contract
 
-	company, vErr := requireString(raw, "company", "Company cannot be empty")
+	company, vErr := validation.RequiredTrimmedString(raw, "company", "Field required", "Company cannot be empty")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -120,19 +120,4 @@ func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (Upd
 		}
 	}
 	return p, nil
-}
-
-func requireString(raw map[string]json.RawMessage, key, emptyMsg string) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return "", &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	s, err := validation.RawTrimmedString(v)
-	if err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if s == "" {
-		return "", &httputil.ValidationError{Field: key, Msg: emptyMsg}
-	}
-	return s, nil
 }


### PR DESCRIPTION
## Summary
- replace duplicate required string trimming helpers with validation.RequiredTrimmedString
- inline thin wrappers that only forwarded to the shared helper
- preserve existing missing, type, and empty-string validation messages

## Verification
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check