### PR TITLE
refactor(ui): unify number/money formatter to Polish locale

### DIFF
--- a/src/lib/components/ContributionAdjustedReturns.svelte
+++ b/src/lib/components/ContributionAdjustedReturns.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { resolveApiUrl } from '$lib/api';
 	import { toast } from '$lib/stores/toast.svelte';
-	import { formatPLN, formatNumber } from '$lib/utils/format';
+	import { formatPLN, formatNumber, formatSignedPLN } from '$lib/utils/format';
 
 	interface ScopeProp {
 		type: 'all' | 'category' | 'wrapper' | 'account';
@@ -156,7 +156,7 @@
 						? 'text-success-500'
 						: 'text-error-500'}"
 				>
-					{data.valuation_change >= 0 ? '+' : ''}{formatPLN(data.valuation_change)}
+					{formatSignedPLN(data.valuation_change)}
 				</dd>
 			</div>
 			{#if (data.dividends_received_net ?? 0) !== 0}

--- a/src/lib/components/ContributionAdjustedReturns.svelte
+++ b/src/lib/components/ContributionAdjustedReturns.svelte
@@ -86,8 +86,8 @@
 	});
 
 	function fmtPct(n: number): string {
-		const sign = n >= 0 ? '+' : '';
-		return `${sign}${formatNumber(Math.abs(n), 2)}%`;
+		const sign = n > 0 ? '+' : '';
+		return `${sign}${formatNumber(n, 2)}%`;
 	}
 </script>
 

--- a/src/lib/components/ContributionAdjustedReturns.svelte
+++ b/src/lib/components/ContributionAdjustedReturns.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { resolveApiUrl } from '$lib/api';
 	import { toast } from '$lib/stores/toast.svelte';
+	import { formatPLN, formatNumber } from '$lib/utils/format';
 
 	interface ScopeProp {
 		type: 'all' | 'category' | 'wrapper' | 'account';
@@ -84,13 +85,9 @@
 		return () => controller.abort();
 	});
 
-	function fmt(n: number): string {
-		return n.toLocaleString('pl-PL', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-	}
-
 	function fmtPct(n: number): string {
 		const sign = n >= 0 ? '+' : '';
-		return `${sign}${n.toFixed(2)}%`;
+		return `${sign}${formatNumber(Math.abs(n), 2)}%`;
 	}
 </script>
 
@@ -133,11 +130,11 @@
 				<dt class="text-xs text-surface-600-400 shrink-0">
 					Wpłacono netto
 					<span class="block text-[10px] opacity-70">
-						+{fmt(data.deposits)} / -{fmt(data.withdrawals)}
+						+{formatPLN(data.deposits)} / −{formatPLN(data.withdrawals)}
 					</span>
 				</dt>
 				<dd class="text-base font-semibold text-right tabular-nums">
-					{fmt(data.net_contributed)} PLN
+					{formatPLN(data.net_contributed)}
 				</dd>
 			</div>
 			<div class="flex items-baseline justify-between gap-3 py-2">
@@ -146,7 +143,7 @@
 					<span class="block text-[10px] opacity-70">na {data.as_of}</span>
 				</dt>
 				<dd class="text-base font-semibold text-right tabular-nums">
-					{fmt(data.current_value)} PLN
+					{formatPLN(data.current_value)}
 				</dd>
 			</div>
 			<div class="flex items-baseline justify-between gap-3 py-2">
@@ -159,7 +156,7 @@
 						? 'text-success-500'
 						: 'text-error-500'}"
 				>
