### PR TITLE
refactor(validation): share upper enum string parsing

### DIFF
--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -31,7 +31,13 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Amount = amount
 
-	currency, vErr := optionalCurrency(raw, "PLN")
+	currency, vErr := validation.OptionalUpperTrimmedEnumString(
+		raw,
+		"currency",
+		validCurrencies,
+		"PLN",
+		"Currency must be one of [CHF, EUR, GBP, PLN, USD]",
+	)
 	if vErr != nil {
 		return r, vErr
 	}
@@ -93,16 +99,15 @@ func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 	} else if d != nil {
 		p.Amount = d
 	}
-	if v, ok := raw["currency"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: "currency", Msg: "must be a string"}
-		}
-		s = strings.ToUpper(strings.TrimSpace(s))
-		if _, ok := validCurrencies[s]; !ok {
-			return &httputil.ValidationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
-		}
-		p.Currency = &s
+	if s, vErr := validation.OptionalUpperTrimmedEnumStringPtr(
+		raw,
+		"currency",
+		validCurrencies,
+		"Currency must be one of [CHF, EUR, GBP, PLN, USD]",
+	); vErr != nil {
+		return vErr
+	} else if s != nil {
+		p.Currency = s
 	}
 	if v, ok := raw["company"]; ok && !validation.IsNull(v) {
 		var s string
@@ -155,22 +160,4 @@ func patchEnums(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Valida
 		p.ContractType = &s
 	}
 	return nil
-}
-
-// --- shared decoders ---
-
-func optionalCurrency(raw map[string]json.RawMessage, fallback string) (string, *httputil.ValidationError) {
-	v, ok := raw["currency"]
-	if !ok || validation.IsNull(v) {
-		return fallback, nil
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: "currency", Msg: "must be a string"}
-	}
-	s = strings.ToUpper(strings.TrimSpace(s))
-	if _, ok := validCurrencies[s]; !ok {
-		return "", &httputil.ValidationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
-	}
-	return s, nil
 }

--- a/backend-go/internal/company_valuations/validation.go
+++ b/backend-go/internal/company_valuations/validation.go
@@ -33,7 +33,13 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Date = t
 
-	currency, vErr := optionalCurrency(raw)
+	currency, vErr := validation.OptionalUpperTrimmedEnumString(
+		raw,
+		"currency",
+		validCurrencies,
+		"USD",
+		"Currency must be one of [CHF, EUR, GBP, PLN, USD]",
+	)
 	if vErr != nil {
 		return r, vErr
 	}
@@ -115,16 +121,15 @@ func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 		}
 		p.Company = &s
 	}
-	if v, ok := raw["currency"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: "currency", Msg: "must be a string"}
-		}
-		s = strings.ToUpper(strings.TrimSpace(s))
-		if _, valid := validCurrencies[s]; !valid {
-			return &httputil.ValidationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
-		}
-		p.Currency = &s
+	if s, vErr := validation.OptionalUpperTrimmedEnumStringPtr(
+		raw,
+		"currency",
+		validCurrencies,
+		"Currency must be one of [CHF, EUR, GBP, PLN, USD]",
+	); vErr != nil {
+		return vErr
+	} else if s != nil {
+		p.Currency = s
 	}
 	if v, ok := raw["source"]; ok && !validation.IsNull(v) {
 		var s string
@@ -176,24 +181,6 @@ func patchNumbers(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 		return vErr
 	}
 	return nil
-}
-
-// --- shared decoders ---
-
-func optionalCurrency(raw map[string]json.RawMessage) (string, *httputil.ValidationError) {
-	v, ok := raw["currency"]
-	if !ok || validation.IsNull(v) {
-		return "USD", nil // Python default
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: "currency", Msg: "must be a string"}
-	}
-	s = strings.ToUpper(strings.TrimSpace(s))
-	if _, ok := validCurrencies[s]; !ok {
-		return "", &httputil.ValidationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
-	}
-	return s, nil
 }
 
 func optionalDiscountPct(raw map[string]json.RawMessage) (*decimal.Decimal, *httputil.ValidationError) {

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -120,7 +120,13 @@ func requireGrantBasics(raw map[string]json.RawMessage, r *createRequest) *httpu
 	}
 	r.StrikePrice = strike
 
