### PR TITLE
refactor(validation): share required int parsing

### DIFF
--- a/backend-go/internal/holdings/validation.go
+++ b/backend-go/internal/holdings/validation.go
@@ -81,15 +81,19 @@ func validAssetType(t string) bool {
 
 func buildLotInput(raw map[string]json.RawMessage) (Lot, *httputil.ValidationError) {
 	var l Lot
-	if vErr := requireInt(raw, "account_id", &l.AccountID); vErr != nil {
+	accountID, vErr := validation.RequiredInt(raw, "account_id", "required", "must be integer")
+	if vErr != nil {
 		return l, vErr
 	}
+	l.AccountID = accountID
 	if l.AccountID <= 0 {
 		return l, &httputil.ValidationError{Field: "account_id", Msg: "must be positive"}
 	}
-	if vErr := requireInt(raw, "security_id", &l.SecurityID); vErr != nil {
+	securityID, vErr := validation.RequiredInt(raw, "security_id", "required", "must be integer")
+	if vErr != nil {
 		return l, vErr
 	}
+	l.SecurityID = securityID
 	if l.SecurityID <= 0 {
 		return l, &httputil.ValidationError{Field: "security_id", Msg: "must be positive"}
 	}
@@ -174,15 +178,19 @@ func buildQuoteInput(raw map[string]json.RawMessage, securityID int) (PriceQuote
 func buildDividendInput(raw map[string]json.RawMessage) (Dividend, *httputil.ValidationError) {
 	var d Dividend
 	d.Currency = "PLN"
-	if vErr := requireInt(raw, "account_id", &d.AccountID); vErr != nil {
+	accountID, vErr := validation.RequiredInt(raw, "account_id", "required", "must be integer")
+	if vErr != nil {
 		return d, vErr
 	}
+	d.AccountID = accountID
 	if d.AccountID <= 0 {
 		return d, &httputil.ValidationError{Field: "account_id", Msg: "must be positive"}
 	}
-	if vErr := requireInt(raw, "security_id", &d.SecurityID); vErr != nil {
+	securityID, vErr := validation.RequiredInt(raw, "security_id", "required", "must be integer")
+	if vErr != nil {
 		return d, vErr
 	}
+	d.SecurityID = securityID
 	if d.SecurityID <= 0 {
 		return d, &httputil.ValidationError{Field: "security_id", Msg: "must be positive"}
 	}
@@ -227,17 +235,6 @@ func buildDividendInput(raw map[string]json.RawMessage) (Dividend, *httputil.Val
 		}
 	}
 	return d, nil
-}
-
-func requireInt(raw map[string]json.RawMessage, key string, dest *int) *httputil.ValidationError {
-	v, ok := raw[key]
-	if !ok || string(v) == "null" {
-		return &httputil.ValidationError{Field: key, Msg: "required"}
-	}
-	if err := json.Unmarshal(v, dest); err != nil {
-		return &httputil.ValidationError{Field: key, Msg: "must be integer"}
-	}
-	return nil
 }
 
 func requireString(raw map[string]json.RawMessage, key string, dest *string) *httputil.ValidationError {

--- a/backend-go/internal/recurring/validation.go
+++ b/backend-go/internal/recurring/validation.go
@@ -26,9 +26,11 @@ func buildInput(raw map[string]json.RawMessage) (CreateInput, *httputil.Validati
 }
 
 func readAccountAndAmount(raw map[string]json.RawMessage, in *CreateInput) *httputil.ValidationError {
-	if err := requireInt(raw, "account_id", &in.AccountID); err != nil {
+	accountID, err := validation.RequiredInt(raw, "account_id", "required", "must be integer")
+	if err != nil {
 		return err
 	}
+	in.AccountID = accountID
 	if in.AccountID <= 0 {
 		return &httputil.ValidationError{Field: "account_id", Msg: "must be positive"}
 	}
@@ -127,17 +129,6 @@ func readDatesAndActive(raw map[string]json.RawMessage, in *CreateInput) *httput
 		if jerr := json.Unmarshal(v, &in.Active); jerr != nil {
 			return &httputil.ValidationError{Field: "active", Msg: "must be a boolean"}
 		}
-	}
-	return nil
-}
-
-func requireInt(raw map[string]json.RawMessage, key string, dest *int) *httputil.ValidationError {
-	v, ok := raw[key]
-	if !ok || string(v) == "null" {
-		return &httputil.ValidationError{Field: key, Msg: "required"}
-	}
-	if err := json.Unmarshal(v, dest); err != nil {
-		return &httputil.ValidationError{Field: key, Msg: "must be integer"}
 	}
 	return nil
 }

--- a/backend-go/internal/retirement/validation.go
+++ b/backend-go/internal/retirement/validation.go
@@ -74,7 +74,7 @@ func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) 
 	// PPK contributions are always generated for a specific person — a null
 	// (jointly owned) owner is rejected up front rather than failing later
 	// with a confusing 404.
-	owner, vErr := requireInt(raw, "owner_user_id")
+	owner, vErr := validation.RequiredInt(raw, "owner_user_id", "Field required", "must be an integer")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -120,17 +120,4 @@ func optionalBool(raw map[string]json.RawMessage, key string) (bool, *httputil.V
 		return false, &httputil.ValidationError{Field: key, Msg: "must be a boolean"}
 	}
 	return b, nil
-}
-
-// requireInt reads an integer key that must be present and non-null.
-func requireInt(raw map[string]json.RawMessage, key string) (int, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return 0, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
-	}
-	return n, nil
 }

--- a/backend-go/internal/simulations/validation.go
+++ b/backend-go/internal/simulations/validation.go
@@ -37,7 +37,7 @@ func buildMortgageInputs(raw map[string]json.RawMessage) (MortgageInputs, *httpu
 	if in.AnnualInterestRate <= 0 || in.AnnualInterestRate > 30 {
 		return in, &httputil.ValidationError{Field: "annual_interest_rate", Msg: "Annual interest rate must be between 0 and 30%"}
 	}
-	in.RemainingMonths, vErr = requireInt(raw, "remaining_months")
+	in.RemainingMonths, vErr = validation.RequiredInt(raw, "remaining_months", "Field required", "must be an integer")
 	if vErr != nil {
 		return in, vErr
 	}
@@ -99,7 +99,7 @@ func buildWiborInputs(raw map[string]json.RawMessage) (WiborScenarioInputs, *htt
 	if in.BaseAnnualRate <= 0 || in.BaseAnnualRate > 30 {
 		return in, &httputil.ValidationError{Field: "base_annual_rate", Msg: "Base annual rate must be > 0 and <= 30%"}
 	}
-	in.RemainingMonths, vErr = requireInt(raw, "remaining_months")
+	in.RemainingMonths, vErr = validation.RequiredInt(raw, "remaining_months", "Field required", "must be an integer")
 	if vErr != nil {
 		return in, vErr
 	}
@@ -431,20 +431,8 @@ func requireFloat(raw map[string]json.RawMessage, key string) (float64, *httputi
 	return f, nil
 }
 
-func requireInt(raw map[string]json.RawMessage, key string) (int, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return 0, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
-	}
-	return n, nil
-}
-
 func requireAge(raw map[string]json.RawMessage, key string) (int, *httputil.ValidationError) {
-	n, vErr := requireInt(raw, key)
+	n, vErr := validation.RequiredInt(raw, key, "Field required", "must be an integer")
 	if vErr != nil {
 		return 0, vErr
 	}

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -109,6 +109,25 @@ func RequiredIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httpu
 	return &n, nil
 }
 
+// RequiredInt reads a required integer field and returns the supplied messages
+// so callers can preserve existing endpoint wire contracts.
+func RequiredInt(
+	raw map[string]json.RawMessage,
+	key string,
+	missingMsg string,
+	typeMsg string,
+) (int, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return 0, &httputil.ValidationError{Field: key, Msg: missingMsg}
+	}
+	n, err := RawInt(v)
+	if err != nil {
+		return 0, &httputil.ValidationError{Field: key, Msg: typeMsg}
+	}
+	return n, nil
+}
+
 // RequiredIntRange reads a required integer field and validates it falls
 // within the inclusive [lo, hi] range.
 func RequiredIntRange(
@@ -118,13 +137,9 @@ func RequiredIntRange(
 	hi int,
 	rangeMsg string,
 ) (int, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || IsNull(v) {
-		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	n, err := RawInt(v)
-	if err != nil {
-		return 0, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
+	n, vErr := RequiredInt(raw, key, "Field required", "must be an integer")
+	if vErr != nil {
+		return 0, vErr
 	}
 	if n < lo || n > hi {
 		return 0, &httputil.ValidationError{Field: key, Msg: rangeMsg}

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -134,6 +134,40 @@ func TestRequiredIntOrNull(t *testing.T) {
 	requireValidation(t, vErr, "owner_user_id", "must be an integer")
 }
 
+func TestRequiredInt(t *testing.T) {
+	got, vErr := RequiredInt(
+		map[string]json.RawMessage{"account_id": json.RawMessage(`7`)},
+		"account_id",
+		"required",
+		"must be integer",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != 7 {
+		t.Fatalf("got = %d", got)
+	}
+
+	_, vErr = RequiredInt(map[string]json.RawMessage{}, "account_id", "required", "must be integer")
+	requireValidation(t, vErr, "account_id", "required")
+
+	_, vErr = RequiredInt(
+		map[string]json.RawMessage{"account_id": json.RawMessage(`null`)},
+		"account_id",
+		"required",
+		"must be integer",
+	)
+	requireValidation(t, vErr, "account_id", "required")
+
+	_, vErr = RequiredInt(
+		map[string]json.RawMessage{"account_id": json.RawMessage(`"7"`)},
+		"account_id",
+		"required",
+		"must be integer",
+	)
+	requireValidation(t, vErr, "account_id", "must be integer")
+}
+
 func TestRequiredIntRange(t *testing.T) {
 	got, vErr := RequiredIntRange(
 		map[string]json.RawMessage{"year": json.RawMessage(`2026`)},


### PR DESCRIPTION
## Summary
- add shared required integer validation with caller-provided messages
- reuse it from required integer range validation
- replace local required-int helpers in recurring, holdings, retirement, and simulations

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check