### PR TITLE
refactor(validation): share positive int parsing

### DIFF
--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -107,7 +107,7 @@ func requireGrantBasics(raw map[string]json.RawMessage, r *createRequest) *httpu
 	}
 	r.OwnerUserID = ownerID
 
-	totalShares, vErr := requirePositiveInt(raw, "total_shares", "Total shares must be greater than 0")
+	totalShares, vErr := validation.RequiredPositiveInt(raw, "total_shares", "Total shares must be greater than 0")
 	if vErr != nil {
 		return vErr
 	}
@@ -140,13 +140,18 @@ func requireGrantVesting(raw map[string]json.RawMessage, r *createRequest) *http
 	}
 	r.VestStartDate = vsd
 
-	cliff, vErr := optionalNonNegativeInt(raw, "vest_cliff_months", "Cliff months must be non-negative", 0)
+	cliff, vErr := validation.OptionalNonNegativeIntDefault(
+		raw,
+		"vest_cliff_months",
+		"Cliff months must be non-negative",
+		0,
+	)
 	if vErr != nil {
 		return vErr
 	}
 	r.VestCliffMonths = cliff
 
-	total, vErr := requirePositiveInt(raw, "vest_total_months", "Total vesting months must be greater than 0")
+	total, vErr := validation.RequiredPositiveInt(raw, "vest_total_months", "Total vesting months must be greater than 0")
 	if vErr != nil {
 		return vErr
 	}
