### PR TITLE
fix(cpi): normalize yoy_rate to percentage in /api/cpi/series

### DIFF
--- a/backend-bb-tests/golden/cpi_series.json
+++ b/backend-bb-tests/golden/cpi_series.json
@@ -5,117 +5,117 @@
     {
       "cumulative_index": 100.0,
       "year": 2003,
-      "yoy_rate": 100.8
+      "yoy_rate": 0.8
     },
     {
       "cumulative_index": 103.5,
       "year": 2004,
-      "yoy_rate": 103.5
+      "yoy_rate": 3.5
     },
     {
       "cumulative_index": 105.6735,
       "year": 2005,
-      "yoy_rate": 102.1
+      "yoy_rate": 2.1
     },
     {
       "cumulative_index": 106.730235,
       "year": 2006,
-      "yoy_rate": 101.0
+      "yoy_rate": 1.0
     },
     {
       "cumulative_index": 109.398490875,
       "year": 2007,
-      "yoy_rate": 102.5
+      "yoy_rate": 2.5
     },
     {
       "cumulative_index": 113.99322749175,
       "year": 2008,
-      "yoy_rate": 104.2
+      "yoy_rate": 4.2
     },
     {
       "cumulative_index": 117.98299045396125,
       "year": 2009,
-      "yoy_rate": 103.5
+      "yoy_rate": 3.5
     },
     {
       "cumulative_index": 121.05054820576424,
       "year": 2010,
-      "yoy_rate": 102.6
+      "yoy_rate": 2.6
     },
     {
       "cumulative_index": 126.2557217786121,
       "year": 2011,
-      "yoy_rate": 104.3
+      "yoy_rate": 4.3
     },
     {
       "cumulative_index": 130.92718348442077,
       "year": 2012,
-      "yoy_rate": 103.7
+      "yoy_rate": 3.7
     },
     {
       "cumulative_index": 132.10552813578053,
       "year": 2013,
-      "yoy_rate": 100.9
+      "yoy_rate": 0.9
     },
     {
       "cumulative_index": 132.10552813578053,
       "year": 2014,
-      "yoy_rate": 100.0
+      "yoy_rate": 0.0
     },
     {
       "cumulative_index": 130.91657838255853,
       "year": 2015,
-      "yoy_rate": 99.1
+      "yoy_rate": -0.9
     },
     {
       "cumulative_index": 130.13107891226318,
       "year": 2016,
-      "yoy_rate": 99.4
+      "yoy_rate": -0.6
     },
     {
       "cumulative_index": 132.73370049050843,
       "year": 2017,
-      "yoy_rate": 102.0
+      "yoy_rate": 2.0
     },
     {
       "cumulative_index": 134.85743969835656,
       "year": 2018,
-      "yoy_rate": 101.6
+      "yoy_rate": 1.6
     },
     {
       "cumulative_index": 137.95916081141877,
       "year": 2019,
-      "yoy_rate": 102.3
+      "yoy_rate": 2.3
     },
     {
       "cumulative_index": 142.649772279007,
       "year": 2020,
-      "yoy_rate": 103.4
+      "yoy_rate": 3.4
     },
     {
       "cumulative_index": 149.92491066523635,
       "year": 2021,
-      "yoy_rate": 105.1
+      "yoy_rate": 5.1
     },
     {
       "cumulative_index": 171.5140978010304,
       "year": 2022,
-      "yoy_rate": 114.4
+      "yoy_rate": 14.4
     },
     {
       "cumulative_index": 191.06670495034786,
       "year": 2023,
-      "yoy_rate": 111.4
+      "yoy_rate": 11.4
     },
     {
       "cumulative_index": 197.94510632856037,
       "year": 2024,
-      "yoy_rate": 103.6
+      "yoy_rate": 3.6
     },
     {
       "cumulative_index": 205.07113015638856,
       "year": 2025,
-      "yoy_rate": 103.6
+      "yoy_rate": 3.6
     }
   ],
   "source": "GUS-BDL-217230"

--- a/backend-go/internal/cpi/handler.go
+++ b/backend-go/internal/cpi/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
+	"github.com/shopspring/decimal"
 )
 
 // MonthlyFetcher is the slice of cpi.EurostatHICPFetcher / cpi.FREDFetcher
