### PR TITLE
feat(ui): standardize row actions and add badge icon labels

### DIFF
--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -485,7 +485,7 @@
 				<button
 					type="button"
 					class="btn preset-tonal-surface btn-sm gap-1"
-					aria-label="Transakcje"
+					aria-label="Transakcje: {transactionCounts[account.id] || 0}"
 					title="Liczba transakcji"
 					onclick={() => openTransactions(account.id, account.name, account.account_wrapper)}
 				>

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -476,6 +476,7 @@
 				type="button"
 				class="btn-icon btn-icon-sm"
 				aria-label="Edytuj"
+				title="Edytuj"
 				onclick={() => startEdit(account)}
 			>
 				<Pencil size={16} />
@@ -485,6 +486,7 @@
 					type="button"
 					class="btn preset-tonal-surface btn-sm gap-1"
 					aria-label="Transakcje"
+					title="Liczba transakcji"
 					onclick={() => openTransactions(account.id, account.name, account.account_wrapper)}
 				>
 					<BarChart3 size={14} />
@@ -493,8 +495,9 @@
 			{/if}
 			<button
 				type="button"
-				class="btn-icon btn-icon-sm"
+				class="btn-icon btn-icon-sm preset-tonal-error"
 				aria-label="Usuń"
+				title="Usuń"
 				onclick={() => handleDelete(account.id)}
 			>
 				<Trash2 size={16} />
@@ -516,14 +519,16 @@
 				type="button"
 				class="btn-icon btn-icon-sm"
 				aria-label="Edytuj"
+				title="Edytuj"
 				onclick={() => startEdit(account)}
 			>
 				<Pencil size={16} />
 			</button>
 			<button
 				type="button"
-				class="btn-icon btn-icon-sm"
+				class="btn-icon btn-icon-sm preset-tonal-error"
 				aria-label="Usuń"
+				title="Usuń"
 				onclick={() => handleDelete(account.id)}
 			>
 				<Trash2 size={16} />

--- a/src/routes/assets/+page.svelte
+++ b/src/routes/assets/+page.svelte
@@ -207,14 +207,16 @@
 										type="button"
 										class="btn-icon btn-icon-sm"
 										aria-label="Edytuj"
+										title="Edytuj"
 										onclick={() => startEdit(asset)}
 									>
 										<Pencil size={16} />
 									</button>
 									<button
 										type="button"
-										class="btn-icon btn-icon-sm"
+										class="btn-icon btn-icon-sm preset-tonal-error"
 										aria-label="Usuń"
+										title="Usuń"
 										onclick={() => handleDelete(asset.id)}
 									>
 										<Trash2 size={16} />

--- a/src/routes/debts/+page.svelte
+++ b/src/routes/debts/+page.svelte
@@ -357,6 +357,7 @@
 										type="button"
 										class="btn preset-tonal-surface btn-sm gap-1"
 										aria-label="Historia wpłat"
+										title="Liczba wpłat"
 										onclick={() => openPayments(debt)}
 									>
 										<CircleDollarSign size={14} />
@@ -366,14 +367,16 @@
 										type="button"
 										class="btn-icon btn-icon-sm"
 										aria-label="Edytuj"
+										title="Edytuj"
 										onclick={() => startEdit(debt)}
 									>
 										<Pencil size={16} />
 									</button>
 									<button
 										type="button"
-										class="btn-icon btn-icon-sm"
+										class="btn-icon btn-icon-sm preset-tonal-error"
 										aria-label="Usuń"
+										title="Usuń"
 										onclick={() => handleDelete(debt.id)}
 									>
 										<Trash2 size={16} />

--- a/src/routes/debts/+page.svelte
+++ b/src/routes/debts/+page.svelte
@@ -356,7 +356,7 @@
 									<button
 										type="button"
 										class="btn preset-tonal-surface btn-sm gap-1"
-										aria-label="Historia wpłat"
+										aria-label="Historia wpłat: {paymentCounts[debt.account_id] || 0}"
 										title="Liczba wpłat"
 										onclick={() => openPayments(debt)}
 									>

--- a/src/routes/snapshots/+page.svelte
+++ b/src/routes/snapshots/+page.svelte
@@ -103,12 +103,12 @@
 								<td class="text-right">
 									<button
 										type="button"
-										class="btn btn-sm preset-tonal-primary gap-1"
-										onclick={() => goto(`/snapshots/${snapshot.id}/edit`)}
+										class="btn-icon btn-icon-sm"
+										aria-label="Edytuj"
 										title="Edytuj snapshot"
+										onclick={() => goto(`/snapshots/${snapshot.id}/edit`)}
 									>
-										<Pencil size={14} />
-										Edytuj
+										<Pencil size={16} />
 									</button>
 								</td>
 							</tr>

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -161,8 +161,9 @@
 		<td class="text-right">
 			<button
 				type="button"
-				class="btn-icon btn-icon-sm"
+				class="btn-icon btn-icon-sm preset-tonal-error"
 				aria-label="Usuń"
+				title="Usuń"
 				onclick={() => deleteTransaction(transaction.account_id, transaction.id)}
 			>
 				<Trash2 size={16} />


### PR DESCRIPTION
## Motivation

Row action buttons (Edit/Delete) across different pages were inconsistent — missing accessible labels, wrong button styles, and varying patterns. Badges on Konta and Zobowiązania lacked titles, reducing discoverability for keyboard/screen-reader users.

Closes https://github.com/Automaat/finance-buddy/issues/809

## Implementation information

- Added `title` + `aria-label` to Edit buttons across Konta, Transakcje, Majątek, Zobowiązania rows
- Added `preset-tonal-error` class + `title` to Delete buttons for consistent danger styling
- Converted Snapshoty text "Edytuj" button to icon-only `btn-icon` pattern matching other pages
- Added `title="Liczba transakcji"` to Konta badge and `title="Liczba wpłat"` to Zobowiązania badge for hover/screen-reader discoverability

> Changelog: feat(ui): standardize row actions and add badge icon labels