### PR TITLE
refactor(validation): share required date parsing

### DIFF
--- a/backend-go/internal/holdings/validation.go
+++ b/backend-go/internal/holdings/validation.go
@@ -3,7 +3,6 @@ package holdings
 import (
 	"encoding/json"
 	"strings"
-	"time"
 
 	"github.com/shopspring/decimal"
 
@@ -129,13 +128,9 @@ func buildLotInput(raw map[string]json.RawMessage) (Lot, *httputil.ValidationErr
 		}
 		l.Fee = *fee
 	}
-	dateStr, vErr := validation.RequiredString(raw, "date", "required", "cannot be empty")
+	parsed, vErr := validation.RequiredNonEmptyDate(raw, "date", "required", "cannot be empty")
 	if vErr != nil {
 		return l, vErr
-	}
-	parsed, derr := time.Parse("2006-01-02", dateStr)
-	if derr != nil {
-		return l, &httputil.ValidationError{Field: "date", Msg: "must be YYYY-MM-DD"}
 	}
 	l.Date = parsed
 	return l, nil
@@ -143,13 +138,9 @@ func buildLotInput(raw map[string]json.RawMessage) (Lot, *httputil.ValidationErr
 
 func buildQuoteInput(raw map[string]json.RawMessage, securityID int) (PriceQuote, *httputil.ValidationError) {
 	q := PriceQuote{SecurityID: securityID, Source: "manual"}
-	dateStr, vErr := validation.RequiredString(raw, "date", "required", "cannot be empty")
+	parsed, vErr := validation.RequiredNonEmptyDate(raw, "date", "required", "cannot be empty")
 	if vErr != nil {
 		return q, vErr
-	}
-	parsed, derr := time.Parse("2006-01-02", dateStr)
-	if derr != nil {
-		return q, &httputil.ValidationError{Field: "date", Msg: "must be YYYY-MM-DD"}
 	}
 	q.Date = parsed
 	price, vErr := requireDecimal(raw, "price")
@@ -194,13 +185,9 @@ func buildDividendInput(raw map[string]json.RawMessage) (Dividend, *httputil.Val
 	if d.SecurityID <= 0 {
 		return d, &httputil.ValidationError{Field: "security_id", Msg: "must be positive"}
 	}
-	dateStr, vErr := validation.RequiredString(raw, "pay_date", "required", "cannot be empty")
+	parsed, vErr := validation.RequiredNonEmptyDate(raw, "pay_date", "required", "cannot be empty")
 	if vErr != nil {
 		return d, vErr
-	}
-	parsed, derr := time.Parse("2006-01-02", dateStr)
-	if derr != nil {
-		return d, &httputil.ValidationError{Field: "pay_date", Msg: "must be YYYY-MM-DD"}
 	}
 	d.PayDate = parsed
 	gross, vErr := requireDecimal(raw, "gross_amount")

--- a/backend-go/internal/recurring/validation.go
+++ b/backend-go/internal/recurring/validation.go
@@ -105,9 +105,9 @@ func readCadence(raw map[string]json.RawMessage, in *CreateInput) *httputil.Vali
 }
 
 func readDatesAndActive(raw map[string]json.RawMessage, in *CreateInput) *httputil.ValidationError {
-	startDate, err := requireDate(raw, "start_date")
-	if err != nil {
-		return err
+	startDate, vErr := validation.RequiredDateWithMissingMessage(raw, "start_date", "required")
+	if vErr != nil {
+		return vErr
 	}
 	in.StartDate = startDate
 	if v, ok := raw["end_date"]; ok && string(v) != "null" {
@@ -135,20 +135,4 @@ func readDatesAndActive(raw map[string]json.RawMessage, in *CreateInput) *httput
 
 func requireDecimal(raw map[string]json.RawMessage, key string) (decimal.Decimal, *httputil.ValidationError) {
 	return validation.RequiredDecimalStringOrNumber(raw, key, "required")
-}
-
-func requireDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || string(v) == "null" {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "required"}
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
-	}
-	t, err := time.Parse("2006-01-02", s)
-	if err != nil {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
-	}
-	return t, nil
 }

--- a/backend-go/internal/recurring/validation.go
+++ b/backend-go/internal/recurring/validation.go
@@ -110,7 +110,7 @@ func readDatesAndActive(raw map[string]json.RawMessage, in *CreateInput) *httput
 		return vErr
 	}
 	in.StartDate = startDate
-	if v, ok := raw["end_date"]; ok && string(v) != "null" {
+	if v, ok := raw["end_date"]; ok && !validation.IsNull(v) {
 		var s string
 		if jerr := json.Unmarshal(v, &s); jerr != nil {
 			return &httputil.ValidationError{Field: "end_date", Msg: "must be YYYY-MM-DD or null"}

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -93,16 +93,50 @@ func RequiredString(
 
 // RequiredDate reads a required YYYY-MM-DD field.
 func RequiredDate(raw map[string]json.RawMessage, key string) (time.Time, *httputil.ValidationError) {
+	return RequiredDateWithMissingMessage(raw, key, "Field required")
+}
+
+// RequiredDateWithMissingMessage reads a required YYYY-MM-DD field and returns
+// missingMsg when the key is absent or explicit null.
+func RequiredDateWithMissingMessage(
+	raw map[string]json.RawMessage,
+	key string,
+	missingMsg string,
+) (time.Time, *httputil.ValidationError) {
+	return requiredDate(raw, key, missingMsg, "")
+}
+
+// RequiredNonEmptyDate reads a required YYYY-MM-DD field and rejects an empty
+// string with emptyMsg before date-format validation.
+func RequiredNonEmptyDate(
+	raw map[string]json.RawMessage,
+	key string,
+	missingMsg string,
+	emptyMsg string,
+) (time.Time, *httputil.ValidationError) {
+	return requiredDate(raw, key, missingMsg, emptyMsg)
+}
+
+func requiredDate(
+	raw map[string]json.RawMessage,
+	key string,
+	missingMsg string,
+	emptyMsg string,
+) (time.Time, *httputil.ValidationError) {
 	v, ok := raw[key]
 	if !ok || IsNull(v) {
-		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "Field required"}
+		return time.Time{}, &httputil.ValidationError{Field: key, Msg: missingMsg}
 	}
-	t, err := RawDate(v)
+	s, err := RawString(v)
 	if err != nil {
-		if IsRawDateFormatError(err) {
-			return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
-		}
 		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	}
+	if s == "" && emptyMsg != "" {
+		return time.Time{}, &httputil.ValidationError{Field: key, Msg: emptyMsg}
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, &httputil.ValidationError{Field: key, Msg: "must be YYYY-MM-DD"}
 	}
 	return t, nil
 }

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -164,6 +164,12 @@ func TestRequiredDate(t *testing.T) {
 		t.Fatalf("got = %s", got.Format("2006-01-02"))
 	}
 
+	_, vErr = RequiredDate(map[string]json.RawMessage{}, "date")
+	requireValidation(t, vErr, "date", "Field required")
+
+	_, vErr = RequiredDate(map[string]json.RawMessage{"date": json.RawMessage(`null`)}, "date")
+	requireValidation(t, vErr, "date", "Field required")
+
 	_, vErr = RequiredDate(map[string]json.RawMessage{"date": json.RawMessage(`"26/05/2026"`)}, "date")
 	requireValidation(t, vErr, "date", "must be YYYY-MM-DD")
 

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -186,11 +186,9 @@ func TestRequiredDate(t *testing.T) {
 }
 
 func TestRequiredDateWithMissingMessage(t *testing.T) {
-	got, vErr := RequiredDateWithMissingMessage(
-		map[string]json.RawMessage{"date": json.RawMessage(`"2026-05-26"`)},
-		"date",
-		"required",
-	)
+	got, vErr := RequiredDateWithMissingMessage(map[string]json.RawMessage{
+		"date": json.RawMessage(`"2026-05-26"`),
+	}, "date", "required")
 	if vErr != nil {
 		t.Fatalf("vErr = %#v", vErr)
 	}

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -164,17 +164,25 @@ func TestRequiredDate(t *testing.T) {
 		t.Fatalf("got = %s", got.Format("2006-01-02"))
 	}
 
-	_, vErr = RequiredDate(map[string]json.RawMessage{}, "date")
-	requireValidation(t, vErr, "date", "Field required")
-
-	_, vErr = RequiredDate(map[string]json.RawMessage{"date": json.RawMessage(`null`)}, "date")
-	requireValidation(t, vErr, "date", "Field required")
-
-	_, vErr = RequiredDate(map[string]json.RawMessage{"date": json.RawMessage(`"26/05/2026"`)}, "date")
-	requireValidation(t, vErr, "date", "must be YYYY-MM-DD")
-
-	_, vErr = RequiredDate(map[string]json.RawMessage{"date": json.RawMessage(`20260526`)}, "date")
-	requireValidation(t, vErr, "date", "must be a string")
+	for _, tc := range []struct {
+		name string
+		raw  map[string]json.RawMessage
+		msg  string
+	}{
+		{name: "missing", raw: map[string]json.RawMessage{}, msg: "Field required"},
+		{name: "null", raw: map[string]json.RawMessage{"date": json.RawMessage(`null`)}, msg: "Field required"},
+		{
+			name: "invalid format",
+			raw:  map[string]json.RawMessage{"date": json.RawMessage(`"26/05/2026"`)},
+			msg:  "must be YYYY-MM-DD",
+		},
+		{name: "non-string", raw: map[string]json.RawMessage{"date": json.RawMessage(`20260526`)}, msg: "must be a string"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, vErr = RequiredDate(tc.raw, "date")
+			requireValidation(t, vErr, "date", tc.msg)
+		})
+	}
 }
 
 func TestRequiredDateWithMissingMessage(t *testing.T) {

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -171,6 +171,75 @@ func TestRequiredDate(t *testing.T) {
 	requireValidation(t, vErr, "date", "must be a string")
 }
 
+func TestRequiredDateWithMissingMessage(t *testing.T) {
+	got, vErr := RequiredDateWithMissingMessage(
+		map[string]json.RawMessage{"date": json.RawMessage(`"2026-05-26"`)},
+		"date",
+		"required",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got.Format("2006-01-02") != "2026-05-26" {
+		t.Fatalf("got = %s", got.Format("2006-01-02"))
+	}
+
+	_, vErr = RequiredDateWithMissingMessage(map[string]json.RawMessage{}, "date", "required")
+	requireValidation(t, vErr, "date", "required")
+
+	_, vErr = RequiredDateWithMissingMessage(
+		map[string]json.RawMessage{"date": json.RawMessage(`null`)},
+		"date",
+		"required",
+	)
+	requireValidation(t, vErr, "date", "required")
+
+	_, vErr = RequiredDateWithMissingMessage(
+		map[string]json.RawMessage{"date": json.RawMessage(`"26/05/2026"`)},
+		"date",
+		"required",
+	)
+	requireValidation(t, vErr, "date", "must be YYYY-MM-DD")
+
+	_, vErr = RequiredDateWithMissingMessage(
+		map[string]json.RawMessage{"date": json.RawMessage(`20260526`)},
+		"date",
+		"required",
+	)
+	requireValidation(t, vErr, "date", "must be a string")
+}
+
+func TestRequiredNonEmptyDate(t *testing.T) {
+	got, vErr := RequiredNonEmptyDate(
+		map[string]json.RawMessage{"date": json.RawMessage(`"2026-05-26"`)},
+		"date",
+		"required",
+		"cannot be empty",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got.Format("2006-01-02") != "2026-05-26" {
+		t.Fatalf("got = %s", got.Format("2006-01-02"))
+	}
+
+	_, vErr = RequiredNonEmptyDate(
+		map[string]json.RawMessage{"date": json.RawMessage(`""`)},
+		"date",
+		"required",
+		"cannot be empty",
+	)
+	requireValidation(t, vErr, "date", "cannot be empty")
+
+	_, vErr = RequiredNonEmptyDate(
+		map[string]json.RawMessage{"date": json.RawMessage(`"26/05/2026"`)},
+		"date",
+		"required",
+		"cannot be empty",
+	)
+	requireValidation(t, vErr, "date", "must be YYYY-MM-DD")
+}
+
 func TestOptionalDate(t *testing.T) {
 	got, vErr := OptionalDate(map[string]json.RawMessage{"date": json.RawMessage(`"2026-05-26"`)}, "date")
 	if vErr != nil {


### PR DESCRIPTION
## Summary
- add shared required-date helpers for custom missing and empty-string messages
- reuse them in holdings and recurring validators
- remove recurring's local required-date parser and repeated holdings date parse blocks

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check