### PR TITLE
refactor(validation): share optional date parsing

### DIFF
--- a/backend-go/internal/company_valuations/validation.go
+++ b/backend-go/internal/company_valuations/validation.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/shopspring/decimal"
 
@@ -144,16 +143,10 @@ func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 		}
 		p.Notes = &s
 	}
-	if v, ok := raw["date"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: "date", Msg: "must be a string"}
-		}
-		t, err := time.Parse("2006-01-02", s)
-		if err != nil {
-			return &httputil.ValidationError{Field: "date", Msg: "must be YYYY-MM-DD"}
-		}
-		p.Date = &t
+	if t, vErr := validation.OptionalDate(raw, "date"); vErr != nil {
+		return vErr
+	} else if t != nil {
+		p.Date = t
 	}
 	return nil
 }

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -169,16 +169,10 @@ func optionalGrantLiquidity(raw map[string]json.RawMessage, r *createRequest) *h
 		}
 		r.RequiresLiquidityEvent = b
 	}
-	if v, ok := raw["liquidity_event_date"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: "liquidity_event_date", Msg: "must be a string"}
-		}
-		t, err := time.Parse("2006-01-02", s)
-		if err != nil {
-			return &httputil.ValidationError{Field: "liquidity_event_date", Msg: "must be YYYY-MM-DD"}
-		}
-		r.LiquidityEventDate = &t
+	if t, vErr := validation.OptionalDate(raw, "liquidity_event_date"); vErr != nil {
+		return vErr
+	} else if t != nil {
+		r.LiquidityEventDate = t
 	}
 	return nil
 }
@@ -282,19 +276,13 @@ func patchDates(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Valida
 		{"vest_start_date", &p.VestStartDate},
 		{"liquidity_event_date", &p.LiquidityEventDate},
 	} {
-		v, ok := raw[f.key]
-		if !ok || validation.IsNull(v) {
-			continue
+		t, vErr := validation.OptionalDate(raw, f.key)
+		if vErr != nil {
+			return vErr
 		}
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: f.key, Msg: "must be a string"}
+		if t != nil {
+			*f.dest = t
 		}
-		t, err := time.Parse("2006-01-02", s)
-		if err != nil {
-			return &httputil.ValidationError{Field: f.key, Msg: "must be YYYY-MM-DD"}
-		}
-		*f.dest = &t
 	}
 	return nil
 }

--- a/backend-go/internal/snapshots/validation.go
+++ b/backend-go/internal/snapshots/validation.go
@@ -48,16 +48,10 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 
 func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.ValidationError) {
 	var p UpdatePatch
-	if v, ok := raw["date"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return p, &httputil.ValidationError{Field: "date", Msg: "must be a string"}
-		}
-		t, err := time.Parse("2006-01-02", s)
-		if err != nil {
-			return p, &httputil.ValidationError{Field: "date", Msg: "must be YYYY-MM-DD"}
-		}
-		p.Date = &t
+	if t, vErr := validation.OptionalDate(raw, "date"); vErr != nil {
+		return p, vErr
+	} else if t != nil {
+		p.Date = t
 	}
 	if v, ok := raw["notes"]; ok {
 		p.NotesSet = true

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -70,6 +70,23 @@ func RequiredDate(raw map[string]json.RawMessage, key string) (time.Time, *httpu
 	return t, nil
 }
 
+// OptionalDate reads an optional YYYY-MM-DD field. Missing or explicit null
+// returns nil.
+func OptionalDate(raw map[string]json.RawMessage, key string) (*time.Time, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return nil, nil
+	}
+	t, err := RawDate(v)
+	if err != nil {
+		if IsRawDateFormatError(err) {
+			return nil, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
+		}
+		return nil, &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	}
+	return &t, nil
+}
+
 // RequiredDateNotFuture reads a required YYYY-MM-DD field and rejects dates
 // after the current UTC day returned by now.
 func RequiredDateNotFuture(
@@ -106,21 +123,17 @@ func OptionalDateNotFuture(
 	now func() time.Time,
 	futureMsg string,
 ) (*time.Time, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || IsNull(v) {
-		return nil, nil
+	t, vErr := OptionalDate(raw, key)
+	if vErr != nil {
+		return nil, vErr
 	}
-	t, err := RawDate(v)
-	if err != nil {
-		if IsRawDateFormatError(err) {
-			return nil, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
-		}
-		return nil, &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	if t == nil {
+		return nil, nil
 	}
 	if t.After(todayUTC(now)) {
 		return nil, &httputil.ValidationError{Field: key, Msg: futureMsg}
 	}
-	return &t, nil
+	return t, nil
 }
 
 func todayUTC(now func() time.Time) time.Time {

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -86,6 +86,32 @@ func TestRequiredDate(t *testing.T) {
 	requireValidation(t, vErr, "date", "must be a string")
 }
 
+func TestOptionalDate(t *testing.T) {
+	got, vErr := OptionalDate(map[string]json.RawMessage{"date": json.RawMessage(`"2026-05-26"`)}, "date")
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || got.Format("2006-01-02") != "2026-05-26" {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalDate(map[string]json.RawMessage{}, "date")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalDate(map[string]json.RawMessage{"date": json.RawMessage(`null`)}, "date")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalDate(map[string]json.RawMessage{"date": json.RawMessage(`"26/05/2026"`)}, "date")
+	requireValidation(t, vErr, "date", "must be YYYY-MM-DD")
+
+	_, vErr = OptionalDate(map[string]json.RawMessage{"date": json.RawMessage(`20260526`)}, "date")
+	requireValidation(t, vErr, "date", "must be a string")
+}
+
 func TestRequiredDateNotFuture(t *testing.T) {
 	now := func() time.Time { return time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC) }
 


### PR DESCRIPTION
## Summary
- add shared validation.OptionalDate for optional YYYY-MM-DD fields
- route OptionalDateNotFuture through the shared optional date parser
- reuse OptionalDate in snapshots, company valuations, and equity grant validation

## Verification
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check