### PR TITLE
refactor(validation): share required string parsing

### DIFF
--- a/backend-go/internal/holdings/validation.go
+++ b/backend-go/internal/holdings/validation.go
@@ -97,8 +97,8 @@ func buildLotInput(raw map[string]json.RawMessage) (Lot, *httputil.ValidationErr
 	if l.SecurityID <= 0 {
 		return l, &httputil.ValidationError{Field: "security_id", Msg: "must be positive"}
 	}
-	var sideStr string
-	if vErr := requireString(raw, "side", &sideStr); vErr != nil {
+	sideStr, vErr := validation.RequiredString(raw, "side", "required", "cannot be empty")
+	if vErr != nil {
 		return l, vErr
 	}
 	if !IsValidSide(sideStr) {
@@ -129,7 +129,7 @@ func buildLotInput(raw map[string]json.RawMessage) (Lot, *httputil.ValidationErr
 		}
 		l.Fee = *fee
 	}
-	dateStr, vErr := requireString2(raw, "date")
+	dateStr, vErr := validation.RequiredString(raw, "date", "required", "cannot be empty")
 	if vErr != nil {
 		return l, vErr
 	}
@@ -143,7 +143,7 @@ func buildLotInput(raw map[string]json.RawMessage) (Lot, *httputil.ValidationErr
 
 func buildQuoteInput(raw map[string]json.RawMessage, securityID int) (PriceQuote, *httputil.ValidationError) {
 	q := PriceQuote{SecurityID: securityID, Source: "manual"}
-	dateStr, vErr := requireString2(raw, "date")
+	dateStr, vErr := validation.RequiredString(raw, "date", "required", "cannot be empty")
 	if vErr != nil {
 		return q, vErr
 	}
@@ -194,7 +194,7 @@ func buildDividendInput(raw map[string]json.RawMessage) (Dividend, *httputil.Val
 	if d.SecurityID <= 0 {
 		return d, &httputil.ValidationError{Field: "security_id", Msg: "must be positive"}
 	}
-	dateStr, vErr := requireString2(raw, "pay_date")
+	dateStr, vErr := validation.RequiredString(raw, "pay_date", "required", "cannot be empty")
 	if vErr != nil {
 		return d, vErr
 	}
@@ -235,28 +235,6 @@ func buildDividendInput(raw map[string]json.RawMessage) (Dividend, *httputil.Val
 		}
 	}
 	return d, nil
-}
-
-func requireString(raw map[string]json.RawMessage, key string, dest *string) *httputil.ValidationError {
-	v, ok := raw[key]
-	if !ok || string(v) == "null" {
-		return &httputil.ValidationError{Field: key, Msg: "required"}
-	}
-	if err := json.Unmarshal(v, dest); err != nil {
-		return &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if *dest == "" {
-		return &httputil.ValidationError{Field: key, Msg: "cannot be empty"}
-	}
-	return nil
-}
-
-func requireString2(raw map[string]json.RawMessage, key string) (string, *httputil.ValidationError) {
-	var s string
-	if vErr := requireString(raw, key, &s); vErr != nil {
-		return "", vErr
-	}
-	return s, nil
 }
 
 func requireDecimal(raw map[string]json.RawMessage, key string) (decimal.Decimal, *httputil.ValidationError) {

--- a/backend-go/internal/recurring/validation.go
+++ b/backend-go/internal/recurring/validation.go
@@ -83,9 +83,9 @@ func readOptionalStrings(raw map[string]json.RawMessage, in *CreateInput) *httpu
 }
 
 func readCadence(raw map[string]json.RawMessage, in *CreateInput) *httputil.ValidationError {
-	var freq string
-	if err := requireString(raw, "frequency", &freq); err != nil {
-		return err
+	freq, vErr := validation.RequiredString(raw, "frequency", "required", "cannot be empty")
+	if vErr != nil {
+		return vErr
 	}
 	if !IsValidFrequency(freq) {
 		return &httputil.ValidationError{Field: "frequency", Msg: "invalid cadence"}
@@ -130,20 +130,6 @@ func readDatesAndActive(raw map[string]json.RawMessage, in *CreateInput) *httput
 		return vErr
 	}
 	in.Active = active
-	return nil
-}
-
-func requireString(raw map[string]json.RawMessage, key string, dest *string) *httputil.ValidationError {
-	v, ok := raw[key]
-	if !ok || string(v) == "null" {
-		return &httputil.ValidationError{Field: key, Msg: "required"}
-	}
-	if err := json.Unmarshal(v, dest); err != nil {
-		return &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	if *dest == "" {
-		return &httputil.ValidationError{Field: key, Msg: "cannot be empty"}
-	}
 	return nil
 }
 

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -69,6 +69,28 @@ func OptionalString(raw map[string]json.RawMessage, key string) (*string, *httpu
 	return &s, nil
 }
 
+// RequiredString reads a required string field without trimming and returns
+// caller-supplied missing/empty messages.
+func RequiredString(
+	raw map[string]json.RawMessage,
+	key string,
+	missingMsg string,
+	emptyMsg string,
+) (string, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return "", &httputil.ValidationError{Field: key, Msg: missingMsg}
+	}
+	s, err := RawString(v)
+	if err != nil {
+		return "", &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	}
+	if s == "" {
+		return "", &httputil.ValidationError{Field: key, Msg: emptyMsg}
+	}
+	return s, nil
+}
+
 // RequiredDate reads a required YYYY-MM-DD field.
 func RequiredDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
 	v, ok := raw[key]

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -113,6 +113,48 @@ func TestOptionalString(t *testing.T) {
 	requireValidation(t, vErr, "notes", "must be a string")
 }
 
+func TestRequiredString(t *testing.T) {
+	got, vErr := RequiredString(
+		map[string]json.RawMessage{"frequency": json.RawMessage(`" monthly "`)},
+		"frequency",
+		"required",
+		"cannot be empty",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got != " monthly " {
+		t.Fatalf("got = %q", got)
+	}
+
+	_, vErr = RequiredString(map[string]json.RawMessage{}, "frequency", "required", "cannot be empty")
+	requireValidation(t, vErr, "frequency", "required")
+
+	_, vErr = RequiredString(
+		map[string]json.RawMessage{"frequency": json.RawMessage(`null`)},
+		"frequency",
+		"required",
+		"cannot be empty",
+	)
+	requireValidation(t, vErr, "frequency", "required")
+
+	_, vErr = RequiredString(
+		map[string]json.RawMessage{"frequency": json.RawMessage(`7`)},
+		"frequency",
+		"required",
+		"cannot be empty",
+	)
+	requireValidation(t, vErr, "frequency", "must be a string")
+
+	_, vErr = RequiredString(
+		map[string]json.RawMessage{"frequency": json.RawMessage(`""`)},
+		"frequency",
+		"required",
+		"cannot be empty",
+	)
+	requireValidation(t, vErr, "frequency", "cannot be empty")
+}
+
 func TestRequiredDate(t *testing.T) {
 	got, vErr := RequiredDate(map[string]json.RawMessage{"date": json.RawMessage(`"2026-05-26"`)}, "date")
 	if vErr != nil {


### PR DESCRIPTION
## Summary
- add validation.RequiredString for required raw string fields that should not be trimmed
- reuse it in holdings and recurring validators
- remove duplicate local required-string helpers

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check