### PR TITLE
fix(ui): darken primary buttons and style disabled state

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -136,15 +136,15 @@ body {
 	}
 }
 
-/* Primary buttons: use -600 shade (white text on medium rose) so active state
+/* Primary filled: use -600 shade (white text on medium rose) so active state
    is unmistakably distinct from the disabled state. The -500 preset is too pale
-   and reads as already-disabled. */
-button.preset-filled-primary-500 {
+   and reads as already-disabled. Targets all elements (buttons, anchors, nav). */
+.preset-filled-primary-500 {
 	background-color: var(--color-primary-600);
 	color: var(--color-primary-contrast-600);
 }
 
-button.preset-filled-primary-500:not(:disabled):hover {
+.preset-filled-primary-500:not(:disabled):hover {
 	background-color: var(--color-primary-700);
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -140,12 +140,13 @@ body {
    is unmistakably distinct from the disabled state. The -500 preset is too pale
    and reads as already-disabled. Targets all elements (buttons, anchors, nav). */
 .preset-filled-primary-500 {
-	background-color: var(--color-primary-600);
+	background-color: var(--color-primary);
 	color: var(--color-primary-contrast-600);
 }
 
-.preset-filled-primary-500:not(:disabled):hover {
-	background-color: var(--color-primary-700);
+button.preset-filled-primary-500:not(:disabled):hover,
+a.preset-filled-primary-500:hover {
+	background-color: var(--color-primary-hover);
 }
 
 /* Disabled buttons: clearly inactive regardless of variant. */

--- a/src/app.css
+++ b/src/app.css
@@ -51,7 +51,8 @@ body {
 	--color-background: var(--color-surface-50);
 	--color-surface: var(--color-surface-100);
 	--color-border: var(--color-surface-300);
-	--color-primary: var(--color-primary-500);
+	--color-primary: var(--color-primary-600);
+	--color-primary-hover: var(--color-primary-700);
 	--color-accent: var(--color-surface-200);
 	--color-success: var(--color-success-500);
 	--color-error: var(--color-error-500);
@@ -133,4 +134,22 @@ body {
 	.table-scroll-mobile {
 		overflow-x: auto;
 	}
+}
+
+/* Primary buttons: use -600 shade (white text on medium rose) so active state
+   is unmistakably distinct from the disabled state. The -500 preset is too pale
+   and reads as already-disabled. */
+button.preset-filled-primary-500 {
+	background-color: var(--color-primary-600);
+	color: var(--color-primary-contrast-600);
+}
+
+button.preset-filled-primary-500:not(:disabled):hover {
+	background-color: var(--color-primary-700);
+}
+
+/* Disabled buttons: clearly inactive regardless of variant. */
+button:disabled {
+	opacity: 0.45;
+	cursor: not-allowed;
 }


### PR DESCRIPTION
## Motivation

Primary action buttons were visually indistinguishable from disabled ones — both appeared washed-out under Skeleton UI's default rose theme. This caused usability confusion where interactive buttons looked inactive.

Closes https://github.com/Automaat/finance-buddy/issues/803

## Implementation information

- Overridden `--color-primary` CSS variables to use darker rose shades so filled primary buttons render with sufficient contrast
- Added explicit disabled-state styles (reduced opacity, `cursor-not-allowed`) to differentiate inactive controls from active ones
- Extended the primary-filled override to cover all interactive elements (buttons, anchors styled as buttons) — not just the primary variant — so the fix applies consistently across the UI

> Changelog: fix(ui): darken primary buttons and style disabled state