### PR TITLE
refactor(ui): unify date formatting via single formatDate util

### DIFF
--- a/src/lib/components/BondsMaturityLadder.svelte
+++ b/src/lib/components/BondsMaturityLadder.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { formatPLN } from '$lib/utils/format';
+	import { formatPLN, formatDate } from '$lib/utils/format';
 	import { daysLabel } from '$lib/utils/yearEnd';
 	import { CalendarClock, Coins, ArrowDownToLine } from 'lucide-svelte';
 	import type {
@@ -83,7 +83,7 @@
 				<span>
 					Najbliższy wykup: <strong>{nextMaturity.type}</strong> · {nextMaturity.count}
 					{nextMaturity.count === 1 ? 'obligacja' : 'obligacji'}
-					· {nextMaturity.date} ({nextMaturity.days_until}
+					· {formatDate(nextMaturity.date)} ({nextMaturity.days_until}
 					{daysLabel(nextMaturity.days_until)})
 				</span>
 			</div>

--- a/src/lib/components/DashboardCharts.svelte
+++ b/src/lib/components/DashboardCharts.svelte
@@ -3,7 +3,7 @@
 	import { goto } from '$app/navigation';
 	import * as echarts from 'echarts';
 	import type { ECElementEvent, EChartsOption } from 'echarts';
-	import { formatPLN, formatNumber } from '$lib/utils/format';
+	import { formatPLN, formatNumber, formatDate } from '$lib/utils/format';
 	import { isMobile, isTablet } from '$lib/utils/viewport';
 	import { chartPalette, chartValue, chartValueGradient } from '$lib/utils/theme';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
@@ -71,7 +71,7 @@
 		tooltip: {
 			trigger: 'axis',
 			formatter: (params: any) => {
-				const date = new Date(params[0].value[0]).toLocaleDateString('pl-PL');
+				const date = formatDate(params[0].value[0]);
 				const value = formatPLN(params[0].value[1]);
 				return `${date}<br/>Wartość: ${value}`;
 			}

--- a/src/lib/components/PIT38Report.svelte
+++ b/src/lib/components/PIT38Report.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { resolveApiUrl } from '$lib/api';
-	import { formatPLN } from '$lib/utils/format';
+	import { formatPLN, formatDate } from '$lib/utils/format';
 	import { FileSpreadsheet, Download } from 'lucide-svelte';
 
 	interface SaleRow {
@@ -129,7 +129,7 @@
 				<tbody>
 					{#each report.rows as row (`${row.date}-${row.symbol}`)}
 						<tr>
-							<td>{row.date}</td>
+							<td>{formatDate(row.date)}</td>
 							<td>{row.symbol}</td>
 							<td>{row.currency}</td>
 							<td class="text-right">{row.quantity}</td>

--- a/src/lib/components/SnapshotForm.svelte
+++ b/src/lib/components/SnapshotForm.svelte
@@ -7,6 +7,7 @@
 	import type { OwnerOption } from '$lib/types/owners';
 	import { categoryLabel } from '$lib/utils/categories';
 	import { round2, staleQuotes, type HoldingQuote } from '$lib/utils/quoteFreshness';
+	import { formatDate } from '$lib/utils/format';
 	import NewAccountModal from './snapshot/NewAccountModal.svelte';
 	import NewAssetModal from './snapshot/NewAssetModal.svelte';
 	import ValueRow from './snapshot/ValueRow.svelte';
@@ -453,7 +454,7 @@
 					<li>
 						{q.name}:
 						{#if q.date}
-							{q.date} ({q.daysOld} dni temu)
+							{formatDate(q.date)} ({q.daysOld} dni temu)
 						{:else}
 							brak notowania
 						{/if}

--- a/src/lib/utils/charts/waterfall.test.ts
+++ b/src/lib/utils/charts/waterfall.test.ts
@@ -123,7 +123,7 @@ describe('buildWaterfallOption', () => {
 		expect(tooltip.formatter({ dataIndex: 0 })).toContain('Saldo początkowe');
 	});
 
-	it('xAxis falls back to the raw date when it is not parsable', () => {
+	it('xAxis renders the shared empty marker when a date is not parsable', () => {
 		const opt = buildWaterfallOption([
 			{
 				date: 'not-a-date',
@@ -143,7 +143,9 @@ describe('buildWaterfallOption', () => {
 			}
 		]);
 		const xAxis = opt.xAxis as { data: string[] };
-		expect(xAxis.data).toEqual(['not-a-date', 'still-not-a-date']);
+		// Dates now route through the shared formatDate util, which renders an
+		// unparsable value as the em-dash placeholder rather than echoing it.
+		expect(xAxis.data).toEqual(['—', '—']);
 	});
 
 	it('both yAxis formatters render k-shorthand', () => {

--- a/src/lib/utils/charts/waterfall.ts
+++ b/src/lib/utils/charts/waterfall.ts
@@ -1,6 +1,7 @@
 import type { BarSeriesOption, EChartsOption, LineSeriesOption } from 'echarts';
 import type { TopLevelFormatterParams } from 'echarts/types/dist/shared';
 import { chartPositive, chartNegative, chartValue } from '$lib/utils/theme';
+import { formatDate } from '../format';
 
 export interface NetWorthPoint {
 	date: string;
@@ -55,12 +56,6 @@ function fmtPLN(value: number): string {
 	return `${sign}${abs} PLN`;
 }
 
-function formatMonth(dateISO: string): string {
-	const d = new Date(dateISO);
-	if (Number.isNaN(d.getTime())) return dateISO;
-	return d.toLocaleDateString('pl-PL', { year: '2-digit', month: 'short' });
-}
-
 export interface WaterfallChartOptions {
 	maxMonths?: number; // crop to the most recent N steps (mobile = 6)
 	isMobile?: boolean; // shrink the in-canvas title so it doesn't clip on phones
@@ -75,7 +70,7 @@ export function buildWaterfallOption(
 ): EChartsOption {
 	const sliced = options.maxMonths ? steps.slice(-options.maxMonths) : steps;
 
-	const months = sliced.map((s) => formatMonth(s.date));
+	const months = sliced.map((s) => formatDate(s.date));
 	const assetSeries: BarSeriesOption = {
 		name: 'Δ Aktywa',
 		type: 'bar',
@@ -117,7 +112,7 @@ export function buildWaterfallOption(
 				const idx = items[0].dataIndex as number;
 				const step = sliced[idx];
 				if (!step) return '';
-				const month = escapeHtml(formatMonth(step.date));
+				const month = escapeHtml(formatDate(step.date));
 				const netDelta = step.endingNetWorth - step.startingNetWorth;
 				return (
 					`<strong>${month}</strong><br/>` +

--- a/src/lib/utils/format.test.ts
+++ b/src/lib/utils/format.test.ts
@@ -116,6 +116,11 @@ describe('formatDate', () => {
 		expect(formatDate('2024-03-15')).toMatch(/2024/);
 	});
 
+	it('preserves the calendar day for date-only strings regardless of timezone', () => {
+		expect(formatDate('2026-01-31')).toContain('31');
+		expect(formatDate('2025-12-05')).toContain('05');
+	});
+
 	it('formats a Date instance', () => {
 		expect(formatDate(new Date('2024-03-15'))).toMatch(/2024/);
 	});

--- a/src/lib/utils/format.test.ts
+++ b/src/lib/utils/format.test.ts
@@ -131,6 +131,12 @@ describe('formatDate', () => {
 		expect(formatDate('')).toBe('—');
 		expect(formatDate('not-a-date')).toBe('—');
 	});
+
+	it('returns — for date-only strings with out-of-range components', () => {
+		expect(formatDate('2026-02-31')).toBe('—');
+		expect(formatDate('2026-13-01')).toBe('—');
+		expect(formatDate('2026-00-15')).toBe('—');
+	});
 });
 
 describe('formatNumber', () => {

--- a/src/lib/utils/format.test.ts
+++ b/src/lib/utils/format.test.ts
@@ -125,6 +125,10 @@ describe('formatDate', () => {
 		expect(formatDate(new Date('2024-03-15'))).toMatch(/2024/);
 	});
 
+	it('can format timestamps against the UTC calendar day', () => {
+		expect(formatDate('2026-01-31T23:30:00Z', { timeZone: 'UTC' })).toMatch(/31.*01.*2026/);
+	});
+
 	it('returns — for empty and invalid input', () => {
 		expect(formatDate(null)).toBe('—');
 		expect(formatDate(undefined)).toBe('—');

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -6,10 +6,16 @@ const percentFormatter = new Intl.NumberFormat('pl-PL', {
 
 const numberFormatterCache = new Map<number, Intl.NumberFormat>();
 
-const dateFormatter = new Intl.DateTimeFormat('pl-PL', {
+const dateFormatterOptions: Intl.DateTimeFormatOptions = {
 	year: 'numeric',
 	month: '2-digit',
 	day: '2-digit'
+};
+
+const dateFormatter = new Intl.DateTimeFormat('pl-PL', dateFormatterOptions);
+const utcDateFormatter = new Intl.DateTimeFormat('pl-PL', {
+	...dateFormatterOptions,
+	timeZone: 'UTC'
 });
 
 export interface Change {
@@ -51,23 +57,35 @@ export function formatPercent(value: number | null | undefined): string {
 
 const dateOnlyRe = /^\d{4}-\d{2}-\d{2}$/;
 
-export function formatDate(value: string | Date | null | undefined): string {
+export function formatDate(
+	value: string | Date | null | undefined,
+	options?: { timeZone?: 'UTC' }
+): string {
 	if (!value) return '—';
 	let date: Date;
 	if (typeof value === 'string' && dateOnlyRe.test(value)) {
 		// Parse YYYY-MM-DD as local date — new Date(string) treats it as UTC
 		// which shifts the displayed day backward in negative-UTC-offset zones.
 		const [year, month, day] = value.split('-').map(Number);
-		date = new Date(year, month - 1, day);
+		date =
+			options?.timeZone === 'UTC'
+				? new Date(Date.UTC(year, month - 1, day))
+				: new Date(year, month - 1, day);
 		// Reject overflow (e.g. Feb 31 rolls into March in JS)
-		if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+		if (
+			options?.timeZone === 'UTC'
+				? date.getUTCFullYear() !== year ||
+					date.getUTCMonth() !== month - 1 ||
+					date.getUTCDate() !== day
+				: date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day
+		) {
 			return '—';
 		}
 	} else {
 		date = value instanceof Date ? value : new Date(value as string);
 	}
 	if (Number.isNaN(date.getTime())) return '—';
-	return dateFormatter.format(date);
+	return (options?.timeZone === 'UTC' ? utcDateFormatter : dateFormatter).format(date);
 }
 
 export function formatSignedPLN(value: number | null | undefined): string {

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -49,9 +49,19 @@ export function formatPercent(value: number | null | undefined): string {
 	return percentFormatter.format(value / 100);
 }
 
+const dateOnlyRe = /^\d{4}-\d{2}-\d{2}$/;
+
 export function formatDate(value: string | Date | null | undefined): string {
 	if (!value) return '—';
-	const date = value instanceof Date ? value : new Date(value);
+	let date: Date;
+	if (typeof value === 'string' && dateOnlyRe.test(value)) {
+		// Parse YYYY-MM-DD as local date — new Date(string) treats it as UTC
+		// which shifts the displayed day backward in negative-UTC-offset zones.
+		const [year, month, day] = value.split('-').map(Number);
+		date = new Date(year, month - 1, day);
+	} else {
+		date = value instanceof Date ? value : new Date(value as string);
+	}
 	if (Number.isNaN(date.getTime())) return '—';
 	return dateFormatter.format(date);
 }

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -59,6 +59,10 @@ export function formatDate(value: string | Date | null | undefined): string {
 		// which shifts the displayed day backward in negative-UTC-offset zones.
 		const [year, month, day] = value.split('-').map(Number);
 		date = new Date(year, month - 1, day);
+		// Reject overflow (e.g. Feb 31 rolls into March in JS)
+		if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+			return '—';
+		}
 	} else {
 		date = value instanceof Date ? value : new Date(value as string);
 	}

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -2,7 +2,7 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import Skeleton from '$lib/components/Skeleton.svelte';
 	import SortableTable, { type SortableColumn } from '$lib/components/SortableTable.svelte';
-	import { formatPLN, formatNumber } from '$lib/utils/format';
+	import { formatPLN, formatNumber, formatDate } from '$lib/utils/format';
 	import { Wallet, TrendingDown, Pencil, Trash2, Plus, BarChart3 } from 'lucide-svelte';
 	import { resolveApiUrl } from '$lib/api';
 	import { invalidateAll } from '$app/navigation';
@@ -854,7 +854,7 @@
 						<tbody>
 							{#each transactionsData.transactions as transaction}
 								<tr>
-									<td>{new Date(transaction.date).toLocaleDateString('pl-PL')}</td>
+									<td>{formatDate(transaction.date)}</td>
 									<td class="font-semibold text-primary-600-400">{formatPLN(transaction.amount)}</td
 									>
 									<td>{ownerName(owners, transaction.owner_user_id)}</td>

--- a/src/routes/ekspozycja/+page.svelte
+++ b/src/routes/ekspozycja/+page.svelte
@@ -3,7 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { Globe } from 'lucide-svelte';
-	import { formatPLN } from '$lib/utils/format';
+	import { formatPLN, formatDate } from '$lib/utils/format';
 	import { chartPalette } from '$lib/utils/theme';
 	import { createChart, type ChartHandle } from '$lib/utils/charts/lifecycle';
 	import type { PageData } from './$types';
@@ -151,7 +151,7 @@
 			</div>
 			<div class="card preset-tonal-surface p-4">
 				<div class="text-xs text-surface-600-400">Snapshot</div>
-				<div class="text-2xl font-bold">{report.snapshot_date}</div>
+				<div class="text-2xl font-bold">{formatDate(report.snapshot_date)}</div>
 			</div>
 		</div>
 

--- a/src/routes/investments/bonds/+page.svelte
+++ b/src/routes/investments/bonds/+page.svelte
@@ -4,7 +4,7 @@
 	import type { EChartsOption } from 'echarts';
 	import Modal from '$lib/components/Modal.svelte';
 	import BondsMaturityLadder from '$lib/components/BondsMaturityLadder.svelte';
-	import { formatPLN } from '$lib/utils/format';
+	import { formatPLN, formatDate } from '$lib/utils/format';
 	import { chartValue, chartValueGradient } from '$lib/utils/theme';
 	import { createChart } from '$lib/utils/charts/lifecycle';
 	import { Banknote, Pencil, Plus, Trash2, TrendingUp } from 'lucide-svelte';
@@ -242,7 +242,7 @@
 			formatter: (params: unknown) => {
 				const arr = params as Array<{ value: [string, number]; data: YTMPoint }>;
 				const p = arr[0];
-				const date = new Date(p.value[0]).toLocaleDateString('pl-PL');
+				const date = formatDate(p.value[0]);
 				const value = formatPLN(p.value[1]);
 				const rate = (p.data.year_rate ?? 0).toFixed(2);
 				return `${date}<br/>Wartość: ${value}<br/>Stopa roku: ${rate}%`;

--- a/src/routes/investments/bonds/+page.svelte
+++ b/src/routes/investments/bonds/+page.svelte
@@ -504,8 +504,8 @@
 								<td>{formatPLN(bond.face_value)}</td>
 								<td class="font-semibold text-primary-600-400">{formatPLN(bond.current_value)}</td>
 								<td>{bond.current_yield.toFixed(2)}%</td>
-								<td>{bond.purchase_date}</td>
-								<td>{bond.maturity_date}</td>
+								<td>{formatDate(bond.purchase_date)}</td>
+								<td>{formatDate(bond.maturity_date)}</td>
 								<td class="text-right whitespace-nowrap">
 									<button
 										type="button"

--- a/src/routes/investments/holdings/+page.svelte
+++ b/src/routes/investments/holdings/+page.svelte
@@ -8,6 +8,7 @@
 	import PIT38Report from '$lib/components/PIT38Report.svelte';
 	import { Plus, Trash2, BarChart, RefreshCw, Coins } from 'lucide-svelte';
 	import { CrudForm } from '$lib/stores/crudForm.svelte';
+	import { formatDate } from '$lib/utils/format';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
@@ -469,7 +470,9 @@
 									{fmt(h.latest_quote)}
 									{h.security.currency}
 									<div class="text-xs font-normal text-surface-600-400">
-										{h.latest_quote_date}{#if h.latest_quote_rate_pln && h.security.currency !== 'PLN'}
+										{formatDate(
+											h.latest_quote_date
+										)}{#if h.latest_quote_rate_pln && h.security.currency !== 'PLN'}
 											· {fmt(h.latest_quote_rate_pln)} PLN/{h.security.currency}{/if}
 									</div>
 								{:else}
@@ -634,7 +637,7 @@
 					<tbody>
 						{#each data.dividends as d (d.id)}
 							<tr>
-								<td>{d.pay_date}</td>
+								<td>{formatDate(d.pay_date)}</td>
 								<td class="font-semibold">{securityLabel(d.security_id)}</td>
 								<td class="text-surface-700-300">{accountLabel(d.account_id)}</td>
 								<td class="text-right">{fmt(d.gross_amount)} {d.currency}</td>

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -15,6 +15,7 @@
 	import { applyMobileChartTweaks } from '$lib/utils/charts/responsive';
 	import { isMobile } from '$lib/utils/viewport';
 	import { ownerName, type OwnerOption } from '$lib/types/owners';
+	import { formatDate } from '$lib/utils/format';
 	import ContributionAdjustedReturns from '$lib/components/ContributionAdjustedReturns.svelte';
 	import CurrencyExposureWidget from '$lib/components/CurrencyExposureWidget.svelte';
 	import RealYieldsTable from '$lib/components/RealYieldsTable.svelte';
@@ -218,7 +219,7 @@
 		<div class="flex flex-wrap items-baseline justify-between gap-2">
 			<h2 class="h2">Przegląd finansowy</h2>
 			{#if snapshotDate}
-				<span class="text-sm text-surface-600-400">stan na {snapshotDate}</span>
+				<span class="text-sm text-surface-600-400">stan na {formatDate(snapshotDate)}</span>
 			{/if}
 		</div>
 

--- a/src/routes/metryki/page.test.ts
+++ b/src/routes/metryki/page.test.ts
@@ -287,7 +287,7 @@ describe('Metryki Page with populated data', () => {
 
 	it('shows the snapshot date and one consolidated mortgage card', () => {
 		render(Page, { props: { data: populatedData } });
-		expect(screen.getByText('stan na 2026-05-24')).toBeTruthy();
+		expect(screen.getByText('stan na 24.05.2026')).toBeTruthy();
 		// the three legacy mortgage cards collapse into one with a payoff line
 		expect(screen.getByText('Hipoteka do spłaty')).toBeTruthy();
 		expect(screen.queryByText('Ile miesięcy do spłaty hipoteki')).toBeNull();

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -7,7 +7,7 @@
 	import EquityFormModal from '$lib/components/salaries/EquityFormModal.svelte';
 	import SalaryFormModal from '$lib/components/salaries/SalaryFormModal.svelte';
 	import ValuationFormModal from '$lib/components/salaries/ValuationFormModal.svelte';
-	import { formatPLN } from '$lib/utils/format';
+	import { formatPLN, formatDate } from '$lib/utils/format';
 	import {
 		formatPctSigned,
 		formatPlnSigned,
@@ -1189,7 +1189,7 @@
 				formatter: (params: unknown) => {
 					if (!params || !Array.isArray(params) || params.length === 0) return '';
 					const rows = params as Array<{ value: [string, number]; seriesName: string }>;
-					let result = `${new Date(rows[0].value[0]).toLocaleDateString('pl-PL')}<br/>`;
+					let result = `${formatDate(rows[0].value[0])}<br/>`;
 					rows.forEach((p) => {
 						result += `${p.seriesName}: ${formatPLN(p.value[1])}<br/>`;
 					});
@@ -1452,7 +1452,7 @@
 					<tbody>
 						{#each visibleSalaryRecords as record}
 							<tr>
-								<td>{new Date(record.date).toLocaleDateString('pl-PL')}</td>
+								<td>{formatDate(record.date)}</td>
 								<td>{ownerName(owners, record.owner_user_id)}</td>
 								<td>{record.company}</td>
 								<td class="font-semibold text-primary-600-400">{formatPLN(record.gross_amount)}</td>
@@ -1527,7 +1527,7 @@
 								<tbody>
 									{#each bonuses as bonus (bonus.id)}
 										<tr>
-											<td>{new Date(bonus.date).toLocaleDateString('pl-PL')}</td>
+											<td>{formatDate(bonus.date)}</td>
 											<td>{bonusTypeLabels[bonus.type]}</td>
 											<td>{ownerName(owners, bonus.owner_user_id)}</td>
 											<td class="font-semibold text-primary-600-400">
@@ -1628,7 +1628,7 @@
 								<tbody>
 									{#each group.grants as grant (grant.id)}
 										<tr>
-											<td>{new Date(grant.grant_date).toLocaleDateString('pl-PL')}</td>
+											<td>{formatDate(grant.grant_date)}</td>
 											<td>{equityTypeLabels[grant.type]}</td>
 											<td>{ownerName(owners, grant.owner_user_id)}</td>
 											<td class="font-semibold">
@@ -1656,7 +1656,7 @@
 													{/if}
 													{#if grant.valuation_date}
 														<br /><span class="text-surface-700-300"
-															>wg {new Date(grant.valuation_date).toLocaleDateString('pl-PL')}</span
+															>wg {formatDate(grant.valuation_date)}</span
 														>
 													{/if}
 												{:else if grant.valuation_date}
@@ -1753,7 +1753,7 @@
 						{#each valuations as valuation (valuation.id)}
 							<tr>
 								<td class="font-semibold">{valuation.company}</td>
-								<td>{new Date(valuation.date).toLocaleDateString('pl-PL')}</td>
+								<td>{formatDate(valuation.date)}</td>
 								<td>{formatCurrency(valuation.fmv_per_share, valuation.currency)}</td>
 								<td class="text-xs">
 									{#if valuation.fmv_low !== null || valuation.fmv_high !== null}
@@ -1824,7 +1824,7 @@
 						<div class="flex items-baseline justify-between flex-wrap gap-2">
 							<strong class="text-lg">{ownerName(owners, ctx.owner_user_id)}</strong>
 							<span class="text-xs text-surface-700-300">
-								od {new Date(ctx.last_change_date).toLocaleDateString('pl-PL')}
+								od {formatDate(ctx.last_change_date)}
 								{#if getPreviousCompany(ctx.owner_user_id, ctx.previous_change_date)}
 									· {getPreviousCompany(ctx.owner_user_id, ctx.previous_change_date)}
 								{/if}

--- a/src/routes/settings/config/+page.svelte
+++ b/src/routes/settings/config/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { formatPLN } from '$lib/utils/format';
+	import { formatPLN, formatDate } from '$lib/utils/format';
 	import {
 		Settings,
 		Umbrella,
@@ -621,8 +621,8 @@
 									{r.value}
 									<span class="text-xs text-surface-700-300">{r.unit}</span>
 								</td>
-								<td class="whitespace-nowrap">{r.effective_date}</td>
-								<td class="whitespace-nowrap">{r.last_checked_date}</td>
+								<td class="whitespace-nowrap">{formatDate(r.effective_date)}</td>
+								<td class="whitespace-nowrap">{formatDate(r.last_checked_date)}</td>
 								<td>
 									<a
 										href={r.source_url}

--- a/src/routes/simulations/compare/+page.svelte
+++ b/src/routes/simulations/compare/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { resolveApiUrl } from '$lib/api';
+	import { formatDate } from '$lib/utils/format';
 	import { GitCompareArrows, ArrowLeft } from 'lucide-svelte';
 
 	interface RetirementScenarioInputs {
@@ -200,7 +201,7 @@
 	// strings doesn't double-up.
 	function fmtUpdatedAt(s: string): string {
 		const utc = s.endsWith('Z') ? s : s + 'Z';
-		return new Date(utc).toLocaleDateString('pl-PL');
+		return formatDate(utc);
 	}
 
 	// Per-row min/max for color-coding so differences are easy to scan.

--- a/src/routes/simulations/compare/+page.svelte
+++ b/src/routes/simulations/compare/+page.svelte
@@ -187,10 +187,6 @@
 		return v.toLocaleString('pl-PL', { maximumFractionDigits: 0 }) + ' PLN';
 	}
 
-	function fmtDate(d: Date): string {
-		return d.toLocaleDateString('pl-PL', { year: 'numeric', month: 'long' });
-	}
-
 	function fmtPct(v: number): string {
 		return (v * 100).toFixed(1) + '%';
 	}
@@ -404,9 +400,9 @@
 						{/each}
 					</tr>
 					<tr>
-						<td>Data FI (m-c/rok)</td>
+						<td>Data FI</td>
 						{#each results as r (r.scenario.id)}
-							<td class="text-right">{fmtDate(r.fiDate)}</td>
+							<td class="text-right">{formatDate(r.fiDate)}</td>
 						{/each}
 					</tr>
 					{#if requiredCapital > 0}

--- a/src/routes/simulations/compare/+page.svelte
+++ b/src/routes/simulations/compare/+page.svelte
@@ -197,7 +197,7 @@
 	// strings doesn't double-up.
 	function fmtUpdatedAt(s: string): string {
 		const utc = s.endsWith('Z') ? s : s + 'Z';
-		return formatDate(utc);
+		return formatDate(utc, { timeZone: 'UTC' });
 	}
 
 	// Per-row min/max for color-coding so differences are easy to scan.

--- a/src/routes/snapshots/+page.svelte
+++ b/src/routes/snapshots/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import Skeleton from '$lib/components/Skeleton.svelte';
-	import { formatPLN } from '$lib/utils/format';
+	import { formatPLN, formatDate } from '$lib/utils/format';
 	import { Plus, Camera, Pencil } from 'lucide-svelte';
 	import type { PageData } from './$types';
 
@@ -90,11 +90,7 @@
 						{#each snapshots as snapshot}
 							<tr>
 								<td class="font-medium">
-									{new Date(snapshot.date).toLocaleDateString('pl-PL', {
-										year: 'numeric',
-										month: 'long',
-										day: 'numeric'
-									})}
+									{formatDate(snapshot.date)}
 								</td>
 								<td class="font-semibold text-primary-600-400"
 									>{formatPLN(snapshot.total_net_worth)}</td

--- a/src/routes/snapshots/[id]/edit/+page.svelte
+++ b/src/routes/snapshots/[id]/edit/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SnapshotForm from '$lib/components/SnapshotForm.svelte';
+	import { formatDate } from '$lib/utils/format';
 	import type { PageData } from './$types';
 
 	interface Props {
@@ -15,7 +16,9 @@
 
 <div class="mb-6 space-y-1">
 	<h1 class="h2">Edytuj migawkę</h1>
-	<p class="text-surface-700-300 text-sm">Zaktualizuj wartości z dnia {data.snapshot.date}</p>
+	<p class="text-surface-700-300 text-sm">
+		Zaktualizuj wartości z dnia {formatDate(data.snapshot.date)}
+	</p>
 </div>
 
 <SnapshotForm

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Modal from '$lib/components/Modal.svelte';
 	import SortableTable, { type SortableColumn } from '$lib/components/SortableTable.svelte';
-	import { formatPLN } from '$lib/utils/format';
+	import { formatPLN, formatDate } from '$lib/utils/format';
 	import { Plus, Landmark, Search, BarChart3, Trash2 } from 'lucide-svelte';
 	import { api } from '$lib/apiClient';
 	import { goto, invalidateAll } from '$app/navigation';
@@ -152,12 +152,12 @@
 
 {#snippet transactionRow(transaction: Transaction)}
 	<tr>
-		<td data-label="Data zakupu">{new Date(transaction.date).toLocaleDateString('pl-PL')}</td>
+		<td data-label="Data zakupu">{formatDate(transaction.date)}</td>
 		<td class="font-medium" data-label="Konto">{transaction.account_name}</td>
 		<td data-label="Właściciel">{ownerName(owners, transaction.owner_user_id)}</td>
-		<td class="font-semibold text-primary-600-400" data-label="Kwota"
-			>{formatPLN(transaction.amount)}</td
-		>
+		<td class="font-semibold text-primary-600-400" data-label="Kwota">
+			{formatPLN(transaction.amount)}
+		</td>
 		<td class="text-right">
 			<button
 				type="button"

--- a/src/routes/transactions/recurring/+page.svelte
+++ b/src/routes/transactions/recurring/+page.svelte
@@ -3,6 +3,7 @@
 	import { resolveApiUrl } from '$lib/api';
 	import { toast } from '$lib/stores/toast.svelte';
 	import { confirm } from '$lib/stores/confirm.svelte';
+	import { formatDate } from '$lib/utils/format';
 	import Modal from '$lib/components/Modal.svelte';
 	import { Plus, Play, SkipForward, Trash2, Pencil } from 'lucide-svelte';
 	import type { PageData } from './$types';
@@ -282,10 +283,10 @@
 											<button
 												type="button"
 												class="badge preset-tonal-warning cursor-pointer"
-												title="Przywróć {d}"
+												title="Przywróć {formatDate(d)}"
 												onclick={() => unskip(row, d)}
 											>
-												{d} ×
+												{formatDate(d)} ×
 											</button>
 										{/each}
 									</div>


### PR DESCRIPTION
## Motivation

Date rendering was scattered across the frontend — raw `new Date().toLocaleDateString('pl-PL')` calls appeared in 15+ components and chart formatters. This created two problems: inconsistent fallback behaviour (no graceful `—` for null/empty values) and a subtle timezone bug where `new Date('YYYY-MM-DD')` parses date-only strings as UTC midnight, shifting the displayed day backward in any timezone with a negative UTC offset.

Closes https://github.com/Automaat/finance-buddy/issues/804

## Implementation information

- Hardened `formatDate` in `src/lib/utils/format.ts` to detect `YYYY-MM-DD` strings and parse them as local date (avoiding the UTC shift); overflow dates (e.g. Feb 31) are rejected and render as `—`
- Replaced all raw `new Date().toLocaleDateString('pl-PL')` call sites in routes and components with `formatDate` — covers accounts, bonds, ekspozycja, holdings, metryki, PIT38, salaries, settings/config, simulations/compare, snapshots, transactions, recurring transactions, and SnapshotForm
- Removed the now-redundant `formatMonth` helper from `waterfall.ts` and the `fmtDate` helper from `simulations/compare`; both routed through `formatDate`
- Added tests for the timezone-safe parsing and out-of-range date rejection in `format.test.ts`
- Updated `waterfall.test.ts` to reflect that unparsable dates now render as `—` instead of echoing the raw string
- Updated `metryki/page.test.ts` to assert the formatted output (`24.05.2026`) instead of the raw ISO string