### PR TITLE
refactor(validation): reuse optional date parsing

### DIFF
--- a/backend-go/internal/bonds/validation.go
+++ b/backend-go/internal/bonds/validation.go
@@ -71,16 +71,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 	if vErr := patchPositiveAmount(raw, "face_value", &p.FaceValue, "Face value must be greater than 0"); vErr != nil {
 		return p, vErr
 	}
-	if v, ok := raw["purchase_date"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return p, &httputil.ValidationError{Field: "purchase_date", Msg: "must be a string"}
-		}
-		t, err := time.Parse("2006-01-02", s)
-		if err != nil {
-			return p, &httputil.ValidationError{Field: "purchase_date", Msg: "must be YYYY-MM-DD"}
-		}
-		p.PurchaseDate = &t
+	if t, vErr := validation.OptionalDate(raw, "purchase_date"); vErr != nil {
+		return p, vErr
+	} else if t != nil {
+		p.PurchaseDate = t
 	}
 	if _, ok := raw["owner_user_id"]; ok {
 		p.OwnerUserIDSet = true

--- a/backend-go/internal/goals/validation.go
+++ b/backend-go/internal/goals/validation.go
@@ -76,16 +76,10 @@ func patchScalarFields(raw map[string]json.RawMessage, p *UpdatePatch) *httputil
 	if vErr := patchPositiveAmount(raw, "target_amount", &p.TargetAmount, "Target amount must be greater than 0"); vErr != nil {
 		return vErr
 	}
-	if v, ok := raw["target_date"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: "target_date", Msg: "must be a string"}
-		}
-		t, err := time.Parse("2006-01-02", s)
-		if err != nil {
-			return &httputil.ValidationError{Field: "target_date", Msg: "must be YYYY-MM-DD"}
-		}
-		p.TargetDate = &t
+	if t, vErr := validation.OptionalDate(raw, "target_date"); vErr != nil {
+		return vErr
+	} else if t != nil {
+		p.TargetDate = t
 	}
 	if vErr := patchNonNegativeAmount(raw, "current_amount", &p.CurrentAmount, "Current amount must be non-negative"); vErr != nil {
 		return vErr


### PR DESCRIPTION
## Summary
- replace remaining matching PATCH date parsers in bonds and goals with validation.OptionalDate
- preserve missing/null no-op behavior and existing validation messages

## Verification
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check