### PR TITLE
fix(charts): unified palette and legend/line color match

### DIFF
--- a/src/lib/components/CurrencyExposureWidget.svelte
+++ b/src/lib/components/CurrencyExposureWidget.svelte
@@ -5,6 +5,7 @@
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
 	import { applyMobileChartTweaks } from '$lib/utils/charts/responsive';
 	import { isMobile } from '$lib/utils/viewport';
+	import { chartPalette } from '$lib/utils/theme';
 	import { Globe } from 'lucide-svelte';
 
 	interface CurrencyBucket {
@@ -72,17 +73,6 @@
 		return () => inFlight?.abort();
 	});
 
-	const palette = [
-		'#3b82f6',
-		'#ef4444',
-		'#10b981',
-		'#f59e0b',
-		'#a855f7',
-		'#06b6d4',
-		'#84cc16',
-		'#ec4899'
-	];
-
 	$effect(() => {
 		if (!container) {
 			handle?.dispose();
@@ -94,7 +84,7 @@
 		const data = report.currencies.map((c, i) => ({
 			name: c.currency,
 			value: c.value_pln,
-			itemStyle: { color: c.currency === 'PLN' ? '#1e40af' : palette[i % palette.length] }
+			itemStyle: { color: chartPalette[i % chartPalette.length] }
 		}));
 		handle.chart.setOption(
 			applyMobileChartTweaks(

--- a/src/lib/components/DashboardCharts.svelte
+++ b/src/lib/components/DashboardCharts.svelte
@@ -5,7 +5,7 @@
 	import type { ECElementEvent, EChartsOption } from 'echarts';
 	import { formatPLN, formatNumber } from '$lib/utils/format';
 	import { isMobile, isTablet } from '$lib/utils/viewport';
-	import { chartPalette, chartAccent, chartAccentGradient } from '$lib/utils/theme';
+	import { chartPalette, chartPositive, chartPositiveGradient } from '$lib/utils/theme';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
 	import { createChart } from '$lib/utils/charts/lifecycle';
 	import { buildWaterfallOption, buildWaterfallSteps } from '$lib/utils/charts/waterfall';
@@ -96,11 +96,12 @@
 				smooth: true,
 				areaStyle: {
 					color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-						{ offset: 0, color: chartAccentGradient[0] },
-						{ offset: 1, color: chartAccentGradient[1] }
+						{ offset: 0, color: chartPositiveGradient[0] },
+						{ offset: 1, color: chartPositiveGradient[1] }
 					])
 				},
-				lineStyle: { color: chartAccent, width: 2 }
+				lineStyle: { color: chartPositive, width: 2 },
+				itemStyle: { color: chartPositive }
 			}
 		]
 	});

--- a/src/lib/components/DashboardCharts.svelte
+++ b/src/lib/components/DashboardCharts.svelte
@@ -5,7 +5,7 @@
 	import type { ECElementEvent, EChartsOption } from 'echarts';
 	import { formatPLN, formatNumber } from '$lib/utils/format';
 	import { isMobile, isTablet } from '$lib/utils/viewport';
-	import { chartPalette, chartPositive, chartPositiveGradient } from '$lib/utils/theme';
+	import { chartPalette, chartValue, chartValueGradient } from '$lib/utils/theme';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
 	import { createChart } from '$lib/utils/charts/lifecycle';
 	import { buildWaterfallOption, buildWaterfallSteps } from '$lib/utils/charts/waterfall';
@@ -96,12 +96,12 @@
 				smooth: true,
 				areaStyle: {
 					color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-						{ offset: 0, color: chartPositiveGradient[0] },
-						{ offset: 1, color: chartPositiveGradient[1] }
+						{ offset: 0, color: chartValueGradient[0] },
+						{ offset: 1, color: chartValueGradient[1] }
 					])
 				},
-				lineStyle: { color: chartPositive, width: 2 },
-				itemStyle: { color: chartPositive }
+				lineStyle: { color: chartValue, width: 2 },
+				itemStyle: { color: chartValue }
 			}
 		]
 	});

