### PR TITLE
refactor(validation): share required int range parsing

### DIFF
--- a/backend-go/internal/retirement/validation.go
+++ b/backend-go/internal/retirement/validation.go
@@ -26,7 +26,7 @@ var validWrappers = map[string]struct{}{
 func buildLimitRequest(raw map[string]json.RawMessage, now func() time.Time) (limitRequest, *httputil.ValidationError) {
 	var r limitRequest
 	currentYear := now().UTC().Year()
-	year, vErr := requireIntRange(raw, "year", 2000, currentYear+10,
+	year, vErr := validation.RequiredIntRange(raw, "year", 2000, currentYear+10,
 		fmt.Sprintf("Year must be between 2000 and %d", currentYear+10))
 	if vErr != nil {
 		return r, vErr
@@ -80,14 +80,14 @@ func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) 
 	}
 	r.OwnerUserID = &owner
 
-	month, vErr := requireIntRange(raw, "month", 1, 12, "Month must be between 1 and 12")
+	month, vErr := validation.RequiredIntRange(raw, "month", 1, 12, "Month must be between 1 and 12")
 	if vErr != nil {
 		return r, vErr
 	}
 	r.Month = month
 
 	currentYear := now().UTC().Year()
-	year, vErr := requireIntRange(raw, "year", 2019, currentYear+1,
+	year, vErr := validation.RequiredIntRange(raw, "year", 2019, currentYear+1,
 		fmt.Sprintf("Year must be between 2019 and %d", currentYear+1))
 	if vErr != nil {
 		return r, vErr
@@ -131,21 +131,6 @@ func requireInt(raw map[string]json.RawMessage, key string) (int, *httputil.Vali
 	var n int
 	if err := json.Unmarshal(v, &n); err != nil {
 		return 0, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
-	}
-	return n, nil
-}
-
-func requireIntRange(raw map[string]json.RawMessage, key string, lo, hi int, msg string) (int, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return 0, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
-	}
-	if n < lo || n > hi {
-		return 0, &httputil.ValidationError{Field: key, Msg: msg}
 	}
 	return n, nil
 }

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -109,6 +109,29 @@ func RequiredIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httpu
 	return &n, nil
 }
 
+// RequiredIntRange reads a required integer field and validates it falls
+// within the inclusive [lo, hi] range.
+func RequiredIntRange(
+	raw map[string]json.RawMessage,
+	key string,
+	lo int,
+	hi int,
+	rangeMsg string,
+) (int, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
+	}
+	n, err := RawInt(v)
+	if err != nil {
+		return 0, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
+	}
+	if n < lo || n > hi {
+		return 0, &httputil.ValidationError{Field: key, Msg: rangeMsg}
+	}
+	return n, nil
+}
+
 // RequiredEnumString reads a required string field and checks it belongs to
 // the provided allowed set.
 func RequiredEnumString(

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -134,6 +134,43 @@ func TestRequiredIntOrNull(t *testing.T) {
 	requireValidation(t, vErr, "owner_user_id", "must be an integer")
 }
 
+func TestRequiredIntRange(t *testing.T) {
+	got, vErr := RequiredIntRange(
+		map[string]json.RawMessage{"year": json.RawMessage(`2026`)},
+		"year",
+		2000,
+		2030,
+		"Year must be between 2000 and 2030",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != 2026 {
+		t.Fatalf("got = %d", got)
+	}
+
+	_, vErr = RequiredIntRange(map[string]json.RawMessage{}, "year", 2000, 2030, "Year must be between 2000 and 2030")
+	requireValidation(t, vErr, "year", "Field required")
+
+	_, vErr = RequiredIntRange(
+		map[string]json.RawMessage{"year": json.RawMessage(`"2026"`)},
+		"year",
+		2000,
+		2030,
+		"Year must be between 2000 and 2030",
+	)
+	requireValidation(t, vErr, "year", "must be an integer")
+
+	_, vErr = RequiredIntRange(
+		map[string]json.RawMessage{"year": json.RawMessage(`1999`)},
+		"year",
+		2000,
+		2030,
+		"Year must be between 2000 and 2030",
+	)
+	requireValidation(t, vErr, "year", "Year must be between 2000 and 2030")
+}
+
 func TestRequiredEnumString(t *testing.T) {
 	allowed := map[string]struct{}{"employment": {}, "b2b": {}}
 

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -153,6 +153,15 @@ func TestRequiredIntRange(t *testing.T) {
 	requireValidation(t, vErr, "year", "Field required")
 
 	_, vErr = RequiredIntRange(
+		map[string]json.RawMessage{"year": json.RawMessage(`null`)},
+		"year",
+		2000,
+		2030,
+		"Year must be between 2000 and 2030",
+	)
+	requireValidation(t, vErr, "year", "Field required")
+
+	_, vErr = RequiredIntRange(
 		map[string]json.RawMessage{"year": json.RawMessage(`"2026"`)},
 		"year",
 		2000,

--- a/backend-go/internal/zus/validation.go
+++ b/backend-go/internal/zus/validation.go
@@ -90,7 +90,7 @@ func readMisc(raw map[string]json.RawMessage, in *Inputs) *httputil.ValidationEr
 		return err
 	}
 	in.KapitalPoczatkowy = kapital
-	work, err := requireIntRange(raw, "work_start_year", 1970, 2030, "Work start year must be between 1970 and 2030")
+	work, err := validation.RequiredIntRange(raw, "work_start_year", 1970, 2030, "Work start year must be between 1970 and 2030")
 	if err != nil {
 		return err
 	}
@@ -208,21 +208,6 @@ func optionalIntRange(raw map[string]json.RawMessage, key string, fallback, lo, 
 	}
 	if validation.IsNull(v) {
 		return 0, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
-	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return 0, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
-	}
-	if n < lo || n > hi {
-		return 0, &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	return n, nil
-}
-
-func requireIntRange(raw map[string]json.RawMessage, key string, lo, hi int, msg string) (int, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
 	}
 	var n int
 	if err := json.Unmarshal(v, &n); err != nil {

--- a/backend-go/internal/zus/validation_test.go
+++ b/backend-go/internal/zus/validation_test.go
@@ -161,10 +161,3 @@ func TestOptionalIntRangeNullIsError(t *testing.T) {
 		t.Fatalf("expected error on null, got %+v", vErr)
 	}
 }
-
-func TestRequireIntRangeRequired(t *testing.T) {
-	_, vErr := requireIntRange(map[string]json.RawMessage{}, "x", 0, 10, "msg")
-	if vErr == nil || vErr.Field != "x" {
-		t.Fatalf("expected required, got %+v", vErr)
-	}
-}


### PR DESCRIPTION
## Summary
- add validation.RequiredIntRange for required inclusive integer ranges
- reuse it from retirement and ZUS validators
- move required-range helper coverage into the shared validation package

## Verification
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check