### PR TITLE
fix(charts): show Brak danych for zero-data time-series

### DIFF
--- a/src/lib/utils/charts/metryki.test.ts
+++ b/src/lib/utils/charts/metryki.test.ts
@@ -104,6 +104,9 @@ describe('buildInvestmentTrendChartOption', () => {
 	it('returns empty state for empty series', () => {
 		const option = buildInvestmentTrendChartOption([]);
 		expect(option.series).toEqual([]);
+		expect(option.xAxis).toEqual([]);
+		expect(option.yAxis).toEqual([]);
+		expect((option.legend as { data: unknown[] }).data).toEqual([]);
 		const graphic = option.graphic as Array<{ style: { text: string } }>;
 		expect(graphic[0].style.text).toBe('Brak danych');
 	});
@@ -113,6 +116,9 @@ describe('buildInvestmentTrendChartOption', () => {
 			{ date: '2023-01-31', value: 0, contributions: 0 }
 		]);
 		expect(option.series).toEqual([]);
+		expect(option.xAxis).toEqual([]);
+		expect(option.yAxis).toEqual([]);
+		expect((option.legend as { data: unknown[] }).data).toEqual([]);
 		const graphic = option.graphic as Array<{ style: { text: string } }>;
 		expect(graphic[0].style.text).toBe('Brak danych');
 	});