-					{data.valuation_change >= 0 ? '+' : ''}{fmt(data.valuation_change)} PLN
+					{data.valuation_change >= 0 ? '+' : ''}{formatPLN(data.valuation_change)}
 				</dd>
 			</div>
 			{#if (data.dividends_received_net ?? 0) !== 0}
@@ -169,7 +166,7 @@
 						<span class="block text-[10px] opacity-70">w okresie, po podatku</span>
 					</dt>
 					<dd class="text-base font-semibold text-right tabular-nums text-success-500">
-						+{fmt(data.dividends_received_net ?? 0)} PLN
+						+{formatPLN(data.dividends_received_net ?? 0)}
 					</dd>
 				</div>
 			{/if}

--- a/src/lib/components/ContributionAdjustedReturns.test.ts
+++ b/src/lib/components/ContributionAdjustedReturns.test.ts
@@ -111,7 +111,10 @@ describe('ContributionAdjustedReturns', () => {
 		render(ContributionAdjustedReturns, { props: { scope: { type: 'all' } } });
 		await waitFor(() => {
 			expect(screen.getByText('Dywidendy (netto)')).toBeTruthy();
-			expect(screen.getByText((t) => /\+150,50\s*PLN/.test(t))).toBeTruthy();
+			// dividends_received_net=150.5 → formatPLN rounds to whole zł (≈150–151 zł)
+			expect(
+				screen.getByText((t) => t.startsWith('+') && t.trimEnd().endsWith('zł') && /15[01]/.test(t))
+			).toBeTruthy();
 		});
 	});
 

--- a/src/lib/components/DashboardCharts.svelte
+++ b/src/lib/components/DashboardCharts.svelte
@@ -3,7 +3,7 @@
 	import { goto } from '$app/navigation';
 	import * as echarts from 'echarts';
 	import type { ECElementEvent, EChartsOption } from 'echarts';
-	import { formatPLN } from '$lib/utils/format';
+	import { formatPLN, formatNumber } from '$lib/utils/format';
 	import { isMobile, isTablet } from '$lib/utils/viewport';
 	import { chartPalette, chartAccent, chartAccentGradient } from '$lib/utils/theme';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
@@ -111,7 +111,13 @@
 			left: 'center',
 			textStyle: { fontSize: titleFontSize }
 		},
-		tooltip: { trigger: 'item', formatter: '{b}: {c} PLN ({d}%)' },
+		tooltip: {
+			trigger: 'item',
+			formatter: (params: unknown) => {
+				const p = params as { name: string; value: number; percent: number };
+				return `${p.name}: ${formatPLN(p.value)} (${formatNumber(p.percent, 1)}%)`;
+			}
+		},
 		// On a phone the radial callout labels collide and get clipped at the
 		// card edges, so swap them for a scrollable legend along the bottom.
 		legend: $isMobile

--- a/src/lib/components/SalaryCalculator.svelte
+++ b/src/lib/components/SalaryCalculator.svelte
@@ -14,6 +14,7 @@
 		calculateOffer,
 		findBreakEvenAmount
 	} from '$lib/utils/compensation';
+	import { formatPLN, formatNumber } from '$lib/utils/format';
 
 	interface Props {
 		data: { latestSalaries: SalaryRecord[]; owners: OwnerOption[] };
@@ -158,7 +159,10 @@
 			bold: true
 		},
 		{ label: 'Koszt pracodawcy', value: (b) => fmt(b.employerCost) },
-		{ label: 'Efektywna stawka podatkowa', value: (b) => `${b.effectiveTaxRate.toFixed(1)}%` },
+		{
+			label: 'Efektywna stawka podatkowa',
+			value: (b) => `${formatNumber(b.effectiveTaxRate, 1)}%`
+		},
 		{ label: 'Ekwiwalent urlopowy', value: (b) => fmt(b.vacationEquivalent) }
 	];
 
@@ -198,7 +202,7 @@
 					const items = params as { name: string; value: number; seriesName: string }[];
 					let html = `<strong>${escapeHtml(items[0].name)}</strong><br/>`;
 					for (const p of items) {
-						html += `${escapeHtml(p.seriesName)}: ${fmt(p.value)} PLN<br/>`;
+						html += `${escapeHtml(p.seriesName)}: ${formatPLN(p.value)}<br/>`;
 					}
 					return html;
 				}
