### PR TITLE
refactor(validation): share optional bool parsing

### DIFF
--- a/backend-go/internal/accounts/validation.go
+++ b/backend-go/internal/accounts/validation.go
@@ -82,7 +82,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.ReceivesContributions = recv
 
-	excl, vErr := optionalBoolDefaultFalse(raw, "excluded_from_fire")
+	excl, vErr := validation.OptionalBoolDefault(raw, "excluded_from_fire", false)
 	if vErr != nil {
 		return r, vErr
 	}
@@ -164,19 +164,15 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 			p.SquareMeters = &d
 		}
 	}
-	if v, ok := raw["receives_contributions"]; ok && !validation.IsNull(v) {
-		var b bool
-		if err := json.Unmarshal(v, &b); err != nil {
-			return p, &httputil.ValidationError{Field: "receives_contributions", Msg: "must be a boolean"}
-		}
-		p.ReceivesContributions = &b
+	if b, vErr := validation.OptionalBool(raw, "receives_contributions"); vErr != nil {
+		return p, vErr
+	} else if b != nil {
+		p.ReceivesContributions = b
 	}
-	if v, ok := raw["excluded_from_fire"]; ok && !validation.IsNull(v) {
-		var b bool
-		if err := json.Unmarshal(v, &b); err != nil {
-			return p, &httputil.ValidationError{Field: "excluded_from_fire", Msg: "must be a boolean"}
-		}
-		p.ExcludedFromFire = &b
+	if b, vErr := validation.OptionalBool(raw, "excluded_from_fire"); vErr != nil {
+		return p, vErr
+	} else if b != nil {
+		p.ExcludedFromFire = b
 	}
 	if v, ok := raw["interest_rate_pct"]; ok {
 		p.InterestRatePctSet = true
@@ -265,18 +261,6 @@ func optionalBoolDefaultTrue(raw map[string]json.RawMessage, key string) (bool, 
 	}
 	if validation.IsNull(v) {
 		return false, &httputil.ValidationError{Field: key, Msg: "must be a boolean"}
-	}
-	var b bool
-	if err := json.Unmarshal(v, &b); err != nil {
-		return false, &httputil.ValidationError{Field: key, Msg: "must be a boolean"}
-	}
-	return b, nil
-}
-
-func optionalBoolDefaultFalse(raw map[string]json.RawMessage, key string) (bool, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return false, nil
 	}
 	var b bool
 	if err := json.Unmarshal(v, &b); err != nil {

--- a/backend-go/internal/bonds/validation.go
+++ b/backend-go/internal/bonds/validation.go
@@ -100,12 +100,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 	if vErr := patchRatePercent(raw, "margin", &p.Margin); vErr != nil {
 		return p, vErr
 	}
-	if v, ok := raw["capitalize"]; ok && !validation.IsNull(v) {
-		var b bool
-		if err := json.Unmarshal(v, &b); err != nil {
-			return p, &httputil.ValidationError{Field: "capitalize", Msg: "must be a boolean"}
-		}
-		p.Capitalize = &b
+	if b, vErr := validation.OptionalBool(raw, "capitalize"); vErr != nil {
+		return p, vErr
+	} else if b != nil {
+		p.Capitalize = b
 	}
 	return p, nil
 }

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -172,12 +172,10 @@ func requireGrantVesting(raw map[string]json.RawMessage, r *createRequest) *http
 }
 
 func optionalGrantLiquidity(raw map[string]json.RawMessage, r *createRequest) *httputil.ValidationError {
-	if v, ok := raw["requires_liquidity_event"]; ok && !validation.IsNull(v) {
-		var b bool
-		if err := json.Unmarshal(v, &b); err != nil {
-			return &httputil.ValidationError{Field: "requires_liquidity_event", Msg: "must be a boolean"}
-		}
-		r.RequiresLiquidityEvent = b
+	if b, vErr := validation.OptionalBool(raw, "requires_liquidity_event"); vErr != nil {
+		return vErr
+	} else if b != nil {
+		r.RequiresLiquidityEvent = *b
 	}
 	if t, vErr := validation.OptionalDate(raw, "liquidity_event_date"); vErr != nil {
 		return vErr
@@ -294,12 +292,10 @@ func patchNumbersAndBools(raw map[string]json.RawMessage, p *UpdatePatch) *httpu
 	} else if d != nil {
 		p.StrikePrice = d
 	}
-	if v, ok := raw["requires_liquidity_event"]; ok && !validation.IsNull(v) {
-		var b bool
-		if err := json.Unmarshal(v, &b); err != nil {
-			return &httputil.ValidationError{Field: "requires_liquidity_event", Msg: "must be a boolean"}
-		}
-		p.RequiresLiquidityEvent = &b
+	if b, vErr := validation.OptionalBool(raw, "requires_liquidity_event"); vErr != nil {
+		return vErr
+	} else if b != nil {
+		p.RequiresLiquidityEvent = b
 	}
 	return nil
 }

--- a/backend-go/internal/goals/validation.go
+++ b/backend-go/internal/goals/validation.go
@@ -95,12 +95,10 @@ func patchScalarFields(raw map[string]json.RawMessage, p *UpdatePatch) *httputil
 	} else if d != nil {
 		p.MonthlyContribution = d
 	}
-	if v, ok := raw["is_completed"]; ok && !validation.IsNull(v) {
-		var b bool
-		if err := json.Unmarshal(v, &b); err != nil {
-			return &httputil.ValidationError{Field: "is_completed", Msg: "must be a boolean"}
-		}
-		p.IsCompleted = &b
+	if b, vErr := validation.OptionalBool(raw, "is_completed"); vErr != nil {
+		return vErr
+	} else if b != nil {
+		p.IsCompleted = b
 	}
 	return nil
 }

--- a/backend-go/internal/recurring/validation.go
+++ b/backend-go/internal/recurring/validation.go
@@ -125,11 +125,11 @@ func readDatesAndActive(raw map[string]json.RawMessage, in *CreateInput) *httput
 		in.EndDate = &t
 	}
 	in.Active = true
-	if v, ok := raw["active"]; ok && string(v) != "null" {
-		if jerr := json.Unmarshal(v, &in.Active); jerr != nil {
-			return &httputil.ValidationError{Field: "active", Msg: "must be a boolean"}
-		}
+	active, vErr := validation.OptionalBoolDefault(raw, "active", true)
+	if vErr != nil {
+		return vErr
 	}
+	in.Active = active
 	return nil
 }
 

--- a/backend-go/internal/retirement/validation.go
+++ b/backend-go/internal/retirement/validation.go
@@ -111,13 +111,5 @@ func buildGenerateRequest(raw map[string]json.RawMessage, now func() time.Time) 
 // non-bool value (e.g. "true" sent as a string) is rejected so the client
 // gets a 422 instead of silently degrading to false.
 func optionalBool(raw map[string]json.RawMessage, key string) (bool, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return false, nil
-	}
-	var b bool
-	if err := json.Unmarshal(v, &b); err != nil {
-		return false, &httputil.ValidationError{Field: key, Msg: "must be a boolean"}
-	}
-	return b, nil
+	return validation.OptionalBoolDefault(raw, key, false)
 }

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -137,6 +137,33 @@ func OptionalDateNotFuture(
 	return t, nil
 }
 
+// OptionalBool reads an optional boolean field. Missing and explicit null
+// return nil.
+func OptionalBool(raw map[string]json.RawMessage, key string) (*bool, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return nil, nil
+	}
+	var b bool
+	if err := json.Unmarshal(v, &b); err != nil {
+		return nil, &httputil.ValidationError{Field: key, Msg: "must be a boolean"}
+	}
+	return &b, nil
+}
+
+// OptionalBoolDefault is the default-valued variant of OptionalBool. Missing
+// and explicit null return fallback.
+func OptionalBoolDefault(raw map[string]json.RawMessage, key string, fallback bool) (bool, *httputil.ValidationError) {
+	b, vErr := OptionalBool(raw, key)
+	if vErr != nil {
+		return false, vErr
+	}
+	if b == nil {
+		return fallback, nil
+	}
+	return *b, nil
+}
+
 func todayUTC(now func() time.Time) time.Time {
 	if now == nil {
 		now = time.Now

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -210,6 +210,61 @@ func TestOptionalDateNotFuture(t *testing.T) {
 	requireValidation(t, vErr, "date", "must be a string")
 }
 
+func TestOptionalBool(t *testing.T) {
+	got, vErr := OptionalBool(
+		map[string]json.RawMessage{"active": json.RawMessage(`true`)},
+		"active",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || *got != true {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalBool(map[string]json.RawMessage{}, "active")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalBool(map[string]json.RawMessage{"active": json.RawMessage(`null`)}, "active")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalBool(map[string]json.RawMessage{"active": json.RawMessage(`"true"`)}, "active")
+	requireValidation(t, vErr, "active", "must be a boolean")
+}
+
+func TestOptionalBoolDefault(t *testing.T) {
+	got, vErr := OptionalBoolDefault(map[string]json.RawMessage{}, "active", true)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != true {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalBoolDefault(map[string]json.RawMessage{"active": json.RawMessage(`null`)}, "active", true)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != true {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalBoolDefault(map[string]json.RawMessage{"active": json.RawMessage(`false`)}, "active", true)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != false {
+		t.Fatalf("got = %v", got)
+	}
+
+	_, vErr = OptionalBoolDefault(map[string]json.RawMessage{"active": json.RawMessage(`"false"`)}, "active", true)
+	requireValidation(t, vErr, "active", "must be a boolean")
+}
+
 func TestOptionalInt(t *testing.T) {
 	got, vErr := OptionalInt(
 		map[string]json.RawMessage{"owner_user_id": json.RawMessage(`7`)},


### PR DESCRIPTION
## Summary
- add shared OptionalBool and OptionalBoolDefault validation helpers
- reuse them for sparse-update/default boolean parsing where null currently means no-op/default
- leave null-as-error boolean validators untouched

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check