### PR TITLE
refactor(validation): share optional non-empty trimmed strings

### DIFF
--- a/backend-go/internal/holdings/validation.go
+++ b/backend-go/internal/holdings/validation.go
@@ -151,17 +151,10 @@ func buildQuoteInput(raw map[string]json.RawMessage, securityID int) (PriceQuote
 		return q, &httputil.ValidationError{Field: "price", Msg: "must not be negative"}
 	}
 	q.Price = price
-	if v, ok := raw["source"]; ok && string(v) != "null" {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			return q, &httputil.ValidationError{Field: "source", Msg: "must be a string"}
-		}
-		if s = strings.TrimSpace(s); s != "" {
-			if len(s) > 40 {
-				return q, &httputil.ValidationError{Field: "source", Msg: "max 40 chars"}
-			}
-			q.Source = s
-		}
+	if s, vErr := validation.OptionalNonEmptyTrimmedStringMax(raw, "source", 40, "max 40 chars"); vErr != nil {
+		return q, vErr
+	} else if s != nil {
+		q.Source = *s
 	}
 	return q, nil
 }

--- a/backend-go/internal/recurring/validation.go
+++ b/backend-go/internal/recurring/validation.go
@@ -2,7 +2,6 @@ package recurring
 
 import (
 	"encoding/json"
-	"strings"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -50,31 +49,20 @@ func readAccountAndAmount(raw map[string]json.RawMessage, in *CreateInput) *http
 }
 
 func readOptionalStrings(raw map[string]json.RawMessage, in *CreateInput) *httputil.ValidationError {
-	if v, ok := raw["transaction_type"]; ok && string(v) != "null" {
-		var s string
-		if jerr := json.Unmarshal(v, &s); jerr != nil {
-			return &httputil.ValidationError{Field: "transaction_type", Msg: "must be a string"}
-		}
-		if s = strings.TrimSpace(s); s != "" {
-			in.TransactionType = &s
-		}
+	if s, vErr := validation.OptionalNonEmptyTrimmedString(raw, "transaction_type"); vErr != nil {
+		return vErr
+	} else if s != nil {
+		in.TransactionType = s
 	}
-	if v, ok := raw["category"]; ok && string(v) != "null" {
-		var s string
-		if jerr := json.Unmarshal(v, &s); jerr != nil {
-			return &httputil.ValidationError{Field: "category", Msg: "must be a string"}
-		}
-		if s = strings.TrimSpace(s); s != "" {
-			if len(s) > 50 {
-				return &httputil.ValidationError{Field: "category", Msg: "max 50 chars"}
-			}
-			in.Category = &s
-		}
+	if s, vErr := validation.OptionalNonEmptyTrimmedStringMax(raw, "category", 50, "max 50 chars"); vErr != nil {
+		return vErr
+	} else if s != nil {
+		in.Category = s
 	}
-	if v, ok := raw["description"]; ok && string(v) != "null" {
-		if jerr := json.Unmarshal(v, &in.Description); jerr != nil {
-			return &httputil.ValidationError{Field: "description", Msg: "must be a string"}
-		}
+	if s, vErr := validation.OptionalString(raw, "description"); vErr != nil {
+		return vErr
+	} else if s != nil {
+		in.Description = *s
 	}
 	if len(in.Description) > 200 {
 		return &httputil.ValidationError{Field: "description", Msg: "max 200 chars"}

--- a/backend-go/internal/validation/fields.go
+++ b/backend-go/internal/validation/fields.go
@@ -55,6 +55,41 @@ func OptionalTrimmedString(
 	return &s, nil
 }
 
+// OptionalNonEmptyTrimmedString reads an optional string field, trims
+// whitespace, and returns nil when the trimmed value is empty.
+func OptionalNonEmptyTrimmedString(raw map[string]json.RawMessage, key string) (*string, *httputil.ValidationError) {
+	v, ok := raw[key]
+	if !ok || IsNull(v) {
+		return nil, nil
+	}
+	s, err := RawTrimmedString(v)
+	if err != nil {
+		return nil, &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	}
+	if s == "" {
+		return nil, nil
+	}
+	return &s, nil
+}
+
+// OptionalNonEmptyTrimmedStringMax is OptionalNonEmptyTrimmedString with a
+// maximum length check for non-empty values.
+func OptionalNonEmptyTrimmedStringMax(
+	raw map[string]json.RawMessage,
+	key string,
+	maxLen int,
+	maxMsg string,
+) (*string, *httputil.ValidationError) {
+	s, vErr := OptionalNonEmptyTrimmedString(raw, key)
+	if vErr != nil {
+		return nil, vErr
+	}
+	if s != nil && len(*s) > maxLen {
+		return nil, &httputil.ValidationError{Field: key, Msg: maxMsg}
+	}
+	return s, nil
+}
+
 // OptionalString reads an optional string field without trimming or empty
 // validation. Missing or explicit null returns nil.
 func OptionalString(raw map[string]json.RawMessage, key string) (*string, *httputil.ValidationError) {

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -124,6 +124,31 @@ func TestOptionalNonEmptyTrimmedStringMax(t *testing.T) {
 		t.Fatalf("got = %v", got)
 	}
 
+	got, vErr = OptionalNonEmptyTrimmedStringMax(map[string]json.RawMessage{}, "source", 10, "max 10 chars")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalNonEmptyTrimmedStringMax(
+		map[string]json.RawMessage{"source": json.RawMessage(`null`)},
+		"source",
+		10,
+		"max 10 chars",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalNonEmptyTrimmedStringMax(
+		map[string]json.RawMessage{"source": json.RawMessage(`"  "`)},
+		"source",
+		10,
+		"max 10 chars",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
 	_, vErr = OptionalNonEmptyTrimmedStringMax(
 		map[string]json.RawMessage{"source": json.RawMessage(`"too-long"`)},
 		"source",
@@ -131,6 +156,14 @@ func TestOptionalNonEmptyTrimmedStringMax(t *testing.T) {
 		"max 3 chars",
 	)
 	requireValidation(t, vErr, "source", "max 3 chars")
+
+	_, vErr = OptionalNonEmptyTrimmedStringMax(
+		map[string]json.RawMessage{"source": json.RawMessage(`7`)},
+		"source",
+		10,
+		"max 10 chars",
+	)
+	requireValidation(t, vErr, "source", "must be a string")
 }
 
 func TestOptionalString(t *testing.T) {

--- a/backend-go/internal/validation/fields_test.go
+++ b/backend-go/internal/validation/fields_test.go
@@ -70,6 +70,69 @@ func TestOptionalTrimmedString(t *testing.T) {
 	requireValidation(t, vErr, "name", "Name cannot be empty")
 }
 
+func TestOptionalNonEmptyTrimmedString(t *testing.T) {
+	got, vErr := OptionalNonEmptyTrimmedString(
+		map[string]json.RawMessage{"category": json.RawMessage(`"  bills  "`)},
+		"category",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || *got != "bills" {
+		t.Fatalf("got = %v", got)
+	}
+
+	got, vErr = OptionalNonEmptyTrimmedString(map[string]json.RawMessage{}, "category")
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalNonEmptyTrimmedString(
+		map[string]json.RawMessage{"category": json.RawMessage(`null`)},
+		"category",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	got, vErr = OptionalNonEmptyTrimmedString(
+		map[string]json.RawMessage{"category": json.RawMessage(`"  "`)},
+		"category",
+	)
+	if vErr != nil || got != nil {
+		t.Fatalf("got = %v vErr = %#v", got, vErr)
+	}
+
+	_, vErr = OptionalNonEmptyTrimmedString(
+		map[string]json.RawMessage{"category": json.RawMessage(`7`)},
+		"category",
+	)
+	requireValidation(t, vErr, "category", "must be a string")
+}
+
+func TestOptionalNonEmptyTrimmedStringMax(t *testing.T) {
+	got, vErr := OptionalNonEmptyTrimmedStringMax(
+		map[string]json.RawMessage{"source": json.RawMessage(`" broker "`)},
+		"source",
+		10,
+		"max 10 chars",
+	)
+	if vErr != nil {
+		t.Fatalf("vErr = %#v", vErr)
+	}
+	if got == nil || *got != "broker" {
+		t.Fatalf("got = %v", got)
+	}
+
+	_, vErr = OptionalNonEmptyTrimmedStringMax(
+		map[string]json.RawMessage{"source": json.RawMessage(`"too-long"`)},
+		"source",
+		3,
+		"max 3 chars",
+	)
+	requireValidation(t, vErr, "source", "max 3 chars")
+}
+
 func TestOptionalString(t *testing.T) {
 	got, vErr := OptionalString(
 		map[string]json.RawMessage{"notes": json.RawMessage(`"  keep spaces  "`)},


### PR DESCRIPTION
## Summary
- add shared optional non-empty trimmed string helpers, including max-length validation
- reuse them for recurring transaction/category fields and holdings quote source
- reuse OptionalString for recurring description to remove another raw string decode block

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check