@@ -375,7 +379,7 @@
 
 				<div class="winner-banner">
 					🏆 {winner.name}
-					<span class="winner-net">{fmt(winner.netMonthly)} PLN netto/mies.</span>
+					<span class="winner-net">{formatPLN(winner.netMonthly)} netto/mies.</span>
 				</div>
 
 				<div class="chart-container" bind:this={chartContainer}></div>

--- a/src/lib/components/SalaryCalculator.svelte
+++ b/src/lib/components/SalaryCalculator.svelte
@@ -169,7 +169,7 @@
 	const baseline = $derived(results?.find((r) => r.isCurrentJob) ?? null);
 
 	function fmt(v: number): string {
-		return v.toLocaleString('pl-PL', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+		return formatNumber(v, 2);
 	}
 
 	function contractLabel(type: ContractType): string {

--- a/src/lib/utils/format.test.ts
+++ b/src/lib/utils/format.test.ts
@@ -156,6 +156,30 @@ describe('formatNumber', () => {
 		const result = formatNumber(-5, 2);
 		expect(result).toMatch(/[-−]5,00/);
 	});
+
+	it('uses NBSP thousands separator for 4-digit values', () => {
+		// pl-PL CLDR minimumGroupingDigits=2 would skip grouping at 1000–9999
+		// without the manual post-processing fix.
+		const result = formatNumber(1000, 2);
+		expect(result).toContain(' ');
+	});
+
+	it('uses NBSP thousands separator consistently across magnitudes', () => {
+		expect(formatNumber(1234, 0)).toContain(' ');
+		expect(formatNumber(9999, 0)).toContain(' ');
+		expect(formatNumber(10000, 0)).toContain(' ');
+	});
+
+	it('does not add separator below 1000', () => {
+		expect(formatNumber(999, 2)).toBe('999,00');
+	});
+});
+
+describe('formatPLN thousands separator', () => {
+	it('groups 4-digit values with NBSP', () => {
+		expect(formatPLN(1000)).toContain(' ');
+		expect(formatPLN(9999)).toContain(' ');
+	});
 });
 
 describe('calculateChange', () => {

--- a/src/lib/utils/format.test.ts
+++ b/src/lib/utils/format.test.ts
@@ -151,6 +151,11 @@ describe('formatNumber', () => {
 	it('defaults to 2 decimal places', () => {
 		expect(formatNumber(1.5)).toBe('1,50');
 	});
+
+	it('preserves sign for negative values', () => {
+		const result = formatNumber(-5, 2);
+		expect(result).toMatch(/[-−]5,00/);
+	});
 });
 
 describe('calculateChange', () => {

--- a/src/lib/utils/format.test.ts
+++ b/src/lib/utils/format.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
 	calculateChange,
 	formatDate,
+	formatNumber,
 	formatPLN,
 	formatPercent,
 	formatSignedPLN,
@@ -124,6 +125,31 @@ describe('formatDate', () => {
 		expect(formatDate(undefined)).toBe('—');
 		expect(formatDate('')).toBe('—');
 		expect(formatDate('not-a-date')).toBe('—');
+	});
+});
+
+describe('formatNumber', () => {
+	it('uses comma as decimal separator', () => {
+		expect(formatNumber(1.5, 1)).toContain(',');
+		expect(formatNumber(1.5, 1)).not.toContain('.');
+	});
+
+	it('contains the correct digits', () => {
+		expect(formatNumber(1234.5, 1)).toMatch(/1.*234.*5/);
+	});
+
+	it('rounds to specified decimal places', () => {
+		expect(formatNumber(1.234, 2)).toBe('1,23');
+	});
+
+	it('returns — for null, undefined and NaN', () => {
+		expect(formatNumber(null)).toBe('—');
+		expect(formatNumber(undefined)).toBe('—');
+		expect(formatNumber(NaN)).toBe('—');
+	});
+
+	it('defaults to 2 decimal places', () => {
+		expect(formatNumber(1.5)).toBe('1,50');
 	});
 });
 

--- a/src/lib/utils/format.test.ts
+++ b/src/lib/utils/format.test.ts
@@ -154,20 +154,20 @@ describe('formatNumber', () => {
 
 	it('preserves sign for negative values', () => {
 		const result = formatNumber(-5, 2);
-		expect(result).toMatch(/[-−]5,00/);
+		expect(result).toMatch(/−5,00/);
 	});
 
 	it('uses NBSP thousands separator for 4-digit values', () => {
 		// pl-PL CLDR minimumGroupingDigits=2 would skip grouping at 1000–9999
 		// without the manual post-processing fix.
 		const result = formatNumber(1000, 2);
-		expect(result).toContain(' ');
+		expect(result).toContain(' ');
 	});
 
 	it('uses NBSP thousands separator consistently across magnitudes', () => {
-		expect(formatNumber(1234, 0)).toContain(' ');
-		expect(formatNumber(9999, 0)).toContain(' ');
-		expect(formatNumber(10000, 0)).toContain(' ');
+		expect(formatNumber(1234, 0)).toContain(' ');
+		expect(formatNumber(9999, 0)).toContain(' ');
+		expect(formatNumber(10000, 0)).toContain(' ');
 	});
 
 	it('does not add separator below 1000', () => {
@@ -177,8 +177,8 @@ describe('formatNumber', () => {
 
 describe('formatPLN thousands separator', () => {
 	it('groups 4-digit values with NBSP', () => {
-		expect(formatPLN(1000)).toContain(' ');
-		expect(formatPLN(9999)).toContain(' ');
+		expect(formatPLN(1000)).toContain(' ');
+		expect(formatPLN(9999)).toContain(' ');
 	});
 });
 

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,9 +1,3 @@
-const plnFormatter = new Intl.NumberFormat('pl-PL', {
-	style: 'currency',
-	currency: 'PLN',
-	maximumFractionDigits: 0
-});
-
 const percentFormatter = new Intl.NumberFormat('pl-PL', {
 	style: 'percent',
 	minimumFractionDigits: 1,
@@ -16,9 +10,31 @@ const dateFormatter = new Intl.DateTimeFormat('pl-PL', {
 	day: '2-digit'
 });
 
+export interface Change {
+	absolute: number;
+	percent: number;
+	direction: 'up' | 'down' | 'flat';
+}
+
+// pl-PL CLDR sets minimumGroupingDigits=2, so Intl only groups at 10 000+.
+// Disable built-in grouping and insert NBSP manually from 1 000 upward.
+export function formatNumber(value: number | null | undefined, decimals = 2): string {
+	if (value == null || Number.isNaN(value)) return '—';
+	const isNeg = value < 0;
+	const formatted = new Intl.NumberFormat('pl-PL', {
+		minimumFractionDigits: decimals,
+		maximumFractionDigits: decimals,
+		useGrouping: false
+	}).format(Math.abs(value));
+	const [intPart, fracPart] = formatted.split(',');
+	const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+	const result = fracPart !== undefined ? `${grouped},${fracPart}` : grouped;
+	return isNeg ? `-${result}` : result;
+}
+
 export function formatPLN(value: number | null | undefined): string {
 	if (value == null || Number.isNaN(value)) return '—';
-	return plnFormatter.format(value);
+	return `${formatNumber(value, 0)} zł`;
 }
 
 export function formatPercent(value: number | null | undefined): string {
@@ -33,17 +49,11 @@ export function formatDate(value: string | Date | null | undefined): string {
 	return dateFormatter.format(date);
 }
 
-export interface Change {
-	absolute: number;
-	percent: number;
-	direction: 'up' | 'down' | 'flat';
-}
-
 export function formatSignedPLN(value: number | null | undefined): string {
 	if (value == null || Number.isNaN(value)) return '—';
-	if (value === 0) return plnFormatter.format(0);
+	if (value === 0) return `${formatNumber(0, 0)} zł`;
 	const sign = value > 0 ? '+' : '−';
-	return `${sign}${plnFormatter.format(Math.abs(value))}`;
+	return `${sign}${formatNumber(Math.abs(value), 0)} zł`;
 }
 
 export function formatSignedPercent(value: number | null | undefined): string {
@@ -58,12 +68,4 @@ export function calculateChange(current: number, previous: number): Change {
 	const percent = previous === 0 ? 0 : (absolute / Math.abs(previous)) * 100;
 	const direction: Change['direction'] = absolute > 0 ? 'up' : absolute < 0 ? 'down' : 'flat';
 	return { absolute, percent, direction };
-}
-
-export function formatNumber(value: number | null | undefined, decimals = 2): string {
-	if (value == null || Number.isNaN(value)) return '—';
-	return new Intl.NumberFormat('pl-PL', {
-		minimumFractionDigits: decimals,
-		maximumFractionDigits: decimals
-	}).format(value);
 }

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -4,6 +4,8 @@ const percentFormatter = new Intl.NumberFormat('pl-PL', {
 	maximumFractionDigits: 1
 });
 
+const numberFormatterCache = new Map<number, Intl.NumberFormat>();
+
 const dateFormatter = new Intl.DateTimeFormat('pl-PL', {
 	year: 'numeric',
 	month: '2-digit',
@@ -17,24 +19,29 @@ export interface Change {
 }
 
 // pl-PL CLDR sets minimumGroupingDigits=2, so Intl only groups at 10 000+.
-// Disable built-in grouping and insert NBSP manually from 1 000 upward.
+// Disable built-in grouping and insert U+202F manually from 1 000 upward.
 export function formatNumber(value: number | null | undefined, decimals = 2): string {
 	if (value == null || Number.isNaN(value)) return '—';
 	const isNeg = value < 0;
-	const formatted = new Intl.NumberFormat('pl-PL', {
-		minimumFractionDigits: decimals,
-		maximumFractionDigits: decimals,
-		useGrouping: false
-	}).format(Math.abs(value));
+	let nf = numberFormatterCache.get(decimals);
+	if (!nf) {
+		nf = new Intl.NumberFormat('pl-PL', {
+			minimumFractionDigits: decimals,
+			maximumFractionDigits: decimals,
+			useGrouping: false
+		});
+		numberFormatterCache.set(decimals, nf);
+	}
+	const formatted = nf.format(Math.abs(value));
 	const [intPart, fracPart] = formatted.split(',');
-	const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+	const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
 	const result = fracPart !== undefined ? `${grouped},${fracPart}` : grouped;
-	return isNeg ? `-${result}` : result;
+	return isNeg ? `−${result}` : result;
 }
 
 export function formatPLN(value: number | null | undefined): string {
 	if (value == null || Number.isNaN(value)) return '—';
-	return `${formatNumber(value, 0)} zł`;
+	return `${formatNumber(value, 0)} zł`;
 }
 
 export function formatPercent(value: number | null | undefined): string {
@@ -51,9 +58,9 @@ export function formatDate(value: string | Date | null | undefined): string {
 
 export function formatSignedPLN(value: number | null | undefined): string {
 	if (value == null || Number.isNaN(value)) return '—';
-	if (value === 0) return `${formatNumber(0, 0)} zł`;
+	if (value === 0) return `${formatNumber(0, 0)} zł`;
 	const sign = value > 0 ? '+' : '−';
-	return `${sign}${formatNumber(Math.abs(value), 0)} zł`;
+	return `${sign}${formatNumber(Math.abs(value), 0)} zł`;
 }
 
 export function formatSignedPercent(value: number | null | undefined): string {

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -59,3 +59,11 @@ export function calculateChange(current: number, previous: number): Change {
 	const direction: Change['direction'] = absolute > 0 ? 'up' : absolute < 0 ? 'down' : 'flat';
 	return { absolute, percent, direction };
 }
+
+export function formatNumber(value: number | null | undefined, decimals = 2): string {
+	if (value == null || Number.isNaN(value)) return '—';
+	return new Intl.NumberFormat('pl-PL', {
+		minimumFractionDigits: decimals,
+		maximumFractionDigits: decimals
+	}).format(value);
+}

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -2,7 +2,7 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import Skeleton from '$lib/components/Skeleton.svelte';
 	import SortableTable, { type SortableColumn } from '$lib/components/SortableTable.svelte';
-	import { formatPLN } from '$lib/utils/format';
+	import { formatPLN, formatNumber } from '$lib/utils/format';
 	import { Wallet, TrendingDown, Pencil, Trash2, Plus, BarChart3 } from 'lucide-svelte';
 	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
@@ -149,7 +149,7 @@
 
 	function formatPct(v: number): string {
 		const sign = v > 0 ? '+' : '';
-		return `${sign}${v.toFixed(2)}%`;
+		return `${sign}${formatNumber(Math.abs(v), 2)}%`;
 	}
 
 	// Color buckets per issue #573 acceptance: green > 1%, amber 0–1%, red < 0%.
@@ -168,7 +168,7 @@
 	// backend `rules` table.
 	function realYieldTooltip(a: Account): string {
 		if (a.interest_rate_pct == null) return '';
-		const nominal = a.interest_rate_pct.toFixed(2);
+		const nominal = formatNumber(a.interest_rate_pct, 2);
 		const shielded = a.account_wrapper === 'IKE' || a.account_wrapper === 'IKZE';
 		const belkaPart = shielded
 			? `bez podatku Belki (opakowanie ${a.account_wrapper})`
@@ -176,7 +176,7 @@
 		if (a.cpi_yoy_pct == null || a.cpi_as_of_year == null) {
 			return `Nominalne ${nominal}% · ${belkaPart} · brak danych CPI`;
 		}
-		const cpi = a.cpi_yoy_pct.toFixed(2);
+		const cpi = formatNumber(a.cpi_yoy_pct, 2);
 		return `Nominalne ${nominal}% · ${belkaPart} · minus CPI ${a.cpi_as_of_year}: ${cpi}%`;
 	}
 
@@ -465,7 +465,7 @@
 				</span>
 			{:else if account.interest_rate_pct != null}
 				<span class="text-surface-700-300" title={realYieldTooltip(account)}>
-					{account.interest_rate_pct.toFixed(2)}%
+					{formatNumber(account.interest_rate_pct, 2)}%
 				</span>
 			{:else}
 				<span class="text-surface-500-500" aria-hidden="true">—</span>

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -149,7 +149,7 @@
 
 	function formatPct(v: number): string {
 		const sign = v > 0 ? '+' : '';
-		return `${sign}${formatNumber(Math.abs(v), 2)}%`;
+		return `${sign}${formatNumber(v, 2)}%`;
 	}
 
 	// Color buckets per issue #573 acceptance: green > 1%, amber 0–1%, red < 0%.


### PR DESCRIPTION
## Motivation

All monetary and numeric values were formatted inconsistently — some used `toLocaleString`, some hardcoded `pl-PL`, and percentage formatters silently dropped the minus sign on negative values. Thousands separators were also inconsistent (comma vs NBSP). Issue #805 tracked consolidating this into a single, correct formatter.

## Implementation information

- Introduced a single `formatNumber` utility in `src/lib/utils/` using the `pl-PL` locale with NBSP (U+202F) as the thousands-group separator, consistent with Polish typographic convention (e.g. `1 000`).
- Removed all scattered `toLocaleString` / inline `Intl.NumberFormat` calls and routed them through the shared formatter.
- Fixed percentage formatters to preserve the minus sign for negative values.
- No API or backend changes — purely frontend formatting.

Closes https://github.com/Automaat/finance-buddy/issues/805

> Changelog: refactor(ui): unify number/money formatter to Polish locale