### PR TITLE
refactor(accounts): reuse optional validation helpers

### DIFF
--- a/backend-go/internal/accounts/validation.go
+++ b/backend-go/internal/accounts/validation.go
@@ -69,7 +69,7 @@ func buildCreateRequest(raw map[string]json.RawMessage) (createRequest, *httputi
 	}
 	r.Purpose = purpose
 
-	sq, vErr := optionalDecimal(raw, "square_meters")
+	sq, vErr := validation.OptionalDecimal(raw, "square_meters")
 	if vErr != nil {
 		return r, vErr
 	}
@@ -235,18 +235,6 @@ func optionalString(raw map[string]json.RawMessage, key, fallback string) (strin
 	return s, nil
 }
 
-func optionalDecimal(raw map[string]json.RawMessage, key string) (*decimal.Decimal, *httputil.ValidationError) {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return nil, nil
-	}
-	d, err := validation.RawDecimal(v)
-	if err != nil {
-		return nil, &httputil.ValidationError{Field: key, Msg: "must be a number"}
-	}
-	return &d, nil
-}
-
 func optionalBoolDefaultTrue(raw map[string]json.RawMessage, key string) (bool, *httputil.ValidationError) {
 	v, ok := raw[key]
 	if !ok {
@@ -263,14 +251,12 @@ func optionalBoolDefaultTrue(raw map[string]json.RawMessage, key string) (bool, 
 }
 
 func patchPlainString(raw map[string]json.RawMessage, key string, dest **string) *httputil.ValidationError {
-	v, ok := raw[key]
-	if !ok || validation.IsNull(v) {
-		return nil
+	s, vErr := validation.OptionalString(raw, key)
+	if vErr != nil {
+		return vErr
 	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return &httputil.ValidationError{Field: key, Msg: "must be a string"}
+	if s != nil {
+		*dest = s
 	}
-	*dest = &s
 	return nil
 }

--- a/backend-go/internal/accounts/validation_test.go
+++ b/backend-go/internal/accounts/validation_test.go
@@ -320,16 +320,16 @@ func TestIsNullVariants(t *testing.T) {
 
 func TestOptionalDecimalParsesAndFails(t *testing.T) {
 	good := rawJSON(t, map[string]any{"x": 12.345})
-	d, vErr := optionalDecimal(good, "x")
+	d, vErr := validation.OptionalDecimal(good, "x")
 	if vErr != nil || d == nil || !d.Equal(decimal.RequireFromString("12.345")) {
 		t.Fatalf("good parse failed: %+v err=%+v", d, vErr)
 	}
 	bad := rawJSON(t, map[string]any{"x": "not-a-number"})
-	if _, vErr := optionalDecimal(bad, "x"); vErr == nil {
+	if _, vErr := validation.OptionalDecimal(bad, "x"); vErr == nil {
 		t.Fatalf("expected error on bad number")
 	}
 	missing := map[string]json.RawMessage{}
-	if d, vErr := optionalDecimal(missing, "x"); d != nil || vErr != nil {
+	if d, vErr := validation.OptionalDecimal(missing, "x"); d != nil || vErr != nil {
 		t.Fatalf("missing should be nil/nil, got %+v err=%+v", d, vErr)
 	}
 }


### PR DESCRIPTION
## Summary
- reuse validation.OptionalDecimal for account square_meters create parsing
- reuse validation.OptionalString inside the account plain-string patch helper
- update accounts tests to exercise the shared optional decimal helper

## Tests
- go test ./internal/accounts
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
- git diff --check