### PR TITLE
refactor(ui): enforce neutral value colors

### DIFF
--- a/src/lib/components/BondsMaturityLadder.svelte
+++ b/src/lib/components/BondsMaturityLadder.svelte
@@ -102,9 +102,7 @@
 					<header class="flex items-center justify-between gap-2 flex-wrap">
 						<h4 class="font-semibold capitalize">{group.monthLabel}</h4>
 						<span class="text-sm text-surface-700-300">
-							Łącznie netto: <strong class="text-primary-600-400"
-								>{formatPLN(group.totalNet)}</strong
-							>
+							Łącznie netto: <strong>{formatPLN(group.totalNet)}</strong>
 						</span>
 					</header>
 					<div class="table-wrap">
@@ -142,7 +140,7 @@
 										<td class="text-right text-surface-700-300">
 											{ev.tax > 0 ? formatPLN(ev.tax) : '—'}
 										</td>
-										<td class="text-right font-semibold text-primary-600-400">
+										<td class="text-right font-semibold">
 											{formatPLN(ev.net_cashflow)}
 										</td>
 									</tr>

--- a/src/lib/components/IKZEOptimizer.svelte
+++ b/src/lib/components/IKZEOptimizer.svelte
@@ -161,9 +161,7 @@
 						</div>
 						<div>
 							<dt class="text-xs text-surface-600-400">{refundLabel(row.marginal_tax_rate)}</dt>
-							<dd class="font-bold {refund.hasRate ? 'text-success-600-400' : ''}">
-								{refund.text}
-							</dd>
+							<dd class="font-bold">{refund.text}</dd>
 						</div>
 					</dl>
 

--- a/src/lib/components/IKZEPITTracker.svelte
+++ b/src/lib/components/IKZEPITTracker.svelte
@@ -122,7 +122,7 @@
 						</div>
 						<div>
 							<div class="text-xs text-surface-600-400">Szac. oszczędność PIT</div>
-							<div class="font-bold text-success-600-400">{formatPLN(row.pit_savings)}</div>
+							<div class="font-bold">{formatPLN(row.pit_savings)}</div>
 						</div>
 					</div>
 				</article>

--- a/src/lib/components/MetricCard.svelte
+++ b/src/lib/components/MetricCard.svelte
@@ -4,7 +4,7 @@
 		value: number | null | undefined;
 		decimals?: number;
 		suffix?: string;
-		color?: 'green' | 'blue' | 'red' | 'yellow' | 'neutral';
+		signed?: boolean;
 		// Optional explanation shown as a native tooltip on the label (and a
 		// subtle dotted underline as the affordance), for cryptic metrics.
 		tooltip?: string;
@@ -21,7 +21,7 @@
 		value,
 		decimals = 0,
 		suffix = '',
-		color = 'neutral',
+		signed = false,
 		tooltip,
 		secondary,
 		emptyHint,
@@ -36,17 +36,20 @@
 	);
 
 	const isEmpty = $derived(value == null || Number.isNaN(value));
-	const displayValue = $derived(isEmpty ? '—' : formatter.format(value as number) + suffix);
+	const displayValue = $derived.by(() => {
+		if (isEmpty) return '—';
+		if (!signed || value === 0) return formatter.format(value as number) + suffix;
+		const sign = (value as number) > 0 ? '+' : '−';
+		return sign + formatter.format(Math.abs(value as number)) + suffix;
+	});
 	const showHint = $derived(isEmpty && emptyHint != null);
 
 	const valueClass = $derived(
-		{
-			green: 'text-success-600-400',
-			red: 'text-error-600-400',
-			blue: 'text-primary-600-400',
-			yellow: 'text-warning-600-400',
-			neutral: 'text-surface-950-50'
-		}[color]
+		signed && !isEmpty && value !== 0
+			? (value as number) > 0
+				? 'text-success-600-400'
+				: 'text-error-600-400'
+			: 'text-surface-950-50'
 	);
 </script>
 

