### PR TITLE
refactor(validation): share date future checks

### DIFF
--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
@@ -20,12 +19,9 @@ import (
 func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputil.ValidationError) {
 	var r createRequest
 
-	t, vErr := validation.RequiredDate(raw, "date")
+	t, vErr := validation.RequiredDateNotFuture(raw, "date", nil)
 	if vErr != nil {
 		return r, vErr
-	}
-	if t.After(today()) {
-		return r, &httputil.ValidationError{Field: "date", Msg: "Date cannot be in the future"}
 	}
 	r.Date = t
 
@@ -87,19 +83,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 }
 
 func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.ValidationError {
-	if v, ok := raw["date"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: "date", Msg: "must be a string"}
-		}
-		t, err := time.Parse("2006-01-02", s)
-		if err != nil {
-			return &httputil.ValidationError{Field: "date", Msg: "must be YYYY-MM-DD"}
-		}
-		if t.After(today()) {
-			return &httputil.ValidationError{Field: "date", Msg: "Date cannot be in the future"}
-		}
-		p.Date = &t
+	if t, vErr := validation.OptionalDateNotFuture(raw, "date", nil, "Date cannot be in the future"); vErr != nil {
+		return vErr
+	} else if t != nil {
+		p.Date = t
 	}
 	if v, ok := raw["amount"]; ok && !validation.IsNull(v) {
 		d, err := validation.RawDecimal(v)
@@ -195,9 +182,4 @@ func optionalCurrency(raw map[string]json.RawMessage, fallback string) (string, 
 		return "", &httputil.ValidationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
 	}
 	return s, nil
-}
-
-func today() time.Time {
-	now := time.Now().UTC()
-	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 }

--- a/backend-go/internal/debts/validation.go
+++ b/backend-go/internal/debts/validation.go
@@ -40,7 +40,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.DebtType = dt
 
-	sd, vErr := requireDateNotFuture(raw, "start_date", "Start date cannot be in the future")
+	sd, vErr := validation.RequiredDateNotFutureWithMessage(raw, "start_date", time.Now, "Start date cannot be in the future")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -102,19 +102,15 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.DebtType = &s
 	}
