### PR TITLE
refactor(validation): reuse raw null checks

### DIFF
--- a/backend-go/internal/holdings/validation.go
+++ b/backend-go/internal/holdings/validation.go
@@ -39,7 +39,7 @@ func buildSecurityInput(raw map[string]json.RawMessage) (Security, *httputil.Val
 	if len(s.Name) > 200 {
 		return s, &httputil.ValidationError{Field: "name", Msg: "max 200 chars"}
 	}
-	if v, ok := raw["asset_type"]; ok && string(v) != "null" {
+	if v, ok := raw["asset_type"]; ok && !validation.IsNull(v) {
 		if err := json.Unmarshal(v, &s.AssetType); err != nil {
 			return s, &httputil.ValidationError{Field: "asset_type", Msg: "must be a string"}
 		}

--- a/backend-go/internal/recurring/validation.go
+++ b/backend-go/internal/recurring/validation.go
@@ -79,7 +79,7 @@ func readCadence(raw map[string]json.RawMessage, in *CreateInput) *httputil.Vali
 		return &httputil.ValidationError{Field: "frequency", Msg: "invalid cadence"}
 	}
 	in.Frequency = Frequency(freq)
-	if v, ok := raw["day_of_month"]; ok && string(v) != "null" {
+	if v, ok := raw["day_of_month"]; ok && !validation.IsNull(v) {
 		var d int
 		if jerr := json.Unmarshal(v, &d); jerr != nil {
 			return &httputil.ValidationError{Field: "day_of_month", Msg: "must be integer or null"}

--- a/backend-go/internal/scenarios/validation.go
+++ b/backend-go/internal/scenarios/validation.go
@@ -39,7 +39,7 @@ func validateCreate(name, kind string, inputs json.RawMessage) *httputil.Validat
 	if _, ok := validKinds[kind]; !ok {
 		return &httputil.ValidationError{Field: "kind", Msg: "Kind must be one of: monte-carlo, mortgage-vs-invest, retirement, wibor"}
 	}
-	if len(inputs) == 0 || validation.IsNull(inputs) {
+	if inputsMissingOrNull(inputs) {
 		return &httputil.ValidationError{Field: "inputs_json", Msg: "Inputs must be a JSON object"}
 	}
 	if len(inputs) > maxInputsBytes {
@@ -67,7 +67,7 @@ func validateUpdate(name string, inputs json.RawMessage) *httputil.ValidationErr
 	if len(trimmed) > maxNameLen {
 		return &httputil.ValidationError{Field: "name", Msg: "Name must be at most 200 characters"}
 	}
-	if len(inputs) == 0 || validation.IsNull(inputs) {
+	if inputsMissingOrNull(inputs) {
 		return &httputil.ValidationError{Field: "inputs_json", Msg: "Inputs must be a JSON object"}
 	}
 	if len(inputs) > maxInputsBytes {
@@ -91,4 +91,8 @@ func validateCloneName(name string) *httputil.ValidationError {
 		return &httputil.ValidationError{Field: "name", Msg: "Name must be at most 200 characters"}
 	}
 	return nil
+}
+
+func inputsMissingOrNull(inputs json.RawMessage) bool {
+	return len(inputs) == 0 || validation.IsNull(inputs)
 }

--- a/backend-go/internal/scenarios/validation.go
+++ b/backend-go/internal/scenarios/validation.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
+	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 )
 
 // validKinds enumerates the simulation kinds the frontend can save under.
@@ -38,7 +39,7 @@ func validateCreate(name, kind string, inputs json.RawMessage) *httputil.Validat
 	if _, ok := validKinds[kind]; !ok {
 		return &httputil.ValidationError{Field: "kind", Msg: "Kind must be one of: monte-carlo, mortgage-vs-invest, retirement, wibor"}
 	}
-	if len(inputs) == 0 || string(inputs) == "null" {
+	if len(inputs) == 0 || validation.IsNull(inputs) {
 		return &httputil.ValidationError{Field: "inputs_json", Msg: "Inputs must be a JSON object"}
 	}
 	if len(inputs) > maxInputsBytes {
@@ -66,7 +67,7 @@ func validateUpdate(name string, inputs json.RawMessage) *httputil.ValidationErr
 	if len(trimmed) > maxNameLen {
 		return &httputil.ValidationError{Field: "name", Msg: "Name must be at most 200 characters"}
 	}
-	if len(inputs) == 0 || string(inputs) == "null" {
+	if len(inputs) == 0 || validation.IsNull(inputs) {
 		return &httputil.ValidationError{Field: "inputs_json", Msg: "Inputs must be a JSON object"}
 	}
 	if len(inputs) > maxInputsBytes {

--- a/backend-go/internal/scenarios/validation_test.go
+++ b/backend-go/internal/scenarios/validation_test.go
@@ -63,6 +63,14 @@ func TestValidateCreateInputsMissing(t *testing.T) {
 	}
 }
 
+func TestValidateCreateInputsWhitespaceNull(t *testing.T) {
+	t.Parallel()
+	err := validateCreate("Plan", "retirement", json.RawMessage(`  null  `))
+	if err == nil || err.Field != "inputs_json" || err.Msg != "Inputs must be a JSON object" {
+		t.Fatalf("expected inputs object error for whitespace null, got %+v", err)
+	}
+}
+
 func TestValidateCreateInputsTooLarge(t *testing.T) {
 	t.Parallel()
 	// Build a JSON object that exceeds maxInputsBytes.
@@ -84,6 +92,14 @@ func TestValidateUpdateInputsMustBeObject(t *testing.T) {
 	t.Parallel()
 	if err := validateUpdate("Plan", json.RawMessage(`[]`)); err == nil || err.Field != "inputs_json" {
 		t.Fatalf("expected inputs error, got %+v", err)
+	}
+}
+
+func TestValidateUpdateInputsWhitespaceNull(t *testing.T) {
+	t.Parallel()
+	err := validateUpdate("Plan", json.RawMessage(`  null  `))
+	if err == nil || err.Field != "inputs_json" || err.Msg != "Inputs must be a JSON object" {
+		t.Fatalf("expected inputs object error for whitespace null, got %+v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace remaining literal RawMessage null string comparisons with validation.IsNull
- cover recurring day_of_month, holdings asset_type, and scenario inputs_json checks
- preserve existing validation messages while accepting whitespace-padded null consistently

## Tests
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check