-	currency, vErr := optionalCurrency(raw, "USD")
+	currency, vErr := validation.OptionalUpperTrimmedEnumString(
+		raw,
+		"currency",
+		validCurrencies,
+		"USD",
+		"Currency must be one of [CHF, EUR, GBP, PLN, USD]",
+	)
 	if vErr != nil {
 		return vErr
 	}
@@ -223,8 +229,15 @@ func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 	if vErr := patchOwnerUserID(raw, p); vErr != nil {
 		return vErr
 	}
-	if vErr := patchCurrency(raw, &p.Currency); vErr != nil {
+	if s, vErr := validation.OptionalUpperTrimmedEnumStringPtr(
+		raw,
+		"currency",
+		validCurrencies,
+		"Currency must be one of [CHF, EUR, GBP, PLN, USD]",
+	); vErr != nil {
 		return vErr
+	} else if s != nil {
+		p.Currency = s
 	}
 	if vErr := patchEnumString(raw, "vest_frequency", validFrequencies, &p.VestFrequency); vErr != nil {
 		return vErr
@@ -350,22 +363,6 @@ func optionalEnumString(raw map[string]json.RawMessage, key string, allowed map[
 	return s, nil
 }
 
-func optionalCurrency(raw map[string]json.RawMessage, fallback string) (string, *httputil.ValidationError) {
-	v, ok := raw["currency"]
-	if !ok || validation.IsNull(v) {
-		return fallback, nil
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: "currency", Msg: "must be a string"}
-	}
-	s = strings.ToUpper(strings.TrimSpace(s))
-	if _, ok := validCurrencies[s]; !ok {
-		return "", &httputil.ValidationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
-	}
-	return s, nil
-}
-
 // --- PATCH helpers ---
 
 func patchEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}, dest **string) *httputil.ValidationError {
@@ -396,23 +393,6 @@ func patchNonEmptyString(raw map[string]json.RawMessage, key, emptyMsg string, d
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return &httputil.ValidationError{Field: key, Msg: emptyMsg}
-	}
-	*dest = &s
-	return nil
-}
-
-func patchCurrency(raw map[string]json.RawMessage, dest **string) *httputil.ValidationError {
-	v, ok := raw["currency"]
-	if !ok || validation.IsNull(v) {
-		return nil
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return &httputil.ValidationError{Field: "currency", Msg: "must be a string"}
-	}
-	s = strings.ToUpper(strings.TrimSpace(s))
-	if _, ok := validCurrencies[s]; !ok {
-		return &httputil.ValidationError{Field: "currency", Msg: "Currency must be one of [CHF, EUR, GBP, PLN, USD]"}
 	}
 	*dest = &s
 	return nil

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -236,6 +237,49 @@ func RequiredEnumString(
 		return "", &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
 	}
 	return s, nil
+}
+
+// OptionalUpperTrimmedEnumString reads an optional string field, trims
+// whitespace, uppercases it, and checks it belongs to the provided allowed set.
+// Missing and explicit null return fallback.
+func OptionalUpperTrimmedEnumString(
+	raw map[string]json.RawMessage,
+	key string,
+	allowed map[string]struct{},
+	fallback string,
+	invalidMsg string,
+) (string, *httputil.ValidationError) {
+	s, vErr := OptionalUpperTrimmedEnumStringPtr(raw, key, allowed, invalidMsg)
+	if vErr != nil {
+		return "", vErr
+	}
+	if s == nil {
+		return fallback, nil
+	}
+	return *s, nil
+}
+
+// OptionalUpperTrimmedEnumStringPtr is the sparse-update variant of
+// OptionalUpperTrimmedEnumString. Missing and explicit null return nil.
+func OptionalUpperTrimmedEnumStringPtr(
+	raw map[string]json.RawMessage,
+	key string,
+	allowed map[string]struct{},
+	invalidMsg string,
+) (*string, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return nil, nil
+	}
+	s, err := RawString(v)
+	if err != nil {
+		return nil, &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	}
+	s = strings.ToUpper(strings.TrimSpace(s))
+	if _, ok := allowed[s]; !ok {
+		return nil, &httputil.ValidationError{Field: key, Msg: invalidMsg}
+	}
+	return &s, nil
 }
 
 // RequiredDecimal reads a required JSON number field. Quoted numeric strings

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -481,6 +481,22 @@ func TestOptionalUpperTrimmedEnumStringPtr(t *testing.T) {
 	if vErr != nil || got != nil {
 		t.Fatalf("got = %v vErr = %#v", got, vErr)
 	}
+
+	_, vErr = OptionalUpperTrimmedEnumStringPtr(
+		map[string]json.RawMessage{"currency": json.RawMessage(`7`)},
+		"currency",
+		allowed,
+		"invalid currency",
+	)
+	requireValidation(t, vErr, "currency", "must be a string")
+
+	_, vErr = OptionalUpperTrimmedEnumStringPtr(
+		map[string]json.RawMessage{"currency": json.RawMessage(`"EUR"`)},
+		"currency",
+		allowed,
+		"invalid currency",
+	)
+	requireValidation(t, vErr, "currency", "invalid currency")
 }
 
 func TestRequiredDecimal(t *testing.T) {

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -390,6 +390,99 @@ func TestRequiredEnumString(t *testing.T) {
 	requireValidation(t, vErr, "contract_type", `invalid value "mandate"`)
 }
 
+func TestOptionalUpperTrimmedEnumString(t *testing.T) {
+	allowed := map[string]struct{}{"PLN": {}, "USD": {}}
+	got, vErr := OptionalUpperTrimmedEnumString(
+		map[string]json.RawMessage{"currency": json.RawMessage(`" usd "`)},
+		"currency",
+		allowed,
+		"PLN",
+		"invalid currency",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != "USD" {
+		t.Fatalf("got = %q", got)
+	}
+
+	got, vErr = OptionalUpperTrimmedEnumString(
+		map[string]json.RawMessage{},
+		"currency",
+		allowed,
+		"PLN",
+		"invalid currency",
+	)
+	if vErr != nil || got != "PLN" {
+		t.Fatalf("got = %q vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalUpperTrimmedEnumString(
+		map[string]json.RawMessage{"currency": json.RawMessage(`null`)},
+		"currency",
+		allowed,
+		"PLN",
+		"invalid currency",
+	)
+	if vErr != nil || got != "PLN" {
+		t.Fatalf("got = %q vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalUpperTrimmedEnumString(
+		map[string]json.RawMessage{"currency": json.RawMessage(`7`)},
+		"currency",
+		allowed,
+		"PLN",
+		"invalid currency",
+	)
+	requireValidation(t, vErr, "currency", "must be a string")
+
+	_, vErr = OptionalUpperTrimmedEnumString(
+		map[string]json.RawMessage{"currency": json.RawMessage(`"EUR"`)},
+		"currency",
+		allowed,
+		"PLN",
+		"invalid currency",
+	)
+	requireValidation(t, vErr, "currency", "invalid currency")
+}
+
+func TestOptionalUpperTrimmedEnumStringPtr(t *testing.T) {
+	allowed := map[string]struct{}{"PLN": {}, "USD": {}}
+	got, vErr := OptionalUpperTrimmedEnumStringPtr(
+		map[string]json.RawMessage{"currency": json.RawMessage(`" pln "`)},
+		"currency",
+		allowed,
+		"invalid currency",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || *got != "PLN" {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalUpperTrimmedEnumStringPtr(
+		map[string]json.RawMessage{},
+		"currency",
+		allowed,
+		"invalid currency",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalUpperTrimmedEnumStringPtr(
+		map[string]json.RawMessage{"currency": json.RawMessage(`null`)},
+		"currency",
+		allowed,
+		"invalid currency",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+}
+
 func TestRequiredDecimal(t *testing.T) {
 	got, vErr := RequiredDecimal(
 		map[string]json.RawMessage{"amount": json.RawMessage(`123.45`)},


### PR DESCRIPTION
## Summary
- add shared optional trim+uppercase enum string helpers
- reuse them for currency parsing in bonus events, company valuations, and equity grants
- keep each domain's allowed currency set, defaults, and validation messages intact

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check