### PR TITLE
refactor(validation): share non-negative decimal parsing

### DIFF
--- a/backend-go/internal/company_valuations/validation.go
+++ b/backend-go/internal/company_valuations/validation.go
@@ -40,17 +40,22 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Currency = currency
 
-	fmv, vErr := requireNonNegativeDecimal(raw, "fmv_per_share", "FMV per share must be non-negative")
+	fmv, vErr := validation.RequiredNonNegativeDecimal(
+		raw,
+		"fmv_per_share",
+		"Field required",
+		"FMV per share must be non-negative",
+	)
 	if vErr != nil {
 		return r, vErr
 	}
 	r.FMVPerShare = fmv
 
-	r.FMVLow, vErr = optionalNonNegativeDecimal(raw, "fmv_low", "FMV range values must be non-negative")
+	r.FMVLow, vErr = validation.OptionalNonNegativeDecimal(raw, "fmv_low", "FMV range values must be non-negative")
 	if vErr != nil {
 		return r, vErr
 	}
-	r.FMVHigh, vErr = optionalNonNegativeDecimal(raw, "fmv_high", "FMV range values must be non-negative")
+	r.FMVHigh, vErr = validation.OptionalNonNegativeDecimal(raw, "fmv_high", "FMV range values must be non-negative")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -162,7 +167,7 @@ func patchNumbers(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 		{"fmv_low", "fmv_low", "FMV values must be non-negative", &p.FMVLow},
 		{"fmv_high", "fmv_high", "FMV values must be non-negative", &p.FMVHigh},
 	} {
-		d, vErr := optionalNonNegativeDecimal(raw, f.key, f.msg)
+		d, vErr := validation.OptionalNonNegativeDecimal(raw, f.key, f.msg)
 		if vErr != nil {
 			vErr.Field = f.field
 			return vErr
@@ -196,39 +201,6 @@ func optionalCurrency(raw map[string]json.RawMessage) (string, *httputil.Validat
 		return "", &httputil.ValidationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
 	}
 	return s, nil
-}
-
-// requireNonNegativeDecimal parses a required JSON number as a Decimal using
-// the raw token (no float64 intermediate) so Numeric column precision is
-// preserved end-to-end.
-func requireNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	d, err := validation.RawDecimal(v)
-	if err != nil {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
-	}
-	if d.IsNegative() {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	return d, nil
-}
-
-func optionalNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) (*decimal.Decimal, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return nil, nil
-	}
-	d, err := validation.RawDecimal(v)
-	if err != nil {
-		return nil, &httputil.ValidationError{Field: key, Msg: "must be a number"}
-	}
-	if d.IsNegative() {
-		return nil, &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	return &d, nil
 }
 
 func optionalDiscountPct(raw map[string]json.RawMessage) (*decimal.Decimal, *httputil.ValidationError) {

--- a/backend-go/internal/debts/validation.go
+++ b/backend-go/internal/debts/validation.go
@@ -52,7 +52,12 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.InitialAmount = ia
 
-	ir, vErr := requireNonNegativeDecimal(raw, "interest_rate", "Interest rate must be greater than or equal to 0")
+	ir, vErr := validation.RequiredNonNegativeDecimal(
+		raw,
+		"interest_rate",
+		"Field required",
+		"Interest rate must be greater than or equal to 0",
+	)
 	if vErr != nil {
 		return r, vErr
 	}
@@ -121,15 +126,14 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.InitialAmount = &d
 	}