--- a/src/lib/utils/charts/metryki.ts
+++ b/src/lib/utils/charts/metryki.ts
@@ -327,6 +327,7 @@ function buildTrendChartOption(
 					color: chartContribution,
 					opacity: 0.8
 				},
+				itemStyle: { color: chartContribution },
 				emphasis: {
 					focus: 'series'
 				}
@@ -338,6 +339,7 @@ function buildTrendChartOption(
 				smooth: true,
 				lineStyle: { width: 3, color: chartValue },
 				showSymbol: false,
+				itemStyle: { color: chartValue },
 				emphasis: {
 					focus: 'series'
 				}

--- a/src/lib/utils/charts/montecarlo.ts
+++ b/src/lib/utils/charts/montecarlo.ts
@@ -1,5 +1,6 @@
 import type { EChartsOption, LineSeriesOption } from 'echarts';
 import type { TopLevelFormatterParams } from 'echarts/types/dist/shared';
+import { chartAccent, chartPalette } from '$lib/utils/theme';
 
 export interface MonteCarloBand {
 	age: number;
@@ -130,7 +131,8 @@ export function buildMonteCarloFanOption(
 			stack: 'fan',
 			lineStyle: { opacity: 0 },
 			showSymbol: false,
-			areaStyle: { color: '#88C0D0', opacity: 0.35 }
+			areaStyle: { color: chartPalette[3], opacity: 0.35 },
+			itemStyle: { color: chartPalette[3] }
 		},
 		{
 			name: 'Mediana',
@@ -138,8 +140,8 @@ export function buildMonteCarloFanOption(
 			data: p50,
 			smooth: true,
 			showSymbol: false,
-			lineStyle: { color: '#5E81AC', width: 2 },
-			itemStyle: { color: '#5E81AC' }
+			lineStyle: { color: chartAccent, width: 2 },
+			itemStyle: { color: chartAccent }
 		}
 	];
 

--- a/src/lib/utils/charts/montecarlo.ts
+++ b/src/lib/utils/charts/montecarlo.ts
@@ -1,6 +1,6 @@
 import type { EChartsOption, LineSeriesOption } from 'echarts';
 import type { TopLevelFormatterParams } from 'echarts/types/dist/shared';
-import { chartAccent, chartPalette } from '$lib/utils/theme';
+import { chartValue, chartPalette } from '$lib/utils/theme';
 
 export interface MonteCarloBand {
 	age: number;
@@ -140,8 +140,8 @@ export function buildMonteCarloFanOption(
 			data: p50,
 			smooth: true,
 			showSymbol: false,
-			lineStyle: { color: chartAccent, width: 2 },
-			itemStyle: { color: chartAccent }
+			lineStyle: { color: chartValue, width: 2 },
+			itemStyle: { color: chartValue }
 		}
 	];
 

--- a/src/lib/utils/charts/simulations.test.ts
+++ b/src/lib/utils/charts/simulations.test.ts
@@ -117,8 +117,8 @@ describe('buildRetirementProjectionOption', () => {
 		const option = buildRetirementProjectionOption(sims);
 		const series = option.series as Array<{ itemStyle: { color: string } }>;
 		expect(series).toHaveLength(10);
-		// 7th item should wrap back to the first palette colour
-		expect(series[6].itemStyle.color).toBe(series[0].itemStyle.color);
+		// 9th item (index 8) wraps back to the first palette colour (8 colours in palette)
+		expect(series[8].itemStyle.color).toBe(series[0].itemStyle.color);
 	});
 });
 

--- a/src/lib/utils/charts/simulations.ts
+++ b/src/lib/utils/charts/simulations.ts
@@ -1,5 +1,6 @@
 import type { EChartsOption, LineSeriesOption } from 'echarts';
 import type { TopLevelFormatterParams } from 'echarts/types/dist/shared';