@@ -120,6 +126,9 @@ describe('buildInvestmentTrendChartOption', () => {
 	it('returns empty state for date-only point with no value or contributions', () => {
 		const option = buildInvestmentTrendChartOption([{ date: '2023-01-31' }]);
 		expect(option.series).toEqual([]);
+		expect(option.xAxis).toEqual([]);
+		expect(option.yAxis).toEqual([]);
+		expect((option.legend as { data: unknown[] }).data).toEqual([]);
 		const graphic = option.graphic as Array<{ style: { text: string } }>;
 		expect(graphic[0].style.text).toBe('Brak danych');
 	});
@@ -142,6 +151,9 @@ describe('buildWrapperTrendChartOption', () => {
 	it('returns empty state for empty series', () => {
 		const option = buildWrapperTrendChartOption('Puste', []);
 		expect(option.series).toEqual([]);
+		expect(option.xAxis).toEqual([]);
+		expect(option.yAxis).toEqual([]);
+		expect((option.legend as { data: unknown[] }).data).toEqual([]);
 		const graphic = option.graphic as Array<{ style: { text: string } }>;
 		expect(graphic[0].style.text).toBe('Brak danych');
 	});
@@ -152,6 +164,9 @@ describe('buildWrapperTrendChartOption', () => {
 			{ date: '2023-02-28', value: 0, contributions: 0 }
 		]);
 		expect(option.series).toEqual([]);
+		expect(option.xAxis).toEqual([]);
+		expect(option.yAxis).toEqual([]);
+		expect((option.legend as { data: unknown[] }).data).toEqual([]);
 		const graphic = option.graphic as Array<{ style: { text: string } }>;
 		expect(graphic[0].style.text).toBe('Brak danych');
 	});

--- a/src/lib/utils/charts/metryki.test.ts
+++ b/src/lib/utils/charts/metryki.test.ts
@@ -94,17 +94,25 @@ describe('buildInvestmentTrendChartOption', () => {
 		expect(xAxis.data).toEqual(['2023-01-31', '2023-12-31']);
 	});
 
-	it('defaults missing values to zero', () => {
-		const option = buildInvestmentTrendChartOption([{ date: '2023-01-31' }]);
+	it('defaults missing contributions to zero', () => {
+		const option = buildInvestmentTrendChartOption([{ date: '2023-01-31', value: 1000 }]);
 		const series = option.series as Array<{ data: number[] }>;
 		expect(series[0].data).toEqual([0]);
-		expect(series[1].data).toEqual([0]);
+		expect(series[1].data).toEqual([1000]);
 	});
 
-	it('handles an empty input', () => {
+	it('returns empty state for empty series', () => {
 		const option = buildInvestmentTrendChartOption([]);
-		const series = option.series as Array<{ data: number[] }>;
-		expect(series[0].data).toEqual([]);
+		expect(option.series).toEqual([]);
+		expect(option.graphic).toBeDefined();
+	});
+
+	it('returns empty state for all-zero series', () => {
+		const option = buildInvestmentTrendChartOption([
+			{ date: '2023-01-31', value: 0, contributions: 0 }
+		]);
+		expect(option.series).toEqual([]);
+		expect(option.graphic).toBeDefined();
 	});
 });
 
@@ -122,10 +130,19 @@ describe('buildWrapperTrendChartOption', () => {
 		expect(series[1].data).toEqual([1000, 2200]);
 	});
 
-	it('handles an empty input', () => {
+	it('returns empty state for empty series', () => {
 		const option = buildWrapperTrendChartOption('Puste', []);
-		const series = option.series as Array<{ data: number[] }>;
-		expect(series[0].data).toEqual([]);
+		expect(option.series).toEqual([]);
+		expect(option.graphic).toBeDefined();
+	});
+
+	it('returns empty state for all-zero series', () => {
+		const option = buildWrapperTrendChartOption('IKZE w czasie', [
+			{ date: '2023-01-31', value: 0, contributions: 0 },
+			{ date: '2023-02-28', value: 0, contributions: 0 }
+		]);
+		expect(option.series).toEqual([]);
+		expect(option.graphic).toBeDefined();
 	});
 });
 

--- a/src/lib/utils/charts/metryki.test.ts
+++ b/src/lib/utils/charts/metryki.test.ts
@@ -104,7 +104,8 @@ describe('buildInvestmentTrendChartOption', () => {
 	it('returns empty state for empty series', () => {
 		const option = buildInvestmentTrendChartOption([]);
 		expect(option.series).toEqual([]);
-		expect(option.graphic).toBeDefined();
+		const graphic = option.graphic as Array<{ style: { text: string } }>;
+		expect(graphic[0].style.text).toBe('Brak danych');
 	});
 
 	it('returns empty state for all-zero series', () => {
@@ -112,7 +113,15 @@ describe('buildInvestmentTrendChartOption', () => {
 			{ date: '2023-01-31', value: 0, contributions: 0 }
 		]);
 		expect(option.series).toEqual([]);
-		expect(option.graphic).toBeDefined();
+		const graphic = option.graphic as Array<{ style: { text: string } }>;
+		expect(graphic[0].style.text).toBe('Brak danych');
+	});
+
+	it('returns empty state for date-only point with no value or contributions', () => {
+		const option = buildInvestmentTrendChartOption([{ date: '2023-01-31' }]);
+		expect(option.series).toEqual([]);
+		const graphic = option.graphic as Array<{ style: { text: string } }>;
+		expect(graphic[0].style.text).toBe('Brak danych');
 	});
 });
 
@@ -133,7 +142,8 @@ describe('buildWrapperTrendChartOption', () => {
 	it('returns empty state for empty series', () => {
 		const option = buildWrapperTrendChartOption('Puste', []);
 		expect(option.series).toEqual([]);
-		expect(option.graphic).toBeDefined();
+		const graphic = option.graphic as Array<{ style: { text: string } }>;
+		expect(graphic[0].style.text).toBe('Brak danych');
 	});
 
 	it('returns empty state for all-zero series', () => {
@@ -142,7 +152,8 @@ describe('buildWrapperTrendChartOption', () => {
 			{ date: '2023-02-28', value: 0, contributions: 0 }
 		]);
 		expect(option.series).toEqual([]);
-		expect(option.graphic).toBeDefined();
+		const graphic = option.graphic as Array<{ style: { text: string } }>;
+		expect(graphic[0].style.text).toBe('Brak danych');
 	});
 });
 

--- a/src/lib/utils/charts/metryki.ts
+++ b/src/lib/utils/charts/metryki.ts
@@ -240,8 +240,9 @@ function buildTrendChartOption(
 	if (isEmptyOrZero) {
 		return {
 			...baseChartOption(title, isMobile),
-			xAxis: { show: false },
-			yAxis: { show: false },
+			xAxis: [],
+			yAxis: [],
+			legend: { data: [] },
 			series: [],
 			graphic: [
 				{

--- a/src/lib/utils/charts/metryki.ts
+++ b/src/lib/utils/charts/metryki.ts
@@ -233,6 +233,27 @@ function buildTrendChartOption(
 	axisFontSize: number,
 	isMobile = false
 ): EChartsOption {
+	const isEmptyOrZero =
+		series.length === 0 ||
+		series.every((p) => (p.value ?? 0) === 0 && (p.contributions ?? 0) === 0);
+
+	if (isEmptyOrZero) {
+		return {
+			...baseChartOption(title, isMobile),
+			xAxis: { show: false },
+			yAxis: { show: false },
+			series: [],
+			graphic: [
+				{
+					type: 'text',
+					left: 'center',
+					top: 'middle',
+					style: { text: 'Brak danych', fontSize: 16, fill: chartInkMuted }
+				}
+			]
+		};
+	}
+
 	const dates = series.map((item) => item.date);
 	const values = series.map((item) => item.value ?? 0);
 	const contributions = series.map((item) => item.contributions ?? 0);


### PR DESCRIPTION
## Motivation

Time-series charts for accounts/categories with no holdings (e.g. IKZE, Obligacje before any entries) rendered as a degenerate flat-line chart at 0k/0k. This was misleading — it looked like data existed but was zero, rather than communicating that no data is available yet.

Closes https://github.com/Automaat/finance-buddy/issues/801

> Changelog: fix(charts): show Brak danych for zero-data time-series

## Implementation information

- `buildTrendChartOption` in `src/lib/utils/charts/metryki.ts` now detects when all data points are zero (or there are no data points) and returns an ECharts option with hidden axes and a centered 'Brak danych' graphic instead of the degenerate chart.
- Tests in `metryki.test.ts` updated: the 'handles an empty input' case now asserts the empty-state option shape (no series, graphic defined); the 'defaults missing values to zero' test was adjusted to use a non-zero value so it tests field-level defaulting without triggering the empty-state path; new tests cover the all-zero series case.