-	if v, ok := raw["start_date"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return p, &httputil.ValidationError{Field: "start_date", Msg: "must be a string"}
-		}
-		t, err := time.Parse("2006-01-02", s)
-		if err != nil {
-			return p, &httputil.ValidationError{Field: "start_date", Msg: "must be YYYY-MM-DD"}
-		}
-		if t.After(today()) {
-			return p, &httputil.ValidationError{Field: "start_date", Msg: "Start date cannot be in the future"}
-		}
-		p.StartDate = &t
+	if t, vErr := validation.OptionalDateNotFuture(
+		raw,
+		"start_date",
+		time.Now,
+		"Start date cannot be in the future",
+	); vErr != nil {
+		return p, vErr
+	} else if t != nil {
+		p.StartDate = t
 	}
 	if v, ok := raw["initial_amount"]; ok && !validation.IsNull(v) {
 		d, err := validation.RawDecimal(v)
@@ -160,17 +156,6 @@ func requireOwnerUserID(raw map[string]json.RawMessage) (*int, *httputil.Validat
 	return validation.RequiredIntOrNull(raw, "owner_user_id")
 }
 
-func requireDateNotFuture(raw map[string]json.RawMessage, key, msg string) (time.Time, *httputil.ValidationError) {
-	t, vErr := validation.RequiredDate(raw, key)
-	if vErr != nil {
-		return time.Time{}, vErr
-	}
-	if t.After(today()) {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	return t, nil
-}
-
 func optionalCurrencyPLN(raw map[string]json.RawMessage) (string, *httputil.ValidationError) {
 	v, ok := raw["currency"]
 	if !ok || validation.IsNull(v) {
@@ -184,9 +169,4 @@ func optionalCurrencyPLN(raw map[string]json.RawMessage) (string, *httputil.Vali
 		return "", &httputil.ValidationError{Field: "currency", Msg: "Currency must be 'PLN'"}
 	}
 	return s, nil
-}
-
-func today() time.Time {
-	t := time.Now().UTC()
-	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
 }

--- a/backend-go/internal/salaries/validation.go
+++ b/backend-go/internal/salaries/validation.go
@@ -26,12 +26,9 @@ type createRequest struct {
 // fields surface "Field required" on missing.
 func buildCreateRequest(raw map[string]json.RawMessage, now func() time.Time) (createRequest, *httputil.ValidationError) {
 	var r createRequest
-	t, vErr := validation.RequiredDate(raw, "date")
+	t, vErr := validation.RequiredDateNotFuture(raw, "date", now)
 	if vErr != nil {
 		return r, vErr
-	}
-	if t.After(truncateDay(now().UTC())) {
-		return r, &httputil.ValidationError{Field: "date", Msg: "Date cannot be in the future"}
 	}
 	r.Date = t
 
@@ -64,18 +61,10 @@ func buildCreateRequest(raw map[string]json.RawMessage, now func() time.Time) (c
 // buildUpdatePatch reads the PATCH body. Null = no-op (Pydantic semantics).
 func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (UpdatePatch, *httputil.ValidationError) {
 	var p UpdatePatch
-	if v, ok := raw["date"]; ok && !validation.IsNull(v) {
-		t, err := validation.RawDate(v)
-		if err != nil {
-			if validation.IsRawDateFormatError(err) {
-				return p, &httputil.ValidationError{Field: "date", Msg: "must be YYYY-MM-DD"}
-			}
-			return p, &httputil.ValidationError{Field: "date", Msg: "must be a string"}
-		}
-		if t.After(truncateDay(now().UTC())) {
-			return p, &httputil.ValidationError{Field: "date", Msg: "Date cannot be in the future"}
-		}
-		p.Date = &t
+	if t, vErr := validation.OptionalDateNotFuture(raw, "date", now, "Date cannot be in the future"); vErr != nil {
+		return p, vErr
+	} else if t != nil {
+		p.Date = t
 	}
 	if v, ok := raw["gross_amount"]; ok && !validation.IsNull(v) {
 		d, err := validation.RawDecimal(v)

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -77,19 +77,58 @@ func RequiredDateNotFuture(
 	key string,
 	now func() time.Time,
 ) (time.Time, *httputil.ValidationError) {
+	return RequiredDateNotFutureWithMessage(raw, key, now, "Date cannot be in the future")
+}
+
+// RequiredDateNotFutureWithMessage reads a required YYYY-MM-DD field and
+// rejects dates after the current UTC day returned by now with futureMsg.
+func RequiredDateNotFutureWithMessage(
+	raw map[string]json.RawMessage,
+	key string,
+	now func() time.Time,
+	futureMsg string,
+) (time.Time, *httputil.ValidationError) {
 	t, vErr := RequiredDate(raw, key)
 	if vErr != nil {
 		return time.Time{}, vErr
 	}
+	if t.After(todayUTC(now)) {
+		return time.Time{}, &httputil.ValidationError{Field: key, Msg: futureMsg}
+	}
+	return t, nil
+}
+
+// OptionalDateNotFuture reads an optional YYYY-MM-DD field and rejects dates
+// after the current UTC day returned by now with futureMsg.
+func OptionalDateNotFuture(
+	raw map[string]json.RawMessage,
+	key string,
+	now func() time.Time,
+	futureMsg string,
+) (*time.Time, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return nil, nil
+	}
+	t, err := RawDate(v)
+	if err != nil {
+		if IsRawDateFormatError(err) {
+			return nil, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
+		}
+		return nil, &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	}
+	if t.After(todayUTC(now)) {
+		return nil, &httputil.ValidationError{Field: key, Msg: futureMsg}
+	}
+	return &t, nil
+}
+
+func todayUTC(now func() time.Time) time.Time {
 	if now == nil {
 		now = time.Now
 	}
 	today := now().UTC()
-	today = time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)
-	if t.After(today) {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Date cannot be in the future"}
-	}
-	return t, nil
+	return time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)
 }
 
 // RequiredIntOrNull reads a required integer field where explicit null is

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -116,6 +116,74 @@ func TestRequiredDateNotFuture(t *testing.T) {
 	requireValidation(t, vErr, "date", "must be YYYY-MM-DD")
 }
 
+func TestRequiredDateNotFutureWithMessage(t *testing.T) {
+	now := func() time.Time { return time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC) }
+
+	_, vErr := RequiredDateNotFutureWithMessage(
+		map[string]json.RawMessage{"start_date": json.RawMessage(`"2026-06-21"`)},
+		"start_date",
+		now,
+		"Start date cannot be in the future",
+	)
+	requireValidation(t, vErr, "start_date", "Start date cannot be in the future")
+}
+
+func TestOptionalDateNotFuture(t *testing.T) {
+	now := func() time.Time { return time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC) }
+
+	got, vErr := OptionalDateNotFuture(
+		map[string]json.RawMessage{"date": json.RawMessage(`"2026-06-20"`)},
+		"date",
+		now,
+		"Date cannot be in the future",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || got.Format("2006-01-02") != "2026-06-20" {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalDateNotFuture(map[string]json.RawMessage{}, "date", now, "Date cannot be in the future")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalDateNotFuture(
+		map[string]json.RawMessage{"date": json.RawMessage(`null`)},
+		"date",
+		now,
+		"Date cannot be in the future",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalDateNotFuture(
+		map[string]json.RawMessage{"date": json.RawMessage(`"2026-06-21"`)},
+		"date",
+		now,
+		"Date cannot be in the future",
+	)
+	requireValidation(t, vErr, "date", "Date cannot be in the future")
+
+	_, vErr = OptionalDateNotFuture(
+		map[string]json.RawMessage{"date": json.RawMessage(`"06/20/2026"`)},
+		"date",
+		now,
+		"Date cannot be in the future",
+	)
+	requireValidation(t, vErr, "date", "must be YYYY-MM-DD")
+
+	_, vErr = OptionalDateNotFuture(
+		map[string]json.RawMessage{"date": json.RawMessage(`20260620`)},
+		"date",
+		now,
+		"Date cannot be in the future",
+	)
+	requireValidation(t, vErr, "date", "must be a string")
+}
+
 func TestRequiredIntOrNull(t *testing.T) {
 	got, vErr := RequiredIntOrNull(map[string]json.RawMessage{"owner_user_id": json.RawMessage(`7`)}, "owner_user_id")
 	if vErr != nil {


### PR DESCRIPTION
## Summary
- add shared required/optional date-not-future helpers with custom future-date messages
- reuse the helpers in salaries, bonus events, and debts create/update validation
- cover custom required and optional date paths in validation tests

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check