-	if v, ok := raw["interest_rate"]; ok && !validation.IsNull(v) {
-		d, err := validation.RawDecimal(v)
-		if err != nil {
-			return p, &httputil.ValidationError{Field: "interest_rate", Msg: "must be a number"}
-		}
-		if d.IsNegative() {
-			return p, &httputil.ValidationError{Field: "interest_rate", Msg: "Interest rate must be greater than or equal to 0"}
-		}
-		p.InterestRate = &d
+	if d, vErr := validation.OptionalNonNegativeDecimal(
+		raw,
+		"interest_rate",
+		"Interest rate must be greater than or equal to 0",
+	); vErr != nil {
+		return p, vErr
+	} else if d != nil {
+		p.InterestRate = d
 	}
 	if v, ok := raw["currency"]; ok && !validation.IsNull(v) {
 		var s string
@@ -165,21 +169,6 @@ func requireDateNotFuture(raw map[string]json.RawMessage, key, msg string) (time
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: msg}
 	}
 	return t, nil
-}
-
-func requireNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) (decimal.Decimal, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	d, err := validation.RawDecimal(v)
-	if err != nil {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: "must be a number"}
-	}
-	if d.IsNegative() {
-		return decimal.Decimal{}, &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	return d, nil
 }
 
 func optionalCurrencyPLN(raw map[string]json.RawMessage) (string, *httputil.ValidationError) {

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -114,7 +114,7 @@ func requireGrantBasics(raw map[string]json.RawMessage, r *createRequest) *httpu
 	}
 	r.TotalShares = totalShares
 
-	strike, vErr := optionalNonNegativeDecimal(raw, "strike_price", "Strike price must be non-negative")
+	strike, vErr := validation.OptionalNonNegativeDecimal(raw, "strike_price", "Strike price must be non-negative")
 	if vErr != nil {
 		return vErr
 	}
@@ -258,15 +258,10 @@ func patchNumbersAndBools(raw map[string]json.RawMessage, p *UpdatePatch) *httpu
 	if vErr := patchPositiveInt(raw, "vest_total_months", "Total vesting months must be greater than 0", &p.VestTotalMonths); vErr != nil {
 		return vErr
 	}