@@ -261,14 +266,28 @@ func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 }
 
 func patchNumbersAndBools(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.ValidationError {
-	if vErr := patchPositiveInt(raw, "total_shares", "Total shares must be greater than 0", &p.TotalShares); vErr != nil {
+	if totalShares, vErr := validation.OptionalPositiveInt(raw, "total_shares", "Total shares must be greater than 0"); vErr != nil {
 		return vErr
+	} else if totalShares != nil {
+		p.TotalShares = totalShares
 	}
-	if vErr := patchNonNegativeIntPtr(raw, "vest_cliff_months", "Cliff months must be non-negative", &p.VestCliffMonths); vErr != nil {
+	if cliffMonths, vErr := validation.OptionalNonNegativeInt(
+		raw,
+		"vest_cliff_months",
+		"Cliff months must be non-negative",
+	); vErr != nil {
 		return vErr
+	} else if cliffMonths != nil {
+		p.VestCliffMonths = cliffMonths
 	}
-	if vErr := patchPositiveInt(raw, "vest_total_months", "Total vesting months must be greater than 0", &p.VestTotalMonths); vErr != nil {
+	if totalMonths, vErr := validation.OptionalPositiveInt(
+		raw,
+		"vest_total_months",
+		"Total vesting months must be greater than 0",
+	); vErr != nil {
 		return vErr
+	} else if totalMonths != nil {
+		p.VestTotalMonths = totalMonths
 	}
 	if d, vErr := validation.OptionalNonNegativeDecimal(raw, "strike_price", "Strike price must be non-negative"); vErr != nil {
 		return vErr
@@ -322,37 +341,6 @@ func patchSchedule(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Val
 	return nil
 }
 
-// --- shared decoders ---
-
-func requirePositiveInt(raw map[string]json.RawMessage, key, msg string) (int, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return 0, &httputil.ValidationError{Field: key, Msg: "Field required"}
-	}
-	var n int
-	if err := json.Unmarshal(v, &n); err != nil {
-		return 0, &httputil.ValidationError{Field: key, Msg: "must be an integer"}
-	}
-	if n <= 0 {
-		return 0, &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	return n, nil
-}
-
-func optionalNonNegativeInt(raw map[string]json.RawMessage, key, msg string, fallback int) (int, *httputil.ValidationError) {
-	n, vErr := validation.OptionalInt(raw, key, "must be an integer")
-	if vErr != nil {
-		return 0, vErr
-	}
-	if n == nil {
-		return fallback, nil
-	}
-	if *n < 0 {
-		return 0, &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	return *n, nil
-}
-
 // --- PATCH helpers ---
 
 func patchNonEmptyString(raw map[string]json.RawMessage, key, emptyMsg string, dest **string) *httputil.ValidationError {
@@ -369,36 +357,6 @@ func patchNonEmptyString(raw map[string]json.RawMessage, key, emptyMsg string, d
 		return &httputil.ValidationError{Field: key, Msg: emptyMsg}
 	}
 	*dest = &s
-	return nil
-}
-
-func patchPositiveInt(raw map[string]json.RawMessage, key, msg string, dest **int) *httputil.ValidationError {
-	n, vErr := validation.OptionalInt(raw, key, "must be an integer")
-	if vErr != nil {
-		return vErr
-	}
-	if n == nil {
-		return nil
-	}
-	if *n <= 0 {
-		return &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	*dest = n
-	return nil
-}
-
-func patchNonNegativeIntPtr(raw map[string]json.RawMessage, key, msg string, dest **int) *httputil.ValidationError {
-	n, vErr := validation.OptionalInt(raw, key, "must be an integer")
-	if vErr != nil {
-		return vErr
-	}
-	if n == nil {
-		return nil
-	}
-	if *n < 0 {
-		return &httputil.ValidationError{Field: key, Msg: msg}
-	}
-	*dest = n
 	return nil
 }
 

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -218,6 +218,75 @@ func RequiredIntRange(
 	return n, nil
 }
 
+// RequiredPositiveInt reads a required integer field and rejects zero or
+// negative values with the supplied positiveMsg.
+func RequiredPositiveInt(
+	raw map[string]json.RawMessage,
+	key string,
+	positiveMsg string,
+) (int, *httputil.ValidationError) {
+	n, vErr := RequiredInt(raw, key, "Field required", "must be an integer")
+	if vErr != nil {
+		return 0, vErr
+	}
+	if n <= 0 {
+		return 0, &httputil.ValidationError{Field: key, Msg: positiveMsg}
+	}
+	return n, nil
+}
+
+// OptionalPositiveInt reads an optional integer field and rejects zero or
+// negative values with the supplied positiveMsg.
+func OptionalPositiveInt(
+	raw map[string]json.RawMessage,
+	key string,
+	positiveMsg string,
+) (*int, *httputil.ValidationError) {
+	n, vErr := OptionalInt(raw, key, "must be an integer")
+	if vErr != nil {
+		return nil, vErr
+	}
+	if n != nil && *n <= 0 {
+		return nil, &httputil.ValidationError{Field: key, Msg: positiveMsg}
+	}
+	return n, nil
+}
+
+// OptionalNonNegativeInt reads an optional integer field and rejects negative
+// values with the supplied nonNegativeMsg.
+func OptionalNonNegativeInt(
+	raw map[string]json.RawMessage,
+	key string,
+	nonNegativeMsg string,
+) (*int, *httputil.ValidationError) {
+	n, vErr := OptionalInt(raw, key, "must be an integer")
+	if vErr != nil {
+		return nil, vErr
+	}
+	if n != nil && *n < 0 {
+		return nil, &httputil.ValidationError{Field: key, Msg: nonNegativeMsg}
+	}
+	return n, nil
+}
+
+// OptionalNonNegativeIntDefault is the default-valued variant of
+// OptionalNonNegativeInt. Missing and explicit null return fallback.
+func OptionalNonNegativeIntDefault(
+	raw map[string]json.RawMessage,
+	key string,
+	nonNegativeMsg string,
+	fallback int,
+) (int, *httputil.ValidationError) {
+	n, vErr := OptionalNonNegativeInt(raw, key, nonNegativeMsg)
+	if vErr != nil {
+		return 0, vErr
+	}
+	if n == nil {
+		return fallback, nil
+	}
+	return *n, nil
+}
+
 // RequiredEnumString reads a required string field and checks it belongs to
 // the provided allowed set.
 func RequiredEnumString(

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -386,6 +386,13 @@ func TestRequiredPositiveInt(t *testing.T) {
 		"Shares must be greater than 0",
 	)
 	requireValidation(t, vErr, "shares", "Shares must be greater than 0")
+
+	_, vErr = RequiredPositiveInt(
+		map[string]json.RawMessage{"shares": json.RawMessage(`-1`)},
+		"shares",
+		"Shares must be greater than 0",
+	)
+	requireValidation(t, vErr, "shares", "Shares must be greater than 0")
 }
 
 func TestOptionalPositiveInt(t *testing.T) {
@@ -424,6 +431,13 @@ func TestOptionalPositiveInt(t *testing.T) {
 
 	_, vErr = OptionalPositiveInt(
 		map[string]json.RawMessage{"shares": json.RawMessage(`0`)},
+		"shares",
+		"Shares must be greater than 0",
+	)
+	requireValidation(t, vErr, "shares", "Shares must be greater than 0")
+
+	_, vErr = OptionalPositiveInt(
+		map[string]json.RawMessage{"shares": json.RawMessage(`-1`)},
 		"shares",
 		"Shares must be greater than 0",
 	)

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -350,6 +350,177 @@ func TestRequiredIntRange(t *testing.T) {
 	requireValidation(t, vErr, "year", "Year must be between 2000 and 2030")
 }
 
+func TestRequiredPositiveInt(t *testing.T) {
+	got, vErr := RequiredPositiveInt(
+		map[string]json.RawMessage{"shares": json.RawMessage(`7`)},
+		"shares",
+		"Shares must be greater than 0",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != 7 {
+		t.Fatalf("got = %d", got)
+	}
+
+	_, vErr = RequiredPositiveInt(map[string]json.RawMessage{}, "shares", "Shares must be greater than 0")
+	requireValidation(t, vErr, "shares", "Field required")
+
+	_, vErr = RequiredPositiveInt(
+		map[string]json.RawMessage{"shares": json.RawMessage(`null`)},
+		"shares",
+		"Shares must be greater than 0",
+	)
+	requireValidation(t, vErr, "shares", "Field required")
+
+	_, vErr = RequiredPositiveInt(
+		map[string]json.RawMessage{"shares": json.RawMessage(`"7"`)},
+		"shares",
+		"Shares must be greater than 0",
+	)
+	requireValidation(t, vErr, "shares", "must be an integer")
+
+	_, vErr = RequiredPositiveInt(
+		map[string]json.RawMessage{"shares": json.RawMessage(`0`)},
+		"shares",
+		"Shares must be greater than 0",
+	)
+	requireValidation(t, vErr, "shares", "Shares must be greater than 0")
+}
+
+func TestOptionalPositiveInt(t *testing.T) {
+	got, vErr := OptionalPositiveInt(
+		map[string]json.RawMessage{"shares": json.RawMessage(`7`)},
+		"shares",
+		"Shares must be greater than 0",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || *got != 7 {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalPositiveInt(map[string]json.RawMessage{}, "shares", "Shares must be greater than 0")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalPositiveInt(
+		map[string]json.RawMessage{"shares": json.RawMessage(`null`)},
+		"shares",
+		"Shares must be greater than 0",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalPositiveInt(
+		map[string]json.RawMessage{"shares": json.RawMessage(`"7"`)},
+		"shares",
+		"Shares must be greater than 0",
+	)
+	requireValidation(t, vErr, "shares", "must be an integer")
+
+	_, vErr = OptionalPositiveInt(
+		map[string]json.RawMessage{"shares": json.RawMessage(`0`)},
+		"shares",
+		"Shares must be greater than 0",
+	)
+	requireValidation(t, vErr, "shares", "Shares must be greater than 0")
+}
+
+func TestOptionalNonNegativeInt(t *testing.T) {
+	got, vErr := OptionalNonNegativeInt(
+		map[string]json.RawMessage{"months": json.RawMessage(`0`)},
+		"months",
+		"Months must be non-negative",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || *got != 0 {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalNonNegativeInt(map[string]json.RawMessage{}, "months", "Months must be non-negative")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalNonNegativeInt(
+		map[string]json.RawMessage{"months": json.RawMessage(`null`)},
+		"months",
+		"Months must be non-negative",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalNonNegativeInt(
+		map[string]json.RawMessage{"months": json.RawMessage(`"0"`)},
+		"months",
+		"Months must be non-negative",
+	)
+	requireValidation(t, vErr, "months", "must be an integer")
+
+	_, vErr = OptionalNonNegativeInt(
+		map[string]json.RawMessage{"months": json.RawMessage(`-1`)},
+		"months",
+		"Months must be non-negative",
+	)
+	requireValidation(t, vErr, "months", "Months must be non-negative")
+}
+
+func TestOptionalNonNegativeIntDefault(t *testing.T) {
+	got, vErr := OptionalNonNegativeIntDefault(
+		map[string]json.RawMessage{},
+		"months",
+		"Months must be non-negative",
+		12,
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != 12 {
+		t.Fatalf("got = %d", got)
+	}
+
+	got, vErr = OptionalNonNegativeIntDefault(
+		map[string]json.RawMessage{"months": json.RawMessage(`null`)},
+		"months",
+		"Months must be non-negative",
+		12,
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != 12 {
+		t.Fatalf("got = %d", got)
+	}
+
+	got, vErr = OptionalNonNegativeIntDefault(
+		map[string]json.RawMessage{"months": json.RawMessage(`3`)},
+		"months",
+		"Months must be non-negative",
+		12,
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != 3 {
+		t.Fatalf("got = %d", got)
+	}
+
+	_, vErr = OptionalNonNegativeIntDefault(
+		map[string]json.RawMessage{"months": json.RawMessage(`-1`)},
+		"months",
+		"Months must be non-negative",
+		12,
+	)
+	requireValidation(t, vErr, "months", "Months must be non-negative")
+}
+
 func TestRequiredEnumString(t *testing.T) {
 	allowed := map[string]struct{}{"employment": {}, "b2b": {}}
 


### PR DESCRIPTION
## Summary
- add shared required/optional positive int and optional non-negative int helpers
- reuse them in equity grant create and patch validation
- remove matching local int validation helpers

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check