@@ -92,12 +93,14 @@ func (h *Handler) GetSeries(w http.ResponseWriter, r *http.Request) {
 	indexMap := CumulativeIndex(yoyMap)
 	years := sortedYears(indexMap)
 	points := make([]cpiPoint, 0, len(years))
+	hundred := decimal.NewFromInt(100)
 	for _, y := range years {
-		yoyRaw, _ := yoyMap[y].Float64()
+		// Subtract in decimal to preserve GUS one-decimal precision (e.g. 100.8 → 0.8).
+		yoyRaw, _ := yoyMap[y].Sub(hundred).Float64()
 		idx, _ := indexMap[y].Float64()
 		points = append(points, cpiPoint{
 			Year:            y,
-			YoYRate:         wire.PyFloat(yoyRaw - 100), // normalize from GUS format (114.4) to percentage (14.4)
+			YoYRate:         wire.PyFloat(yoyRaw),
 			CumulativeIndex: wire.PyFloat(idx),
 		})
 	}

--- a/backend-go/internal/cpi/handler.go
+++ b/backend-go/internal/cpi/handler.go
@@ -93,11 +93,11 @@ func (h *Handler) GetSeries(w http.ResponseWriter, r *http.Request) {
 	years := sortedYears(indexMap)
 	points := make([]cpiPoint, 0, len(years))
 	for _, y := range years {
-		yoy, _ := yoyMap[y].Float64()
+		yoyRaw, _ := yoyMap[y].Float64()
 		idx, _ := indexMap[y].Float64()
 		points = append(points, cpiPoint{
 			Year:            y,
-			YoYRate:         wire.PyFloat(yoy),
+			YoYRate:         wire.PyFloat(yoyRaw - 100), // normalize from GUS format (114.4) to percentage (14.4)
 			CumulativeIndex: wire.PyFloat(idx),
 		})
 	}

--- a/backend-go/internal/cpi/handler.go
+++ b/backend-go/internal/cpi/handler.go
@@ -97,11 +97,11 @@ func (h *Handler) GetSeries(w http.ResponseWriter, r *http.Request) {
 	hundred := decimal.NewFromInt(100)
 	for _, y := range years {
 		// Subtract in decimal to preserve GUS one-decimal precision (e.g. 100.8 → 0.8).
-		yoyRaw, _ := yoyMap[y].Sub(hundred).Float64()
+		yoyRate, _ := yoyMap[y].Sub(hundred).Float64()
 		idx, _ := indexMap[y].Float64()
 		points = append(points, cpiPoint{
 			Year:            y,
-			YoYRate:         wire.PyFloat(yoyRaw),
+			YoYRate:         wire.PyFloat(yoyRate),
 			CumulativeIndex: wire.PyFloat(idx),
 		})
 	}

--- a/backend-go/internal/cpi/handler.go
+++ b/backend-go/internal/cpi/handler.go
@@ -9,10 +9,11 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/Automaat/finance-buddy/backend-go/internal/httputil"
 	"github.com/Automaat/finance-buddy/backend-go/internal/validation"
 	"github.com/Automaat/finance-buddy/backend-go/internal/wire"
-	"github.com/shopspring/decimal"
 )
 
 // MonthlyFetcher is the slice of cpi.EurostatHICPFetcher / cpi.FREDFetcher


### PR DESCRIPTION
## Motivation

The CPI YoY bars chart was plotting values around 100–115% instead of the expected 0–15% range. GUS stores CPI as an index value (e.g. 114.4 means +14.4% YoY), but `/api/cpi/series` was returning the raw index, so the frontend rendered wildly inflated bar heights.

Closes https://github.com/Automaat/finance-buddy/issues/800

## Implementation information

- Subtract 100 from the raw GUS `YoYRate` index value in the handler before writing the API response, so the frontend receives the actual percentage (e.g. 0.8, not 100.8).
- `CumulativeIndex` still reads from the raw DB map so compounding math is unaffected.
- The subtraction is done via `shopspring/decimal` before calling `Float64()` to avoid `float64` precision loss (e.g. `100.8 - 100` via float64 yielded `0.7999999999999972`).
- Updated the `backend-bb-tests/golden/cpi_series.json` fixture to match the corrected response shape.