--- a/src/lib/components/MetricCard.svelte
+++ b/src/lib/components/MetricCard.svelte
@@ -36,16 +36,22 @@
 	);
 
 	const isEmpty = $derived(value == null || Number.isNaN(value));
+	// True when a non-zero value rounds to zero at the current decimal
+	// precision, preventing misleading "−0,00" display and error coloring.
+	const roundsToZero = $derived(
+		!isEmpty && value !== 0 && Math.round(Math.abs(value as number) * 10 ** decimals) === 0
+	);
 	const displayValue = $derived.by(() => {
 		if (isEmpty) return '—';
-		if (!signed || value === 0) return formatter.format(value as number) + suffix;
+		if (!signed) return formatter.format(value as number) + suffix;
+		if (value === 0 || roundsToZero) return formatter.format(0) + suffix;
 		const sign = (value as number) > 0 ? '+' : '−';
 		return sign + formatter.format(Math.abs(value as number)) + suffix;
 	});
 	const showHint = $derived(isEmpty && emptyHint != null);
 
 	const valueClass = $derived(
-		signed && !isEmpty && value !== 0
+		signed && !isEmpty && value !== 0 && !roundsToZero
 			? (value as number) > 0
 				? 'text-success-600-400'
 				: 'text-error-600-400'

--- a/src/lib/components/MetricCard.test.ts
+++ b/src/lib/components/MetricCard.test.ts
@@ -16,9 +16,15 @@ describe('MetricCard', () => {
 		expect(screen.getByText('—')).toBeTruthy();
 	});
 
-	it('applies the colour class for the chosen colour', () => {
-		render(MetricCard, { props: { label: 'Zysk', value: 10, color: 'green' } });
+	it('uses neutral ink for ordinary values', () => {
+		render(MetricCard, { props: { label: 'Wartość', value: 10 } });
 		const valueEl = screen.getByText('10');
+		expect(valueEl.className).toContain('text-surface-950-50');
+	});
+
+	it('colors only explicitly signed values', () => {
+		render(MetricCard, { props: { label: 'Zysk', value: 10, signed: true } });
+		const valueEl = screen.getByText('+10');
 		expect(valueEl.className).toContain('text-success-600-400');
 	});
 

--- a/src/lib/components/MetricCard.test.ts
+++ b/src/lib/components/MetricCard.test.ts
@@ -28,6 +28,18 @@ describe('MetricCard', () => {
 		expect(valueEl.className).toContain('text-success-600-400');
 	});
 
+	it('treats near-zero signed values that round to zero as neutral', () => {
+		render(MetricCard, {
+			props: { label: 'Zmiana', value: -0.004, decimals: 2, suffix: '%', signed: true }
+		});
+		const valueEl = screen.getByText((text) => text.includes('0,00') && text.includes('%'));
+		// Must NOT show a sign prefix or error/success color
+		expect(valueEl.textContent).not.toMatch(/[+−]/);
+		expect(valueEl.className).toContain('text-surface-950-50');
+		expect(valueEl.className).not.toContain('text-error');
+		expect(valueEl.className).not.toContain('text-success');
+	});
+
 	it('exposes the tooltip as a title on the label', () => {
 		render(MetricCard, { props: { label: 'Koszt', value: 5, tooltip: 'Wyjaśnienie' } });
 		expect(screen.getByText('Koszt').getAttribute('title')).toBe('Wyjaśnienie');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -214,7 +214,7 @@
 				<header>
 					<h3 class="h4 flex items-center gap-2"><TrendingUp size={18} /> Aktywa</h3>
 				</header>
-				<div class="text-3xl font-bold text-success-600-400">
+				<div class="text-3xl font-bold">
 					{formatPLN(dashboard.total_assets)}
 				</div>
 				<div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1">
@@ -237,7 +237,7 @@
 				<header>
 					<h3 class="h4 flex items-center gap-2"><TrendingDown size={18} /> Zobowiązania</h3>
 				</header>
-				<div class="text-3xl font-bold text-error-600-400">
+				<div class="text-3xl font-bold">
 					{formatPLN(dashboard.total_liabilities)}
 				</div>
 				<div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1">
@@ -349,11 +349,7 @@
 							<div class="text-xs text-surface-700-300">
 								{surplus ? 'Nadwyżka' : 'Brakuje'}
 							</div>
-							<div
-								class="text-2xl font-bold {surplus
-									? 'text-success-600-400'
-									: 'text-warning-600-400'}"
-							>
+							<div class="text-2xl font-bold">
 								{formatPLN(Math.abs(coastGap))}
 							</div>
 							<div class="text-xs text-surface-700-300">
@@ -495,11 +491,7 @@
 								<div class="text-xs text-surface-700-300">
 									{#if bridgeSurplus}Nadwyżka{:else if bridgeExact}Pokryty{:else}Brakuje{/if}
 								</div>
-								<div
-									class="text-xl font-bold {bridgeOK
-										? 'text-success-600-400'
-										: 'text-warning-600-400'}"
-								>
+								<div class="text-xl font-bold">
 									{formatPLN(Math.abs(bridgeGap))}
 								</div>
 								<div class="text-xs text-surface-700-300">
@@ -520,7 +512,7 @@
 				<header>
 					<h3 class="h4 flex items-center gap-2"><Coins size={18} /> Obligacje skarbowe</h3>
 				</header>
-				<div class="text-3xl font-bold text-primary-600-400">
+				<div class="text-3xl font-bold">
 					{formatPLN(dashboard.treasuryBondsValue)}
 				</div>
 				<p class="text-xs text-surface-700-300">

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -452,7 +452,7 @@
 		</td>
 		<td data-label="Kategoria">{categoryLabels[account.category] || account.category}</td>
 		<td data-label="Właściciel">{ownerName(owners, account.owner_user_id)}</td>
-		<td class="font-semibold text-primary-600-400" data-label="Wartość">
+		<td class="font-semibold" data-label="Wartość">
 			{formatPLN(account.current_value)}
 		</td>
 		<td class="whitespace-nowrap" data-label="Realne %">
@@ -511,7 +511,7 @@
 		<td class="font-medium" data-label="Nazwa">{account.name}</td>
 		<td data-label="Kategoria">{categoryLabels[account.category] || account.category}</td>
 		<td data-label="Właściciel">{ownerName(owners, account.owner_user_id)}</td>
-		<td class="font-semibold text-error-600-400" data-label="Wartość">
+		<td class="font-semibold" data-label="Wartość">
 			{formatPLN(account.current_value)}
 		</td>
 		<td class="text-right whitespace-nowrap">
@@ -832,9 +832,7 @@
 			<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
 				<h3 class="h4">Historia transakcji</h3>
 				<p class="text-sm text-surface-700-300">
-					Zainwestowano łącznie: <strong class="text-primary-600-400"
-						>{formatPLN(transactionsData.total_invested)}</strong
-					>
+					Zainwestowano łącznie: <strong>{formatPLN(transactionsData.total_invested)}</strong>
 				</p>
 			</div>
 
@@ -855,8 +853,7 @@
 							{#each transactionsData.transactions as transaction}
 								<tr>
 									<td>{formatDate(transaction.date)}</td>
-									<td class="font-semibold text-primary-600-400">{formatPLN(transaction.amount)}</td
-									>
+									<td class="font-semibold">{formatPLN(transaction.amount)}</td>
 									<td>{ownerName(owners, transaction.owner_user_id)}</td>
 									<td class="text-right">
 										<button

--- a/src/routes/assets/+page.svelte
+++ b/src/routes/assets/+page.svelte
@@ -201,7 +201,7 @@
 						{#each data.assets as asset}
 							<tr>
 								<td class="font-medium">{asset.name}</td>
-								<td class="font-semibold text-primary-600-400">{formatPLN(asset.current_value)}</td>
+								<td class="font-semibold">{formatPLN(asset.current_value)}</td>
 								<td class="text-right whitespace-nowrap">
 									<button
 										type="button"

--- a/src/routes/debts/+page.svelte
+++ b/src/routes/debts/+page.svelte
@@ -333,7 +333,7 @@
 								<td class="font-semibold" data-label="Kwota początkowa"
 									>{formatPLN(debt.initial_amount)}</td
 								>
-								<td class="font-semibold text-error-600-400" data-label="Pozostało">
+								<td class="font-semibold" data-label="Pozostało">
 									{#if debt.latest_balance !== null}
 										<div>{formatPLN(debt.latest_balance)}</div>
 										{#if debt.latest_balance_date}
@@ -346,9 +346,7 @@
 									{/if}
 								</td>
 								<td class="font-semibold" data-label="Wpłacono">{formatPLN(debt.total_paid)}</td>
-								<td class="font-semibold text-error-600-400" data-label="Odsetki"
-									>{formatPLN(debt.interest_paid)}</td
-								>
+								<td class="font-semibold" data-label="Odsetki">{formatPLN(debt.interest_paid)}</td>
 								<td data-label="Oprocentowanie">{debt.interest_rate}%</td>
 								<td data-label="Data">{formatDate(debt.start_date)}</td>
 								<td data-label="Właściciel">{ownerName(owners, debt.account_owner_user_id)}</td>

--- a/src/routes/investments/bonds/+page.svelte
+++ b/src/routes/investments/bonds/+page.svelte
@@ -303,7 +303,7 @@
 	</div>
 	<div class="card preset-filled-surface-100-900 p-4 space-y-1">
 		<header class="text-sm text-surface-700-300">Wartość bieżąca</header>
-		<div class="text-2xl font-bold text-primary-600-400">{formatPLN(data.total_value)}</div>
+		<div class="text-2xl font-bold">{formatPLN(data.total_value)}</div>
 	</div>
 	<div class="card preset-filled-surface-100-900 p-4 space-y-1">
 		<header class="text-sm text-surface-700-300">Zysk</header>
@@ -502,7 +502,7 @@
 									{data.accounts.find((a) => a.id === bond.account_id)?.name ?? '—'}
 								</td>
 								<td>{formatPLN(bond.face_value)}</td>
-								<td class="font-semibold text-primary-600-400">{formatPLN(bond.current_value)}</td>
+								<td class="font-semibold">{formatPLN(bond.current_value)}</td>
 								<td>{bond.current_yield.toFixed(2)}%</td>
 								<td>{formatDate(bond.purchase_date)}</td>
 								<td>{formatDate(bond.maturity_date)}</td>

--- a/src/routes/investments/holdings/+page.svelte
+++ b/src/routes/investments/holdings/+page.svelte
@@ -391,7 +391,7 @@
 			</div>
 			<div class="card preset-filled-surface-100-900 p-4 space-y-1">
 				<header class="text-sm text-surface-700-300">Wartość bieżąca</header>
-				<div class="text-2xl font-bold text-primary-600-400">{fmtPLN(totalValue)}</div>
+				<div class="text-2xl font-bold">{fmtPLN(totalValue)}</div>
 			</div>
 			<div class="card preset-filled-surface-100-900 p-4 space-y-1">
 				<header class="text-sm text-surface-700-300">Zysk</header>
@@ -610,9 +610,7 @@
 			<h2 class="h3 flex items-center gap-2"><Coins size={18} /> Dywidendy</h2>
 			{#if data.dividends.length > 0}
 				<span class="text-sm text-surface-700-300">
-					Netto łącznie: <span class="font-semibold text-success-500"
-						>{fmtPLN(totalDividendsNet)}</span
-					>
+					Netto łącznie: <span class="font-semibold">{fmtPLN(totalDividendsNet)}</span>
 				</span>
 			{/if}
 		</header>
@@ -644,9 +642,7 @@
 								<td class="text-right text-surface-600-400"
 									>{fmt(d.withholding_tax)} {d.currency}</td
 								>
-								<td class="text-right font-semibold text-success-500"
-									>{fmt(d.net_amount)} {d.currency}</td
-								>
+								<td class="text-right font-semibold">{fmt(d.net_amount)} {d.currency}</td>
 								<td class="text-right">
 									<button
 										type="button"

--- a/src/routes/investments/ppk/+page.svelte
+++ b/src/routes/investments/ppk/+page.svelte
@@ -46,7 +46,7 @@
 		</div>
 		<div class="card preset-filled-surface-100-900 p-4 space-y-1">
 			<header class="text-sm text-surface-700-300">Wartość bieżąca</header>
-			<div class="text-2xl font-bold text-primary-600-400">{formatPLN(totalValue)}</div>
+			<div class="text-2xl font-bold">{formatPLN(totalValue)}</div>
 		</div>
 		<div class="card preset-filled-surface-100-900 p-4 space-y-1">
 			<header class="text-sm text-surface-700-300">Zysk</header>
@@ -78,50 +78,39 @@
 						value={stat.total_value}
 						decimals={0}
 						suffix=" PLN"
-						color="green"
 					/>
 					<MetricCard
 						label="Wpłaty pracownika"
 						value={stat.employee_contributed}
 						decimals={0}
 						suffix=" PLN"
-						color="blue"
 					/>
 					<MetricCard
 						label="Wpłaty pracodawcy"
 						value={stat.employer_contributed}
 						decimals={0}
 						suffix=" PLN"
-						color="blue"
 					/>
 					<MetricCard
 						label="Dopłaty państwa"
 						value={stat.government_contributed}
 						decimals={0}
 						suffix=" PLN"
-						color="blue"
 					/>
 					<MetricCard
 						label="Łącznie wpłacone"
 						value={stat.total_contributed}
 						decimals={0}
 						suffix=" PLN"
-						color="blue"
 					/>
 					<MetricCard
 						label="Zyski z inwestycji"
 						value={stat.returns}
 						decimals={0}
 						suffix=" PLN"
-						color={stat.returns >= 0 ? 'green' : 'red'}
+						signed
 					/>
-					<MetricCard
-						label="ROI"
-						value={stat.roi_percentage}
-						decimals={2}
-						suffix="%"
-						color={stat.roi_percentage >= 0 ? 'green' : 'red'}
-					/>
+					<MetricCard label="ROI" value={stat.roi_percentage} decimals={2} suffix="%" signed />
 				</div>
 			</div>
 		{/each}
@@ -154,7 +143,7 @@
 									<td class="text-xs text-surface-700-300">
 										{account.is_active ? 'Aktywne' : 'Nieaktywne'}
 									</td>
-									<td class="text-right font-semibold text-primary-600-400">
+									<td class="text-right font-semibold">
 										{formatPLN(account.current_value)}
 									</td>
 								</tr>

--- a/src/routes/metryki/+page.svelte
+++ b/src/routes/metryki/+page.svelte
@@ -204,7 +204,6 @@
 						value={ppkStat.total_value}
 						decimals={0}
 						suffix=" PLN"
-						color="green"
 					/>
 
 					<MetricCard
@@ -212,7 +211,6 @@
 						value={ppkStat.employee_contributed}
 						decimals={0}
 						suffix=" PLN"
-						color="blue"
 					/>
 
 					<MetricCard
@@ -220,7 +218,6 @@
 						value={ppkStat.employer_contributed}
 						decimals={0}
 						suffix=" PLN"
-						color="blue"
 					/>
 
 					<MetricCard
@@ -228,7 +225,6 @@
 						value={ppkStat.government_contributed}
 						decimals={0}
 						suffix=" PLN"
-						color="blue"
 					/>
 
 					<MetricCard
@@ -236,7 +232,6 @@
 						value={ppkStat.total_contributed}
 						decimals={0}
 						suffix=" PLN"
-						color="blue"
 					/>
 
 					<MetricCard
@@ -244,7 +239,7 @@
 						value={ppkStat.returns}
 						decimals={0}
 						suffix=" PLN"
-						color={ppkStat.returns >= 0 ? 'green' : 'red'}
+						signed
 					/>
 
 					<MetricCard
@@ -252,7 +247,7 @@
 						value={ppkStat.roi_percentage}
 						decimals={2}
 						suffix="%"
-						color={ppkStat.roi_percentage >= 0 ? 'green' : 'red'}
+						signed
 					/>
 				</div>
 			{/each}
@@ -275,7 +270,6 @@
 						value={pit.total_contributed}
 						decimals={0}
 						suffix=" PLN"
-						color="blue"
 					/>
 
 					<MetricCard
@@ -283,7 +277,6 @@
 						value={pit.marginal_tax_rate == null ? null : pit.marginal_tax_rate * 100}
 						decimals={0}
 						suffix="%"
-						color="blue"
 					/>
 
 					<MetricCard
@@ -291,7 +284,6 @@
 						value={pit.pit_savings}
 						decimals={0}
 						suffix=" PLN"
-						color="green"
 					/>
 				</div>
 			{/each}
@@ -306,7 +298,6 @@
 					value={data.stockStats.total_value}
 					decimals={0}
 					suffix=" PLN"
-					color="green"
 				/>
 
 				<MetricCard
@@ -314,7 +305,6 @@
 					value={data.stockStats.total_contributed}
 					decimals={0}
 					suffix=" PLN"
-					color="blue"
 				/>
 
 				<MetricCard
@@ -322,7 +312,7 @@
 					value={data.stockStats.returns}
 					decimals={0}
 					suffix=" PLN"
-					color={data.stockStats.returns >= 0 ? 'green' : 'red'}
+					signed
 				/>
 
 				<MetricCard
@@ -330,7 +320,7 @@
 					value={data.stockStats.roi_percentage}
 					decimals={2}
 					suffix="%"
-					color={data.stockStats.roi_percentage >= 0 ? 'green' : 'red'}
+					signed
 				/>
 			</div>
 		{/if}
@@ -344,7 +334,6 @@
 					value={data.bondStats.total_value}
 					decimals={0}
 					suffix=" PLN"
-					color="green"
 				/>
 
 				<MetricCard
@@ -352,7 +341,6 @@
 					value={data.bondStats.total_contributed}
 					decimals={0}
 					suffix=" PLN"
-					color="blue"
 				/>
 
 				<MetricCard
@@ -360,7 +348,7 @@
 					value={data.bondStats.returns}
 					decimals={0}
 					suffix=" PLN"
-					color={data.bondStats.returns >= 0 ? 'green' : 'red'}
+					signed
 				/>
 
 				<MetricCard
@@ -368,7 +356,7 @@
 					value={data.bondStats.roi_percentage}
 					decimals={2}
 					suffix="%"
-					color={data.bondStats.roi_percentage >= 0 ? 'green' : 'red'}
+					signed
 				/>
 			</div>
 		{/if}

--- a/src/routes/salaries/+page.svelte
+++ b/src/routes/salaries/+page.svelte
@@ -1326,7 +1326,7 @@
 						</div>
 					{/if}
 					{#if compSummary.equityLockedYearPln > 0}
-						<div class="text-xs text-warning-500">
+						<div class="text-xs text-surface-700-300">
 							+ {formatPLN(compSummary.equityLockedYearPln)} zablokowane (RSU, czeka na zdarzenie płynnościowe)
 						</div>
 					{/if}
@@ -1338,7 +1338,7 @@
 					<div class="text-xs text-surface-700-300">
 						Łącznie {includeEquityInTotal ? '(z udziałami)' : '(bez udziałów)'}
 					</div>
-					<div class="text-xl font-bold text-primary-600-400">{formatPLN(totalCompGross)}</div>
+					<div class="text-xl font-bold">{formatPLN(totalCompGross)}</div>
 					<div class="text-xs text-surface-700-300">
 						po podatku (szac.): {formatPLN(totalCompNet)}
 					</div>
@@ -1455,7 +1455,7 @@
 								<td>{formatDate(record.date)}</td>
 								<td>{ownerName(owners, record.owner_user_id)}</td>
 								<td>{record.company}</td>
-								<td class="font-semibold text-primary-600-400">{formatPLN(record.gross_amount)}</td>
+								<td class="font-semibold">{formatPLN(record.gross_amount)}</td>
 								<td>{record.contract_type}</td>
 								<td class="text-right whitespace-nowrap">
 									<button
@@ -1530,7 +1530,7 @@
 											<td>{formatDate(bonus.date)}</td>
 											<td>{bonusTypeLabels[bonus.type]}</td>
 											<td>{ownerName(owners, bonus.owner_user_id)}</td>
-											<td class="font-semibold text-primary-600-400">
+											<td class="font-semibold">
 												{formatBonusAmount(bonus.amount, bonus.currency)}
 												{#if bonus.currency !== 'PLN' && bonus.amount_pln !== null}
 													<br /><span class="text-xs font-normal text-surface-700-300">
@@ -1660,7 +1660,7 @@
 														>
 													{/if}
 												{:else if grant.valuation_date}
-													<span class="text-warning-500">{formatRange(grant)}</span>
+													<span class="text-surface-700-300">{formatRange(grant)}</span>
 												{:else}
 													<span class="text-surface-700-300">brak wyceny</span>
 												{/if}

--- a/src/routes/snapshots/+page.svelte
+++ b/src/routes/snapshots/+page.svelte
@@ -92,9 +92,7 @@
 								<td class="font-medium">
 									{formatDate(snapshot.date)}
 								</td>
-								<td class="font-semibold text-primary-600-400"
-									>{formatPLN(snapshot.total_net_worth)}</td
-								>
+								<td class="font-semibold">{formatPLN(snapshot.total_net_worth)}</td>
 								<td class="italic text-surface-700-300">{snapshot.notes || '—'}</td>
 								<td class="text-right">
 									<button

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -155,9 +155,7 @@
 		<td data-label="Data zakupu">{formatDate(transaction.date)}</td>
 		<td class="font-medium" data-label="Konto">{transaction.account_name}</td>
 		<td data-label="Właściciel">{ownerName(owners, transaction.owner_user_id)}</td>
-		<td class="font-semibold text-primary-600-400" data-label="Kwota">
-			{formatPLN(transaction.amount)}
-		</td>
+		<td class="font-semibold" data-label="Kwota">{formatPLN(transaction.amount)}</td>
 		<td class="text-right">
 			<button
 				type="button"
@@ -250,9 +248,9 @@
 		<header class="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
 			<h3 class="h3 flex items-center gap-2"><BarChart3 size={20} /> Historia transakcji</h3>
 			<p class="text-sm text-surface-700-300">
-				Zainwestowano łącznie: <strong class="text-primary-600-400 font-bold"
-					>{formatPLN(data.transactions.total_invested)}</strong
-				>
+				Zainwestowano łącznie: <strong class="font-bold">
+					{formatPLN(data.transactions.total_invested)}
+				</strong>
 			</p>
 		</header>
 


### PR DESCRIPTION
## Motivation

Values currently use competing accent colors without a consistent rule, which makes financial screens harder to scan. This refactor enforces neutral ink for ordinary values and reserves color for sign/delta semantics.

> Changelog: refactor(ui): enforce neutral value colors

## Implementation information

Updates the UI color treatment for value-heavy views so color carries meaning only for positive/negative/delta states, while ordinary labels and values stay neutral.

Closes https://github.com/Automaat/finance-buddy/issues/810

## Supporting documentation

Part of the UX/UI review cleanup.