### PR TITLE
refactor(validation): share optional int parsing

### DIFF
--- a/backend-go/internal/accounts/validation.go
+++ b/backend-go/internal/accounts/validation.go
@@ -119,17 +119,13 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 	if vErr := patchEnumString(raw, "category", validCategories, &p.Category); vErr != nil {
 		return p, vErr
 	}
-	if v, ok := raw["owner_user_id"]; ok {
+	if _, ok := raw["owner_user_id"]; ok {
 		p.OwnerUserIDSet = true
-		if validation.IsNull(v) {
-			p.OwnerUserID = nil
-		} else {
-			var n int
-			if err := json.Unmarshal(v, &n); err != nil {
-				return p, &httputil.ValidationError{Field: "owner_user_id", Msg: "must be an integer"}
-			}
-			p.OwnerUserID = &n
+		ownerID, vErr := validation.OptionalInt(raw, "owner_user_id", "must be an integer")
+		if vErr != nil {
+			return p, vErr
 		}
+		p.OwnerUserID = ownerID
 	}
 	if vErr := patchPlainString(raw, "currency", &p.Currency); vErr != nil {
 		return p, vErr

--- a/backend-go/internal/bonds/validation.go
+++ b/backend-go/internal/bonds/validation.go
@@ -82,25 +82,21 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.PurchaseDate = &t
 	}
-	if v, ok := raw["owner_user_id"]; ok {
+	if _, ok := raw["owner_user_id"]; ok {
 		p.OwnerUserIDSet = true
-		if !validation.IsNull(v) {
-			var id int
-			if err := json.Unmarshal(v, &id); err != nil {
-				return p, &httputil.ValidationError{Field: "owner_user_id", Msg: "must be an integer"}
-			}
-			p.OwnerUserID = &id
+		ownerID, vErr := validation.OptionalInt(raw, "owner_user_id", "must be an integer")
+		if vErr != nil {
+			return p, vErr
 		}
+		p.OwnerUserID = ownerID
 	}
-	if v, ok := raw["account_id"]; ok {
+	if _, ok := raw["account_id"]; ok {
 		p.AccountIDSet = true
-		if !validation.IsNull(v) {
-			var id int
-			if err := json.Unmarshal(v, &id); err != nil {
-				return p, &httputil.ValidationError{Field: "account_id", Msg: "must be an integer"}
-			}
-			p.AccountID = &id
+		accountID, vErr := validation.OptionalInt(raw, "account_id", "must be an integer")
+		if vErr != nil {
+			return p, vErr
 		}
+		p.AccountID = accountID
 	}
 	if vErr := patchRatePercent(raw, "first_year_rate", &p.FirstYearRate); vErr != nil {
 		return p, vErr

--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -120,17 +120,13 @@ func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 		}
 		p.Company = &s
 	}
-	if v, ok := raw["owner_user_id"]; ok {
+	if _, ok := raw["owner_user_id"]; ok {
 		p.OwnerUserIDSet = true
-		if validation.IsNull(v) {
-			p.OwnerUserID = nil
-		} else {
-			var n int
-			if err := json.Unmarshal(v, &n); err != nil {
-				return &httputil.ValidationError{Field: "owner_user_id", Msg: "must be an integer"}
-			}
-			p.OwnerUserID = &n
+		ownerID, vErr := validation.OptionalInt(raw, "owner_user_id", "must be an integer")
+		if vErr != nil {
+			return vErr
 		}
+		p.OwnerUserID = ownerID
 	}
 	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
 		var s string

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -322,18 +322,17 @@ func requirePositiveInt(raw map[string]json.RawMessage, key, msg string) (int, *
 }
 
 func optionalNonNegativeInt(raw map[string]json.RawMessage, key, msg string, fallback int) (int, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
+	n, vErr := validation.OptionalInt(raw, key, "must be an integer")
+	if vErr != nil {
+		return 0, vErr
+	}
+	if n == nil {
 		return fallback, nil
 	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return 0, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
-	}
-	if n < 0 {
+	if *n < 0 {
 		return 0, &httputil.ValidationError{Field: key, Msg: msg}
 	}
-	return n, nil
+	return *n, nil
 }
 
 func optionalEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}, fallback string) (string, *httputil.ValidationError) {
@@ -420,53 +419,47 @@ func patchCurrency(raw map[string]json.RawMessage, dest **string) *httputil.Vali
 }
 
 func patchPositiveInt(raw map[string]json.RawMessage, key, msg string, dest **int) *httputil.ValidationError {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
+	n, vErr := validation.OptionalInt(raw, key, "must be an integer")
+	if vErr != nil {
+		return vErr
+	}
+	if n == nil {
 		return nil
 	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return &httputil.ValidationError{Field: key, Msg: "must be an integer"}
-	}
-	if n <= 0 {
+	if *n <= 0 {
 		return &httputil.ValidationError{Field: key, Msg: msg}
 	}
-	*dest = &n
+	*dest = n
 	return nil
 }
 
 func patchNonNegativeIntPtr(raw map[string]json.RawMessage, key, msg string, dest **int) *httputil.ValidationError {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
+	n, vErr := validation.OptionalInt(raw, key, "must be an integer")
+	if vErr != nil {
+		return vErr
+	}
+	if n == nil {
 		return nil
 	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return &httputil.ValidationError{Field: key, Msg: "must be an integer"}
-	}
-	if n < 0 {
+	if *n < 0 {
 		return &httputil.ValidationError{Field: key, Msg: msg}
 	}
-	*dest = &n
+	*dest = n
 	return nil
 }
 
 // patchOwnerUserID reads owner_user_id from a PATCH body: present marks the
 // field set; explicit null clears it (jointly owned).
 func patchOwnerUserID(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.ValidationError {
-	v, ok := raw["owner_user_id"]
+	_, ok := raw["owner_user_id"]
 	if !ok {
 		return nil
 	}
 	p.OwnerUserIDSet = true
-	if validation.IsNull(v) {
-		p.OwnerUserID = nil
-		return nil
+	ownerID, vErr := validation.OptionalInt(raw, "owner_user_id", "must be an integer")
+	if vErr != nil {
+		return vErr
 	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return &httputil.ValidationError{Field: "owner_user_id", Msg: "must be an integer"}
-	}
-	p.OwnerUserID = &n
+	p.OwnerUserID = ownerID
 	return nil
 }

--- a/backend-go/internal/goals/validation.go
+++ b/backend-go/internal/goals/validation.go
@@ -106,15 +106,13 @@ func patchScalarFields(raw map[string]json.RawMessage, p *UpdatePatch) *httputil
 // patchNullableRefs handles the two fields where the caller can explicitly
 // send null to clear the link (account_id, category).
 func patchNullableRefs(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.ValidationError {
-	if v, ok := raw["account_id"]; ok {
+	if _, ok := raw["account_id"]; ok {
 		p.AccountIDSet = true
-		if !validation.IsNull(v) {
-			var id int
-			if err := json.Unmarshal(v, &id); err != nil {
-				return &httputil.ValidationError{Field: "account_id", Msg: "must be an integer"}
-			}
-			p.AccountID = &id
+		accountID, vErr := validation.OptionalInt(raw, "account_id", "must be an integer")
+		if vErr != nil {
+			return vErr
 		}
+		p.AccountID = accountID
 	}
 	if v, ok := raw["category"]; ok {
 		p.CategorySet = true

--- a/backend-go/internal/recurring/validation.go
+++ b/backend-go/internal/recurring/validation.go
@@ -39,12 +39,12 @@ func readAccountAndAmount(raw map[string]json.RawMessage, in *CreateInput) *http
 		return err
 	}
 	in.Amount = amount
-	if v, ok := raw["owner_user_id"]; ok && string(v) != "null" {
-		var n int
-		if jerr := json.Unmarshal(v, &n); jerr != nil {
-			return &httputil.ValidationError{Field: "owner_user_id", Msg: "must be integer or null"}
-		}
-		in.OwnerUserID = &n
+	ownerID, vErr := validation.OptionalInt(raw, "owner_user_id", "must be integer or null")
+	if vErr != nil {
+		return vErr
+	}
+	if ownerID != nil {
+		in.OwnerUserID = ownerID
 	}
 	return nil
 }

--- a/backend-go/internal/salaries/validation.go
+++ b/backend-go/internal/salaries/validation.go
@@ -96,17 +96,13 @@ func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (Upd
 		}
 		p.Company = &s
 	}
-	if v, ok := raw["owner_user_id"]; ok {
+	if _, ok := raw["owner_user_id"]; ok {
 		p.OwnerUserIDSet = true
-		if validation.IsNull(v) {
-			p.OwnerUserID = nil
-		} else {
-			n, err := validation.RawInt(v)
-			if err != nil {
-				return p, &httputil.ValidationError{Field: "owner_user_id", Msg: "must be an integer"}
-			}
-			p.OwnerUserID = &n
+		ownerID, vErr := validation.OptionalInt(raw, "owner_user_id", "must be an integer")
+		if vErr != nil {
+			return p, vErr
 		}
+		p.OwnerUserID = ownerID
 	}
 	return p, nil
 }

--- a/backend-go/internal/snapshots/validation.go
+++ b/backend-go/internal/snapshots/validation.go
@@ -2,7 +2,6 @@ package snapshots
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
@@ -130,13 +129,5 @@ func parseValueEntry(e map[string]json.RawMessage) (ValueInput, *httputil.Valida
 }
 
 func optionalInt(raw map[string]json.RawMessage, key string) (*int, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return nil, nil
-	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return nil, &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("%s must be an integer", key)}
-	}
-	return &n, nil
+	return validation.OptionalInt(raw, key, key+" must be an integer")
 }

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -144,6 +144,24 @@ func todayUTC(now func() time.Time) time.Time {
 	return time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)
 }
 
+// OptionalInt reads an optional integer field. Missing or explicit null
+// returns nil.
+func OptionalInt(
+	raw map[string]json.RawMessage,
+	key string,
+	typeMsg string,
+) (*int, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return nil, nil
+	}
+	n, err := RawInt(v)
+	if err != nil {
+		return nil, &httputil.ValidationError{Field: key, Msg: typeMsg}
+	}
+	return &n, nil
+}
+
 // RequiredIntOrNull reads a required integer field where explicit null is
 // allowed and maps to nil.
 func RequiredIntOrNull(raw map[string]json.RawMessage, key string) (*int, *httputil.ValidationError) {

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -210,6 +210,48 @@ func TestOptionalDateNotFuture(t *testing.T) {
 	requireValidation(t, vErr, "date", "must be a string")
 }
 
+func TestOptionalInt(t *testing.T) {
+	got, vErr := OptionalInt(
+		map[string]json.RawMessage{"owner_user_id": json.RawMessage(`7`)},
+		"owner_user_id",
+		"must be an integer",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || *got != 7 {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalInt(map[string]json.RawMessage{}, "owner_user_id", "must be an integer")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalInt(
+		map[string]json.RawMessage{"owner_user_id": json.RawMessage(`null`)},
+		"owner_user_id",
+		"must be an integer",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalInt(
+		map[string]json.RawMessage{"owner_user_id": json.RawMessage(`"7"`)},
+		"owner_user_id",
+		"must be an integer",
+	)
+	requireValidation(t, vErr, "owner_user_id", "must be an integer")
+
+	_, vErr = OptionalInt(
+		map[string]json.RawMessage{"owner_user_id": json.RawMessage(`"7"`)},
+		"owner_user_id",
+		"must be integer or null",
+	)
+	requireValidation(t, vErr, "owner_user_id", "must be integer or null")
+}
+
 func TestRequiredIntOrNull(t *testing.T) {
 	got, vErr := RequiredIntOrNull(map[string]json.RawMessage{"owner_user_id": json.RawMessage(`7`)}, "owner_user_id")
 	if vErr != nil {


### PR DESCRIPTION
## Summary
- add shared validation.OptionalInt for optional integer fields with caller-specific type messages
- reuse OptionalInt in nullable owner/account patch fields and recurring owner parsing
- reuse OptionalInt inside existing equity grant and snapshot helpers

## Verification
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check