### PR TITLE
refactor(validation): share optional string parsing

### DIFF
--- a/backend-go/internal/bonus_events/validation.go
+++ b/backend-go/internal/bonus_events/validation.go
@@ -64,12 +64,10 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 		return r, vErr
 	}
 
-	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return r, &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
-		}
-		r.Notes = &s
+	if s, vErr := validation.OptionalString(raw, "notes"); vErr != nil {
+		return r, vErr
+	} else if s != nil {
+		r.Notes = s
 	}
 	return r, nil
 }
@@ -121,12 +119,10 @@ func patchScalars(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 		}
 		p.OwnerUserID = ownerID
 	}
-	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
-		}
-		p.Notes = &s
+	if s, vErr := validation.OptionalString(raw, "notes"); vErr != nil {
+		return vErr
+	} else if s != nil {
+		p.Notes = s
 	}
 	return nil
 }

--- a/backend-go/internal/company_valuations/validation.go
+++ b/backend-go/internal/company_valuations/validation.go
@@ -84,12 +84,10 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Source = source
 
-	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return r, &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
-		}
-		r.Notes = &s
+	if s, vErr := validation.OptionalString(raw, "notes"); vErr != nil {
+		return r, vErr
+	} else if s != nil {
+		r.Notes = s
 	}
 	return r, nil
 }
@@ -134,12 +132,10 @@ func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 		}
 		p.Source = &s
 	}
-	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
-		}
-		p.Notes = &s
+	if s, vErr := validation.OptionalString(raw, "notes"); vErr != nil {
+		return vErr
+	} else if s != nil {
+		p.Notes = s
 	}
 	if t, vErr := validation.OptionalDate(raw, "date"); vErr != nil {
 		return vErr

--- a/backend-go/internal/debts/validation.go
+++ b/backend-go/internal/debts/validation.go
@@ -67,12 +67,10 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Currency = cur
 
-	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return r, &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
-		}
-		r.Notes = &s
+	if s, vErr := validation.OptionalString(raw, "notes"); vErr != nil {
+		return r, vErr
+	} else if s != nil {
+		r.Notes = s
 	}
 	return r, nil
 }
@@ -127,13 +125,11 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		}
 		p.Currency = &s
 	}
-	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return p, &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
-		}
+	if s, vErr := validation.OptionalString(raw, "notes"); vErr != nil {
+		return p, vErr
+	} else if s != nil {
 		p.NotesSet = true
-		p.Notes = &s
+		p.Notes = s
 	}
 	return p, nil
 }

--- a/backend-go/internal/equity_grants/validation.go
+++ b/backend-go/internal/equity_grants/validation.go
@@ -191,12 +191,10 @@ func optionalGrantTaxNotes(raw map[string]json.RawMessage, r *createRequest) *ht
 	}
 	r.TaxTreatment = tax
 
-	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
-		}
-		r.Notes = &s
+	if s, vErr := validation.OptionalString(raw, "notes"); vErr != nil {
+		return vErr
+	} else if s != nil {
+		r.Notes = s
 	}
 	return nil
 }
@@ -254,12 +252,10 @@ func patchStrings(raw map[string]json.RawMessage, p *UpdatePatch) *httputil.Vali
 	} else if tax != nil {
 		p.TaxTreatment = tax
 	}
-	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
-		}
-		p.Notes = &s
+	if s, vErr := validation.OptionalString(raw, "notes"); vErr != nil {
+		return vErr
+	} else if s != nil {
+		p.Notes = s
 	}
 	return nil
 }

--- a/backend-go/internal/retirement/validation.go
+++ b/backend-go/internal/retirement/validation.go
@@ -51,12 +51,10 @@ func buildLimitRequest(raw map[string]json.RawMessage, now func() time.Time) (li
 	}
 	r.LimitAmount = amt
 
-	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return r, &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
-		}
-		r.Notes = &s
+	if s, vErr := validation.OptionalString(raw, "notes"); vErr != nil {
+		return r, vErr
+	} else if s != nil {
+		r.Notes = s
 	}
 	return r, nil
 }

--- a/backend-go/internal/snapshots/validation.go
+++ b/backend-go/internal/snapshots/validation.go
@@ -22,12 +22,10 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Date = t
 
-	if v, ok := raw["notes"]; ok && !validation.IsNull(v) {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return r, &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
-		}
-		r.Notes = &s
+	if s, vErr := validation.OptionalString(raw, "notes"); vErr != nil {
+		return r, vErr
+	} else if s != nil {
+		r.Notes = s
 	}
 
 	vRaw, ok := raw["values"]
@@ -57,11 +55,11 @@ func buildUpdatePatch(raw map[string]json.RawMessage) (UpdatePatch, *httputil.Va
 		if validation.IsNull(v) {
 			p.Notes = nil
 		} else {
-			var s string
-			if err := json.Unmarshal(v, &s); err != nil {
-				return p, &httputil.ValidationError{Field: "notes", Msg: "must be a string"}
+			s, vErr := validation.OptionalString(raw, "notes")
+			if vErr != nil {
+				return p, vErr
 			}
-			p.Notes = &s
+			p.Notes = s
 		}
 	}
 	if v, ok := raw["values"]; ok && !validation.IsNull(v) {

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -55,6 +55,20 @@ func OptionalTrimmedString(
 	return &s, nil
 }
 
+// OptionalString reads an optional string field without trimming or empty
+// validation. Missing or explicit null returns nil.
+func OptionalString(raw map[string]json.RawMessage, key string) (*string, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return nil, nil
+	}
+	s, err := RawString(v)
+	if err != nil {
+		return nil, &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	}
+	return &s, nil
+}
+
 // RequiredDate reads a required YYYY-MM-DD field.
 func RequiredDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
 	v, ok := raw[key]

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -70,6 +70,49 @@ func TestOptionalTrimmedString(t *testing.T) {
 	requireValidation(t, vErr, "name", "Name cannot be empty")
 }
 
+func TestOptionalString(t *testing.T) {
+	got, vErr := OptionalString(
+		map[string]json.RawMessage{"notes": json.RawMessage(`"  keep spaces  "`)},
+		"notes",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || *got != "  keep spaces  " {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalString(map[string]json.RawMessage{}, "notes")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalString(
+		map[string]json.RawMessage{"notes": json.RawMessage(`null`)},
+		"notes",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalString(
+		map[string]json.RawMessage{"notes": json.RawMessage(`""`)},
+		"notes",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || *got != "" {
+		t.Fatalf("got = %v", got)
+	}
+
+	_, vErr = OptionalString(
+		map[string]json.RawMessage{"notes": json.RawMessage(`7`)},
+		"notes",
+	)
+	requireValidation(t, vErr, "notes", "must be a string")
+}
+
 func TestRequiredDate(t *testing.T) {
 	got, vErr := RequiredDate(map[string]json.RawMessage{"date": json.RawMessage(`"2026-05-26"`)}, "date")
 	if vErr != nil {


### PR DESCRIPTION
## Summary
- add validation.OptionalString for optional raw string fields that allow empty values
- reuse it for repeated notes parsing across finance validators
- preserve null no-op behavior, including snapshot PATCH null-clears

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check