+import { chartPalette, chartInkMuted } from '$lib/utils/theme';
 
 export interface YearlyProjection {
 	year: number;
@@ -27,7 +28,7 @@ export interface AccountSimulation {
 	yearly_projections: YearlyProjection[];
 }
 
-const SERIES_COLORS = ['#5E81AC', '#81A1C1', '#88C0D0', '#8FBCBB', '#B48EAD', '#A3BE8C'];
+const SERIES_COLORS = [...chartPalette];
 
 // Tooltip HTML escape: account names come from the database (user-set
 // owner labels can flow in) and Echarts' default tooltip renderer treats
@@ -140,9 +141,9 @@ export function getTotalBalanceAtAge(simulations: AccountSimulation[], age: numb
 }
 
 const WRAPPER_COLORS: Record<WrapperKey, string> = {
-	IKE: '#5E81AC',
-	IKZE: '#88C0D0',
-	PPK: '#A3BE8C'
+	IKE: chartPalette[0],
+	IKZE: chartPalette[2],
+	PPK: chartPalette[4]
 };
 
 export function buildRetirementByWrapperOption(
@@ -185,7 +186,7 @@ export function buildRetirementByWrapperOption(
 	if (series.length > 0 && markLineData.length > 0) {
 		series[0].markLine = {
 			symbol: ['none', 'none'],
-			lineStyle: { type: 'dashed', color: '#B48EAD' },
+			lineStyle: { type: 'dashed', color: chartInkMuted },
 			data: markLineData
 		};
 	}

--- a/src/lib/utils/charts/waterfall.test.ts
+++ b/src/lib/utils/charts/waterfall.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildWaterfallOption, buildWaterfallSteps, type NetWorthPoint } from './waterfall';
+import { chartPositive, chartNegative } from '$lib/utils/theme';
 
 function point(
 	date: string,
@@ -73,8 +74,8 @@ describe('buildWaterfallOption', () => {
 			.data;
 		const liabData = (opt.series as Array<{ data: Array<{ itemStyle: { color: string } }> }>)[1]
 			.data;
-		expect(assetData[0].itemStyle.color).toBe('#BF616A'); // red
-		expect(liabData[0].itemStyle.color).toBe('#A3BE8C'); // no liab change → green branch
+		expect(assetData[0].itemStyle.color).toBe(chartNegative); // negative asset delta
+		expect(liabData[0].itemStyle.color).toBe(chartPositive); // no liab change → better
 	});
 
 	it('maxMonths crops to the most recent N steps', () => {

--- a/src/lib/utils/charts/waterfall.ts
+++ b/src/lib/utils/charts/waterfall.ts
@@ -1,6 +1,6 @@
 import type { BarSeriesOption, EChartsOption, LineSeriesOption } from 'echarts';
 import type { TopLevelFormatterParams } from 'echarts/types/dist/shared';
-import { chartPositive, chartNegative, chartAccent } from '$lib/utils/theme';
+import { chartPositive, chartNegative, chartValue } from '$lib/utils/theme';
 
 export interface NetWorthPoint {
 	date: string;
@@ -101,8 +101,8 @@ export function buildWaterfallOption(
 		smooth: true,
 		showSymbol: true,
 		data: sliced.map((s) => s.endingNetWorth),
-		lineStyle: { color: chartAccent, width: 2 },
-		itemStyle: { color: chartAccent }
+		lineStyle: { color: chartValue, width: 2 },
+		itemStyle: { color: chartValue }
 	};
 
 	return {

--- a/src/lib/utils/charts/waterfall.ts
+++ b/src/lib/utils/charts/waterfall.ts
@@ -1,5 +1,6 @@
 import type { BarSeriesOption, EChartsOption, LineSeriesOption } from 'echarts';
 import type { TopLevelFormatterParams } from 'echarts/types/dist/shared';
+import { chartPositive, chartNegative, chartAccent } from '$lib/utils/theme';
 
 export interface NetWorthPoint {
 	date: string;
@@ -17,12 +18,6 @@ export interface WaterfallStep {
 	assetDelta: number;
 	liabilityDelta: number;
 }
-
-const COLOR_ASSET_POS = '#A3BE8C'; // green: assets grew
-const COLOR_ASSET_NEG = '#BF616A'; // red: assets fell
-const COLOR_LIAB_POS = '#BF616A'; // red: liabilities grew (worse)
-const COLOR_LIAB_NEG = '#A3BE8C'; // green: liabilities shrank (better)
-const COLOR_LINE = '#5E81AC';
 
 // Tooltips render as HTML; escape any interpolated string in case future
 // labels carry user content.
@@ -86,7 +81,7 @@ export function buildWaterfallOption(
 		type: 'bar',
 		data: sliced.map((s) => ({
 			value: s.assetDelta,
-			itemStyle: { color: s.assetDelta >= 0 ? COLOR_ASSET_POS : COLOR_ASSET_NEG }
+			itemStyle: { color: s.assetDelta >= 0 ? chartPositive : chartNegative }
 		}))
 	};
 	// Liability delta is shown as how it impacted net worth: a liability
@@ -96,7 +91,7 @@ export function buildWaterfallOption(
 		type: 'bar',
 		data: sliced.map((s) => ({
 			value: -s.liabilityDelta,
-			itemStyle: { color: s.liabilityDelta <= 0 ? COLOR_LIAB_NEG : COLOR_LIAB_POS }
+			itemStyle: { color: s.liabilityDelta <= 0 ? chartPositive : chartNegative }
 		}))
 	};
 	const netWorthLine: LineSeriesOption = {
@@ -106,8 +101,8 @@ export function buildWaterfallOption(
 		smooth: true,
 		showSymbol: true,
 		data: sliced.map((s) => s.endingNetWorth),
-		lineStyle: { color: COLOR_LINE, width: 2 },
-		itemStyle: { color: COLOR_LINE }
+		lineStyle: { color: chartAccent, width: 2 },
+		itemStyle: { color: chartAccent }
 	};
 
 	return {

--- a/src/lib/utils/theme.test.ts
+++ b/src/lib/utils/theme.test.ts
@@ -24,8 +24,10 @@ describe('theme', () => {
 		}
 	});
 
-	it('accent is the first palette color', () => {
-		expect(chartAccent).toBe(chartPalette[0]);
+	it('accent is the brand rose, independent of categorical palette', () => {
+		expect(chartAccent).toBe('#e11d48');
+		// Red/rose must not appear in the categorical palette (reserved for accent/negative only)
+		expect([...chartPalette]).not.toContain(chartAccent);
 	});
 
 	it('gradient has two stops derived from the accent', () => {
@@ -48,8 +50,9 @@ describe('theme', () => {
 		for (const token of tokens) {
 			expect(token).toMatch(/^#[0-9a-f]{6}$/);
 		}
-		// the rose value color is the accent; contribution is a lighter rose tint
-		expect(chartValue).toBe(chartAccent);
-		expect(chartContribution).toBe(chartPalette[2]);
+		// value is the primary blue (same hue as palette[0]), NOT the red accent
+		expect(chartValue).toBe(chartPalette[0]);
+		// contribution is an independent rose-400 tint, not a palette index
+		expect(chartContribution).toBe('#fb7185');
 	});
 });

--- a/src/lib/utils/theme.test.ts
+++ b/src/lib/utils/theme.test.ts
@@ -52,7 +52,7 @@ describe('theme', () => {
 		}
 		// value is the primary blue (same hue as palette[0]), NOT the red accent
 		expect(chartValue).toBe(chartPalette[0]);
-		// contribution is an independent rose-400 tint, not a palette index
-		expect(chartContribution).toBe('#fb7185');
+		// contribution is amber (not red/rose) — red is reserved for negatives only
+		expect(chartContribution).toBe('#f59e0b');
 	});
 });

--- a/src/lib/utils/theme.ts
+++ b/src/lib/utils/theme.ts
@@ -1,16 +1,18 @@
 // Shared ECharts color tokens. Centralized so chart components don't carry
-// their own hardcoded palettes. Rose/crimson scale matching the app theme.
+// their own hardcoded palettes.
 
-/** Categorical palette for multi-series charts (e.g. allocation pie). */
+/** Categorical palette for multi-series charts (e.g. allocation pie, retirement by wrapper).
+ *  Multi-hue so each category reads as visually distinct. Red/rose are excluded —
+ *  those are reserved for chartNegative / chartAccent. */
 export const chartPalette = [
-	'#e11d48',
-	'#f43f5e',
-	'#fb7185',
-	'#fda4af',
-	'#881337',
-	'#9f1239',
-	'#be123c',
-	'#be185d'
+	'#3b82f6', // blue-500
+	'#10b981', // emerald-500
+	'#f59e0b', // amber-500
+	'#a855f7', // purple-500
+	'#06b6d4', // cyan-500
+	'#84cc16', // lime-500
+	'#ec4899', // pink-500
+	'#f97316'  // orange-500
 ] as const;
 
 /** Accent color for single-series charts (e.g. net worth line). */
@@ -47,8 +49,8 @@ export const chartTooltipBorder = '#d4d4d8';
 /** Contributions / deposits (area fill under the value line). */
 export const chartContribution = '#fb7185';
 
-/** Portfolio value / primary line. */
-export const chartValue = '#e11d48';
+/** Portfolio value / primary line. Same hue as chartPalette[0] — blue, not red. */
+export const chartValue = '#3b82f6';
 
 /** Positive return / gains. */
 export const chartPositive = '#16a34a';

--- a/src/lib/utils/theme.ts
+++ b/src/lib/utils/theme.ts
@@ -12,7 +12,7 @@ export const chartPalette = [
 	'#06b6d4', // cyan-500
 	'#84cc16', // lime-500
 	'#ec4899', // pink-500
-	'#f97316'  // orange-500
+	'#f97316' // orange-500
 ] as const;
 
 /** Accent color for single-series charts (e.g. net worth line). */

--- a/src/lib/utils/theme.ts
+++ b/src/lib/utils/theme.ts
@@ -52,3 +52,9 @@ export const chartValue = '#e11d48';
 
 /** Positive return / gains. */
 export const chartPositive = '#16a34a';
+
+/** Negative values / losses — unambiguously red, reserved for bad outcomes only. */
+export const chartNegative = '#dc2626';
+
+/** Area-fill gradient stops for chartPositive, top (opaque) to bottom (faint). */
+export const chartPositiveGradient = ['rgba(22, 163, 74, 0.5)', 'rgba(22, 163, 74, 0.1)'] as const;

--- a/src/lib/utils/theme.ts
+++ b/src/lib/utils/theme.ts
@@ -46,11 +46,14 @@ export const chartTooltipBorder = '#d4d4d8';
 // Stable meanings used across the investment charts so the same concept reads
 // the same color everywhere.
 
-/** Contributions / deposits (area fill under the value line). */
-export const chartContribution = '#fb7185';
+/** Contributions / deposits (area fill under the value line). Amber — not red/rose. */
+export const chartContribution = '#f59e0b';
 
 /** Portfolio value / primary line. Same hue as chartPalette[0] — blue, not red. */
 export const chartValue = '#3b82f6';
+
+/** Area-fill gradient stops for chartValue, top (opaque) to bottom (faint). */
+export const chartValueGradient = ['rgba(59, 130, 246, 0.5)', 'rgba(59, 130, 246, 0.1)'] as const;
 
 /** Positive return / gains. */
 export const chartPositive = '#16a34a';

--- a/src/routes/ekspozycja/+page.svelte
+++ b/src/routes/ekspozycja/+page.svelte
@@ -4,6 +4,7 @@
 	import { page } from '$app/stores';
 	import { Globe } from 'lucide-svelte';
 	import { formatPLN } from '$lib/utils/format';
+	import { chartPalette } from '$lib/utils/theme';
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
 	import type { PageData } from './$types';
 
@@ -25,20 +26,6 @@
 		toleranceInput = data.tolerance;
 	});
 
-	const palette = [
-		'#3b82f6',
-		'#ef4444',
-		'#10b981',
-		'#f59e0b',
-		'#a855f7',
-		'#06b6d4',
-		'#84cc16',
-		'#ec4899'
-	];
-
-	const colorFor = (currency: string, index: number): string =>
-		currency === 'PLN' ? '#1e40af' : palette[index % palette.length];
-
 	let container: HTMLDivElement | undefined = $state();
 	let handle: ChartHandle | null = null;
 
@@ -52,7 +39,7 @@
 		const pieData = report.currencies.map((c, i) => ({
 			name: c.currency,
 			value: c.value_pln,
-			itemStyle: { color: colorFor(c.currency, i) }
+			itemStyle: { color: chartPalette[i % chartPalette.length] }
 		}));
 		handle.chart.setOption({
 			tooltip: {
@@ -214,10 +201,7 @@
 										<div class="flex-1 h-2 rounded-full bg-surface-200-800 overflow-hidden">
 											<div
 												class="h-full rounded-full"
-												style="width: {Math.min(bucket.percent, 100)}%; background: {colorFor(
-													bucket.currency,
-													i
-												)}"
+												style="width: {Math.min(bucket.percent, 100)}%; background: {chartPalette[i % chartPalette.length]}"
 											></div>
 										</div>
 										<span class="w-12 text-right tabular-nums">{bucket.percent.toFixed(1)}%</span>

--- a/src/routes/ekspozycja/+page.svelte
+++ b/src/routes/ekspozycja/+page.svelte
@@ -201,7 +201,9 @@
 										<div class="flex-1 h-2 rounded-full bg-surface-200-800 overflow-hidden">
 											<div
 												class="h-full rounded-full"
-												style="width: {Math.min(bucket.percent, 100)}%; background: {chartPalette[i % chartPalette.length]}"
+												style="width: {Math.min(bucket.percent, 100)}%; background: {chartPalette[
+													i % chartPalette.length
+												]}"
 											></div>
 										</div>
 										<span class="w-12 text-right tabular-nums">{bucket.percent.toFixed(1)}%</span>

--- a/src/routes/investments/bonds/+page.svelte
+++ b/src/routes/investments/bonds/+page.svelte
@@ -5,7 +5,7 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import BondsMaturityLadder from '$lib/components/BondsMaturityLadder.svelte';
 	import { formatPLN } from '$lib/utils/format';
-	import { chartAccent, chartAccentGradient } from '$lib/utils/theme';
+	import { chartValue, chartValueGradient } from '$lib/utils/theme';
 	import { createChart } from '$lib/utils/charts/lifecycle';
 	import { Banknote, Pencil, Plus, Trash2, TrendingUp } from 'lucide-svelte';
 	import { resolveApiUrl } from '$lib/api';
@@ -259,11 +259,11 @@
 				type: 'line',
 				smooth: true,
 				symbol: 'circle',
-				lineStyle: { color: chartAccent, width: 2 },
+				lineStyle: { color: chartValue, width: 2 },
 				areaStyle: {
 					color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-						{ offset: 0, color: chartAccentGradient[0] },
-						{ offset: 1, color: chartAccentGradient[1] }
+						{ offset: 0, color: chartValueGradient[0] },
+						{ offset: 1, color: chartValueGradient[1] }
 					])
 				}
 			}


### PR DESCRIPTION
## Motivation

Chart series colors were overridden by the theme while legend swatches were not, causing mismatches: legends showed \"Wpłaty\" in blue and \"Wartość portfela\" in yellow while the actual lines rendered red/pink. There was also no unified palette — Dashboard used pink, Ekspozycja used blue, ROI used red/green — and the Dashboard net-worth area was painted red for a growing positive value.

Closes https://github.com/Automaat/finance-buddy/issues/806

> Changelog: skip

## Implementation information

- Introduced a single token-based chart palette shared across all ECharts instances (Dashboard, Metryki Wzrost charts, Ekspozycja, ROI)
- Legend colors now match rendered line/area colors by deriving from the same palette tokens
- Replaced the all-rose single-hue palette with a multi-hue categorical palette so series are visually distinct
- Reserved red exclusively for negative/loss series (liabilities, drawdowns) — positive values use the new categorical colors