### PR TITLE
refactor(validation): reuse optional positive decimal parsing

### DIFF
--- a/backend-go/internal/bonds/validation.go
+++ b/backend-go/internal/bonds/validation.go
@@ -68,8 +68,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.Series = &s
 	}
-	if vErr := patchPositiveAmount(raw, "face_value", &p.FaceValue, "Face value must be greater than 0"); vErr != nil {
+	if d, vErr := validation.OptionalPositiveDecimal(raw, "face_value", "Face value must be greater than 0"); vErr != nil {
 		return p, vErr
+	} else if d != nil {
+		p.FaceValue = d
 	}
 	if t, vErr := validation.OptionalDate(raw, "purchase_date"); vErr != nil {
 		return p, vErr
@@ -106,23 +108,6 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		p.Capitalize = &b
 	}
 	return p, nil
-}
-
-func patchPositiveAmount(raw map[string]json.RawMessage, field string, dest **decimal.Decimal, msg string) *httputil.ValidationError {
-	v, ok := raw[field]
-	if !ok || validation.IsNull(v) {
-		return nil
-	}
-	var f float64
-	if err := json.Unmarshal(v, &f); err != nil {
-		return &httputil.ValidationError{Field: field, Msg: "must be a number"}
-	}
-	if f <= 0 {
-		return &httputil.ValidationError{Field: field, Msg: msg}
-	}
-	d := decimal.NewFromFloat(f)
-	*dest = &d
-	return nil
 }
 
 func patchRatePercent(raw map[string]json.RawMessage, field string, dest **decimal.Decimal) *httputil.ValidationError {

--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -88,15 +88,10 @@ func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 	} else if t != nil {
 		p.Date = t
 	}