-	if v, ok := raw["strike_price"]; ok && !validation.IsNull(v) {
-		d, err := validation.RawDecimal(v)
-		if err != nil {
-			return &httputil.ValidationError{Field: "strike_price", Msg: "must be a number"}
-		}
-		if d.IsNegative() {
-			return &httputil.ValidationError{Field: "strike_price", Msg: "Strike price must be non-negative"}
-		}
-		p.StrikePrice = &d
+	if d, vErr := validation.OptionalNonNegativeDecimal(raw, "strike_price", "Strike price must be non-negative"); vErr != nil {
+		return vErr
+	} else if d != nil {
+		p.StrikePrice = d
 	}
 	if v, ok := raw["requires_liquidity_event"]; ok && !validation.IsNull(v) {
 		var b bool
@@ -382,21 +377,6 @@ func optionalCurrency(raw map[string]json.RawMessage, fallback string) (string, 
 		return "", &httputil.ValidationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
 	}
 	return s, nil
-}
-
-func optionalNonNegativeDecimal(raw map[string]json.RawMessage, key, msg string) (*decimal.Decimal, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return nil, nil
-	}
-	d, err := validation.RawDecimal(v)
-	if err != nil {
-		return nil, &httputil.ValidationError{Field: key, Msg: "must be a number"}
-	}
-	if d.IsNegative() {
-		return nil, &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	return &d, nil
 }
 
 // --- PATCH helpers ---

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -189,6 +189,24 @@ func RequiredPositiveDecimal(
 	return d, nil
 }
 
+// RequiredNonNegativeDecimal reads a required JSON number field and rejects
+// negative values with the supplied nonNegativeMsg.
+func RequiredNonNegativeDecimal(
+	raw map[string]json.RawMessage,
+	key string,
+	missingMsg string,
+	nonNegativeMsg string,
+) (decimal.Decimal, *httputil.ValidationError) {
+	d, vErr := RequiredDecimal(raw, key, missingMsg)
+	if vErr != nil {
+		return decimal.Zero, vErr
+	}
+	if d.IsNegative() {
+		return decimal.Zero, &httputil.ValidationError{Field: key, Msg: nonNegativeMsg}
+	}
+	return d, nil
+}
+
 // OptionalDecimal reads an optional JSON number field. Missing and explicit
 // null are treated the same; quoted numeric strings are rejected.
 func OptionalDecimal(
@@ -204,6 +222,23 @@ func OptionalDecimal(
 		return nil, &httputil.ValidationError{Field: key, Msg: "must be a number"}
 	}
 	return &d, nil
+}
+
+// OptionalNonNegativeDecimal reads an optional JSON number field and rejects
+// negative values with the supplied nonNegativeMsg.
+func OptionalNonNegativeDecimal(
+	raw map[string]json.RawMessage,
+	key string,
+	nonNegativeMsg string,
+) (*decimal.Decimal, *httputil.ValidationError) {
+	d, vErr := OptionalDecimal(raw, key)
+	if vErr != nil {
+		return nil, vErr
+	}
+	if d != nil && d.IsNegative() {
+		return nil, &httputil.ValidationError{Field: key, Msg: nonNegativeMsg}
+	}
+	return d, nil
 }
 
 // RequiredDecimalStringOrNumber reads a required decimal field that may arrive

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -275,6 +275,53 @@ func TestRequiredPositiveDecimal(t *testing.T) {
 	requireValidation(t, vErr, "amount", "Amount must be greater than 0")
 }
 
+func TestRequiredNonNegativeDecimal(t *testing.T) {
+	got, vErr := RequiredNonNegativeDecimal(
+		map[string]json.RawMessage{"amount": json.RawMessage(`0`)},
+		"amount",
+		"Field required",
+		"Amount must be non-negative",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if !got.Equal(decimal.Zero) {
+		t.Fatalf("got = %s", got)
+	}
+
+	_, vErr = RequiredNonNegativeDecimal(
+		map[string]json.RawMessage{},
+		"amount",
+		"Field required",
+		"Amount must be non-negative",
+	)
+	requireValidation(t, vErr, "amount", "Field required")
+
+	_, vErr = RequiredNonNegativeDecimal(
+		map[string]json.RawMessage{"amount": json.RawMessage(`null`)},
+		"amount",
+		"Field required",
+		"Amount must be non-negative",
+	)
+	requireValidation(t, vErr, "amount", "Field required")
+
+	_, vErr = RequiredNonNegativeDecimal(
+		map[string]json.RawMessage{"amount": json.RawMessage(`-0.01`)},
+		"amount",
+		"Field required",
+		"Amount must be non-negative",
+	)
+	requireValidation(t, vErr, "amount", "Amount must be non-negative")
+
+	_, vErr = RequiredNonNegativeDecimal(
+		map[string]json.RawMessage{"amount": json.RawMessage(`"0"`)},
+		"amount",
+		"Field required",
+		"Amount must be non-negative",
+	)
+	requireValidation(t, vErr, "amount", "must be a number")
+}
+
 func TestOptionalDecimal(t *testing.T) {
 	got, vErr := OptionalDecimal(
 		map[string]json.RawMessage{"fee": json.RawMessage(`1.25`)},
@@ -298,6 +345,52 @@ func TestOptionalDecimal(t *testing.T) {
 	}
 
 	_, vErr = OptionalDecimal(map[string]json.RawMessage{"fee": json.RawMessage(`"1.25"`)}, "fee")
+	requireValidation(t, vErr, "fee", "must be a number")
+}
+
+func TestOptionalNonNegativeDecimal(t *testing.T) {
+	got, vErr := OptionalNonNegativeDecimal(
+		map[string]json.RawMessage{"fee": json.RawMessage(`0`)},
+		"fee",
+		"Fee must be non-negative",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || !got.Equal(decimal.Zero) {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalNonNegativeDecimal(
+		map[string]json.RawMessage{},
+		"fee",
+		"Fee must be non-negative",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalNonNegativeDecimal(
+		map[string]json.RawMessage{"fee": json.RawMessage(`null`)},
+		"fee",
+		"Fee must be non-negative",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalNonNegativeDecimal(
+		map[string]json.RawMessage{"fee": json.RawMessage(`-0.01`)},
+		"fee",
+		"Fee must be non-negative",
+	)
+	requireValidation(t, vErr, "fee", "Fee must be non-negative")
+
+	_, vErr = OptionalNonNegativeDecimal(
+		map[string]json.RawMessage{"fee": json.RawMessage(`"0"`)},
+		"fee",
+		"Fee must be non-negative",
+	)
 	requireValidation(t, vErr, "fee", "must be a number")
 }
 


### PR DESCRIPTION
## Summary
- add shared required/optional non-negative decimal validation helpers
- replace local helper copies in company valuations, debts, and equity grants
- cover missing, null, negative, and type-error paths in validation tests

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check