### PR TITLE
refactor(validation): reuse optional trimmed string parsing

### DIFF
--- a/backend-go/internal/accounts/validation.go
+++ b/backend-go/internal/accounts/validation.go
@@ -3,7 +3,6 @@ package accounts
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/shopspring/decimal"
 
@@ -105,16 +104,10 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 //     (Pydantic's `Wrapper | None` lets None through and the service writes it)
 func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.ValidationError) {
 	var p UpdatePatch
-	if v, ok := raw["name"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return p, &httputil.ValidationError{Field: "name", Msg: "must be a string"}
-		}
-		s = strings.TrimSpace(s)
-		if s == "" {
-			return p, &httputil.ValidationError{Field: "name", Msg: "Name cannot be empty"}
-		}
-		p.Name = &s
+	if s, vErr := validation.OptionalTrimmedString(raw, "name", "Name cannot be empty"); vErr != nil {
+		return p, vErr
+	} else if s != nil {
+		p.Name = s
 	}
 	if category, vErr := validation.OptionalEnumStringPtr(raw, "category", validCategories); vErr != nil {
 		return p, vErr

--- a/backend-go/internal/bonds/validation.go
+++ b/backend-go/internal/bonds/validation.go
@@ -57,16 +57,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.Type = &t
 	}
-	if v, ok := raw["series"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return p, &httputil.ValidationError{Field: "series", Msg: "must be a string"}
-		}
-		s = strings.TrimSpace(s)
-		if s == "" {
-			return p, &httputil.ValidationError{Field: "series", Msg: "Series cannot be empty"}
-		}
-		p.Series = &s
+	if s, vErr := validation.OptionalTrimmedString(raw, "series", "Series cannot be empty"); vErr != nil {
+		return p, vErr
+	} else if s != nil {
+		p.Series = s
 	}
 	if d, vErr := validation.OptionalPositiveDecimal(raw, "face_value", "Face value must be greater than 0"); vErr != nil {
 		return p, vErr

--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -3,7 +3,6 @@ package bonusevents
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
@@ -109,16 +108,10 @@ func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 	} else if s != nil {
 		p.Currency = s
 	}
-	if v, ok := raw["company"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: "company", Msg: "must be a string"}
-		}
-		s = strings.TrimSpace(s)
-		if s == "" {
-			return &httputil.ValidationError{Field: "company", Msg: "Company cannot be empty"}
-		}
-		p.Company = &s
+	if s, vErr := validation.OptionalTrimmedString(raw, "company", "Company cannot be empty"); vErr != nil {
+		return vErr
+	} else if s != nil {
+		p.Company = s
 	}
 	if _, ok := raw["owner_user_id"]; ok {
 		p.OwnerUserIDSet = true

--- a/backend-go/internal/company_valuations/validation.go
+++ b/backend-go/internal/company_valuations/validation.go
@@ -3,7 +3,6 @@ package companyvaluations
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/shopspring/decimal"
 
@@ -110,16 +109,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 }
 
 func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.ValidationError {
-	if v, ok := raw["company"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: "company", Msg: "must be a string"}
-		}
-		s = strings.TrimSpace(s)
-		if s == "" {
-			return &httputil.ValidationError{Field: "company", Msg: "Company cannot be empty"}
-		}
-		p.Company = &s
+	if s, vErr := validation.OptionalTrimmedString(raw, "company", "Company cannot be empty"); vErr != nil {
+		return vErr
+	} else if s != nil {
+		p.Company = s
 	}
 	if s, vErr := validation.OptionalUpperTrimmedEnumStringPtr(
 		raw,

--- a/backend-go/internal/debts/validation.go
+++ b/backend-go/internal/debts/validation.go
@@ -2,7 +2,6 @@ package debts
 
 import (
 	"encoding/json"
-	"strings"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -80,16 +79,10 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 
 func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.ValidationError) {
 	var p UpdatePatch
-	if v, ok := raw["name"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return p, &httputil.ValidationError{Field: "name", Msg: "must be a string"}
-		}
-		s = strings.TrimSpace(s)
-		if s == "" {
-			return p, &httputil.ValidationError{Field: "name", Msg: "Name cannot be empty"}
-		}
-		p.Name = &s
+	if s, vErr := validation.OptionalTrimmedString(raw, "name", "Name cannot be empty"); vErr != nil {
+		return p, vErr
+	} else if s != nil {
+		p.Name = s
 	}
 	if debtType, vErr := validation.OptionalEnumStringPtr(raw, "debt_type", validDebtTypes); vErr != nil {
 		return p, vErr

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -2,7 +2,6 @@ package equitygrants
 
 import (
 	"encoding/json"
-	"strings"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -227,8 +226,10 @@ func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 	} else if grantType != nil {
 		p.Type = grantType
 	}
-	if vErr := patchNonEmptyString(raw, "company", "Company cannot be empty", &p.Company); vErr != nil {
+	if s, vErr := validation.OptionalTrimmedString(raw, "company", "Company cannot be empty"); vErr != nil {
 		return vErr
+	} else if s != nil {
+		p.Company = s
 	}
 	if vErr := patchOwnerUserID(raw, p); vErr != nil {
 		return vErr
@@ -334,25 +335,6 @@ func patchSchedule(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Val
 	}
 	p.VestCustomScheduleSet = true
 	p.VestCustomSchedule = schedule
-	return nil
-}
-
-// --- PATCH helpers ---
-
-func patchNonEmptyString(raw map[string]json.RawMessage, key, emptyMsg string, dest **string) *httputil.ValidationError {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return nil
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return &httputil.ValidationError{Field: key, Msg: emptyMsg}
-	}
-	*dest = &s
 	return nil
 }
 

--- a/backend-go/internal/goals/validation.go
+++ b/backend-go/internal/goals/validation.go
@@ -60,16 +60,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 // Matches Python's GoalUpdate validators: explicit null is treated as
 // "no-op" (the validator returns None and the service skips that field).
 func patchScalarFields(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.ValidationError {
-	if v, ok := raw["name"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: "name", Msg: "must be a string"}
-		}
-		s = strings.TrimSpace(s)
-		if s == "" {
-			return &httputil.ValidationError{Field: "name", Msg: "Name cannot be empty"}
-		}
-		p.Name = &s
+	if s, vErr := validation.OptionalTrimmedString(raw, "name", "Name cannot be empty"); vErr != nil {
+		return vErr
+	} else if s != nil {
+		p.Name = s
 	}
 	if d, vErr := validation.OptionalPositiveDecimal(raw, "target_amount", "Target amount must be greater than 0"); vErr != nil {
 		return vErr

--- a/backend-go/internal/salaries/validation.go
+++ b/backend-go/internal/salaries/validation.go
@@ -81,15 +81,10 @@ func buildUpdatePatch(raw map[string]json.RawMessage, now func() time.Time) (Upd
 		}
 		p.ContractType = &s
 	}
-	if v, ok := raw["company"]; ok && !validation.IsNull(v) {
-		s, err := validation.RawTrimmedString(v)
-		if err != nil {
-			return p, &httputil.ValidationError{Field: "company", Msg: "must be a string"}
-		}
-		if s == "" {
-			return p, &httputil.ValidationError{Field: "company", Msg: "Company cannot be empty"}
-		}
-		p.Company = &s
+	if s, vErr := validation.OptionalTrimmedString(raw, "company", "Company cannot be empty"); vErr != nil {
+		return p, vErr
+	} else if s != nil {
+		p.Company = s
 	}
 	if _, ok := raw["owner_user_id"]; ok {
 		p.OwnerUserIDSet = true


### PR DESCRIPTION
## Summary
- reuse validation.OptionalTrimmedString for PATCH string fields across finance resources
- remove duplicated JSON decode, trim, and empty-check logic from individual validators

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check