-	if v, ok := raw["amount"]; ok && !validation.IsNull(v) {
-		d, err := validation.RawDecimal(v)
-		if err != nil {
-			return &httputil.ValidationError{Field: "amount", Msg: "must be a number"}
-		}
-		if !d.IsPositive() {
-			return &httputil.ValidationError{Field: "amount", Msg: "Amount must be greater than 0"}
-		}
-		p.Amount = &d
+	if d, vErr := validation.OptionalPositiveDecimal(raw, "amount", "Amount must be greater than 0"); vErr != nil {
+		return vErr
+	} else if d != nil {
+		p.Amount = d
 	}
 	if v, ok := raw["currency"]; ok && !validation.IsNull(v) {
 		var s string

--- a/backend-go/internal/debts/validation.go
+++ b/backend-go/internal/debts/validation.go
@@ -112,15 +112,14 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 	} else if t != nil {
 		p.StartDate = t
 	}
-	if v, ok := raw["initial_amount"]; ok && !validation.IsNull(v) {
-		d, err := validation.RawDecimal(v)
-		if err != nil {
-			return p, &httputil.ValidationError{Field: "initial_amount", Msg: "must be a number"}
-		}
-		if !d.IsPositive() {
-			return p, &httputil.ValidationError{Field: "initial_amount", Msg: "Initial amount must be greater than 0"}
-		}
-		p.InitialAmount = &d
+	if d, vErr := validation.OptionalPositiveDecimal(
+		raw,
+		"initial_amount",
+		"Initial amount must be greater than 0",
+	); vErr != nil {
+		return p, vErr
+	} else if d != nil {
+		p.InitialAmount = d
 	}
 	if d, vErr := validation.OptionalNonNegativeDecimal(
 		raw,

--- a/backend-go/internal/goals/validation.go
+++ b/backend-go/internal/goals/validation.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shopspring/decimal"
-
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
@@ -73,19 +71,29 @@ func patchScalarFields(raw map[string]json.RawMessage, p *UpdatePatch) *httputil
 		}
 		p.Name = &s
 	}
-	if vErr := patchPositiveAmount(raw, "target_amount", &p.TargetAmount, "Target amount must be greater than 0"); vErr != nil {
+	if d, vErr := validation.OptionalPositiveDecimal(raw, "target_amount", "Target amount must be greater than 0"); vErr != nil {
 		return vErr
+	} else if d != nil {
+		p.TargetAmount = d
 	}
 	if t, vErr := validation.OptionalDate(raw, "target_date"); vErr != nil {
 		return vErr
 	} else if t != nil {
 		p.TargetDate = t
 	}
-	if vErr := patchNonNegativeAmount(raw, "current_amount", &p.CurrentAmount, "Current amount must be non-negative"); vErr != nil {
+	if d, vErr := validation.OptionalNonNegativeDecimal(raw, "current_amount", "Current amount must be non-negative"); vErr != nil {
 		return vErr
+	} else if d != nil {
+		p.CurrentAmount = d
 	}
-	if vErr := patchNonNegativeAmount(raw, "monthly_contribution", &p.MonthlyContribution, "Monthly contribution must be non-negative"); vErr != nil {
+	if d, vErr := validation.OptionalNonNegativeDecimal(
+		raw,
+		"monthly_contribution",
+		"Monthly contribution must be non-negative",
+	); vErr != nil {
 		return vErr
+	} else if d != nil {
+		p.MonthlyContribution = d
 	}
 	if v, ok := raw["is_completed"]; ok && !validation.IsNull(v) {
 		var b bool
@@ -124,39 +132,5 @@ func patchNullableRefs(raw map[string]json.RawMessage, p *UpdatePatch) *httputil
 			p.Category = &s
 		}
 	}
-	return nil
-}
-
-func patchPositiveAmount(raw map[string]json.RawMessage, field string, dest **decimal.Decimal, msg string) *httputil.ValidationError {
-	v, ok := raw[field]
-	if !ok || validation.IsNull(v) {
-		return nil
-	}
-	var f float64
-	if err := json.Unmarshal(v, &f); err != nil {
-		return &httputil.ValidationError{Field: field, Msg: "must be a number"}
-	}
-	if f <= 0 {
-		return &httputil.ValidationError{Field: field, Msg: msg}
-	}
-	d := decimal.NewFromFloat(f)
-	*dest = &d
-	return nil
-}
-
-func patchNonNegativeAmount(raw map[string]json.RawMessage, field string, dest **decimal.Decimal, msg string) *httputil.ValidationError {
-	v, ok := raw[field]
-	if !ok || validation.IsNull(v) {
-		return nil
-	}
-	var f float64
-	if err := json.Unmarshal(v, &f); err != nil {
-		return &httputil.ValidationError{Field: field, Msg: "must be a number"}
-	}
-	if f < 0 {
-		return &httputil.ValidationError{Field: field, Msg: msg}
-	}
-	d := decimal.NewFromFloat(f)
-	*dest = &d
 	return nil
 }

--- a/backend-go/internal/salaries/validation.go
+++ b/backend-go/internal/salaries/validation.go
@@ -66,15 +66,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (Upd
 	} else if t != nil {
 		p.Date = t
 	}
-	if v, ok := raw["gross_amount"]; ok && !validation.IsNull(v) {
-		d, err := validation.RawDecimal(v)
-		if err != nil {
-			return p, &httputil.ValidationError{Field: "gross_amount", Msg: "must be a number"}
-		}
-		if !d.IsPositive() {
-			return p, &httputil.ValidationError{Field: "gross_amount", Msg: "Gross amount must be greater than 0"}
-		}
-		p.GrossAmount = &d
+	if d, vErr := validation.OptionalPositiveDecimal(raw, "gross_amount", "Gross amount must be greater than 0"); vErr != nil {
+		return p, vErr
+	} else if d != nil {
+		p.GrossAmount = d
 	}
 	if v, ok := raw["contract_type"]; ok && !validation.IsNull(v) {
 		s, err := validation.RawString(v)

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -309,6 +309,23 @@ func OptionalDecimal(
 	return &d, nil
 }
 
+// OptionalPositiveDecimal reads an optional JSON number field and rejects zero
+// or negative values with the supplied positiveMsg.
+func OptionalPositiveDecimal(
+	raw map[string]json.RawMessage,
+	key string,
+	positiveMsg string,
+) (*decimal.Decimal, *httputil.ValidationError) {
+	d, vErr := OptionalDecimal(raw, key)
+	if vErr != nil {
+		return nil, vErr
+	}
+	if d != nil && !d.IsPositive() {
+		return nil, &httputil.ValidationError{Field: key, Msg: positiveMsg}
+	}
+	return d, nil
+}
+
 // OptionalNonNegativeDecimal reads an optional JSON number field and rejects
 // negative values with the supplied nonNegativeMsg.
 func OptionalNonNegativeDecimal(

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -518,6 +518,52 @@ func TestOptionalDecimal(t *testing.T) {
 	requireValidation(t, vErr, "fee", "must be a number")
 }
 
+func TestOptionalPositiveDecimal(t *testing.T) {
+	got, vErr := OptionalPositiveDecimal(
+		map[string]json.RawMessage{"fee": json.RawMessage(`1.25`)},
+		"fee",
+		"Fee must be greater than 0",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || !got.Equal(decimal.RequireFromString("1.25")) {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalPositiveDecimal(
+		map[string]json.RawMessage{},
+		"fee",
+		"Fee must be greater than 0",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalPositiveDecimal(
+		map[string]json.RawMessage{"fee": json.RawMessage(`null`)},
+		"fee",
+		"Fee must be greater than 0",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalPositiveDecimal(
+		map[string]json.RawMessage{"fee": json.RawMessage(`0`)},
+		"fee",
+		"Fee must be greater than 0",
+	)
+	requireValidation(t, vErr, "fee", "Fee must be greater than 0")
+
+	_, vErr = OptionalPositiveDecimal(
+		map[string]json.RawMessage{"fee": json.RawMessage(`"1.25"`)},
+		"fee",
+		"Fee must be greater than 0",
+	)
+	requireValidation(t, vErr, "fee", "must be a number")
+}
+
 func TestOptionalNonNegativeDecimal(t *testing.T) {
 	got, vErr := OptionalNonNegativeDecimal(
 		map[string]json.RawMessage{"fee": json.RawMessage(`0`)},


### PR DESCRIPTION
## Summary
- add shared OptionalPositiveDecimal validation helper
- reuse it across PATCH amount validators for bonds, goals, bonus events, debts, and salaries
- reuse OptionalNonNegativeDecimal for goal PATCH amount fields

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check