### PR TITLE
refactor(validation): share optional enum parsing

### DIFF
--- a/backend-go/internal/accounts/validation.go
+++ b/backend-go/internal/accounts/validation.go
@@ -58,7 +58,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Currency = cur
 
-	wrap, vErr := optionalEnumOrNull(raw, "account_wrapper", validWrappers)
+	wrap, vErr := validation.OptionalEnumStringPtr(raw, "account_wrapper", validWrappers)
 	if vErr != nil {
 		return r, vErr
 	}
@@ -116,8 +116,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.Name = &s
 	}
-	if vErr := patchEnumString(raw, "category", validCategories, &p.Category); vErr != nil {
+	if category, vErr := validation.OptionalEnumStringPtr(raw, "category", validCategories); vErr != nil {
 		return p, vErr
+	} else if category != nil {
+		p.Category = category
 	}
 	if _, ok := raw["owner_user_id"]; ok {
 		p.OwnerUserIDSet = true
@@ -130,8 +132,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 	if vErr := patchPlainString(raw, "currency", &p.Currency); vErr != nil {
 		return p, vErr
 	}
-	if vErr := patchEnumString(raw, "purpose", validPurposes, &p.Purpose); vErr != nil {
+	if purpose, vErr := validation.OptionalEnumStringPtr(raw, "purpose", validPurposes); vErr != nil {
 		return p, vErr
+	} else if purpose != nil {
+		p.Purpose = purpose
 	}
 	if v, ok := raw["account_wrapper"]; ok {
 		p.AccountWrapperSet = true
@@ -242,21 +246,6 @@ func optionalString(raw map[string]json.RawMessage, key, fallback string) (strin
 	return s, nil
 }
 
-func optionalEnumOrNull(raw map[string]json.RawMessage, key string, allowed map[string]struct{}) (*string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return nil, nil
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return nil, &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if _, ok := allowed[s]; !ok {
-		return nil, &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
-	}
-	return &s, nil
-}
-
 func optionalDecimal(raw map[string]json.RawMessage, key string) (*decimal.Decimal, *httputil.ValidationError) {
 	v, ok := raw[key]
 	if !ok || validation.IsNull(v) {
@@ -294,22 +283,6 @@ func optionalBoolDefaultFalse(raw map[string]json.RawMessage, key string) (bool,
 		return false, &httputil.ValidationError{Field: key, Msg: "must be a boolean"}
 	}
 	return b, nil
-}
-
-func patchEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}, dest **string) *httputil.ValidationError {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return nil
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if _, ok := allowed[s]; !ok {
-		return &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
-	}
-	*dest = &s
-	return nil
 }
 
 func patchPlainString(raw map[string]json.RawMessage, key string, dest **string) *httputil.ValidationError {

--- a/backend-go/internal/debts/validation.go
+++ b/backend-go/internal/debts/validation.go
@@ -2,7 +2,6 @@ package debts
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 
@@ -92,15 +91,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.Name = &s
 	}
-	if v, ok := raw["debt_type"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return p, &httputil.ValidationError{Field: "debt_type", Msg: "must be a string"}
-		}
-		if _, ok := validDebtTypes[s]; !ok {
-			return p, &httputil.ValidationError{Field: "debt_type", Msg: fmt.Sprintf("invalid value %q", s)}
-		}
-		p.DebtType = &s
+	if debtType, vErr := validation.OptionalEnumStringPtr(raw, "debt_type", validDebtTypes); vErr != nil {
+		return p, vErr
+	} else if debtType != nil {
+		p.DebtType = debtType
 	}
 	if t, vErr := validation.OptionalDateNotFuture(
 		raw,

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -2,7 +2,6 @@ package equitygrants
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 
@@ -184,7 +183,7 @@ func optionalGrantLiquidity(raw map[string]json.RawMessage, r *createRequest) *h
 }
 
 func optionalGrantTaxNotes(raw map[string]json.RawMessage, r *createRequest) *httputil.ValidationError {
-	tax, vErr := optionalEnumString(raw, "tax_treatment", validTaxTreatments, "capital_gains_19")
+	tax, vErr := validation.OptionalEnumString(raw, "tax_treatment", validTaxTreatments, "capital_gains_19")
 	if vErr != nil {
 		return vErr
 	}
@@ -220,8 +219,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 }
 
 func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.ValidationError {
-	if vErr := patchEnumString(raw, "type", validGrantTypes, &p.Type); vErr != nil {
+	if grantType, vErr := validation.OptionalEnumStringPtr(raw, "type", validGrantTypes); vErr != nil {
 		return vErr
+	} else if grantType != nil {
+		p.Type = grantType
 	}
 	if vErr := patchNonEmptyString(raw, "company", "Company cannot be empty", &p.Company); vErr != nil {
 		return vErr
@@ -239,11 +240,15 @@ func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 	} else if s != nil {
 		p.Currency = s
 	}
-	if vErr := patchEnumString(raw, "vest_frequency", validFrequencies, &p.VestFrequency); vErr != nil {
+	if frequency, vErr := validation.OptionalEnumStringPtr(raw, "vest_frequency", validFrequencies); vErr != nil {
 		return vErr
+	} else if frequency != nil {
+		p.VestFrequency = frequency
 	}
-	if vErr := patchEnumString(raw, "tax_treatment", validTaxTreatments, &p.TaxTreatment); vErr != nil {
+	if tax, vErr := validation.OptionalEnumStringPtr(raw, "tax_treatment", validTaxTreatments); vErr != nil {
 		return vErr
+	} else if tax != nil {
+		p.TaxTreatment = tax
 	}
 	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
 		var s string
@@ -348,38 +353,7 @@ func optionalNonNegativeInt(raw map[string]json.RawMessage, key, msg string, fal
 	return *n, nil
 }
 
-func optionalEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}, fallback string) (string, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return fallback, nil
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if _, ok := allowed[s]; !ok {
-		return "", &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
-	}
-	return s, nil
-}
-
 // --- PATCH helpers ---
-
-func patchEnumString(raw map[string]json.RawMessage, key string, allowed map[string]struct{}, dest **string) *httputil.ValidationError {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return nil
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if _, ok := allowed[s]; !ok {
-		return &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
-	}
-	*dest = &s
-	return nil
-}
 
 func patchNonEmptyString(raw map[string]json.RawMessage, key, emptyMsg string, dest **string) *httputil.ValidationError {
 	v, ok := raw[key]

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -239,6 +239,45 @@ func RequiredEnumString(
 	return s, nil
 }
 
+// OptionalEnumString reads an optional string field and checks it belongs to
+// the provided allowed set. Missing and explicit null return fallback.
+func OptionalEnumString(
+	raw map[string]json.RawMessage,
+	key string,
+	allowed map[string]struct{},
+	fallback string,
+) (string, *httputil.ValidationError) {
+	s, vErr := OptionalEnumStringPtr(raw, key, allowed)
+	if vErr != nil {
+		return "", vErr
+	}
+	if s == nil {
+		return fallback, nil
+	}
+	return *s, nil
+}
+
+// OptionalEnumStringPtr is the sparse-update variant of OptionalEnumString.
+// Missing and explicit null return nil.
+func OptionalEnumStringPtr(
+	raw map[string]json.RawMessage,
+	key string,
+	allowed map[string]struct{},
+) (*string, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return nil, nil
+	}
+	s, err := RawString(v)
+	if err != nil {
+		return nil, &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	}
+	if _, ok := allowed[s]; !ok {
+		return nil, &httputil.ValidationError{Field: key, Msg: fmt.Sprintf("invalid value %q", s)}
+	}
+	return &s, nil
+}
+
 // OptionalUpperTrimmedEnumString reads an optional string field, trims
 // whitespace, uppercases it, and checks it belongs to the provided allowed set.
 // Missing and explicit null return fallback.

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -390,6 +390,96 @@ func TestRequiredEnumString(t *testing.T) {
 	requireValidation(t, vErr, "contract_type", `invalid value "mandate"`)
 }
 
+func TestOptionalEnumString(t *testing.T) {
+	allowed := map[string]struct{}{"employment": {}, "b2b": {}}
+	got, vErr := OptionalEnumString(
+		map[string]json.RawMessage{"contract_type": json.RawMessage(`"b2b"`)},
+		"contract_type",
+		allowed,
+		"employment",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != "b2b" {
+		t.Fatalf("got = %q", got)
+	}
+
+	got, vErr = OptionalEnumString(map[string]json.RawMessage{}, "contract_type", allowed, "employment")
+	if vErr != nil || got != "employment" {
+		t.Fatalf("got = %q vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalEnumString(
+		map[string]json.RawMessage{"contract_type": json.RawMessage(`null`)},
+		"contract_type",
+		allowed,
+		"employment",
+	)
+	if vErr != nil || got != "employment" {
+		t.Fatalf("got = %q vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalEnumString(
+		map[string]json.RawMessage{"contract_type": json.RawMessage(`7`)},
+		"contract_type",
+		allowed,
+		"employment",
+	)
+	requireValidation(t, vErr, "contract_type", "must be a string")
+
+	_, vErr = OptionalEnumString(
+		map[string]json.RawMessage{"contract_type": json.RawMessage(`"mandate"`)},
+		"contract_type",
+		allowed,
+		"employment",
+	)
+	requireValidation(t, vErr, "contract_type", `invalid value "mandate"`)
+}
+
+func TestOptionalEnumStringPtr(t *testing.T) {
+	allowed := map[string]struct{}{"employment": {}, "b2b": {}}
+	got, vErr := OptionalEnumStringPtr(
+		map[string]json.RawMessage{"contract_type": json.RawMessage(`"b2b"`)},
+		"contract_type",
+		allowed,
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || *got != "b2b" {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalEnumStringPtr(map[string]json.RawMessage{}, "contract_type", allowed)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalEnumStringPtr(
+		map[string]json.RawMessage{"contract_type": json.RawMessage(`null`)},
+		"contract_type",
+		allowed,
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalEnumStringPtr(
+		map[string]json.RawMessage{"contract_type": json.RawMessage(`7`)},
+		"contract_type",
+		allowed,
+	)
+	requireValidation(t, vErr, "contract_type", "must be a string")
+
+	_, vErr = OptionalEnumStringPtr(
+		map[string]json.RawMessage{"contract_type": json.RawMessage(`"mandate"`)},
+		"contract_type",
+		allowed,
+	)
+	requireValidation(t, vErr, "contract_type", `invalid value "mandate"`)
+}
+
 func TestOptionalUpperTrimmedEnumString(t *testing.T) {
 	allowed := map[string]struct{}{"PLN": {}, "USD": {}}
 	got, vErr := OptionalUpperTrimmedEnumString(


### PR DESCRIPTION
## Summary
- add shared optional enum string helpers that match RequiredEnumString validation semantics
- reuse them in accounts, debts, and equity grants where invalid values already use the shared invalid value message
- remove matching local optional/patch enum helpers

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check